### PR TITLE
Add ability to retrieve taglines from site

### DIFF
--- a/lib/src/v3/models/api.dart
+++ b/lib/src/v3/models/api.dart
@@ -124,7 +124,7 @@ class FullSiteView with _$FullSiteView {
     MyUserInfo? myUser,
     FederatedInstances? federatedInstances,
     required String instanceHost,
-    List<Tagline>? taglines,
+    required List<Tagline> taglines,
   }) = _FullSiteView;
 
   const FullSiteView._();
@@ -137,11 +137,12 @@ class FullSiteView with _$FullSiteView {
 class Tagline with _$Tagline {
   @modelSerde
   const factory Tagline({
-    int? id,
-    int? localSiteId,
-    String? content,
+    required int id,
+    required int localSiteId,
+    required String content,
     required DateTime published,
-    String? instanceHost,
+    required String instanceHost,
+    DateTime? updated,
   }) = _Tagline;
 
   const Tagline._();

--- a/lib/src/v3/models/api.dart
+++ b/lib/src/v3/models/api.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../../../v3.dart';
+import '../../utils/force_utc_datetime.dart';
 import '../../utils/serde.dart';
 
 part 'api.freezed.dart';
@@ -123,12 +124,30 @@ class FullSiteView with _$FullSiteView {
     MyUserInfo? myUser,
     FederatedInstances? federatedInstances,
     required String instanceHost,
+    List<Tagline>? taglines,
   }) = _FullSiteView;
 
   const FullSiteView._();
 
   factory FullSiteView.fromJson(Map<String, dynamic> json) =>
       _$FullSiteViewFromJson(json);
+}
+
+@freezed
+class Tagline with _$Tagline {
+  @modelSerde
+  const factory Tagline({
+    int? id,
+    int? localSiteId,
+    String? content,
+    required DateTime published,
+    String? instanceHost,
+  }) = _Tagline;
+
+  const Tagline._();
+
+  factory Tagline.fromJson(Map<String, dynamic> json) =>
+      _$TaglineFromJson(json);
 }
 
 @freezed

--- a/lib/src/v3/models/api.freezed.dart
+++ b/lib/src/v3/models/api.freezed.dart
@@ -1831,6 +1831,7 @@ mixin _$FullSiteView {
   FederatedInstances? get federatedInstances =>
       throw _privateConstructorUsedError;
   String get instanceHost => throw _privateConstructorUsedError;
+  List<Tagline>? get taglines => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -1851,7 +1852,8 @@ abstract class $FullSiteViewCopyWith<$Res> {
       String version,
       MyUserInfo? myUser,
       FederatedInstances? federatedInstances,
-      String instanceHost});
+      String instanceHost,
+      List<Tagline>? taglines});
 
   $SiteViewCopyWith<$Res>? get siteView;
   $MyUserInfoCopyWith<$Res>? get myUser;
@@ -1878,6 +1880,7 @@ class _$FullSiteViewCopyWithImpl<$Res, $Val extends FullSiteView>
     Object? myUser = freezed,
     Object? federatedInstances = freezed,
     Object? instanceHost = null,
+    Object? taglines = freezed,
   }) {
     return _then(_value.copyWith(
       siteView: freezed == siteView
@@ -1908,6 +1911,10 @@ class _$FullSiteViewCopyWithImpl<$Res, $Val extends FullSiteView>
           ? _value.instanceHost
           : instanceHost // ignore: cast_nullable_to_non_nullable
               as String,
+      taglines: freezed == taglines
+          ? _value.taglines
+          : taglines // ignore: cast_nullable_to_non_nullable
+              as List<Tagline>?,
     ) as $Val);
   }
 
@@ -1964,7 +1971,8 @@ abstract class _$$_FullSiteViewCopyWith<$Res>
       String version,
       MyUserInfo? myUser,
       FederatedInstances? federatedInstances,
-      String instanceHost});
+      String instanceHost,
+      List<Tagline>? taglines});
 
   @override
   $SiteViewCopyWith<$Res>? get siteView;
@@ -1992,6 +2000,7 @@ class __$$_FullSiteViewCopyWithImpl<$Res>
     Object? myUser = freezed,
     Object? federatedInstances = freezed,
     Object? instanceHost = null,
+    Object? taglines = freezed,
   }) {
     return _then(_$_FullSiteView(
       siteView: freezed == siteView
@@ -2022,6 +2031,10 @@ class __$$_FullSiteViewCopyWithImpl<$Res>
           ? _value.instanceHost
           : instanceHost // ignore: cast_nullable_to_non_nullable
               as String,
+      taglines: freezed == taglines
+          ? _value._taglines
+          : taglines // ignore: cast_nullable_to_non_nullable
+              as List<Tagline>?,
     ));
   }
 }
@@ -2037,8 +2050,10 @@ class _$_FullSiteView extends _FullSiteView {
       required this.version,
       this.myUser,
       this.federatedInstances,
-      required this.instanceHost})
+      required this.instanceHost,
+      final List<Tagline>? taglines})
       : _admins = admins,
+        _taglines = taglines,
         super._();
 
   factory _$_FullSiteView.fromJson(Map<String, dynamic> json) =>
@@ -2064,10 +2079,19 @@ class _$_FullSiteView extends _FullSiteView {
   final FederatedInstances? federatedInstances;
   @override
   final String instanceHost;
+  final List<Tagline>? _taglines;
+  @override
+  List<Tagline>? get taglines {
+    final value = _taglines;
+    if (value == null) return null;
+    if (_taglines is EqualUnmodifiableListView) return _taglines;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
 
   @override
   String toString() {
-    return 'FullSiteView(siteView: $siteView, admins: $admins, online: $online, version: $version, myUser: $myUser, federatedInstances: $federatedInstances, instanceHost: $instanceHost)';
+    return 'FullSiteView(siteView: $siteView, admins: $admins, online: $online, version: $version, myUser: $myUser, federatedInstances: $federatedInstances, instanceHost: $instanceHost, taglines: $taglines)';
   }
 
   @override
@@ -2084,7 +2108,8 @@ class _$_FullSiteView extends _FullSiteView {
             (identical(other.federatedInstances, federatedInstances) ||
                 other.federatedInstances == federatedInstances) &&
             (identical(other.instanceHost, instanceHost) ||
-                other.instanceHost == instanceHost));
+                other.instanceHost == instanceHost) &&
+            const DeepCollectionEquality().equals(other._taglines, _taglines));
   }
 
   @JsonKey(ignore: true)
@@ -2097,7 +2122,8 @@ class _$_FullSiteView extends _FullSiteView {
       version,
       myUser,
       federatedInstances,
-      instanceHost);
+      instanceHost,
+      const DeepCollectionEquality().hash(_taglines));
 
   @JsonKey(ignore: true)
   @override
@@ -2121,7 +2147,8 @@ abstract class _FullSiteView extends FullSiteView {
       required final String version,
       final MyUserInfo? myUser,
       final FederatedInstances? federatedInstances,
-      required final String instanceHost}) = _$_FullSiteView;
+      required final String instanceHost,
+      final List<Tagline>? taglines}) = _$_FullSiteView;
   const _FullSiteView._() : super._();
 
   factory _FullSiteView.fromJson(Map<String, dynamic> json) =
@@ -2142,8 +2169,232 @@ abstract class _FullSiteView extends FullSiteView {
   @override
   String get instanceHost;
   @override
+  List<Tagline>? get taglines;
+  @override
   @JsonKey(ignore: true)
   _$$_FullSiteViewCopyWith<_$_FullSiteView> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+Tagline _$TaglineFromJson(Map<String, dynamic> json) {
+  return _Tagline.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Tagline {
+  int? get id => throw _privateConstructorUsedError;
+  int? get localSiteId => throw _privateConstructorUsedError;
+  String? get content => throw _privateConstructorUsedError;
+  DateTime get published => throw _privateConstructorUsedError;
+  String? get instanceHost => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $TaglineCopyWith<Tagline> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TaglineCopyWith<$Res> {
+  factory $TaglineCopyWith(Tagline value, $Res Function(Tagline) then) =
+      _$TaglineCopyWithImpl<$Res, Tagline>;
+  @useResult
+  $Res call(
+      {int? id,
+      int? localSiteId,
+      String? content,
+      DateTime published,
+      String? instanceHost});
+}
+
+/// @nodoc
+class _$TaglineCopyWithImpl<$Res, $Val extends Tagline>
+    implements $TaglineCopyWith<$Res> {
+  _$TaglineCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? localSiteId = freezed,
+    Object? content = freezed,
+    Object? published = null,
+    Object? instanceHost = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: freezed == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int?,
+      localSiteId: freezed == localSiteId
+          ? _value.localSiteId
+          : localSiteId // ignore: cast_nullable_to_non_nullable
+              as int?,
+      content: freezed == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String?,
+      published: null == published
+          ? _value.published
+          : published // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      instanceHost: freezed == instanceHost
+          ? _value.instanceHost
+          : instanceHost // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_TaglineCopyWith<$Res> implements $TaglineCopyWith<$Res> {
+  factory _$$_TaglineCopyWith(
+          _$_Tagline value, $Res Function(_$_Tagline) then) =
+      __$$_TaglineCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int? id,
+      int? localSiteId,
+      String? content,
+      DateTime published,
+      String? instanceHost});
+}
+
+/// @nodoc
+class __$$_TaglineCopyWithImpl<$Res>
+    extends _$TaglineCopyWithImpl<$Res, _$_Tagline>
+    implements _$$_TaglineCopyWith<$Res> {
+  __$$_TaglineCopyWithImpl(_$_Tagline _value, $Res Function(_$_Tagline) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? localSiteId = freezed,
+    Object? content = freezed,
+    Object? published = null,
+    Object? instanceHost = freezed,
+  }) {
+    return _then(_$_Tagline(
+      id: freezed == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int?,
+      localSiteId: freezed == localSiteId
+          ? _value.localSiteId
+          : localSiteId // ignore: cast_nullable_to_non_nullable
+              as int?,
+      content: freezed == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String?,
+      published: null == published
+          ? _value.published
+          : published // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      instanceHost: freezed == instanceHost
+          ? _value.instanceHost
+          : instanceHost // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+@modelSerde
+class _$_Tagline extends _Tagline {
+  const _$_Tagline(
+      {this.id,
+      this.localSiteId,
+      this.content,
+      required this.published,
+      this.instanceHost})
+      : super._();
+
+  factory _$_Tagline.fromJson(Map<String, dynamic> json) =>
+      _$$_TaglineFromJson(json);
+
+  @override
+  final int? id;
+  @override
+  final int? localSiteId;
+  @override
+  final String? content;
+  @override
+  final DateTime published;
+  @override
+  final String? instanceHost;
+
+  @override
+  String toString() {
+    return 'Tagline(id: $id, localSiteId: $localSiteId, content: $content, published: $published, instanceHost: $instanceHost)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Tagline &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.localSiteId, localSiteId) ||
+                other.localSiteId == localSiteId) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.published, published) ||
+                other.published == published) &&
+            (identical(other.instanceHost, instanceHost) ||
+                other.instanceHost == instanceHost));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, id, localSiteId, content, published, instanceHost);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_TaglineCopyWith<_$_Tagline> get copyWith =>
+      __$$_TaglineCopyWithImpl<_$_Tagline>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_TaglineToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Tagline extends Tagline {
+  const factory _Tagline(
+      {final int? id,
+      final int? localSiteId,
+      final String? content,
+      required final DateTime published,
+      final String? instanceHost}) = _$_Tagline;
+  const _Tagline._() : super._();
+
+  factory _Tagline.fromJson(Map<String, dynamic> json) = _$_Tagline.fromJson;
+
+  @override
+  int? get id;
+  @override
+  int? get localSiteId;
+  @override
+  String? get content;
+  @override
+  DateTime get published;
+  @override
+  String? get instanceHost;
+  @override
+  @JsonKey(ignore: true)
+  _$$_TaglineCopyWith<_$_Tagline> get copyWith =>
       throw _privateConstructorUsedError;
 }
 

--- a/lib/src/v3/models/api.freezed.dart
+++ b/lib/src/v3/models/api.freezed.dart
@@ -1831,7 +1831,7 @@ mixin _$FullSiteView {
   FederatedInstances? get federatedInstances =>
       throw _privateConstructorUsedError;
   String get instanceHost => throw _privateConstructorUsedError;
-  List<Tagline>? get taglines => throw _privateConstructorUsedError;
+  List<Tagline> get taglines => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -1853,7 +1853,7 @@ abstract class $FullSiteViewCopyWith<$Res> {
       MyUserInfo? myUser,
       FederatedInstances? federatedInstances,
       String instanceHost,
-      List<Tagline>? taglines});
+      List<Tagline> taglines});
 
   $SiteViewCopyWith<$Res>? get siteView;
   $MyUserInfoCopyWith<$Res>? get myUser;
@@ -1880,7 +1880,7 @@ class _$FullSiteViewCopyWithImpl<$Res, $Val extends FullSiteView>
     Object? myUser = freezed,
     Object? federatedInstances = freezed,
     Object? instanceHost = null,
-    Object? taglines = freezed,
+    Object? taglines = null,
   }) {
     return _then(_value.copyWith(
       siteView: freezed == siteView
@@ -1911,10 +1911,10 @@ class _$FullSiteViewCopyWithImpl<$Res, $Val extends FullSiteView>
           ? _value.instanceHost
           : instanceHost // ignore: cast_nullable_to_non_nullable
               as String,
-      taglines: freezed == taglines
+      taglines: null == taglines
           ? _value.taglines
           : taglines // ignore: cast_nullable_to_non_nullable
-              as List<Tagline>?,
+              as List<Tagline>,
     ) as $Val);
   }
 
@@ -1972,7 +1972,7 @@ abstract class _$$_FullSiteViewCopyWith<$Res>
       MyUserInfo? myUser,
       FederatedInstances? federatedInstances,
       String instanceHost,
-      List<Tagline>? taglines});
+      List<Tagline> taglines});
 
   @override
   $SiteViewCopyWith<$Res>? get siteView;
@@ -2000,7 +2000,7 @@ class __$$_FullSiteViewCopyWithImpl<$Res>
     Object? myUser = freezed,
     Object? federatedInstances = freezed,
     Object? instanceHost = null,
-    Object? taglines = freezed,
+    Object? taglines = null,
   }) {
     return _then(_$_FullSiteView(
       siteView: freezed == siteView
@@ -2031,10 +2031,10 @@ class __$$_FullSiteViewCopyWithImpl<$Res>
           ? _value.instanceHost
           : instanceHost // ignore: cast_nullable_to_non_nullable
               as String,
-      taglines: freezed == taglines
+      taglines: null == taglines
           ? _value._taglines
           : taglines // ignore: cast_nullable_to_non_nullable
-              as List<Tagline>?,
+              as List<Tagline>,
     ));
   }
 }
@@ -2051,7 +2051,7 @@ class _$_FullSiteView extends _FullSiteView {
       this.myUser,
       this.federatedInstances,
       required this.instanceHost,
-      final List<Tagline>? taglines})
+      required final List<Tagline> taglines})
       : _admins = admins,
         _taglines = taglines,
         super._();
@@ -2079,14 +2079,12 @@ class _$_FullSiteView extends _FullSiteView {
   final FederatedInstances? federatedInstances;
   @override
   final String instanceHost;
-  final List<Tagline>? _taglines;
+  final List<Tagline> _taglines;
   @override
-  List<Tagline>? get taglines {
-    final value = _taglines;
-    if (value == null) return null;
+  List<Tagline> get taglines {
     if (_taglines is EqualUnmodifiableListView) return _taglines;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
+    return EqualUnmodifiableListView(_taglines);
   }
 
   @override
@@ -2148,7 +2146,7 @@ abstract class _FullSiteView extends FullSiteView {
       final MyUserInfo? myUser,
       final FederatedInstances? federatedInstances,
       required final String instanceHost,
-      final List<Tagline>? taglines}) = _$_FullSiteView;
+      required final List<Tagline> taglines}) = _$_FullSiteView;
   const _FullSiteView._() : super._();
 
   factory _FullSiteView.fromJson(Map<String, dynamic> json) =
@@ -2169,7 +2167,7 @@ abstract class _FullSiteView extends FullSiteView {
   @override
   String get instanceHost;
   @override
-  List<Tagline>? get taglines;
+  List<Tagline> get taglines;
   @override
   @JsonKey(ignore: true)
   _$$_FullSiteViewCopyWith<_$_FullSiteView> get copyWith =>
@@ -2182,11 +2180,12 @@ Tagline _$TaglineFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$Tagline {
-  int? get id => throw _privateConstructorUsedError;
-  int? get localSiteId => throw _privateConstructorUsedError;
-  String? get content => throw _privateConstructorUsedError;
+  int get id => throw _privateConstructorUsedError;
+  int get localSiteId => throw _privateConstructorUsedError;
+  String get content => throw _privateConstructorUsedError;
   DateTime get published => throw _privateConstructorUsedError;
-  String? get instanceHost => throw _privateConstructorUsedError;
+  String get instanceHost => throw _privateConstructorUsedError;
+  DateTime? get updated => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -2199,11 +2198,12 @@ abstract class $TaglineCopyWith<$Res> {
       _$TaglineCopyWithImpl<$Res, Tagline>;
   @useResult
   $Res call(
-      {int? id,
-      int? localSiteId,
-      String? content,
+      {int id,
+      int localSiteId,
+      String content,
       DateTime published,
-      String? instanceHost});
+      String instanceHost,
+      DateTime? updated});
 }
 
 /// @nodoc
@@ -2219,33 +2219,38 @@ class _$TaglineCopyWithImpl<$Res, $Val extends Tagline>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? localSiteId = freezed,
-    Object? content = freezed,
+    Object? id = null,
+    Object? localSiteId = null,
+    Object? content = null,
     Object? published = null,
-    Object? instanceHost = freezed,
+    Object? instanceHost = null,
+    Object? updated = freezed,
   }) {
     return _then(_value.copyWith(
-      id: freezed == id
+      id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int?,
-      localSiteId: freezed == localSiteId
+              as int,
+      localSiteId: null == localSiteId
           ? _value.localSiteId
           : localSiteId // ignore: cast_nullable_to_non_nullable
-              as int?,
-      content: freezed == content
+              as int,
+      content: null == content
           ? _value.content
           : content // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
       published: null == published
           ? _value.published
           : published // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      instanceHost: freezed == instanceHost
+      instanceHost: null == instanceHost
           ? _value.instanceHost
           : instanceHost // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
+      updated: freezed == updated
+          ? _value.updated
+          : updated // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
     ) as $Val);
   }
 }
@@ -2258,11 +2263,12 @@ abstract class _$$_TaglineCopyWith<$Res> implements $TaglineCopyWith<$Res> {
   @override
   @useResult
   $Res call(
-      {int? id,
-      int? localSiteId,
-      String? content,
+      {int id,
+      int localSiteId,
+      String content,
       DateTime published,
-      String? instanceHost});
+      String instanceHost,
+      DateTime? updated});
 }
 
 /// @nodoc
@@ -2275,33 +2281,38 @@ class __$$_TaglineCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? localSiteId = freezed,
-    Object? content = freezed,
+    Object? id = null,
+    Object? localSiteId = null,
+    Object? content = null,
     Object? published = null,
-    Object? instanceHost = freezed,
+    Object? instanceHost = null,
+    Object? updated = freezed,
   }) {
     return _then(_$_Tagline(
-      id: freezed == id
+      id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int?,
-      localSiteId: freezed == localSiteId
+              as int,
+      localSiteId: null == localSiteId
           ? _value.localSiteId
           : localSiteId // ignore: cast_nullable_to_non_nullable
-              as int?,
-      content: freezed == content
+              as int,
+      content: null == content
           ? _value.content
           : content // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
       published: null == published
           ? _value.published
           : published // ignore: cast_nullable_to_non_nullable
               as DateTime,
-      instanceHost: freezed == instanceHost
+      instanceHost: null == instanceHost
           ? _value.instanceHost
           : instanceHost // ignore: cast_nullable_to_non_nullable
-              as String?,
+              as String,
+      updated: freezed == updated
+          ? _value.updated
+          : updated // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
     ));
   }
 }
@@ -2311,30 +2322,33 @@ class __$$_TaglineCopyWithImpl<$Res>
 @modelSerde
 class _$_Tagline extends _Tagline {
   const _$_Tagline(
-      {this.id,
-      this.localSiteId,
-      this.content,
+      {required this.id,
+      required this.localSiteId,
+      required this.content,
       required this.published,
-      this.instanceHost})
+      required this.instanceHost,
+      this.updated})
       : super._();
 
   factory _$_Tagline.fromJson(Map<String, dynamic> json) =>
       _$$_TaglineFromJson(json);
 
   @override
-  final int? id;
+  final int id;
   @override
-  final int? localSiteId;
+  final int localSiteId;
   @override
-  final String? content;
+  final String content;
   @override
   final DateTime published;
   @override
-  final String? instanceHost;
+  final String instanceHost;
+  @override
+  final DateTime? updated;
 
   @override
   String toString() {
-    return 'Tagline(id: $id, localSiteId: $localSiteId, content: $content, published: $published, instanceHost: $instanceHost)';
+    return 'Tagline(id: $id, localSiteId: $localSiteId, content: $content, published: $published, instanceHost: $instanceHost, updated: $updated)';
   }
 
   @override
@@ -2349,13 +2363,14 @@ class _$_Tagline extends _Tagline {
             (identical(other.published, published) ||
                 other.published == published) &&
             (identical(other.instanceHost, instanceHost) ||
-                other.instanceHost == instanceHost));
+                other.instanceHost == instanceHost) &&
+            (identical(other.updated, updated) || other.updated == updated));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType, id, localSiteId, content, published, instanceHost);
+      runtimeType, id, localSiteId, content, published, instanceHost, updated);
 
   @JsonKey(ignore: true)
   @override
@@ -2373,25 +2388,28 @@ class _$_Tagline extends _Tagline {
 
 abstract class _Tagline extends Tagline {
   const factory _Tagline(
-      {final int? id,
-      final int? localSiteId,
-      final String? content,
+      {required final int id,
+      required final int localSiteId,
+      required final String content,
       required final DateTime published,
-      final String? instanceHost}) = _$_Tagline;
+      required final String instanceHost,
+      final DateTime? updated}) = _$_Tagline;
   const _Tagline._() : super._();
 
   factory _Tagline.fromJson(Map<String, dynamic> json) = _$_Tagline.fromJson;
 
   @override
-  int? get id;
+  int get id;
   @override
-  int? get localSiteId;
+  int get localSiteId;
   @override
-  String? get content;
+  String get content;
   @override
   DateTime get published;
   @override
-  String? get instanceHost;
+  String get instanceHost;
+  @override
+  DateTime? get updated;
   @override
   @JsonKey(ignore: true)
   _$$_TaglineCopyWith<_$_Tagline> get copyWith =>

--- a/lib/src/v3/models/api.g.dart
+++ b/lib/src/v3/models/api.g.dart
@@ -217,6 +217,9 @@ _$_FullSiteView _$$_FullSiteViewFromJson(Map<String, dynamic> json) =>
           : FederatedInstances.fromJson(
               json['federated_instances'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
+      taglines: (json['taglines'] as List<dynamic>?)
+          ?.map((e) => Tagline.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
 Map<String, dynamic> _$$_FullSiteViewToJson(_$_FullSiteView instance) =>
@@ -227,6 +230,24 @@ Map<String, dynamic> _$$_FullSiteViewToJson(_$_FullSiteView instance) =>
       'version': instance.version,
       'my_user': instance.myUser?.toJson(),
       'federated_instances': instance.federatedInstances?.toJson(),
+      'instance_host': instance.instanceHost,
+      'taglines': instance.taglines?.map((e) => e.toJson()).toList(),
+    };
+
+_$_Tagline _$$_TaglineFromJson(Map<String, dynamic> json) => _$_Tagline(
+      id: json['id'] as int?,
+      localSiteId: json['local_site_id'] as int?,
+      content: json['content'] as String?,
+      published: const ForceUtcDateTime().fromJson(json['published'] as String),
+      instanceHost: json['instance_host'] as String?,
+    );
+
+Map<String, dynamic> _$$_TaglineToJson(_$_Tagline instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'local_site_id': instance.localSiteId,
+      'content': instance.content,
+      'published': const ForceUtcDateTime().toJson(instance.published),
       'instance_host': instance.instanceHost,
     };
 

--- a/lib/src/v3/models/api.g.dart
+++ b/lib/src/v3/models/api.g.dart
@@ -217,8 +217,8 @@ _$_FullSiteView _$$_FullSiteViewFromJson(Map<String, dynamic> json) =>
           : FederatedInstances.fromJson(
               json['federated_instances'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
-      taglines: (json['taglines'] as List<dynamic>?)
-          ?.map((e) => Tagline.fromJson(e as Map<String, dynamic>))
+      taglines: (json['taglines'] as List<dynamic>)
+          .map((e) => Tagline.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
@@ -231,15 +231,17 @@ Map<String, dynamic> _$$_FullSiteViewToJson(_$_FullSiteView instance) =>
       'my_user': instance.myUser?.toJson(),
       'federated_instances': instance.federatedInstances?.toJson(),
       'instance_host': instance.instanceHost,
-      'taglines': instance.taglines?.map((e) => e.toJson()).toList(),
+      'taglines': instance.taglines.map((e) => e.toJson()).toList(),
     };
 
 _$_Tagline _$$_TaglineFromJson(Map<String, dynamic> json) => _$_Tagline(
-      id: json['id'] as int?,
-      localSiteId: json['local_site_id'] as int?,
-      content: json['content'] as String?,
+      id: json['id'] as int,
+      localSiteId: json['local_site_id'] as int,
+      content: json['content'] as String,
       published: const ForceUtcDateTime().fromJson(json['published'] as String),
-      instanceHost: json['instance_host'] as String?,
+      instanceHost: json['instance_host'] as String,
+      updated: _$JsonConverterFromJson<String, DateTime>(
+          json['updated'], const ForceUtcDateTime().fromJson),
     );
 
 Map<String, dynamic> _$$_TaglineToJson(_$_Tagline instance) =>
@@ -249,7 +251,21 @@ Map<String, dynamic> _$$_TaglineToJson(_$_Tagline instance) =>
       'content': instance.content,
       'published': const ForceUtcDateTime().toJson(instance.published),
       'instance_host': instance.instanceHost,
+      'updated': _$JsonConverterToJson<String, DateTime>(
+          instance.updated, const ForceUtcDateTime().toJson),
     };
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) =>
+    json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) =>
+    value == null ? null : toJson(value);
 
 _$_MyUserInfo _$$_MyUserInfoFromJson(Map<String, dynamic> json) =>
     _$_MyUserInfo(


### PR DESCRIPTION
This PR adds the ability to retrieve [Taglines](https://join-lemmy.org/api/interfaces/Tagline.html) from a Lemmy site. The goal is to show the tagline at the top of the Thunder UI (like Jerboa).

Here is an example of a tagline on [programming.dev](https://programming.dev).

| ![image](https://github.com/thunder-app/lemmy_api_client/assets/7417301/51e599da-87e5-4241-a416-ad3709ea9996) |
| - |

Here's how we can retrieve it via the API now.

``` dart
FullSiteView fullSiteView = await lemmy.run(
  GetSite(
    auth: response.jwt!.raw,
  ),
);

print(fullSiteView.taglines?.first.content);
```

And here's what the output would look like.

```
If you recently signed up (since Jul 9) and used an email, it most likely did not get saved properly. You will need to add it in your profile settings again.
```