### PR TITLE
Add API support for blocking instances on 0.19.x

### DIFF
--- a/lib/src/v3/api/comment.freezed.dart
+++ b/lib/src/v3/api/comment.freezed.dart
@@ -87,11 +87,11 @@ class _$CreateCommentCopyWithImpl<$Res, $Val extends CreateComment>
 }
 
 /// @nodoc
-abstract class _$$CreateCommentImplCopyWith<$Res>
+abstract class _$$_CreateCommentCopyWith<$Res>
     implements $CreateCommentCopyWith<$Res> {
-  factory _$$CreateCommentImplCopyWith(
-          _$CreateCommentImpl value, $Res Function(_$CreateCommentImpl) then) =
-      __$$CreateCommentImplCopyWithImpl<$Res>;
+  factory _$$_CreateCommentCopyWith(
+          _$_CreateComment value, $Res Function(_$_CreateComment) then) =
+      __$$_CreateCommentCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -99,11 +99,11 @@ abstract class _$$CreateCommentImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CreateCommentImplCopyWithImpl<$Res>
-    extends _$CreateCommentCopyWithImpl<$Res, _$CreateCommentImpl>
-    implements _$$CreateCommentImplCopyWith<$Res> {
-  __$$CreateCommentImplCopyWithImpl(
-      _$CreateCommentImpl _value, $Res Function(_$CreateCommentImpl) _then)
+class __$$_CreateCommentCopyWithImpl<$Res>
+    extends _$CreateCommentCopyWithImpl<$Res, _$_CreateComment>
+    implements _$$_CreateCommentCopyWith<$Res> {
+  __$$_CreateCommentCopyWithImpl(
+      _$_CreateComment _value, $Res Function(_$_CreateComment) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -115,7 +115,7 @@ class __$$CreateCommentImplCopyWithImpl<$Res>
     Object? formId = freezed,
     Object? auth = null,
   }) {
-    return _then(_$CreateCommentImpl(
+    return _then(_$_CreateComment(
       content: null == content
           ? _value.content
           : content // ignore: cast_nullable_to_non_nullable
@@ -143,8 +143,8 @@ class __$$CreateCommentImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$CreateCommentImpl extends _CreateComment {
-  const _$CreateCommentImpl(
+class _$_CreateComment extends _CreateComment {
+  const _$_CreateComment(
       {required this.content,
       this.parentId,
       required this.postId,
@@ -152,8 +152,8 @@ class _$CreateCommentImpl extends _CreateComment {
       required this.auth})
       : super._();
 
-  factory _$CreateCommentImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CreateCommentImplFromJson(json);
+  factory _$_CreateComment.fromJson(Map<String, dynamic> json) =>
+      _$$_CreateCommentFromJson(json);
 
   @override
   final String content;
@@ -175,7 +175,7 @@ class _$CreateCommentImpl extends _CreateComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CreateCommentImpl &&
+            other is _$_CreateComment &&
             (identical(other.content, content) || other.content == content) &&
             (identical(other.parentId, parentId) ||
                 other.parentId == parentId) &&
@@ -192,12 +192,12 @@ class _$CreateCommentImpl extends _CreateComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CreateCommentImplCopyWith<_$CreateCommentImpl> get copyWith =>
-      __$$CreateCommentImplCopyWithImpl<_$CreateCommentImpl>(this, _$identity);
+  _$$_CreateCommentCopyWith<_$_CreateComment> get copyWith =>
+      __$$_CreateCommentCopyWithImpl<_$_CreateComment>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CreateCommentImplToJson(
+    return _$$_CreateCommentToJson(
       this,
     );
   }
@@ -209,11 +209,11 @@ abstract class _CreateComment extends CreateComment {
       final int? parentId,
       required final int postId,
       final String? formId,
-      required final String auth}) = _$CreateCommentImpl;
+      required final String auth}) = _$_CreateComment;
   const _CreateComment._() : super._();
 
   factory _CreateComment.fromJson(Map<String, dynamic> json) =
-      _$CreateCommentImpl.fromJson;
+      _$_CreateComment.fromJson;
 
   @override
   String get content;
@@ -227,7 +227,7 @@ abstract class _CreateComment extends CreateComment {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$CreateCommentImplCopyWith<_$CreateCommentImpl> get copyWith =>
+  _$$_CreateCommentCopyWith<_$_CreateComment> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -297,22 +297,22 @@ class _$EditCommentCopyWithImpl<$Res, $Val extends EditComment>
 }
 
 /// @nodoc
-abstract class _$$EditCommentImplCopyWith<$Res>
+abstract class _$$_EditCommentCopyWith<$Res>
     implements $EditCommentCopyWith<$Res> {
-  factory _$$EditCommentImplCopyWith(
-          _$EditCommentImpl value, $Res Function(_$EditCommentImpl) then) =
-      __$$EditCommentImplCopyWithImpl<$Res>;
+  factory _$$_EditCommentCopyWith(
+          _$_EditComment value, $Res Function(_$_EditComment) then) =
+      __$$_EditCommentCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String content, int commentId, String? formId, String auth});
 }
 
 /// @nodoc
-class __$$EditCommentImplCopyWithImpl<$Res>
-    extends _$EditCommentCopyWithImpl<$Res, _$EditCommentImpl>
-    implements _$$EditCommentImplCopyWith<$Res> {
-  __$$EditCommentImplCopyWithImpl(
-      _$EditCommentImpl _value, $Res Function(_$EditCommentImpl) _then)
+class __$$_EditCommentCopyWithImpl<$Res>
+    extends _$EditCommentCopyWithImpl<$Res, _$_EditComment>
+    implements _$$_EditCommentCopyWith<$Res> {
+  __$$_EditCommentCopyWithImpl(
+      _$_EditComment _value, $Res Function(_$_EditComment) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -323,7 +323,7 @@ class __$$EditCommentImplCopyWithImpl<$Res>
     Object? formId = freezed,
     Object? auth = null,
   }) {
-    return _then(_$EditCommentImpl(
+    return _then(_$_EditComment(
       content: null == content
           ? _value.content
           : content // ignore: cast_nullable_to_non_nullable
@@ -347,16 +347,16 @@ class __$$EditCommentImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$EditCommentImpl extends _EditComment {
-  const _$EditCommentImpl(
+class _$_EditComment extends _EditComment {
+  const _$_EditComment(
       {required this.content,
       required this.commentId,
       this.formId,
       required this.auth})
       : super._();
 
-  factory _$EditCommentImpl.fromJson(Map<String, dynamic> json) =>
-      _$$EditCommentImplFromJson(json);
+  factory _$_EditComment.fromJson(Map<String, dynamic> json) =>
+      _$$_EditCommentFromJson(json);
 
   @override
   final String content;
@@ -376,7 +376,7 @@ class _$EditCommentImpl extends _EditComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$EditCommentImpl &&
+            other is _$_EditComment &&
             (identical(other.content, content) || other.content == content) &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
@@ -392,12 +392,12 @@ class _$EditCommentImpl extends _EditComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$EditCommentImplCopyWith<_$EditCommentImpl> get copyWith =>
-      __$$EditCommentImplCopyWithImpl<_$EditCommentImpl>(this, _$identity);
+  _$$_EditCommentCopyWith<_$_EditComment> get copyWith =>
+      __$$_EditCommentCopyWithImpl<_$_EditComment>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$EditCommentImplToJson(
+    return _$$_EditCommentToJson(
       this,
     );
   }
@@ -408,11 +408,11 @@ abstract class _EditComment extends EditComment {
       {required final String content,
       required final int commentId,
       final String? formId,
-      required final String auth}) = _$EditCommentImpl;
+      required final String auth}) = _$_EditComment;
   const _EditComment._() : super._();
 
   factory _EditComment.fromJson(Map<String, dynamic> json) =
-      _$EditCommentImpl.fromJson;
+      _$_EditComment.fromJson;
 
   @override
   String get content;
@@ -424,7 +424,7 @@ abstract class _EditComment extends EditComment {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$EditCommentImplCopyWith<_$EditCommentImpl> get copyWith =>
+  _$$_EditCommentCopyWith<_$_EditComment> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -488,22 +488,22 @@ class _$DeleteCommentCopyWithImpl<$Res, $Val extends DeleteComment>
 }
 
 /// @nodoc
-abstract class _$$DeleteCommentImplCopyWith<$Res>
+abstract class _$$_DeleteCommentCopyWith<$Res>
     implements $DeleteCommentCopyWith<$Res> {
-  factory _$$DeleteCommentImplCopyWith(
-          _$DeleteCommentImpl value, $Res Function(_$DeleteCommentImpl) then) =
-      __$$DeleteCommentImplCopyWithImpl<$Res>;
+  factory _$$_DeleteCommentCopyWith(
+          _$_DeleteComment value, $Res Function(_$_DeleteComment) then) =
+      __$$_DeleteCommentCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, bool deleted, String auth});
 }
 
 /// @nodoc
-class __$$DeleteCommentImplCopyWithImpl<$Res>
-    extends _$DeleteCommentCopyWithImpl<$Res, _$DeleteCommentImpl>
-    implements _$$DeleteCommentImplCopyWith<$Res> {
-  __$$DeleteCommentImplCopyWithImpl(
-      _$DeleteCommentImpl _value, $Res Function(_$DeleteCommentImpl) _then)
+class __$$_DeleteCommentCopyWithImpl<$Res>
+    extends _$DeleteCommentCopyWithImpl<$Res, _$_DeleteComment>
+    implements _$$_DeleteCommentCopyWith<$Res> {
+  __$$_DeleteCommentCopyWithImpl(
+      _$_DeleteComment _value, $Res Function(_$_DeleteComment) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -513,7 +513,7 @@ class __$$DeleteCommentImplCopyWithImpl<$Res>
     Object? deleted = null,
     Object? auth = null,
   }) {
-    return _then(_$DeleteCommentImpl(
+    return _then(_$_DeleteComment(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -533,13 +533,13 @@ class __$$DeleteCommentImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$DeleteCommentImpl extends _DeleteComment {
-  const _$DeleteCommentImpl(
+class _$_DeleteComment extends _DeleteComment {
+  const _$_DeleteComment(
       {required this.commentId, required this.deleted, required this.auth})
       : super._();
 
-  factory _$DeleteCommentImpl.fromJson(Map<String, dynamic> json) =>
-      _$$DeleteCommentImplFromJson(json);
+  factory _$_DeleteComment.fromJson(Map<String, dynamic> json) =>
+      _$$_DeleteCommentFromJson(json);
 
   @override
   final int commentId;
@@ -557,7 +557,7 @@ class _$DeleteCommentImpl extends _DeleteComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$DeleteCommentImpl &&
+            other is _$_DeleteComment &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.deleted, deleted) || other.deleted == deleted) &&
@@ -571,12 +571,12 @@ class _$DeleteCommentImpl extends _DeleteComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$DeleteCommentImplCopyWith<_$DeleteCommentImpl> get copyWith =>
-      __$$DeleteCommentImplCopyWithImpl<_$DeleteCommentImpl>(this, _$identity);
+  _$$_DeleteCommentCopyWith<_$_DeleteComment> get copyWith =>
+      __$$_DeleteCommentCopyWithImpl<_$_DeleteComment>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$DeleteCommentImplToJson(
+    return _$$_DeleteCommentToJson(
       this,
     );
   }
@@ -586,11 +586,11 @@ abstract class _DeleteComment extends DeleteComment {
   const factory _DeleteComment(
       {required final int commentId,
       required final bool deleted,
-      required final String auth}) = _$DeleteCommentImpl;
+      required final String auth}) = _$_DeleteComment;
   const _DeleteComment._() : super._();
 
   factory _DeleteComment.fromJson(Map<String, dynamic> json) =
-      _$DeleteCommentImpl.fromJson;
+      _$_DeleteComment.fromJson;
 
   @override
   int get commentId;
@@ -600,7 +600,7 @@ abstract class _DeleteComment extends DeleteComment {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$DeleteCommentImplCopyWith<_$DeleteCommentImpl> get copyWith =>
+  _$$_DeleteCommentCopyWith<_$_DeleteComment> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -670,22 +670,22 @@ class _$RemoveCommentCopyWithImpl<$Res, $Val extends RemoveComment>
 }
 
 /// @nodoc
-abstract class _$$RemoveCommentImplCopyWith<$Res>
+abstract class _$$_RemoveCommentCopyWith<$Res>
     implements $RemoveCommentCopyWith<$Res> {
-  factory _$$RemoveCommentImplCopyWith(
-          _$RemoveCommentImpl value, $Res Function(_$RemoveCommentImpl) then) =
-      __$$RemoveCommentImplCopyWithImpl<$Res>;
+  factory _$$_RemoveCommentCopyWith(
+          _$_RemoveComment value, $Res Function(_$_RemoveComment) then) =
+      __$$_RemoveCommentCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, bool removed, String? reason, String auth});
 }
 
 /// @nodoc
-class __$$RemoveCommentImplCopyWithImpl<$Res>
-    extends _$RemoveCommentCopyWithImpl<$Res, _$RemoveCommentImpl>
-    implements _$$RemoveCommentImplCopyWith<$Res> {
-  __$$RemoveCommentImplCopyWithImpl(
-      _$RemoveCommentImpl _value, $Res Function(_$RemoveCommentImpl) _then)
+class __$$_RemoveCommentCopyWithImpl<$Res>
+    extends _$RemoveCommentCopyWithImpl<$Res, _$_RemoveComment>
+    implements _$$_RemoveCommentCopyWith<$Res> {
+  __$$_RemoveCommentCopyWithImpl(
+      _$_RemoveComment _value, $Res Function(_$_RemoveComment) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -696,7 +696,7 @@ class __$$RemoveCommentImplCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? auth = null,
   }) {
-    return _then(_$RemoveCommentImpl(
+    return _then(_$_RemoveComment(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -720,16 +720,16 @@ class __$$RemoveCommentImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$RemoveCommentImpl extends _RemoveComment {
-  const _$RemoveCommentImpl(
+class _$_RemoveComment extends _RemoveComment {
+  const _$_RemoveComment(
       {required this.commentId,
       required this.removed,
       this.reason,
       required this.auth})
       : super._();
 
-  factory _$RemoveCommentImpl.fromJson(Map<String, dynamic> json) =>
-      _$$RemoveCommentImplFromJson(json);
+  factory _$_RemoveComment.fromJson(Map<String, dynamic> json) =>
+      _$$_RemoveCommentFromJson(json);
 
   @override
   final int commentId;
@@ -749,7 +749,7 @@ class _$RemoveCommentImpl extends _RemoveComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$RemoveCommentImpl &&
+            other is _$_RemoveComment &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.removed, removed) || other.removed == removed) &&
@@ -765,12 +765,12 @@ class _$RemoveCommentImpl extends _RemoveComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$RemoveCommentImplCopyWith<_$RemoveCommentImpl> get copyWith =>
-      __$$RemoveCommentImplCopyWithImpl<_$RemoveCommentImpl>(this, _$identity);
+  _$$_RemoveCommentCopyWith<_$_RemoveComment> get copyWith =>
+      __$$_RemoveCommentCopyWithImpl<_$_RemoveComment>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$RemoveCommentImplToJson(
+    return _$$_RemoveCommentToJson(
       this,
     );
   }
@@ -781,11 +781,11 @@ abstract class _RemoveComment extends RemoveComment {
       {required final int commentId,
       required final bool removed,
       final String? reason,
-      required final String auth}) = _$RemoveCommentImpl;
+      required final String auth}) = _$_RemoveComment;
   const _RemoveComment._() : super._();
 
   factory _RemoveComment.fromJson(Map<String, dynamic> json) =
-      _$RemoveCommentImpl.fromJson;
+      _$_RemoveComment.fromJson;
 
   @override
   int get commentId;
@@ -797,7 +797,7 @@ abstract class _RemoveComment extends RemoveComment {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$RemoveCommentImplCopyWith<_$RemoveCommentImpl> get copyWith =>
+  _$$_RemoveCommentCopyWith<_$_RemoveComment> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -861,22 +861,22 @@ class _$MarkCommentAsReadCopyWithImpl<$Res, $Val extends MarkCommentAsRead>
 }
 
 /// @nodoc
-abstract class _$$MarkCommentAsReadImplCopyWith<$Res>
+abstract class _$$_MarkCommentAsReadCopyWith<$Res>
     implements $MarkCommentAsReadCopyWith<$Res> {
-  factory _$$MarkCommentAsReadImplCopyWith(_$MarkCommentAsReadImpl value,
-          $Res Function(_$MarkCommentAsReadImpl) then) =
-      __$$MarkCommentAsReadImplCopyWithImpl<$Res>;
+  factory _$$_MarkCommentAsReadCopyWith(_$_MarkCommentAsRead value,
+          $Res Function(_$_MarkCommentAsRead) then) =
+      __$$_MarkCommentAsReadCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentReplyId, bool read, String auth});
 }
 
 /// @nodoc
-class __$$MarkCommentAsReadImplCopyWithImpl<$Res>
-    extends _$MarkCommentAsReadCopyWithImpl<$Res, _$MarkCommentAsReadImpl>
-    implements _$$MarkCommentAsReadImplCopyWith<$Res> {
-  __$$MarkCommentAsReadImplCopyWithImpl(_$MarkCommentAsReadImpl _value,
-      $Res Function(_$MarkCommentAsReadImpl) _then)
+class __$$_MarkCommentAsReadCopyWithImpl<$Res>
+    extends _$MarkCommentAsReadCopyWithImpl<$Res, _$_MarkCommentAsRead>
+    implements _$$_MarkCommentAsReadCopyWith<$Res> {
+  __$$_MarkCommentAsReadCopyWithImpl(
+      _$_MarkCommentAsRead _value, $Res Function(_$_MarkCommentAsRead) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -886,7 +886,7 @@ class __$$MarkCommentAsReadImplCopyWithImpl<$Res>
     Object? read = null,
     Object? auth = null,
   }) {
-    return _then(_$MarkCommentAsReadImpl(
+    return _then(_$_MarkCommentAsRead(
       commentReplyId: null == commentReplyId
           ? _value.commentReplyId
           : commentReplyId // ignore: cast_nullable_to_non_nullable
@@ -906,13 +906,13 @@ class __$$MarkCommentAsReadImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$MarkCommentAsReadImpl extends _MarkCommentAsRead {
-  const _$MarkCommentAsReadImpl(
+class _$_MarkCommentAsRead extends _MarkCommentAsRead {
+  const _$_MarkCommentAsRead(
       {required this.commentReplyId, required this.read, required this.auth})
       : super._();
 
-  factory _$MarkCommentAsReadImpl.fromJson(Map<String, dynamic> json) =>
-      _$$MarkCommentAsReadImplFromJson(json);
+  factory _$_MarkCommentAsRead.fromJson(Map<String, dynamic> json) =>
+      _$$_MarkCommentAsReadFromJson(json);
 
   @override
   final int commentReplyId;
@@ -930,7 +930,7 @@ class _$MarkCommentAsReadImpl extends _MarkCommentAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$MarkCommentAsReadImpl &&
+            other is _$_MarkCommentAsRead &&
             (identical(other.commentReplyId, commentReplyId) ||
                 other.commentReplyId == commentReplyId) &&
             (identical(other.read, read) || other.read == read) &&
@@ -944,13 +944,13 @@ class _$MarkCommentAsReadImpl extends _MarkCommentAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$MarkCommentAsReadImplCopyWith<_$MarkCommentAsReadImpl> get copyWith =>
-      __$$MarkCommentAsReadImplCopyWithImpl<_$MarkCommentAsReadImpl>(
+  _$$_MarkCommentAsReadCopyWith<_$_MarkCommentAsRead> get copyWith =>
+      __$$_MarkCommentAsReadCopyWithImpl<_$_MarkCommentAsRead>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$MarkCommentAsReadImplToJson(
+    return _$$_MarkCommentAsReadToJson(
       this,
     );
   }
@@ -960,11 +960,11 @@ abstract class _MarkCommentAsRead extends MarkCommentAsRead {
   const factory _MarkCommentAsRead(
       {required final int commentReplyId,
       required final bool read,
-      required final String auth}) = _$MarkCommentAsReadImpl;
+      required final String auth}) = _$_MarkCommentAsRead;
   const _MarkCommentAsRead._() : super._();
 
   factory _MarkCommentAsRead.fromJson(Map<String, dynamic> json) =
-      _$MarkCommentAsReadImpl.fromJson;
+      _$_MarkCommentAsRead.fromJson;
 
   @override
   int get commentReplyId;
@@ -974,7 +974,7 @@ abstract class _MarkCommentAsRead extends MarkCommentAsRead {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$MarkCommentAsReadImplCopyWith<_$MarkCommentAsReadImpl> get copyWith =>
+  _$$_MarkCommentAsReadCopyWith<_$_MarkCommentAsRead> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1038,22 +1038,22 @@ class _$SaveCommentCopyWithImpl<$Res, $Val extends SaveComment>
 }
 
 /// @nodoc
-abstract class _$$SaveCommentImplCopyWith<$Res>
+abstract class _$$_SaveCommentCopyWith<$Res>
     implements $SaveCommentCopyWith<$Res> {
-  factory _$$SaveCommentImplCopyWith(
-          _$SaveCommentImpl value, $Res Function(_$SaveCommentImpl) then) =
-      __$$SaveCommentImplCopyWithImpl<$Res>;
+  factory _$$_SaveCommentCopyWith(
+          _$_SaveComment value, $Res Function(_$_SaveComment) then) =
+      __$$_SaveCommentCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, bool save, String auth});
 }
 
 /// @nodoc
-class __$$SaveCommentImplCopyWithImpl<$Res>
-    extends _$SaveCommentCopyWithImpl<$Res, _$SaveCommentImpl>
-    implements _$$SaveCommentImplCopyWith<$Res> {
-  __$$SaveCommentImplCopyWithImpl(
-      _$SaveCommentImpl _value, $Res Function(_$SaveCommentImpl) _then)
+class __$$_SaveCommentCopyWithImpl<$Res>
+    extends _$SaveCommentCopyWithImpl<$Res, _$_SaveComment>
+    implements _$$_SaveCommentCopyWith<$Res> {
+  __$$_SaveCommentCopyWithImpl(
+      _$_SaveComment _value, $Res Function(_$_SaveComment) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1063,7 +1063,7 @@ class __$$SaveCommentImplCopyWithImpl<$Res>
     Object? save = null,
     Object? auth = null,
   }) {
-    return _then(_$SaveCommentImpl(
+    return _then(_$_SaveComment(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -1083,13 +1083,13 @@ class __$$SaveCommentImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$SaveCommentImpl extends _SaveComment {
-  const _$SaveCommentImpl(
+class _$_SaveComment extends _SaveComment {
+  const _$_SaveComment(
       {required this.commentId, required this.save, required this.auth})
       : super._();
 
-  factory _$SaveCommentImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SaveCommentImplFromJson(json);
+  factory _$_SaveComment.fromJson(Map<String, dynamic> json) =>
+      _$$_SaveCommentFromJson(json);
 
   @override
   final int commentId;
@@ -1107,7 +1107,7 @@ class _$SaveCommentImpl extends _SaveComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SaveCommentImpl &&
+            other is _$_SaveComment &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.save, save) || other.save == save) &&
@@ -1121,12 +1121,12 @@ class _$SaveCommentImpl extends _SaveComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SaveCommentImplCopyWith<_$SaveCommentImpl> get copyWith =>
-      __$$SaveCommentImplCopyWithImpl<_$SaveCommentImpl>(this, _$identity);
+  _$$_SaveCommentCopyWith<_$_SaveComment> get copyWith =>
+      __$$_SaveCommentCopyWithImpl<_$_SaveComment>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$SaveCommentImplToJson(
+    return _$$_SaveCommentToJson(
       this,
     );
   }
@@ -1136,11 +1136,11 @@ abstract class _SaveComment extends SaveComment {
   const factory _SaveComment(
       {required final int commentId,
       required final bool save,
-      required final String auth}) = _$SaveCommentImpl;
+      required final String auth}) = _$_SaveComment;
   const _SaveComment._() : super._();
 
   factory _SaveComment.fromJson(Map<String, dynamic> json) =
-      _$SaveCommentImpl.fromJson;
+      _$_SaveComment.fromJson;
 
   @override
   int get commentId;
@@ -1150,7 +1150,7 @@ abstract class _SaveComment extends SaveComment {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$SaveCommentImplCopyWith<_$SaveCommentImpl> get copyWith =>
+  _$$_SaveCommentCopyWith<_$_SaveComment> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1214,22 +1214,22 @@ class _$CreateCommentLikeCopyWithImpl<$Res, $Val extends CreateCommentLike>
 }
 
 /// @nodoc
-abstract class _$$CreateCommentLikeImplCopyWith<$Res>
+abstract class _$$_CreateCommentLikeCopyWith<$Res>
     implements $CreateCommentLikeCopyWith<$Res> {
-  factory _$$CreateCommentLikeImplCopyWith(_$CreateCommentLikeImpl value,
-          $Res Function(_$CreateCommentLikeImpl) then) =
-      __$$CreateCommentLikeImplCopyWithImpl<$Res>;
+  factory _$$_CreateCommentLikeCopyWith(_$_CreateCommentLike value,
+          $Res Function(_$_CreateCommentLike) then) =
+      __$$_CreateCommentLikeCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, VoteType score, String auth});
 }
 
 /// @nodoc
-class __$$CreateCommentLikeImplCopyWithImpl<$Res>
-    extends _$CreateCommentLikeCopyWithImpl<$Res, _$CreateCommentLikeImpl>
-    implements _$$CreateCommentLikeImplCopyWith<$Res> {
-  __$$CreateCommentLikeImplCopyWithImpl(_$CreateCommentLikeImpl _value,
-      $Res Function(_$CreateCommentLikeImpl) _then)
+class __$$_CreateCommentLikeCopyWithImpl<$Res>
+    extends _$CreateCommentLikeCopyWithImpl<$Res, _$_CreateCommentLike>
+    implements _$$_CreateCommentLikeCopyWith<$Res> {
+  __$$_CreateCommentLikeCopyWithImpl(
+      _$_CreateCommentLike _value, $Res Function(_$_CreateCommentLike) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1239,7 +1239,7 @@ class __$$CreateCommentLikeImplCopyWithImpl<$Res>
     Object? score = null,
     Object? auth = null,
   }) {
-    return _then(_$CreateCommentLikeImpl(
+    return _then(_$_CreateCommentLike(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -1259,13 +1259,13 @@ class __$$CreateCommentLikeImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$CreateCommentLikeImpl extends _CreateCommentLike {
-  const _$CreateCommentLikeImpl(
+class _$_CreateCommentLike extends _CreateCommentLike {
+  const _$_CreateCommentLike(
       {required this.commentId, required this.score, required this.auth})
       : super._();
 
-  factory _$CreateCommentLikeImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CreateCommentLikeImplFromJson(json);
+  factory _$_CreateCommentLike.fromJson(Map<String, dynamic> json) =>
+      _$$_CreateCommentLikeFromJson(json);
 
   @override
   final int commentId;
@@ -1283,7 +1283,7 @@ class _$CreateCommentLikeImpl extends _CreateCommentLike {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CreateCommentLikeImpl &&
+            other is _$_CreateCommentLike &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.score, score) || other.score == score) &&
@@ -1297,13 +1297,13 @@ class _$CreateCommentLikeImpl extends _CreateCommentLike {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CreateCommentLikeImplCopyWith<_$CreateCommentLikeImpl> get copyWith =>
-      __$$CreateCommentLikeImplCopyWithImpl<_$CreateCommentLikeImpl>(
+  _$$_CreateCommentLikeCopyWith<_$_CreateCommentLike> get copyWith =>
+      __$$_CreateCommentLikeCopyWithImpl<_$_CreateCommentLike>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CreateCommentLikeImplToJson(
+    return _$$_CreateCommentLikeToJson(
       this,
     );
   }
@@ -1313,11 +1313,11 @@ abstract class _CreateCommentLike extends CreateCommentLike {
   const factory _CreateCommentLike(
       {required final int commentId,
       required final VoteType score,
-      required final String auth}) = _$CreateCommentLikeImpl;
+      required final String auth}) = _$_CreateCommentLike;
   const _CreateCommentLike._() : super._();
 
   factory _CreateCommentLike.fromJson(Map<String, dynamic> json) =
-      _$CreateCommentLikeImpl.fromJson;
+      _$_CreateCommentLike.fromJson;
 
   @override
   int get commentId;
@@ -1327,7 +1327,7 @@ abstract class _CreateCommentLike extends CreateCommentLike {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$CreateCommentLikeImplCopyWith<_$CreateCommentLikeImpl> get copyWith =>
+  _$$_CreateCommentLikeCopyWith<_$_CreateCommentLike> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1385,22 +1385,22 @@ class _$GetCommentCopyWithImpl<$Res, $Val extends GetComment>
 }
 
 /// @nodoc
-abstract class _$$GetCommentImplCopyWith<$Res>
+abstract class _$$_GetCommentCopyWith<$Res>
     implements $GetCommentCopyWith<$Res> {
-  factory _$$GetCommentImplCopyWith(
-          _$GetCommentImpl value, $Res Function(_$GetCommentImpl) then) =
-      __$$GetCommentImplCopyWithImpl<$Res>;
+  factory _$$_GetCommentCopyWith(
+          _$_GetComment value, $Res Function(_$_GetComment) then) =
+      __$$_GetCommentCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int id, String? auth});
 }
 
 /// @nodoc
-class __$$GetCommentImplCopyWithImpl<$Res>
-    extends _$GetCommentCopyWithImpl<$Res, _$GetCommentImpl>
-    implements _$$GetCommentImplCopyWith<$Res> {
-  __$$GetCommentImplCopyWithImpl(
-      _$GetCommentImpl _value, $Res Function(_$GetCommentImpl) _then)
+class __$$_GetCommentCopyWithImpl<$Res>
+    extends _$GetCommentCopyWithImpl<$Res, _$_GetComment>
+    implements _$$_GetCommentCopyWith<$Res> {
+  __$$_GetCommentCopyWithImpl(
+      _$_GetComment _value, $Res Function(_$_GetComment) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1409,7 +1409,7 @@ class __$$GetCommentImplCopyWithImpl<$Res>
     Object? id = null,
     Object? auth = freezed,
   }) {
-    return _then(_$GetCommentImpl(
+    return _then(_$_GetComment(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -1425,11 +1425,11 @@ class __$$GetCommentImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetCommentImpl extends _GetComment {
-  const _$GetCommentImpl({required this.id, this.auth}) : super._();
+class _$_GetComment extends _GetComment {
+  const _$_GetComment({required this.id, this.auth}) : super._();
 
-  factory _$GetCommentImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetCommentImplFromJson(json);
+  factory _$_GetComment.fromJson(Map<String, dynamic> json) =>
+      _$$_GetCommentFromJson(json);
 
   @override
   final int id;
@@ -1445,7 +1445,7 @@ class _$GetCommentImpl extends _GetComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetCommentImpl &&
+            other is _$_GetComment &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.auth, auth) || other.auth == auth));
   }
@@ -1457,12 +1457,12 @@ class _$GetCommentImpl extends _GetComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetCommentImplCopyWith<_$GetCommentImpl> get copyWith =>
-      __$$GetCommentImplCopyWithImpl<_$GetCommentImpl>(this, _$identity);
+  _$$_GetCommentCopyWith<_$_GetComment> get copyWith =>
+      __$$_GetCommentCopyWithImpl<_$_GetComment>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetCommentImplToJson(
+    return _$$_GetCommentToJson(
       this,
     );
   }
@@ -1470,11 +1470,11 @@ class _$GetCommentImpl extends _GetComment {
 
 abstract class _GetComment extends GetComment {
   const factory _GetComment({required final int id, final String? auth}) =
-      _$GetCommentImpl;
+      _$_GetComment;
   const _GetComment._() : super._();
 
   factory _GetComment.fromJson(Map<String, dynamic> json) =
-      _$GetCommentImpl.fromJson;
+      _$_GetComment.fromJson;
 
   @override
   int get id;
@@ -1482,7 +1482,7 @@ abstract class _GetComment extends GetComment {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetCommentImplCopyWith<_$GetCommentImpl> get copyWith =>
+  _$$_GetCommentCopyWith<_$_GetComment> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1606,11 +1606,11 @@ class _$GetCommentsCopyWithImpl<$Res, $Val extends GetComments>
 }
 
 /// @nodoc
-abstract class _$$GetCommentsImplCopyWith<$Res>
+abstract class _$$_GetCommentsCopyWith<$Res>
     implements $GetCommentsCopyWith<$Res> {
-  factory _$$GetCommentsImplCopyWith(
-          _$GetCommentsImpl value, $Res Function(_$GetCommentsImpl) then) =
-      __$$GetCommentsImplCopyWithImpl<$Res>;
+  factory _$$_GetCommentsCopyWith(
+          _$_GetComments value, $Res Function(_$_GetComments) then) =
+      __$$_GetCommentsCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1628,11 +1628,11 @@ abstract class _$$GetCommentsImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$GetCommentsImplCopyWithImpl<$Res>
-    extends _$GetCommentsCopyWithImpl<$Res, _$GetCommentsImpl>
-    implements _$$GetCommentsImplCopyWith<$Res> {
-  __$$GetCommentsImplCopyWithImpl(
-      _$GetCommentsImpl _value, $Res Function(_$GetCommentsImpl) _then)
+class __$$_GetCommentsCopyWithImpl<$Res>
+    extends _$GetCommentsCopyWithImpl<$Res, _$_GetComments>
+    implements _$$_GetCommentsCopyWith<$Res> {
+  __$$_GetCommentsCopyWithImpl(
+      _$_GetComments _value, $Res Function(_$_GetComments) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1650,7 +1650,7 @@ class __$$GetCommentsImplCopyWithImpl<$Res>
     Object? auth = freezed,
     Object? maxDepth = freezed,
   }) {
-    return _then(_$GetCommentsImpl(
+    return _then(_$_GetComments(
       type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -1702,8 +1702,8 @@ class __$$GetCommentsImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetCommentsImpl extends _GetComments {
-  const _$GetCommentsImpl(
+class _$_GetComments extends _GetComments {
+  const _$_GetComments(
       {@JsonKey(name: 'type_') this.type,
       this.sort,
       this.page,
@@ -1717,8 +1717,8 @@ class _$GetCommentsImpl extends _GetComments {
       this.maxDepth})
       : super._();
 
-  factory _$GetCommentsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetCommentsImplFromJson(json);
+  factory _$_GetComments.fromJson(Map<String, dynamic> json) =>
+      _$$_GetCommentsFromJson(json);
 
   @override
   @JsonKey(name: 'type_')
@@ -1753,7 +1753,7 @@ class _$GetCommentsImpl extends _GetComments {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetCommentsImpl &&
+            other is _$_GetComments &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
@@ -1780,12 +1780,12 @@ class _$GetCommentsImpl extends _GetComments {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetCommentsImplCopyWith<_$GetCommentsImpl> get copyWith =>
-      __$$GetCommentsImplCopyWithImpl<_$GetCommentsImpl>(this, _$identity);
+  _$$_GetCommentsCopyWith<_$_GetComments> get copyWith =>
+      __$$_GetCommentsCopyWithImpl<_$_GetComments>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetCommentsImplToJson(
+    return _$$_GetCommentsToJson(
       this,
     );
   }
@@ -1803,11 +1803,11 @@ abstract class _GetComments extends GetComments {
       final int? parentId,
       final bool? savedOnly,
       final String? auth,
-      final int? maxDepth}) = _$GetCommentsImpl;
+      final int? maxDepth}) = _$_GetComments;
   const _GetComments._() : super._();
 
   factory _GetComments.fromJson(Map<String, dynamic> json) =
-      _$GetCommentsImpl.fromJson;
+      _$_GetComments.fromJson;
 
   @override
   @JsonKey(name: 'type_')
@@ -1834,7 +1834,7 @@ abstract class _GetComments extends GetComments {
   int? get maxDepth;
   @override
   @JsonKey(ignore: true)
-  _$$GetCommentsImplCopyWith<_$GetCommentsImpl> get copyWith =>
+  _$$_GetCommentsCopyWith<_$_GetComments> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1898,22 +1898,22 @@ class _$CreateCommentReportCopyWithImpl<$Res, $Val extends CreateCommentReport>
 }
 
 /// @nodoc
-abstract class _$$CreateCommentReportImplCopyWith<$Res>
+abstract class _$$_CreateCommentReportCopyWith<$Res>
     implements $CreateCommentReportCopyWith<$Res> {
-  factory _$$CreateCommentReportImplCopyWith(_$CreateCommentReportImpl value,
-          $Res Function(_$CreateCommentReportImpl) then) =
-      __$$CreateCommentReportImplCopyWithImpl<$Res>;
+  factory _$$_CreateCommentReportCopyWith(_$_CreateCommentReport value,
+          $Res Function(_$_CreateCommentReport) then) =
+      __$$_CreateCommentReportCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, String reason, String auth});
 }
 
 /// @nodoc
-class __$$CreateCommentReportImplCopyWithImpl<$Res>
-    extends _$CreateCommentReportCopyWithImpl<$Res, _$CreateCommentReportImpl>
-    implements _$$CreateCommentReportImplCopyWith<$Res> {
-  __$$CreateCommentReportImplCopyWithImpl(_$CreateCommentReportImpl _value,
-      $Res Function(_$CreateCommentReportImpl) _then)
+class __$$_CreateCommentReportCopyWithImpl<$Res>
+    extends _$CreateCommentReportCopyWithImpl<$Res, _$_CreateCommentReport>
+    implements _$$_CreateCommentReportCopyWith<$Res> {
+  __$$_CreateCommentReportCopyWithImpl(_$_CreateCommentReport _value,
+      $Res Function(_$_CreateCommentReport) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1923,7 +1923,7 @@ class __$$CreateCommentReportImplCopyWithImpl<$Res>
     Object? reason = null,
     Object? auth = null,
   }) {
-    return _then(_$CreateCommentReportImpl(
+    return _then(_$_CreateCommentReport(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -1943,13 +1943,13 @@ class __$$CreateCommentReportImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$CreateCommentReportImpl extends _CreateCommentReport {
-  const _$CreateCommentReportImpl(
+class _$_CreateCommentReport extends _CreateCommentReport {
+  const _$_CreateCommentReport(
       {required this.commentId, required this.reason, required this.auth})
       : super._();
 
-  factory _$CreateCommentReportImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CreateCommentReportImplFromJson(json);
+  factory _$_CreateCommentReport.fromJson(Map<String, dynamic> json) =>
+      _$$_CreateCommentReportFromJson(json);
 
   @override
   final int commentId;
@@ -1967,7 +1967,7 @@ class _$CreateCommentReportImpl extends _CreateCommentReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CreateCommentReportImpl &&
+            other is _$_CreateCommentReport &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.reason, reason) || other.reason == reason) &&
@@ -1981,13 +1981,13 @@ class _$CreateCommentReportImpl extends _CreateCommentReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CreateCommentReportImplCopyWith<_$CreateCommentReportImpl> get copyWith =>
-      __$$CreateCommentReportImplCopyWithImpl<_$CreateCommentReportImpl>(
+  _$$_CreateCommentReportCopyWith<_$_CreateCommentReport> get copyWith =>
+      __$$_CreateCommentReportCopyWithImpl<_$_CreateCommentReport>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CreateCommentReportImplToJson(
+    return _$$_CreateCommentReportToJson(
       this,
     );
   }
@@ -1997,11 +1997,11 @@ abstract class _CreateCommentReport extends CreateCommentReport {
   const factory _CreateCommentReport(
       {required final int commentId,
       required final String reason,
-      required final String auth}) = _$CreateCommentReportImpl;
+      required final String auth}) = _$_CreateCommentReport;
   const _CreateCommentReport._() : super._();
 
   factory _CreateCommentReport.fromJson(Map<String, dynamic> json) =
-      _$CreateCommentReportImpl.fromJson;
+      _$_CreateCommentReport.fromJson;
 
   @override
   int get commentId;
@@ -2011,7 +2011,7 @@ abstract class _CreateCommentReport extends CreateCommentReport {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$CreateCommentReportImplCopyWith<_$CreateCommentReportImpl> get copyWith =>
+  _$$_CreateCommentReportCopyWith<_$_CreateCommentReport> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2076,22 +2076,22 @@ class _$ResolveCommentReportCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$ResolveCommentReportImplCopyWith<$Res>
+abstract class _$$_ResolveCommentReportCopyWith<$Res>
     implements $ResolveCommentReportCopyWith<$Res> {
-  factory _$$ResolveCommentReportImplCopyWith(_$ResolveCommentReportImpl value,
-          $Res Function(_$ResolveCommentReportImpl) then) =
-      __$$ResolveCommentReportImplCopyWithImpl<$Res>;
+  factory _$$_ResolveCommentReportCopyWith(_$_ResolveCommentReport value,
+          $Res Function(_$_ResolveCommentReport) then) =
+      __$$_ResolveCommentReportCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int reportId, bool resolved, String auth});
 }
 
 /// @nodoc
-class __$$ResolveCommentReportImplCopyWithImpl<$Res>
-    extends _$ResolveCommentReportCopyWithImpl<$Res, _$ResolveCommentReportImpl>
-    implements _$$ResolveCommentReportImplCopyWith<$Res> {
-  __$$ResolveCommentReportImplCopyWithImpl(_$ResolveCommentReportImpl _value,
-      $Res Function(_$ResolveCommentReportImpl) _then)
+class __$$_ResolveCommentReportCopyWithImpl<$Res>
+    extends _$ResolveCommentReportCopyWithImpl<$Res, _$_ResolveCommentReport>
+    implements _$$_ResolveCommentReportCopyWith<$Res> {
+  __$$_ResolveCommentReportCopyWithImpl(_$_ResolveCommentReport _value,
+      $Res Function(_$_ResolveCommentReport) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2101,7 +2101,7 @@ class __$$ResolveCommentReportImplCopyWithImpl<$Res>
     Object? resolved = null,
     Object? auth = null,
   }) {
-    return _then(_$ResolveCommentReportImpl(
+    return _then(_$_ResolveCommentReport(
       reportId: null == reportId
           ? _value.reportId
           : reportId // ignore: cast_nullable_to_non_nullable
@@ -2121,13 +2121,13 @@ class __$$ResolveCommentReportImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$ResolveCommentReportImpl extends _ResolveCommentReport {
-  const _$ResolveCommentReportImpl(
+class _$_ResolveCommentReport extends _ResolveCommentReport {
+  const _$_ResolveCommentReport(
       {required this.reportId, required this.resolved, required this.auth})
       : super._();
 
-  factory _$ResolveCommentReportImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ResolveCommentReportImplFromJson(json);
+  factory _$_ResolveCommentReport.fromJson(Map<String, dynamic> json) =>
+      _$$_ResolveCommentReportFromJson(json);
 
   @override
   final int reportId;
@@ -2145,7 +2145,7 @@ class _$ResolveCommentReportImpl extends _ResolveCommentReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ResolveCommentReportImpl &&
+            other is _$_ResolveCommentReport &&
             (identical(other.reportId, reportId) ||
                 other.reportId == reportId) &&
             (identical(other.resolved, resolved) ||
@@ -2160,14 +2160,13 @@ class _$ResolveCommentReportImpl extends _ResolveCommentReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ResolveCommentReportImplCopyWith<_$ResolveCommentReportImpl>
-      get copyWith =>
-          __$$ResolveCommentReportImplCopyWithImpl<_$ResolveCommentReportImpl>(
-              this, _$identity);
+  _$$_ResolveCommentReportCopyWith<_$_ResolveCommentReport> get copyWith =>
+      __$$_ResolveCommentReportCopyWithImpl<_$_ResolveCommentReport>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ResolveCommentReportImplToJson(
+    return _$$_ResolveCommentReportToJson(
       this,
     );
   }
@@ -2177,11 +2176,11 @@ abstract class _ResolveCommentReport extends ResolveCommentReport {
   const factory _ResolveCommentReport(
       {required final int reportId,
       required final bool resolved,
-      required final String auth}) = _$ResolveCommentReportImpl;
+      required final String auth}) = _$_ResolveCommentReport;
   const _ResolveCommentReport._() : super._();
 
   factory _ResolveCommentReport.fromJson(Map<String, dynamic> json) =
-      _$ResolveCommentReportImpl.fromJson;
+      _$_ResolveCommentReport.fromJson;
 
   @override
   int get reportId;
@@ -2191,8 +2190,8 @@ abstract class _ResolveCommentReport extends ResolveCommentReport {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$ResolveCommentReportImplCopyWith<_$ResolveCommentReportImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_ResolveCommentReportCopyWith<_$_ResolveCommentReport> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 ListCommentReports _$ListCommentReportsFromJson(Map<String, dynamic> json) {
@@ -2272,11 +2271,11 @@ class _$ListCommentReportsCopyWithImpl<$Res, $Val extends ListCommentReports>
 }
 
 /// @nodoc
-abstract class _$$ListCommentReportsImplCopyWith<$Res>
+abstract class _$$_ListCommentReportsCopyWith<$Res>
     implements $ListCommentReportsCopyWith<$Res> {
-  factory _$$ListCommentReportsImplCopyWith(_$ListCommentReportsImpl value,
-          $Res Function(_$ListCommentReportsImpl) then) =
-      __$$ListCommentReportsImplCopyWithImpl<$Res>;
+  factory _$$_ListCommentReportsCopyWith(_$_ListCommentReports value,
+          $Res Function(_$_ListCommentReports) then) =
+      __$$_ListCommentReportsCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2288,11 +2287,11 @@ abstract class _$$ListCommentReportsImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ListCommentReportsImplCopyWithImpl<$Res>
-    extends _$ListCommentReportsCopyWithImpl<$Res, _$ListCommentReportsImpl>
-    implements _$$ListCommentReportsImplCopyWith<$Res> {
-  __$$ListCommentReportsImplCopyWithImpl(_$ListCommentReportsImpl _value,
-      $Res Function(_$ListCommentReportsImpl) _then)
+class __$$_ListCommentReportsCopyWithImpl<$Res>
+    extends _$ListCommentReportsCopyWithImpl<$Res, _$_ListCommentReports>
+    implements _$$_ListCommentReportsCopyWith<$Res> {
+  __$$_ListCommentReportsCopyWithImpl(
+      _$_ListCommentReports _value, $Res Function(_$_ListCommentReports) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2304,7 +2303,7 @@ class __$$ListCommentReportsImplCopyWithImpl<$Res>
     Object? unresolvedOnly = freezed,
     Object? auth = null,
   }) {
-    return _then(_$ListCommentReportsImpl(
+    return _then(_$_ListCommentReports(
       page: freezed == page
           ? _value.page
           : page // ignore: cast_nullable_to_non_nullable
@@ -2332,8 +2331,8 @@ class __$$ListCommentReportsImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$ListCommentReportsImpl extends _ListCommentReports {
-  const _$ListCommentReportsImpl(
+class _$_ListCommentReports extends _ListCommentReports {
+  const _$_ListCommentReports(
       {this.page,
       this.limit,
       this.communityId,
@@ -2341,8 +2340,8 @@ class _$ListCommentReportsImpl extends _ListCommentReports {
       required this.auth})
       : super._();
 
-  factory _$ListCommentReportsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ListCommentReportsImplFromJson(json);
+  factory _$_ListCommentReports.fromJson(Map<String, dynamic> json) =>
+      _$$_ListCommentReportsFromJson(json);
 
   @override
   final int? page;
@@ -2364,7 +2363,7 @@ class _$ListCommentReportsImpl extends _ListCommentReports {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ListCommentReportsImpl &&
+            other is _$_ListCommentReports &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
             (identical(other.communityId, communityId) ||
@@ -2382,13 +2381,13 @@ class _$ListCommentReportsImpl extends _ListCommentReports {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ListCommentReportsImplCopyWith<_$ListCommentReportsImpl> get copyWith =>
-      __$$ListCommentReportsImplCopyWithImpl<_$ListCommentReportsImpl>(
+  _$$_ListCommentReportsCopyWith<_$_ListCommentReports> get copyWith =>
+      __$$_ListCommentReportsCopyWithImpl<_$_ListCommentReports>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ListCommentReportsImplToJson(
+    return _$$_ListCommentReportsToJson(
       this,
     );
   }
@@ -2400,11 +2399,11 @@ abstract class _ListCommentReports extends ListCommentReports {
       final int? limit,
       final int? communityId,
       final bool? unresolvedOnly,
-      required final String auth}) = _$ListCommentReportsImpl;
+      required final String auth}) = _$_ListCommentReports;
   const _ListCommentReports._() : super._();
 
   factory _ListCommentReports.fromJson(Map<String, dynamic> json) =
-      _$ListCommentReportsImpl.fromJson;
+      _$_ListCommentReports.fromJson;
 
   @override
   int? get page;
@@ -2418,6 +2417,6 @@ abstract class _ListCommentReports extends ListCommentReports {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$ListCommentReportsImplCopyWith<_$ListCommentReportsImpl> get copyWith =>
+  _$$_ListCommentReportsCopyWith<_$_ListCommentReports> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/comment.g.dart
+++ b/lib/src/v3/api/comment.g.dart
@@ -6,8 +6,8 @@ part of 'comment.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$CreateCommentImpl _$$CreateCommentImplFromJson(Map<String, dynamic> json) =>
-    _$CreateCommentImpl(
+_$_CreateComment _$$_CreateCommentFromJson(Map<String, dynamic> json) =>
+    _$_CreateComment(
       content: json['content'] as String,
       parentId: json['parent_id'] as int?,
       postId: json['post_id'] as int,
@@ -15,7 +15,7 @@ _$CreateCommentImpl _$$CreateCommentImplFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$CreateCommentImplToJson(_$CreateCommentImpl instance) {
+Map<String, dynamic> _$$_CreateCommentToJson(_$_CreateComment instance) {
   final val = <String, dynamic>{
     'content': instance.content,
   };
@@ -33,15 +33,15 @@ Map<String, dynamic> _$$CreateCommentImplToJson(_$CreateCommentImpl instance) {
   return val;
 }
 
-_$EditCommentImpl _$$EditCommentImplFromJson(Map<String, dynamic> json) =>
-    _$EditCommentImpl(
+_$_EditComment _$$_EditCommentFromJson(Map<String, dynamic> json) =>
+    _$_EditComment(
       content: json['content'] as String,
       commentId: json['comment_id'] as int,
       formId: json['form_id'] as String?,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$EditCommentImplToJson(_$EditCommentImpl instance) {
+Map<String, dynamic> _$$_EditCommentToJson(_$_EditComment instance) {
   final val = <String, dynamic>{
     'content': instance.content,
     'comment_id': instance.commentId,
@@ -58,29 +58,29 @@ Map<String, dynamic> _$$EditCommentImplToJson(_$EditCommentImpl instance) {
   return val;
 }
 
-_$DeleteCommentImpl _$$DeleteCommentImplFromJson(Map<String, dynamic> json) =>
-    _$DeleteCommentImpl(
+_$_DeleteComment _$$_DeleteCommentFromJson(Map<String, dynamic> json) =>
+    _$_DeleteComment(
       commentId: json['comment_id'] as int,
       deleted: json['deleted'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$DeleteCommentImplToJson(_$DeleteCommentImpl instance) =>
+Map<String, dynamic> _$$_DeleteCommentToJson(_$_DeleteComment instance) =>
     <String, dynamic>{
       'comment_id': instance.commentId,
       'deleted': instance.deleted,
       'auth': instance.auth,
     };
 
-_$RemoveCommentImpl _$$RemoveCommentImplFromJson(Map<String, dynamic> json) =>
-    _$RemoveCommentImpl(
+_$_RemoveComment _$$_RemoveCommentFromJson(Map<String, dynamic> json) =>
+    _$_RemoveComment(
       commentId: json['comment_id'] as int,
       removed: json['removed'] as bool,
       reason: json['reason'] as String?,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$RemoveCommentImplToJson(_$RemoveCommentImpl instance) {
+Map<String, dynamic> _$$_RemoveCommentToJson(_$_RemoveComment instance) {
   final val = <String, dynamic>{
     'comment_id': instance.commentId,
     'removed': instance.removed,
@@ -97,59 +97,57 @@ Map<String, dynamic> _$$RemoveCommentImplToJson(_$RemoveCommentImpl instance) {
   return val;
 }
 
-_$MarkCommentAsReadImpl _$$MarkCommentAsReadImplFromJson(
-        Map<String, dynamic> json) =>
-    _$MarkCommentAsReadImpl(
+_$_MarkCommentAsRead _$$_MarkCommentAsReadFromJson(Map<String, dynamic> json) =>
+    _$_MarkCommentAsRead(
       commentReplyId: json['comment_reply_id'] as int,
       read: json['read'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$MarkCommentAsReadImplToJson(
-        _$MarkCommentAsReadImpl instance) =>
+Map<String, dynamic> _$$_MarkCommentAsReadToJson(
+        _$_MarkCommentAsRead instance) =>
     <String, dynamic>{
       'comment_reply_id': instance.commentReplyId,
       'read': instance.read,
       'auth': instance.auth,
     };
 
-_$SaveCommentImpl _$$SaveCommentImplFromJson(Map<String, dynamic> json) =>
-    _$SaveCommentImpl(
+_$_SaveComment _$$_SaveCommentFromJson(Map<String, dynamic> json) =>
+    _$_SaveComment(
       commentId: json['comment_id'] as int,
       save: json['save'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$SaveCommentImplToJson(_$SaveCommentImpl instance) =>
+Map<String, dynamic> _$$_SaveCommentToJson(_$_SaveComment instance) =>
     <String, dynamic>{
       'comment_id': instance.commentId,
       'save': instance.save,
       'auth': instance.auth,
     };
 
-_$CreateCommentLikeImpl _$$CreateCommentLikeImplFromJson(
-        Map<String, dynamic> json) =>
-    _$CreateCommentLikeImpl(
+_$_CreateCommentLike _$$_CreateCommentLikeFromJson(Map<String, dynamic> json) =>
+    _$_CreateCommentLike(
       commentId: json['comment_id'] as int,
       score: VoteType.fromJson(json['score'] as int),
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$CreateCommentLikeImplToJson(
-        _$CreateCommentLikeImpl instance) =>
+Map<String, dynamic> _$$_CreateCommentLikeToJson(
+        _$_CreateCommentLike instance) =>
     <String, dynamic>{
       'comment_id': instance.commentId,
       'score': instance.score.toJson(),
       'auth': instance.auth,
     };
 
-_$GetCommentImpl _$$GetCommentImplFromJson(Map<String, dynamic> json) =>
-    _$GetCommentImpl(
+_$_GetComment _$$_GetCommentFromJson(Map<String, dynamic> json) =>
+    _$_GetComment(
       id: json['id'] as int,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$GetCommentImplToJson(_$GetCommentImpl instance) {
+Map<String, dynamic> _$$_GetCommentToJson(_$_GetComment instance) {
   final val = <String, dynamic>{
     'id': instance.id,
   };
@@ -164,8 +162,8 @@ Map<String, dynamic> _$$GetCommentImplToJson(_$GetCommentImpl instance) {
   return val;
 }
 
-_$GetCommentsImpl _$$GetCommentsImplFromJson(Map<String, dynamic> json) =>
-    _$GetCommentsImpl(
+_$_GetComments _$$_GetCommentsFromJson(Map<String, dynamic> json) =>
+    _$_GetComments(
       type: json['type_'] == null
           ? null
           : CommentListingType.fromJson(json['type_'] as String),
@@ -182,7 +180,7 @@ _$GetCommentsImpl _$$GetCommentsImplFromJson(Map<String, dynamic> json) =>
       maxDepth: json['max_depth'] as int?,
     );
 
-Map<String, dynamic> _$$GetCommentsImplToJson(_$GetCommentsImpl instance) {
+Map<String, dynamic> _$$_GetCommentsToJson(_$_GetComments instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -205,41 +203,41 @@ Map<String, dynamic> _$$GetCommentsImplToJson(_$GetCommentsImpl instance) {
   return val;
 }
 
-_$CreateCommentReportImpl _$$CreateCommentReportImplFromJson(
+_$_CreateCommentReport _$$_CreateCommentReportFromJson(
         Map<String, dynamic> json) =>
-    _$CreateCommentReportImpl(
+    _$_CreateCommentReport(
       commentId: json['comment_id'] as int,
       reason: json['reason'] as String,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$CreateCommentReportImplToJson(
-        _$CreateCommentReportImpl instance) =>
+Map<String, dynamic> _$$_CreateCommentReportToJson(
+        _$_CreateCommentReport instance) =>
     <String, dynamic>{
       'comment_id': instance.commentId,
       'reason': instance.reason,
       'auth': instance.auth,
     };
 
-_$ResolveCommentReportImpl _$$ResolveCommentReportImplFromJson(
+_$_ResolveCommentReport _$$_ResolveCommentReportFromJson(
         Map<String, dynamic> json) =>
-    _$ResolveCommentReportImpl(
+    _$_ResolveCommentReport(
       reportId: json['report_id'] as int,
       resolved: json['resolved'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$ResolveCommentReportImplToJson(
-        _$ResolveCommentReportImpl instance) =>
+Map<String, dynamic> _$$_ResolveCommentReportToJson(
+        _$_ResolveCommentReport instance) =>
     <String, dynamic>{
       'report_id': instance.reportId,
       'resolved': instance.resolved,
       'auth': instance.auth,
     };
 
-_$ListCommentReportsImpl _$$ListCommentReportsImplFromJson(
+_$_ListCommentReports _$$_ListCommentReportsFromJson(
         Map<String, dynamic> json) =>
-    _$ListCommentReportsImpl(
+    _$_ListCommentReports(
       page: json['page'] as int?,
       limit: json['limit'] as int?,
       communityId: json['community_id'] as int?,
@@ -247,8 +245,8 @@ _$ListCommentReportsImpl _$$ListCommentReportsImplFromJson(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$ListCommentReportsImplToJson(
-    _$ListCommentReportsImpl instance) {
+Map<String, dynamic> _$$_ListCommentReportsToJson(
+    _$_ListCommentReports instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {

--- a/lib/src/v3/api/community.freezed.dart
+++ b/lib/src/v3/api/community.freezed.dart
@@ -74,22 +74,22 @@ class _$GetCommunityCopyWithImpl<$Res, $Val extends GetCommunity>
 }
 
 /// @nodoc
-abstract class _$$GetCommunityImplCopyWith<$Res>
+abstract class _$$_GetCommunityCopyWith<$Res>
     implements $GetCommunityCopyWith<$Res> {
-  factory _$$GetCommunityImplCopyWith(
-          _$GetCommunityImpl value, $Res Function(_$GetCommunityImpl) then) =
-      __$$GetCommunityImplCopyWithImpl<$Res>;
+  factory _$$_GetCommunityCopyWith(
+          _$_GetCommunity value, $Res Function(_$_GetCommunity) then) =
+      __$$_GetCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int? id, String? name, String? auth});
 }
 
 /// @nodoc
-class __$$GetCommunityImplCopyWithImpl<$Res>
-    extends _$GetCommunityCopyWithImpl<$Res, _$GetCommunityImpl>
-    implements _$$GetCommunityImplCopyWith<$Res> {
-  __$$GetCommunityImplCopyWithImpl(
-      _$GetCommunityImpl _value, $Res Function(_$GetCommunityImpl) _then)
+class __$$_GetCommunityCopyWithImpl<$Res>
+    extends _$GetCommunityCopyWithImpl<$Res, _$_GetCommunity>
+    implements _$$_GetCommunityCopyWith<$Res> {
+  __$$_GetCommunityCopyWithImpl(
+      _$_GetCommunity _value, $Res Function(_$_GetCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -99,7 +99,7 @@ class __$$GetCommunityImplCopyWithImpl<$Res>
     Object? name = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$GetCommunityImpl(
+    return _then(_$_GetCommunity(
       id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -119,11 +119,11 @@ class __$$GetCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetCommunityImpl extends _GetCommunity {
-  const _$GetCommunityImpl({this.id, this.name, this.auth}) : super._();
+class _$_GetCommunity extends _GetCommunity {
+  const _$_GetCommunity({this.id, this.name, this.auth}) : super._();
 
-  factory _$GetCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetCommunityImplFromJson(json);
+  factory _$_GetCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_GetCommunityFromJson(json);
 
   @override
   final int? id;
@@ -141,7 +141,7 @@ class _$GetCommunityImpl extends _GetCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetCommunityImpl &&
+            other is _$_GetCommunity &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -154,12 +154,12 @@ class _$GetCommunityImpl extends _GetCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetCommunityImplCopyWith<_$GetCommunityImpl> get copyWith =>
-      __$$GetCommunityImplCopyWithImpl<_$GetCommunityImpl>(this, _$identity);
+  _$$_GetCommunityCopyWith<_$_GetCommunity> get copyWith =>
+      __$$_GetCommunityCopyWithImpl<_$_GetCommunity>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetCommunityImplToJson(
+    return _$$_GetCommunityToJson(
       this,
     );
   }
@@ -169,11 +169,11 @@ abstract class _GetCommunity extends GetCommunity {
   const factory _GetCommunity(
       {final int? id,
       final String? name,
-      final String? auth}) = _$GetCommunityImpl;
+      final String? auth}) = _$_GetCommunity;
   const _GetCommunity._() : super._();
 
   factory _GetCommunity.fromJson(Map<String, dynamic> json) =
-      _$GetCommunityImpl.fromJson;
+      _$_GetCommunity.fromJson;
 
   @override
   int? get id;
@@ -183,7 +183,7 @@ abstract class _GetCommunity extends GetCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetCommunityImplCopyWith<_$GetCommunityImpl> get copyWith =>
+  _$$_GetCommunityCopyWith<_$_GetCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -278,11 +278,11 @@ class _$CreateCommunityCopyWithImpl<$Res, $Val extends CreateCommunity>
 }
 
 /// @nodoc
-abstract class _$$CreateCommunityImplCopyWith<$Res>
+abstract class _$$_CreateCommunityCopyWith<$Res>
     implements $CreateCommunityCopyWith<$Res> {
-  factory _$$CreateCommunityImplCopyWith(_$CreateCommunityImpl value,
-          $Res Function(_$CreateCommunityImpl) then) =
-      __$$CreateCommunityImplCopyWithImpl<$Res>;
+  factory _$$_CreateCommunityCopyWith(
+          _$_CreateCommunity value, $Res Function(_$_CreateCommunity) then) =
+      __$$_CreateCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -296,11 +296,11 @@ abstract class _$$CreateCommunityImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CreateCommunityImplCopyWithImpl<$Res>
-    extends _$CreateCommunityCopyWithImpl<$Res, _$CreateCommunityImpl>
-    implements _$$CreateCommunityImplCopyWith<$Res> {
-  __$$CreateCommunityImplCopyWithImpl(
-      _$CreateCommunityImpl _value, $Res Function(_$CreateCommunityImpl) _then)
+class __$$_CreateCommunityCopyWithImpl<$Res>
+    extends _$CreateCommunityCopyWithImpl<$Res, _$_CreateCommunity>
+    implements _$$_CreateCommunityCopyWith<$Res> {
+  __$$_CreateCommunityCopyWithImpl(
+      _$_CreateCommunity _value, $Res Function(_$_CreateCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -314,7 +314,7 @@ class __$$CreateCommunityImplCopyWithImpl<$Res>
     Object? nsfw = freezed,
     Object? auth = null,
   }) {
-    return _then(_$CreateCommunityImpl(
+    return _then(_$_CreateCommunity(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -350,8 +350,8 @@ class __$$CreateCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$CreateCommunityImpl extends _CreateCommunity {
-  const _$CreateCommunityImpl(
+class _$_CreateCommunity extends _CreateCommunity {
+  const _$_CreateCommunity(
       {required this.name,
       required this.title,
       this.description,
@@ -361,8 +361,8 @@ class _$CreateCommunityImpl extends _CreateCommunity {
       required this.auth})
       : super._();
 
-  factory _$CreateCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CreateCommunityImplFromJson(json);
+  factory _$_CreateCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_CreateCommunityFromJson(json);
 
   @override
   final String name;
@@ -388,7 +388,7 @@ class _$CreateCommunityImpl extends _CreateCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CreateCommunityImpl &&
+            other is _$_CreateCommunity &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.description, description) ||
@@ -407,13 +407,12 @@ class _$CreateCommunityImpl extends _CreateCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CreateCommunityImplCopyWith<_$CreateCommunityImpl> get copyWith =>
-      __$$CreateCommunityImplCopyWithImpl<_$CreateCommunityImpl>(
-          this, _$identity);
+  _$$_CreateCommunityCopyWith<_$_CreateCommunity> get copyWith =>
+      __$$_CreateCommunityCopyWithImpl<_$_CreateCommunity>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CreateCommunityImplToJson(
+    return _$$_CreateCommunityToJson(
       this,
     );
   }
@@ -427,11 +426,11 @@ abstract class _CreateCommunity extends CreateCommunity {
       final String? icon,
       final String? banner,
       final bool? nsfw,
-      required final String auth}) = _$CreateCommunityImpl;
+      required final String auth}) = _$_CreateCommunity;
   const _CreateCommunity._() : super._();
 
   factory _CreateCommunity.fromJson(Map<String, dynamic> json) =
-      _$CreateCommunityImpl.fromJson;
+      _$_CreateCommunity.fromJson;
 
   @override
   String get name;
@@ -449,7 +448,7 @@ abstract class _CreateCommunity extends CreateCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$CreateCommunityImplCopyWith<_$CreateCommunityImpl> get copyWith =>
+  _$$_CreateCommunityCopyWith<_$_CreateCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -531,11 +530,11 @@ class _$ListCommunitiesCopyWithImpl<$Res, $Val extends ListCommunities>
 }
 
 /// @nodoc
-abstract class _$$ListCommunitiesImplCopyWith<$Res>
+abstract class _$$_ListCommunitiesCopyWith<$Res>
     implements $ListCommunitiesCopyWith<$Res> {
-  factory _$$ListCommunitiesImplCopyWith(_$ListCommunitiesImpl value,
-          $Res Function(_$ListCommunitiesImpl) then) =
-      __$$ListCommunitiesImplCopyWithImpl<$Res>;
+  factory _$$_ListCommunitiesCopyWith(
+          _$_ListCommunities value, $Res Function(_$_ListCommunities) then) =
+      __$$_ListCommunitiesCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -547,11 +546,11 @@ abstract class _$$ListCommunitiesImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ListCommunitiesImplCopyWithImpl<$Res>
-    extends _$ListCommunitiesCopyWithImpl<$Res, _$ListCommunitiesImpl>
-    implements _$$ListCommunitiesImplCopyWith<$Res> {
-  __$$ListCommunitiesImplCopyWithImpl(
-      _$ListCommunitiesImpl _value, $Res Function(_$ListCommunitiesImpl) _then)
+class __$$_ListCommunitiesCopyWithImpl<$Res>
+    extends _$ListCommunitiesCopyWithImpl<$Res, _$_ListCommunities>
+    implements _$$_ListCommunitiesCopyWith<$Res> {
+  __$$_ListCommunitiesCopyWithImpl(
+      _$_ListCommunities _value, $Res Function(_$_ListCommunities) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -563,7 +562,7 @@ class __$$ListCommunitiesImplCopyWithImpl<$Res>
     Object? limit = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$ListCommunitiesImpl(
+    return _then(_$_ListCommunities(
       type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -591,8 +590,8 @@ class __$$ListCommunitiesImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$ListCommunitiesImpl extends _ListCommunities {
-  const _$ListCommunitiesImpl(
+class _$_ListCommunities extends _ListCommunities {
+  const _$_ListCommunities(
       {@JsonKey(name: 'type_') this.type,
       this.sort,
       this.page,
@@ -600,8 +599,8 @@ class _$ListCommunitiesImpl extends _ListCommunities {
       this.auth})
       : super._();
 
-  factory _$ListCommunitiesImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ListCommunitiesImplFromJson(json);
+  factory _$_ListCommunities.fromJson(Map<String, dynamic> json) =>
+      _$$_ListCommunitiesFromJson(json);
 
   @override
   @JsonKey(name: 'type_')
@@ -624,7 +623,7 @@ class _$ListCommunitiesImpl extends _ListCommunities {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ListCommunitiesImpl &&
+            other is _$_ListCommunities &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
@@ -639,13 +638,12 @@ class _$ListCommunitiesImpl extends _ListCommunities {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ListCommunitiesImplCopyWith<_$ListCommunitiesImpl> get copyWith =>
-      __$$ListCommunitiesImplCopyWithImpl<_$ListCommunitiesImpl>(
-          this, _$identity);
+  _$$_ListCommunitiesCopyWith<_$_ListCommunities> get copyWith =>
+      __$$_ListCommunitiesCopyWithImpl<_$_ListCommunities>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ListCommunitiesImplToJson(
+    return _$$_ListCommunitiesToJson(
       this,
     );
   }
@@ -657,11 +655,11 @@ abstract class _ListCommunities extends ListCommunities {
       final SortType? sort,
       final int? page,
       final int? limit,
-      final String? auth}) = _$ListCommunitiesImpl;
+      final String? auth}) = _$_ListCommunities;
   const _ListCommunities._() : super._();
 
   factory _ListCommunities.fromJson(Map<String, dynamic> json) =
-      _$ListCommunitiesImpl.fromJson;
+      _$_ListCommunities.fromJson;
 
   @override
   @JsonKey(name: 'type_')
@@ -676,7 +674,7 @@ abstract class _ListCommunities extends ListCommunities {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$ListCommunitiesImplCopyWith<_$ListCommunitiesImpl> get copyWith =>
+  _$$_ListCommunitiesCopyWith<_$_ListCommunities> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -771,11 +769,11 @@ class _$BanFromCommunityCopyWithImpl<$Res, $Val extends BanFromCommunity>
 }
 
 /// @nodoc
-abstract class _$$BanFromCommunityImplCopyWith<$Res>
+abstract class _$$_BanFromCommunityCopyWith<$Res>
     implements $BanFromCommunityCopyWith<$Res> {
-  factory _$$BanFromCommunityImplCopyWith(_$BanFromCommunityImpl value,
-          $Res Function(_$BanFromCommunityImpl) then) =
-      __$$BanFromCommunityImplCopyWithImpl<$Res>;
+  factory _$$_BanFromCommunityCopyWith(
+          _$_BanFromCommunity value, $Res Function(_$_BanFromCommunity) then) =
+      __$$_BanFromCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -789,11 +787,11 @@ abstract class _$$BanFromCommunityImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$BanFromCommunityImplCopyWithImpl<$Res>
-    extends _$BanFromCommunityCopyWithImpl<$Res, _$BanFromCommunityImpl>
-    implements _$$BanFromCommunityImplCopyWith<$Res> {
-  __$$BanFromCommunityImplCopyWithImpl(_$BanFromCommunityImpl _value,
-      $Res Function(_$BanFromCommunityImpl) _then)
+class __$$_BanFromCommunityCopyWithImpl<$Res>
+    extends _$BanFromCommunityCopyWithImpl<$Res, _$_BanFromCommunity>
+    implements _$$_BanFromCommunityCopyWith<$Res> {
+  __$$_BanFromCommunityCopyWithImpl(
+      _$_BanFromCommunity _value, $Res Function(_$_BanFromCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -807,7 +805,7 @@ class __$$BanFromCommunityImplCopyWithImpl<$Res>
     Object? expires = freezed,
     Object? auth = null,
   }) {
-    return _then(_$BanFromCommunityImpl(
+    return _then(_$_BanFromCommunity(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -843,8 +841,8 @@ class __$$BanFromCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$BanFromCommunityImpl extends _BanFromCommunity {
-  const _$BanFromCommunityImpl(
+class _$_BanFromCommunity extends _BanFromCommunity {
+  const _$_BanFromCommunity(
       {required this.communityId,
       required this.personId,
       required this.ban,
@@ -854,8 +852,8 @@ class _$BanFromCommunityImpl extends _BanFromCommunity {
       required this.auth})
       : super._();
 
-  factory _$BanFromCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$BanFromCommunityImplFromJson(json);
+  factory _$_BanFromCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_BanFromCommunityFromJson(json);
 
   @override
   final int communityId;
@@ -881,7 +879,7 @@ class _$BanFromCommunityImpl extends _BanFromCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$BanFromCommunityImpl &&
+            other is _$_BanFromCommunity &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.personId, personId) ||
@@ -902,13 +900,12 @@ class _$BanFromCommunityImpl extends _BanFromCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$BanFromCommunityImplCopyWith<_$BanFromCommunityImpl> get copyWith =>
-      __$$BanFromCommunityImplCopyWithImpl<_$BanFromCommunityImpl>(
-          this, _$identity);
+  _$$_BanFromCommunityCopyWith<_$_BanFromCommunity> get copyWith =>
+      __$$_BanFromCommunityCopyWithImpl<_$_BanFromCommunity>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$BanFromCommunityImplToJson(
+    return _$$_BanFromCommunityToJson(
       this,
     );
   }
@@ -922,11 +919,11 @@ abstract class _BanFromCommunity extends BanFromCommunity {
       final bool? removeData,
       final String? reason,
       final int? expires,
-      required final String auth}) = _$BanFromCommunityImpl;
+      required final String auth}) = _$_BanFromCommunity;
   const _BanFromCommunity._() : super._();
 
   factory _BanFromCommunity.fromJson(Map<String, dynamic> json) =
-      _$BanFromCommunityImpl.fromJson;
+      _$_BanFromCommunity.fromJson;
 
   @override
   int get communityId;
@@ -944,7 +941,7 @@ abstract class _BanFromCommunity extends BanFromCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$BanFromCommunityImplCopyWith<_$BanFromCommunityImpl> get copyWith =>
+  _$$_BanFromCommunityCopyWith<_$_BanFromCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1014,22 +1011,22 @@ class _$AddModToCommunityCopyWithImpl<$Res, $Val extends AddModToCommunity>
 }
 
 /// @nodoc
-abstract class _$$AddModToCommunityImplCopyWith<$Res>
+abstract class _$$_AddModToCommunityCopyWith<$Res>
     implements $AddModToCommunityCopyWith<$Res> {
-  factory _$$AddModToCommunityImplCopyWith(_$AddModToCommunityImpl value,
-          $Res Function(_$AddModToCommunityImpl) then) =
-      __$$AddModToCommunityImplCopyWithImpl<$Res>;
+  factory _$$_AddModToCommunityCopyWith(_$_AddModToCommunity value,
+          $Res Function(_$_AddModToCommunity) then) =
+      __$$_AddModToCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, int personId, bool added, String auth});
 }
 
 /// @nodoc
-class __$$AddModToCommunityImplCopyWithImpl<$Res>
-    extends _$AddModToCommunityCopyWithImpl<$Res, _$AddModToCommunityImpl>
-    implements _$$AddModToCommunityImplCopyWith<$Res> {
-  __$$AddModToCommunityImplCopyWithImpl(_$AddModToCommunityImpl _value,
-      $Res Function(_$AddModToCommunityImpl) _then)
+class __$$_AddModToCommunityCopyWithImpl<$Res>
+    extends _$AddModToCommunityCopyWithImpl<$Res, _$_AddModToCommunity>
+    implements _$$_AddModToCommunityCopyWith<$Res> {
+  __$$_AddModToCommunityCopyWithImpl(
+      _$_AddModToCommunity _value, $Res Function(_$_AddModToCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1040,7 +1037,7 @@ class __$$AddModToCommunityImplCopyWithImpl<$Res>
     Object? added = null,
     Object? auth = null,
   }) {
-    return _then(_$AddModToCommunityImpl(
+    return _then(_$_AddModToCommunity(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1064,16 +1061,16 @@ class __$$AddModToCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$AddModToCommunityImpl extends _AddModToCommunity {
-  const _$AddModToCommunityImpl(
+class _$_AddModToCommunity extends _AddModToCommunity {
+  const _$_AddModToCommunity(
       {required this.communityId,
       required this.personId,
       required this.added,
       required this.auth})
       : super._();
 
-  factory _$AddModToCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AddModToCommunityImplFromJson(json);
+  factory _$_AddModToCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_AddModToCommunityFromJson(json);
 
   @override
   final int communityId;
@@ -1093,7 +1090,7 @@ class _$AddModToCommunityImpl extends _AddModToCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AddModToCommunityImpl &&
+            other is _$_AddModToCommunity &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.personId, personId) ||
@@ -1110,13 +1107,13 @@ class _$AddModToCommunityImpl extends _AddModToCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$AddModToCommunityImplCopyWith<_$AddModToCommunityImpl> get copyWith =>
-      __$$AddModToCommunityImplCopyWithImpl<_$AddModToCommunityImpl>(
+  _$$_AddModToCommunityCopyWith<_$_AddModToCommunity> get copyWith =>
+      __$$_AddModToCommunityCopyWithImpl<_$_AddModToCommunity>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$AddModToCommunityImplToJson(
+    return _$$_AddModToCommunityToJson(
       this,
     );
   }
@@ -1127,11 +1124,11 @@ abstract class _AddModToCommunity extends AddModToCommunity {
       {required final int communityId,
       required final int personId,
       required final bool added,
-      required final String auth}) = _$AddModToCommunityImpl;
+      required final String auth}) = _$_AddModToCommunity;
   const _AddModToCommunity._() : super._();
 
   factory _AddModToCommunity.fromJson(Map<String, dynamic> json) =
-      _$AddModToCommunityImpl.fromJson;
+      _$_AddModToCommunity.fromJson;
 
   @override
   int get communityId;
@@ -1143,7 +1140,7 @@ abstract class _AddModToCommunity extends AddModToCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$AddModToCommunityImplCopyWith<_$AddModToCommunityImpl> get copyWith =>
+  _$$_AddModToCommunityCopyWith<_$_AddModToCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1238,11 +1235,11 @@ class _$EditCommunityCopyWithImpl<$Res, $Val extends EditCommunity>
 }
 
 /// @nodoc
-abstract class _$$EditCommunityImplCopyWith<$Res>
+abstract class _$$_EditCommunityCopyWith<$Res>
     implements $EditCommunityCopyWith<$Res> {
-  factory _$$EditCommunityImplCopyWith(
-          _$EditCommunityImpl value, $Res Function(_$EditCommunityImpl) then) =
-      __$$EditCommunityImplCopyWithImpl<$Res>;
+  factory _$$_EditCommunityCopyWith(
+          _$_EditCommunity value, $Res Function(_$_EditCommunity) then) =
+      __$$_EditCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1256,11 +1253,11 @@ abstract class _$$EditCommunityImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$EditCommunityImplCopyWithImpl<$Res>
-    extends _$EditCommunityCopyWithImpl<$Res, _$EditCommunityImpl>
-    implements _$$EditCommunityImplCopyWith<$Res> {
-  __$$EditCommunityImplCopyWithImpl(
-      _$EditCommunityImpl _value, $Res Function(_$EditCommunityImpl) _then)
+class __$$_EditCommunityCopyWithImpl<$Res>
+    extends _$EditCommunityCopyWithImpl<$Res, _$_EditCommunity>
+    implements _$$_EditCommunityCopyWith<$Res> {
+  __$$_EditCommunityCopyWithImpl(
+      _$_EditCommunity _value, $Res Function(_$_EditCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1274,7 +1271,7 @@ class __$$EditCommunityImplCopyWithImpl<$Res>
     Object? nsfw = freezed,
     Object? auth = null,
   }) {
-    return _then(_$EditCommunityImpl(
+    return _then(_$_EditCommunity(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1310,8 +1307,8 @@ class __$$EditCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$EditCommunityImpl extends _EditCommunity {
-  const _$EditCommunityImpl(
+class _$_EditCommunity extends _EditCommunity {
+  const _$_EditCommunity(
       {required this.communityId,
       this.title,
       this.description,
@@ -1321,8 +1318,8 @@ class _$EditCommunityImpl extends _EditCommunity {
       required this.auth})
       : super._();
 
-  factory _$EditCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$EditCommunityImplFromJson(json);
+  factory _$_EditCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_EditCommunityFromJson(json);
 
   @override
   final int communityId;
@@ -1348,7 +1345,7 @@ class _$EditCommunityImpl extends _EditCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$EditCommunityImpl &&
+            other is _$_EditCommunity &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.title, title) || other.title == title) &&
@@ -1368,12 +1365,12 @@ class _$EditCommunityImpl extends _EditCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$EditCommunityImplCopyWith<_$EditCommunityImpl> get copyWith =>
-      __$$EditCommunityImplCopyWithImpl<_$EditCommunityImpl>(this, _$identity);
+  _$$_EditCommunityCopyWith<_$_EditCommunity> get copyWith =>
+      __$$_EditCommunityCopyWithImpl<_$_EditCommunity>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$EditCommunityImplToJson(
+    return _$$_EditCommunityToJson(
       this,
     );
   }
@@ -1387,11 +1384,11 @@ abstract class _EditCommunity extends EditCommunity {
       final String? icon,
       final String? banner,
       final bool? nsfw,
-      required final String auth}) = _$EditCommunityImpl;
+      required final String auth}) = _$_EditCommunity;
   const _EditCommunity._() : super._();
 
   factory _EditCommunity.fromJson(Map<String, dynamic> json) =
-      _$EditCommunityImpl.fromJson;
+      _$_EditCommunity.fromJson;
 
   @override
   int get communityId;
@@ -1409,7 +1406,7 @@ abstract class _EditCommunity extends EditCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$EditCommunityImplCopyWith<_$EditCommunityImpl> get copyWith =>
+  _$$_EditCommunityCopyWith<_$_EditCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1473,22 +1470,22 @@ class _$DeleteCommunityCopyWithImpl<$Res, $Val extends DeleteCommunity>
 }
 
 /// @nodoc
-abstract class _$$DeleteCommunityImplCopyWith<$Res>
+abstract class _$$_DeleteCommunityCopyWith<$Res>
     implements $DeleteCommunityCopyWith<$Res> {
-  factory _$$DeleteCommunityImplCopyWith(_$DeleteCommunityImpl value,
-          $Res Function(_$DeleteCommunityImpl) then) =
-      __$$DeleteCommunityImplCopyWithImpl<$Res>;
+  factory _$$_DeleteCommunityCopyWith(
+          _$_DeleteCommunity value, $Res Function(_$_DeleteCommunity) then) =
+      __$$_DeleteCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, bool deleted, String auth});
 }
 
 /// @nodoc
-class __$$DeleteCommunityImplCopyWithImpl<$Res>
-    extends _$DeleteCommunityCopyWithImpl<$Res, _$DeleteCommunityImpl>
-    implements _$$DeleteCommunityImplCopyWith<$Res> {
-  __$$DeleteCommunityImplCopyWithImpl(
-      _$DeleteCommunityImpl _value, $Res Function(_$DeleteCommunityImpl) _then)
+class __$$_DeleteCommunityCopyWithImpl<$Res>
+    extends _$DeleteCommunityCopyWithImpl<$Res, _$_DeleteCommunity>
+    implements _$$_DeleteCommunityCopyWith<$Res> {
+  __$$_DeleteCommunityCopyWithImpl(
+      _$_DeleteCommunity _value, $Res Function(_$_DeleteCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1498,7 +1495,7 @@ class __$$DeleteCommunityImplCopyWithImpl<$Res>
     Object? deleted = null,
     Object? auth = null,
   }) {
-    return _then(_$DeleteCommunityImpl(
+    return _then(_$_DeleteCommunity(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1518,13 +1515,13 @@ class __$$DeleteCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$DeleteCommunityImpl extends _DeleteCommunity {
-  const _$DeleteCommunityImpl(
+class _$_DeleteCommunity extends _DeleteCommunity {
+  const _$_DeleteCommunity(
       {required this.communityId, required this.deleted, required this.auth})
       : super._();
 
-  factory _$DeleteCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$DeleteCommunityImplFromJson(json);
+  factory _$_DeleteCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_DeleteCommunityFromJson(json);
 
   @override
   final int communityId;
@@ -1542,7 +1539,7 @@ class _$DeleteCommunityImpl extends _DeleteCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$DeleteCommunityImpl &&
+            other is _$_DeleteCommunity &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.deleted, deleted) || other.deleted == deleted) &&
@@ -1556,13 +1553,12 @@ class _$DeleteCommunityImpl extends _DeleteCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$DeleteCommunityImplCopyWith<_$DeleteCommunityImpl> get copyWith =>
-      __$$DeleteCommunityImplCopyWithImpl<_$DeleteCommunityImpl>(
-          this, _$identity);
+  _$$_DeleteCommunityCopyWith<_$_DeleteCommunity> get copyWith =>
+      __$$_DeleteCommunityCopyWithImpl<_$_DeleteCommunity>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$DeleteCommunityImplToJson(
+    return _$$_DeleteCommunityToJson(
       this,
     );
   }
@@ -1572,11 +1568,11 @@ abstract class _DeleteCommunity extends DeleteCommunity {
   const factory _DeleteCommunity(
       {required final int communityId,
       required final bool deleted,
-      required final String auth}) = _$DeleteCommunityImpl;
+      required final String auth}) = _$_DeleteCommunity;
   const _DeleteCommunity._() : super._();
 
   factory _DeleteCommunity.fromJson(Map<String, dynamic> json) =
-      _$DeleteCommunityImpl.fromJson;
+      _$_DeleteCommunity.fromJson;
 
   @override
   int get communityId;
@@ -1586,7 +1582,7 @@ abstract class _DeleteCommunity extends DeleteCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$DeleteCommunityImplCopyWith<_$DeleteCommunityImpl> get copyWith =>
+  _$$_DeleteCommunityCopyWith<_$_DeleteCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1667,11 +1663,11 @@ class _$RemoveCommunityCopyWithImpl<$Res, $Val extends RemoveCommunity>
 }
 
 /// @nodoc
-abstract class _$$RemoveCommunityImplCopyWith<$Res>
+abstract class _$$_RemoveCommunityCopyWith<$Res>
     implements $RemoveCommunityCopyWith<$Res> {
-  factory _$$RemoveCommunityImplCopyWith(_$RemoveCommunityImpl value,
-          $Res Function(_$RemoveCommunityImpl) then) =
-      __$$RemoveCommunityImplCopyWithImpl<$Res>;
+  factory _$$_RemoveCommunityCopyWith(
+          _$_RemoveCommunity value, $Res Function(_$_RemoveCommunity) then) =
+      __$$_RemoveCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1683,11 +1679,11 @@ abstract class _$$RemoveCommunityImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$RemoveCommunityImplCopyWithImpl<$Res>
-    extends _$RemoveCommunityCopyWithImpl<$Res, _$RemoveCommunityImpl>
-    implements _$$RemoveCommunityImplCopyWith<$Res> {
-  __$$RemoveCommunityImplCopyWithImpl(
-      _$RemoveCommunityImpl _value, $Res Function(_$RemoveCommunityImpl) _then)
+class __$$_RemoveCommunityCopyWithImpl<$Res>
+    extends _$RemoveCommunityCopyWithImpl<$Res, _$_RemoveCommunity>
+    implements _$$_RemoveCommunityCopyWith<$Res> {
+  __$$_RemoveCommunityCopyWithImpl(
+      _$_RemoveCommunity _value, $Res Function(_$_RemoveCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1699,7 +1695,7 @@ class __$$RemoveCommunityImplCopyWithImpl<$Res>
     Object? expires = freezed,
     Object? auth = null,
   }) {
-    return _then(_$RemoveCommunityImpl(
+    return _then(_$_RemoveCommunity(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1727,8 +1723,8 @@ class __$$RemoveCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$RemoveCommunityImpl extends _RemoveCommunity {
-  const _$RemoveCommunityImpl(
+class _$_RemoveCommunity extends _RemoveCommunity {
+  const _$_RemoveCommunity(
       {required this.communityId,
       required this.removed,
       this.reason,
@@ -1736,8 +1732,8 @@ class _$RemoveCommunityImpl extends _RemoveCommunity {
       required this.auth})
       : super._();
 
-  factory _$RemoveCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$RemoveCommunityImplFromJson(json);
+  factory _$_RemoveCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_RemoveCommunityFromJson(json);
 
   @override
   final int communityId;
@@ -1759,7 +1755,7 @@ class _$RemoveCommunityImpl extends _RemoveCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$RemoveCommunityImpl &&
+            other is _$_RemoveCommunity &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.removed, removed) || other.removed == removed) &&
@@ -1776,13 +1772,12 @@ class _$RemoveCommunityImpl extends _RemoveCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$RemoveCommunityImplCopyWith<_$RemoveCommunityImpl> get copyWith =>
-      __$$RemoveCommunityImplCopyWithImpl<_$RemoveCommunityImpl>(
-          this, _$identity);
+  _$$_RemoveCommunityCopyWith<_$_RemoveCommunity> get copyWith =>
+      __$$_RemoveCommunityCopyWithImpl<_$_RemoveCommunity>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$RemoveCommunityImplToJson(
+    return _$$_RemoveCommunityToJson(
       this,
     );
   }
@@ -1794,11 +1789,11 @@ abstract class _RemoveCommunity extends RemoveCommunity {
       required final bool removed,
       final String? reason,
       final int? expires,
-      required final String auth}) = _$RemoveCommunityImpl;
+      required final String auth}) = _$_RemoveCommunity;
   const _RemoveCommunity._() : super._();
 
   factory _RemoveCommunity.fromJson(Map<String, dynamic> json) =
-      _$RemoveCommunityImpl.fromJson;
+      _$_RemoveCommunity.fromJson;
 
   @override
   int get communityId;
@@ -1812,7 +1807,7 @@ abstract class _RemoveCommunity extends RemoveCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$RemoveCommunityImplCopyWith<_$RemoveCommunityImpl> get copyWith =>
+  _$$_RemoveCommunityCopyWith<_$_RemoveCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1876,22 +1871,22 @@ class _$FollowCommunityCopyWithImpl<$Res, $Val extends FollowCommunity>
 }
 
 /// @nodoc
-abstract class _$$FollowCommunityImplCopyWith<$Res>
+abstract class _$$_FollowCommunityCopyWith<$Res>
     implements $FollowCommunityCopyWith<$Res> {
-  factory _$$FollowCommunityImplCopyWith(_$FollowCommunityImpl value,
-          $Res Function(_$FollowCommunityImpl) then) =
-      __$$FollowCommunityImplCopyWithImpl<$Res>;
+  factory _$$_FollowCommunityCopyWith(
+          _$_FollowCommunity value, $Res Function(_$_FollowCommunity) then) =
+      __$$_FollowCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, bool follow, String auth});
 }
 
 /// @nodoc
-class __$$FollowCommunityImplCopyWithImpl<$Res>
-    extends _$FollowCommunityCopyWithImpl<$Res, _$FollowCommunityImpl>
-    implements _$$FollowCommunityImplCopyWith<$Res> {
-  __$$FollowCommunityImplCopyWithImpl(
-      _$FollowCommunityImpl _value, $Res Function(_$FollowCommunityImpl) _then)
+class __$$_FollowCommunityCopyWithImpl<$Res>
+    extends _$FollowCommunityCopyWithImpl<$Res, _$_FollowCommunity>
+    implements _$$_FollowCommunityCopyWith<$Res> {
+  __$$_FollowCommunityCopyWithImpl(
+      _$_FollowCommunity _value, $Res Function(_$_FollowCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1901,7 +1896,7 @@ class __$$FollowCommunityImplCopyWithImpl<$Res>
     Object? follow = null,
     Object? auth = null,
   }) {
-    return _then(_$FollowCommunityImpl(
+    return _then(_$_FollowCommunity(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1921,13 +1916,13 @@ class __$$FollowCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$FollowCommunityImpl extends _FollowCommunity {
-  const _$FollowCommunityImpl(
+class _$_FollowCommunity extends _FollowCommunity {
+  const _$_FollowCommunity(
       {required this.communityId, required this.follow, required this.auth})
       : super._();
 
-  factory _$FollowCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FollowCommunityImplFromJson(json);
+  factory _$_FollowCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_FollowCommunityFromJson(json);
 
   @override
   final int communityId;
@@ -1945,7 +1940,7 @@ class _$FollowCommunityImpl extends _FollowCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$FollowCommunityImpl &&
+            other is _$_FollowCommunity &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.follow, follow) || other.follow == follow) &&
@@ -1959,13 +1954,12 @@ class _$FollowCommunityImpl extends _FollowCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$FollowCommunityImplCopyWith<_$FollowCommunityImpl> get copyWith =>
-      __$$FollowCommunityImplCopyWithImpl<_$FollowCommunityImpl>(
-          this, _$identity);
+  _$$_FollowCommunityCopyWith<_$_FollowCommunity> get copyWith =>
+      __$$_FollowCommunityCopyWithImpl<_$_FollowCommunity>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$FollowCommunityImplToJson(
+    return _$$_FollowCommunityToJson(
       this,
     );
   }
@@ -1975,11 +1969,11 @@ abstract class _FollowCommunity extends FollowCommunity {
   const factory _FollowCommunity(
       {required final int communityId,
       required final bool follow,
-      required final String auth}) = _$FollowCommunityImpl;
+      required final String auth}) = _$_FollowCommunity;
   const _FollowCommunity._() : super._();
 
   factory _FollowCommunity.fromJson(Map<String, dynamic> json) =
-      _$FollowCommunityImpl.fromJson;
+      _$_FollowCommunity.fromJson;
 
   @override
   int get communityId;
@@ -1989,7 +1983,7 @@ abstract class _FollowCommunity extends FollowCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$FollowCommunityImplCopyWith<_$FollowCommunityImpl> get copyWith =>
+  _$$_FollowCommunityCopyWith<_$_FollowCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2053,22 +2047,22 @@ class _$TransferCommunityCopyWithImpl<$Res, $Val extends TransferCommunity>
 }
 
 /// @nodoc
-abstract class _$$TransferCommunityImplCopyWith<$Res>
+abstract class _$$_TransferCommunityCopyWith<$Res>
     implements $TransferCommunityCopyWith<$Res> {
-  factory _$$TransferCommunityImplCopyWith(_$TransferCommunityImpl value,
-          $Res Function(_$TransferCommunityImpl) then) =
-      __$$TransferCommunityImplCopyWithImpl<$Res>;
+  factory _$$_TransferCommunityCopyWith(_$_TransferCommunity value,
+          $Res Function(_$_TransferCommunity) then) =
+      __$$_TransferCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, int personId, String auth});
 }
 
 /// @nodoc
-class __$$TransferCommunityImplCopyWithImpl<$Res>
-    extends _$TransferCommunityCopyWithImpl<$Res, _$TransferCommunityImpl>
-    implements _$$TransferCommunityImplCopyWith<$Res> {
-  __$$TransferCommunityImplCopyWithImpl(_$TransferCommunityImpl _value,
-      $Res Function(_$TransferCommunityImpl) _then)
+class __$$_TransferCommunityCopyWithImpl<$Res>
+    extends _$TransferCommunityCopyWithImpl<$Res, _$_TransferCommunity>
+    implements _$$_TransferCommunityCopyWith<$Res> {
+  __$$_TransferCommunityCopyWithImpl(
+      _$_TransferCommunity _value, $Res Function(_$_TransferCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2078,7 +2072,7 @@ class __$$TransferCommunityImplCopyWithImpl<$Res>
     Object? personId = null,
     Object? auth = null,
   }) {
-    return _then(_$TransferCommunityImpl(
+    return _then(_$_TransferCommunity(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -2098,13 +2092,13 @@ class __$$TransferCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$TransferCommunityImpl extends _TransferCommunity {
-  const _$TransferCommunityImpl(
+class _$_TransferCommunity extends _TransferCommunity {
+  const _$_TransferCommunity(
       {required this.communityId, required this.personId, required this.auth})
       : super._();
 
-  factory _$TransferCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$TransferCommunityImplFromJson(json);
+  factory _$_TransferCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_TransferCommunityFromJson(json);
 
   @override
   final int communityId;
@@ -2122,7 +2116,7 @@ class _$TransferCommunityImpl extends _TransferCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$TransferCommunityImpl &&
+            other is _$_TransferCommunity &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.personId, personId) ||
@@ -2137,13 +2131,13 @@ class _$TransferCommunityImpl extends _TransferCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$TransferCommunityImplCopyWith<_$TransferCommunityImpl> get copyWith =>
-      __$$TransferCommunityImplCopyWithImpl<_$TransferCommunityImpl>(
+  _$$_TransferCommunityCopyWith<_$_TransferCommunity> get copyWith =>
+      __$$_TransferCommunityCopyWithImpl<_$_TransferCommunity>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$TransferCommunityImplToJson(
+    return _$$_TransferCommunityToJson(
       this,
     );
   }
@@ -2153,11 +2147,11 @@ abstract class _TransferCommunity extends TransferCommunity {
   const factory _TransferCommunity(
       {required final int communityId,
       required final int personId,
-      required final String auth}) = _$TransferCommunityImpl;
+      required final String auth}) = _$_TransferCommunity;
   const _TransferCommunity._() : super._();
 
   factory _TransferCommunity.fromJson(Map<String, dynamic> json) =
-      _$TransferCommunityImpl.fromJson;
+      _$_TransferCommunity.fromJson;
 
   @override
   int get communityId;
@@ -2167,7 +2161,7 @@ abstract class _TransferCommunity extends TransferCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$TransferCommunityImplCopyWith<_$TransferCommunityImpl> get copyWith =>
+  _$$_TransferCommunityCopyWith<_$_TransferCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2231,22 +2225,22 @@ class _$BlockCommunityCopyWithImpl<$Res, $Val extends BlockCommunity>
 }
 
 /// @nodoc
-abstract class _$$BlockCommunityImplCopyWith<$Res>
+abstract class _$$_BlockCommunityCopyWith<$Res>
     implements $BlockCommunityCopyWith<$Res> {
-  factory _$$BlockCommunityImplCopyWith(_$BlockCommunityImpl value,
-          $Res Function(_$BlockCommunityImpl) then) =
-      __$$BlockCommunityImplCopyWithImpl<$Res>;
+  factory _$$_BlockCommunityCopyWith(
+          _$_BlockCommunity value, $Res Function(_$_BlockCommunity) then) =
+      __$$_BlockCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, bool block, String auth});
 }
 
 /// @nodoc
-class __$$BlockCommunityImplCopyWithImpl<$Res>
-    extends _$BlockCommunityCopyWithImpl<$Res, _$BlockCommunityImpl>
-    implements _$$BlockCommunityImplCopyWith<$Res> {
-  __$$BlockCommunityImplCopyWithImpl(
-      _$BlockCommunityImpl _value, $Res Function(_$BlockCommunityImpl) _then)
+class __$$_BlockCommunityCopyWithImpl<$Res>
+    extends _$BlockCommunityCopyWithImpl<$Res, _$_BlockCommunity>
+    implements _$$_BlockCommunityCopyWith<$Res> {
+  __$$_BlockCommunityCopyWithImpl(
+      _$_BlockCommunity _value, $Res Function(_$_BlockCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2256,7 +2250,7 @@ class __$$BlockCommunityImplCopyWithImpl<$Res>
     Object? block = null,
     Object? auth = null,
   }) {
-    return _then(_$BlockCommunityImpl(
+    return _then(_$_BlockCommunity(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -2276,13 +2270,13 @@ class __$$BlockCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$BlockCommunityImpl extends _BlockCommunity {
-  const _$BlockCommunityImpl(
+class _$_BlockCommunity extends _BlockCommunity {
+  const _$_BlockCommunity(
       {required this.communityId, required this.block, required this.auth})
       : super._();
 
-  factory _$BlockCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$BlockCommunityImplFromJson(json);
+  factory _$_BlockCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_BlockCommunityFromJson(json);
 
   @override
   final int communityId;
@@ -2300,7 +2294,7 @@ class _$BlockCommunityImpl extends _BlockCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$BlockCommunityImpl &&
+            other is _$_BlockCommunity &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.block, block) || other.block == block) &&
@@ -2314,13 +2308,12 @@ class _$BlockCommunityImpl extends _BlockCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$BlockCommunityImplCopyWith<_$BlockCommunityImpl> get copyWith =>
-      __$$BlockCommunityImplCopyWithImpl<_$BlockCommunityImpl>(
-          this, _$identity);
+  _$$_BlockCommunityCopyWith<_$_BlockCommunity> get copyWith =>
+      __$$_BlockCommunityCopyWithImpl<_$_BlockCommunity>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$BlockCommunityImplToJson(
+    return _$$_BlockCommunityToJson(
       this,
     );
   }
@@ -2330,11 +2323,11 @@ abstract class _BlockCommunity extends BlockCommunity {
   const factory _BlockCommunity(
       {required final int communityId,
       required final bool block,
-      required final String auth}) = _$BlockCommunityImpl;
+      required final String auth}) = _$_BlockCommunity;
   const _BlockCommunity._() : super._();
 
   factory _BlockCommunity.fromJson(Map<String, dynamic> json) =
-      _$BlockCommunityImpl.fromJson;
+      _$_BlockCommunity.fromJson;
 
   @override
   int get communityId;
@@ -2344,6 +2337,6 @@ abstract class _BlockCommunity extends BlockCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$BlockCommunityImplCopyWith<_$BlockCommunityImpl> get copyWith =>
+  _$$_BlockCommunityCopyWith<_$_BlockCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/community.g.dart
+++ b/lib/src/v3/api/community.g.dart
@@ -6,14 +6,14 @@ part of 'community.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$GetCommunityImpl _$$GetCommunityImplFromJson(Map<String, dynamic> json) =>
-    _$GetCommunityImpl(
+_$_GetCommunity _$$_GetCommunityFromJson(Map<String, dynamic> json) =>
+    _$_GetCommunity(
       id: json['id'] as int?,
       name: json['name'] as String?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$GetCommunityImplToJson(_$GetCommunityImpl instance) {
+Map<String, dynamic> _$$_GetCommunityToJson(_$_GetCommunity instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -28,9 +28,8 @@ Map<String, dynamic> _$$GetCommunityImplToJson(_$GetCommunityImpl instance) {
   return val;
 }
 
-_$CreateCommunityImpl _$$CreateCommunityImplFromJson(
-        Map<String, dynamic> json) =>
-    _$CreateCommunityImpl(
+_$_CreateCommunity _$$_CreateCommunityFromJson(Map<String, dynamic> json) =>
+    _$_CreateCommunity(
       name: json['name'] as String,
       title: json['title'] as String,
       description: json['description'] as String?,
@@ -40,8 +39,7 @@ _$CreateCommunityImpl _$$CreateCommunityImplFromJson(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$CreateCommunityImplToJson(
-    _$CreateCommunityImpl instance) {
+Map<String, dynamic> _$$_CreateCommunityToJson(_$_CreateCommunity instance) {
   final val = <String, dynamic>{
     'name': instance.name,
     'title': instance.title,
@@ -61,9 +59,8 @@ Map<String, dynamic> _$$CreateCommunityImplToJson(
   return val;
 }
 
-_$ListCommunitiesImpl _$$ListCommunitiesImplFromJson(
-        Map<String, dynamic> json) =>
-    _$ListCommunitiesImpl(
+_$_ListCommunities _$$_ListCommunitiesFromJson(Map<String, dynamic> json) =>
+    _$_ListCommunities(
       type: json['type_'] == null
           ? null
           : PostListingType.fromJson(json['type_']),
@@ -73,8 +70,7 @@ _$ListCommunitiesImpl _$$ListCommunitiesImplFromJson(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$ListCommunitiesImplToJson(
-    _$ListCommunitiesImpl instance) {
+Map<String, dynamic> _$$_ListCommunitiesToJson(_$_ListCommunities instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -91,9 +87,8 @@ Map<String, dynamic> _$$ListCommunitiesImplToJson(
   return val;
 }
 
-_$BanFromCommunityImpl _$$BanFromCommunityImplFromJson(
-        Map<String, dynamic> json) =>
-    _$BanFromCommunityImpl(
+_$_BanFromCommunity _$$_BanFromCommunityFromJson(Map<String, dynamic> json) =>
+    _$_BanFromCommunity(
       communityId: json['community_id'] as int,
       personId: json['person_id'] as int,
       ban: json['ban'] as bool,
@@ -103,8 +98,7 @@ _$BanFromCommunityImpl _$$BanFromCommunityImplFromJson(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$BanFromCommunityImplToJson(
-    _$BanFromCommunityImpl instance) {
+Map<String, dynamic> _$$_BanFromCommunityToJson(_$_BanFromCommunity instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
     'person_id': instance.personId,
@@ -124,17 +118,16 @@ Map<String, dynamic> _$$BanFromCommunityImplToJson(
   return val;
 }
 
-_$AddModToCommunityImpl _$$AddModToCommunityImplFromJson(
-        Map<String, dynamic> json) =>
-    _$AddModToCommunityImpl(
+_$_AddModToCommunity _$$_AddModToCommunityFromJson(Map<String, dynamic> json) =>
+    _$_AddModToCommunity(
       communityId: json['community_id'] as int,
       personId: json['person_id'] as int,
       added: json['added'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$AddModToCommunityImplToJson(
-        _$AddModToCommunityImpl instance) =>
+Map<String, dynamic> _$$_AddModToCommunityToJson(
+        _$_AddModToCommunity instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'person_id': instance.personId,
@@ -142,8 +135,8 @@ Map<String, dynamic> _$$AddModToCommunityImplToJson(
       'auth': instance.auth,
     };
 
-_$EditCommunityImpl _$$EditCommunityImplFromJson(Map<String, dynamic> json) =>
-    _$EditCommunityImpl(
+_$_EditCommunity _$$_EditCommunityFromJson(Map<String, dynamic> json) =>
+    _$_EditCommunity(
       communityId: json['community_id'] as int,
       title: json['title'] as String?,
       description: json['description'] as String?,
@@ -153,7 +146,7 @@ _$EditCommunityImpl _$$EditCommunityImplFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$EditCommunityImplToJson(_$EditCommunityImpl instance) {
+Map<String, dynamic> _$$_EditCommunityToJson(_$_EditCommunity instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
   };
@@ -173,25 +166,22 @@ Map<String, dynamic> _$$EditCommunityImplToJson(_$EditCommunityImpl instance) {
   return val;
 }
 
-_$DeleteCommunityImpl _$$DeleteCommunityImplFromJson(
-        Map<String, dynamic> json) =>
-    _$DeleteCommunityImpl(
+_$_DeleteCommunity _$$_DeleteCommunityFromJson(Map<String, dynamic> json) =>
+    _$_DeleteCommunity(
       communityId: json['community_id'] as int,
       deleted: json['deleted'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$DeleteCommunityImplToJson(
-        _$DeleteCommunityImpl instance) =>
+Map<String, dynamic> _$$_DeleteCommunityToJson(_$_DeleteCommunity instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'deleted': instance.deleted,
       'auth': instance.auth,
     };
 
-_$RemoveCommunityImpl _$$RemoveCommunityImplFromJson(
-        Map<String, dynamic> json) =>
-    _$RemoveCommunityImpl(
+_$_RemoveCommunity _$$_RemoveCommunityFromJson(Map<String, dynamic> json) =>
+    _$_RemoveCommunity(
       communityId: json['community_id'] as int,
       removed: json['removed'] as bool,
       reason: json['reason'] as String?,
@@ -199,8 +189,7 @@ _$RemoveCommunityImpl _$$RemoveCommunityImplFromJson(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$RemoveCommunityImplToJson(
-    _$RemoveCommunityImpl instance) {
+Map<String, dynamic> _$$_RemoveCommunityToJson(_$_RemoveCommunity instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
     'removed': instance.removed,
@@ -218,47 +207,43 @@ Map<String, dynamic> _$$RemoveCommunityImplToJson(
   return val;
 }
 
-_$FollowCommunityImpl _$$FollowCommunityImplFromJson(
-        Map<String, dynamic> json) =>
-    _$FollowCommunityImpl(
+_$_FollowCommunity _$$_FollowCommunityFromJson(Map<String, dynamic> json) =>
+    _$_FollowCommunity(
       communityId: json['community_id'] as int,
       follow: json['follow'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$FollowCommunityImplToJson(
-        _$FollowCommunityImpl instance) =>
+Map<String, dynamic> _$$_FollowCommunityToJson(_$_FollowCommunity instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'follow': instance.follow,
       'auth': instance.auth,
     };
 
-_$TransferCommunityImpl _$$TransferCommunityImplFromJson(
-        Map<String, dynamic> json) =>
-    _$TransferCommunityImpl(
+_$_TransferCommunity _$$_TransferCommunityFromJson(Map<String, dynamic> json) =>
+    _$_TransferCommunity(
       communityId: json['community_id'] as int,
       personId: json['person_id'] as int,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$TransferCommunityImplToJson(
-        _$TransferCommunityImpl instance) =>
+Map<String, dynamic> _$$_TransferCommunityToJson(
+        _$_TransferCommunity instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'person_id': instance.personId,
       'auth': instance.auth,
     };
 
-_$BlockCommunityImpl _$$BlockCommunityImplFromJson(Map<String, dynamic> json) =>
-    _$BlockCommunityImpl(
+_$_BlockCommunity _$$_BlockCommunityFromJson(Map<String, dynamic> json) =>
+    _$_BlockCommunity(
       communityId: json['community_id'] as int,
       block: json['block'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$BlockCommunityImplToJson(
-        _$BlockCommunityImpl instance) =>
+Map<String, dynamic> _$$_BlockCommunityToJson(_$_BlockCommunity instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'block': instance.block,

--- a/lib/src/v3/api/person.freezed.dart
+++ b/lib/src/v3/api/person.freezed.dart
@@ -76,10 +76,9 @@ class _$LoginCopyWithImpl<$Res, $Val extends Login>
 }
 
 /// @nodoc
-abstract class _$$LoginImplCopyWith<$Res> implements $LoginCopyWith<$Res> {
-  factory _$$LoginImplCopyWith(
-          _$LoginImpl value, $Res Function(_$LoginImpl) then) =
-      __$$LoginImplCopyWithImpl<$Res>;
+abstract class _$$_LoginCopyWith<$Res> implements $LoginCopyWith<$Res> {
+  factory _$$_LoginCopyWith(_$_Login value, $Res Function(_$_Login) then) =
+      __$$_LoginCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -89,11 +88,9 @@ abstract class _$$LoginImplCopyWith<$Res> implements $LoginCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$LoginImplCopyWithImpl<$Res>
-    extends _$LoginCopyWithImpl<$Res, _$LoginImpl>
-    implements _$$LoginImplCopyWith<$Res> {
-  __$$LoginImplCopyWithImpl(
-      _$LoginImpl _value, $Res Function(_$LoginImpl) _then)
+class __$$_LoginCopyWithImpl<$Res> extends _$LoginCopyWithImpl<$Res, _$_Login>
+    implements _$$_LoginCopyWith<$Res> {
+  __$$_LoginCopyWithImpl(_$_Login _value, $Res Function(_$_Login) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -103,7 +100,7 @@ class __$$LoginImplCopyWithImpl<$Res>
     Object? password = null,
     Object? totp2faToken = freezed,
   }) {
-    return _then(_$LoginImpl(
+    return _then(_$_Login(
       usernameOrEmail: null == usernameOrEmail
           ? _value.usernameOrEmail
           : usernameOrEmail // ignore: cast_nullable_to_non_nullable
@@ -123,15 +120,15 @@ class __$$LoginImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$LoginImpl extends _Login {
-  const _$LoginImpl(
+class _$_Login extends _Login {
+  const _$_Login(
       {required this.usernameOrEmail,
       required this.password,
       @JsonKey(name: 'totp_2fa_token') this.totp2faToken})
       : super._();
 
-  factory _$LoginImpl.fromJson(Map<String, dynamic> json) =>
-      _$$LoginImplFromJson(json);
+  factory _$_Login.fromJson(Map<String, dynamic> json) =>
+      _$$_LoginFromJson(json);
 
   @override
   final String usernameOrEmail;
@@ -150,7 +147,7 @@ class _$LoginImpl extends _Login {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$LoginImpl &&
+            other is _$_Login &&
             (identical(other.usernameOrEmail, usernameOrEmail) ||
                 other.usernameOrEmail == usernameOrEmail) &&
             (identical(other.password, password) ||
@@ -167,12 +164,12 @@ class _$LoginImpl extends _Login {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$LoginImplCopyWith<_$LoginImpl> get copyWith =>
-      __$$LoginImplCopyWithImpl<_$LoginImpl>(this, _$identity);
+  _$$_LoginCopyWith<_$_Login> get copyWith =>
+      __$$_LoginCopyWithImpl<_$_Login>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$LoginImplToJson(
+    return _$$_LoginToJson(
       this,
     );
   }
@@ -180,13 +177,12 @@ class _$LoginImpl extends _Login {
 
 abstract class _Login extends Login {
   const factory _Login(
-          {required final String usernameOrEmail,
-          required final String password,
-          @JsonKey(name: 'totp_2fa_token') final String? totp2faToken}) =
-      _$LoginImpl;
+      {required final String usernameOrEmail,
+      required final String password,
+      @JsonKey(name: 'totp_2fa_token') final String? totp2faToken}) = _$_Login;
   const _Login._() : super._();
 
-  factory _Login.fromJson(Map<String, dynamic> json) = _$LoginImpl.fromJson;
+  factory _Login.fromJson(Map<String, dynamic> json) = _$_Login.fromJson;
 
   @override
   String get usernameOrEmail;
@@ -197,7 +193,7 @@ abstract class _Login extends Login {
   String? get totp2faToken;
   @override
   @JsonKey(ignore: true)
-  _$$LoginImplCopyWith<_$LoginImpl> get copyWith =>
+  _$$_LoginCopyWith<_$_Login> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -305,11 +301,10 @@ class _$RegisterCopyWithImpl<$Res, $Val extends Register>
 }
 
 /// @nodoc
-abstract class _$$RegisterImplCopyWith<$Res>
-    implements $RegisterCopyWith<$Res> {
-  factory _$$RegisterImplCopyWith(
-          _$RegisterImpl value, $Res Function(_$RegisterImpl) then) =
-      __$$RegisterImplCopyWithImpl<$Res>;
+abstract class _$$_RegisterCopyWith<$Res> implements $RegisterCopyWith<$Res> {
+  factory _$$_RegisterCopyWith(
+          _$_Register value, $Res Function(_$_Register) then) =
+      __$$_RegisterCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -325,11 +320,11 @@ abstract class _$$RegisterImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$RegisterImplCopyWithImpl<$Res>
-    extends _$RegisterCopyWithImpl<$Res, _$RegisterImpl>
-    implements _$$RegisterImplCopyWith<$Res> {
-  __$$RegisterImplCopyWithImpl(
-      _$RegisterImpl _value, $Res Function(_$RegisterImpl) _then)
+class __$$_RegisterCopyWithImpl<$Res>
+    extends _$RegisterCopyWithImpl<$Res, _$_Register>
+    implements _$$_RegisterCopyWith<$Res> {
+  __$$_RegisterCopyWithImpl(
+      _$_Register _value, $Res Function(_$_Register) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -345,7 +340,7 @@ class __$$RegisterImplCopyWithImpl<$Res>
     Object? honeypot = freezed,
     Object? answer = freezed,
   }) {
-    return _then(_$RegisterImpl(
+    return _then(_$_Register(
       username: null == username
           ? _value.username
           : username // ignore: cast_nullable_to_non_nullable
@@ -389,8 +384,8 @@ class __$$RegisterImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$RegisterImpl extends _Register {
-  const _$RegisterImpl(
+class _$_Register extends _Register {
+  const _$_Register(
       {required this.username,
       this.email,
       required this.password,
@@ -402,8 +397,8 @@ class _$RegisterImpl extends _Register {
       this.answer})
       : super._();
 
-  factory _$RegisterImpl.fromJson(Map<String, dynamic> json) =>
-      _$$RegisterImplFromJson(json);
+  factory _$_Register.fromJson(Map<String, dynamic> json) =>
+      _$$_RegisterFromJson(json);
 
   @override
   final String username;
@@ -433,7 +428,7 @@ class _$RegisterImpl extends _Register {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$RegisterImpl &&
+            other is _$_Register &&
             (identical(other.username, username) ||
                 other.username == username) &&
             (identical(other.email, email) || other.email == email) &&
@@ -460,12 +455,12 @@ class _$RegisterImpl extends _Register {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$RegisterImplCopyWith<_$RegisterImpl> get copyWith =>
-      __$$RegisterImplCopyWithImpl<_$RegisterImpl>(this, _$identity);
+  _$$_RegisterCopyWith<_$_Register> get copyWith =>
+      __$$_RegisterCopyWithImpl<_$_Register>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$RegisterImplToJson(
+    return _$$_RegisterToJson(
       this,
     );
   }
@@ -481,11 +476,10 @@ abstract class _Register extends Register {
       final String? captchaUuid,
       final String? captchaAnswer,
       final String? honeypot,
-      final String? answer}) = _$RegisterImpl;
+      final String? answer}) = _$_Register;
   const _Register._() : super._();
 
-  factory _Register.fromJson(Map<String, dynamic> json) =
-      _$RegisterImpl.fromJson;
+  factory _Register.fromJson(Map<String, dynamic> json) = _$_Register.fromJson;
 
   @override
   String get username;
@@ -507,7 +501,7 @@ abstract class _Register extends Register {
   String? get answer;
   @override
   @JsonKey(ignore: true)
-  _$$RegisterImplCopyWith<_$RegisterImpl> get copyWith =>
+  _$$_RegisterCopyWith<_$_Register> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -539,29 +533,29 @@ class _$GetCaptchaCopyWithImpl<$Res, $Val extends GetCaptcha>
 }
 
 /// @nodoc
-abstract class _$$GetCaptchaImplCopyWith<$Res> {
-  factory _$$GetCaptchaImplCopyWith(
-          _$GetCaptchaImpl value, $Res Function(_$GetCaptchaImpl) then) =
-      __$$GetCaptchaImplCopyWithImpl<$Res>;
+abstract class _$$_GetCaptchaCopyWith<$Res> {
+  factory _$$_GetCaptchaCopyWith(
+          _$_GetCaptcha value, $Res Function(_$_GetCaptcha) then) =
+      __$$_GetCaptchaCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$GetCaptchaImplCopyWithImpl<$Res>
-    extends _$GetCaptchaCopyWithImpl<$Res, _$GetCaptchaImpl>
-    implements _$$GetCaptchaImplCopyWith<$Res> {
-  __$$GetCaptchaImplCopyWithImpl(
-      _$GetCaptchaImpl _value, $Res Function(_$GetCaptchaImpl) _then)
+class __$$_GetCaptchaCopyWithImpl<$Res>
+    extends _$GetCaptchaCopyWithImpl<$Res, _$_GetCaptcha>
+    implements _$$_GetCaptchaCopyWith<$Res> {
+  __$$_GetCaptchaCopyWithImpl(
+      _$_GetCaptcha _value, $Res Function(_$_GetCaptcha) _then)
       : super(_value, _then);
 }
 
 /// @nodoc
 
 @apiSerde
-class _$GetCaptchaImpl extends _GetCaptcha {
-  const _$GetCaptchaImpl() : super._();
+class _$_GetCaptcha extends _GetCaptcha {
+  const _$_GetCaptcha() : super._();
 
-  factory _$GetCaptchaImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetCaptchaImplFromJson(json);
+  factory _$_GetCaptcha.fromJson(Map<String, dynamic> json) =>
+      _$$_GetCaptchaFromJson(json);
 
   @override
   String toString() {
@@ -571,7 +565,7 @@ class _$GetCaptchaImpl extends _GetCaptcha {
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$GetCaptchaImpl);
+        (other.runtimeType == runtimeType && other is _$_GetCaptcha);
   }
 
   @JsonKey(ignore: true)
@@ -580,18 +574,18 @@ class _$GetCaptchaImpl extends _GetCaptcha {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetCaptchaImplToJson(
+    return _$$_GetCaptchaToJson(
       this,
     );
   }
 }
 
 abstract class _GetCaptcha extends GetCaptcha {
-  const factory _GetCaptcha() = _$GetCaptchaImpl;
+  const factory _GetCaptcha() = _$_GetCaptcha;
   const _GetCaptcha._() : super._();
 
   factory _GetCaptcha.fromJson(Map<String, dynamic> json) =
-      _$GetCaptchaImpl.fromJson;
+      _$_GetCaptcha.fromJson;
 }
 
 SaveUserSettings _$SaveUserSettingsFromJson(Map<String, dynamic> json) {
@@ -776,11 +770,11 @@ class _$SaveUserSettingsCopyWithImpl<$Res, $Val extends SaveUserSettings>
 }
 
 /// @nodoc
-abstract class _$$SaveUserSettingsImplCopyWith<$Res>
+abstract class _$$_SaveUserSettingsCopyWith<$Res>
     implements $SaveUserSettingsCopyWith<$Res> {
-  factory _$$SaveUserSettingsImplCopyWith(_$SaveUserSettingsImpl value,
-          $Res Function(_$SaveUserSettingsImpl) then) =
-      __$$SaveUserSettingsImplCopyWithImpl<$Res>;
+  factory _$$_SaveUserSettingsCopyWith(
+          _$_SaveUserSettings value, $Res Function(_$_SaveUserSettings) then) =
+      __$$_SaveUserSettingsCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -807,11 +801,11 @@ abstract class _$$SaveUserSettingsImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$SaveUserSettingsImplCopyWithImpl<$Res>
-    extends _$SaveUserSettingsCopyWithImpl<$Res, _$SaveUserSettingsImpl>
-    implements _$$SaveUserSettingsImplCopyWith<$Res> {
-  __$$SaveUserSettingsImplCopyWithImpl(_$SaveUserSettingsImpl _value,
-      $Res Function(_$SaveUserSettingsImpl) _then)
+class __$$_SaveUserSettingsCopyWithImpl<$Res>
+    extends _$SaveUserSettingsCopyWithImpl<$Res, _$_SaveUserSettings>
+    implements _$$_SaveUserSettingsCopyWith<$Res> {
+  __$$_SaveUserSettingsCopyWithImpl(
+      _$_SaveUserSettings _value, $Res Function(_$_SaveUserSettings) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -838,7 +832,7 @@ class __$$SaveUserSettingsImplCopyWithImpl<$Res>
     Object? discussionLanguages = freezed,
     Object? auth = null,
   }) {
-    return _then(_$SaveUserSettingsImpl(
+    return _then(_$_SaveUserSettings(
       showNsfw: freezed == showNsfw
           ? _value.showNsfw
           : showNsfw // ignore: cast_nullable_to_non_nullable
@@ -926,8 +920,8 @@ class __$$SaveUserSettingsImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$SaveUserSettingsImpl extends _SaveUserSettings {
-  const _$SaveUserSettingsImpl(
+class _$_SaveUserSettings extends _SaveUserSettings {
+  const _$_SaveUserSettings(
       {this.showNsfw,
       this.theme,
       this.defaultSortType,
@@ -951,8 +945,8 @@ class _$SaveUserSettingsImpl extends _SaveUserSettings {
       : _discussionLanguages = discussionLanguages,
         super._();
 
-  factory _$SaveUserSettingsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SaveUserSettingsImplFromJson(json);
+  factory _$_SaveUserSettings.fromJson(Map<String, dynamic> json) =>
+      _$$_SaveUserSettingsFromJson(json);
 
   @override
   final bool? showNsfw;
@@ -1013,7 +1007,7 @@ class _$SaveUserSettingsImpl extends _SaveUserSettings {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SaveUserSettingsImpl &&
+            other is _$_SaveUserSettings &&
             (identical(other.showNsfw, showNsfw) ||
                 other.showNsfw == showNsfw) &&
             (identical(other.theme, theme) || other.theme == theme) &&
@@ -1080,13 +1074,12 @@ class _$SaveUserSettingsImpl extends _SaveUserSettings {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SaveUserSettingsImplCopyWith<_$SaveUserSettingsImpl> get copyWith =>
-      __$$SaveUserSettingsImplCopyWithImpl<_$SaveUserSettingsImpl>(
-          this, _$identity);
+  _$$_SaveUserSettingsCopyWith<_$_SaveUserSettings> get copyWith =>
+      __$$_SaveUserSettingsCopyWithImpl<_$_SaveUserSettings>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$SaveUserSettingsImplToJson(
+    return _$$_SaveUserSettingsToJson(
       this,
     );
   }
@@ -1113,11 +1106,11 @@ abstract class _SaveUserSettings extends SaveUserSettings {
       final bool? showBotAccounts,
       final bool? showNewPostNotifs,
       final List<int>? discussionLanguages,
-      required final String auth}) = _$SaveUserSettingsImpl;
+      required final String auth}) = _$_SaveUserSettings;
   const _SaveUserSettings._() : super._();
 
   factory _SaveUserSettings.fromJson(Map<String, dynamic> json) =
-      _$SaveUserSettingsImpl.fromJson;
+      _$_SaveUserSettings.fromJson;
 
   @override
   bool? get showNsfw;
@@ -1161,7 +1154,7 @@ abstract class _SaveUserSettings extends SaveUserSettings {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$SaveUserSettingsImplCopyWith<_$SaveUserSettingsImpl> get copyWith =>
+  _$$_SaveUserSettingsCopyWith<_$_SaveUserSettings> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1235,11 +1228,11 @@ class _$ChangePasswordCopyWithImpl<$Res, $Val extends ChangePassword>
 }
 
 /// @nodoc
-abstract class _$$ChangePasswordImplCopyWith<$Res>
+abstract class _$$_ChangePasswordCopyWith<$Res>
     implements $ChangePasswordCopyWith<$Res> {
-  factory _$$ChangePasswordImplCopyWith(_$ChangePasswordImpl value,
-          $Res Function(_$ChangePasswordImpl) then) =
-      __$$ChangePasswordImplCopyWithImpl<$Res>;
+  factory _$$_ChangePasswordCopyWith(
+          _$_ChangePassword value, $Res Function(_$_ChangePassword) then) =
+      __$$_ChangePasswordCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1250,11 +1243,11 @@ abstract class _$$ChangePasswordImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ChangePasswordImplCopyWithImpl<$Res>
-    extends _$ChangePasswordCopyWithImpl<$Res, _$ChangePasswordImpl>
-    implements _$$ChangePasswordImplCopyWith<$Res> {
-  __$$ChangePasswordImplCopyWithImpl(
-      _$ChangePasswordImpl _value, $Res Function(_$ChangePasswordImpl) _then)
+class __$$_ChangePasswordCopyWithImpl<$Res>
+    extends _$ChangePasswordCopyWithImpl<$Res, _$_ChangePassword>
+    implements _$$_ChangePasswordCopyWith<$Res> {
+  __$$_ChangePasswordCopyWithImpl(
+      _$_ChangePassword _value, $Res Function(_$_ChangePassword) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1265,7 +1258,7 @@ class __$$ChangePasswordImplCopyWithImpl<$Res>
     Object? oldPassword = null,
     Object? auth = null,
   }) {
-    return _then(_$ChangePasswordImpl(
+    return _then(_$_ChangePassword(
       newPassword: null == newPassword
           ? _value.newPassword
           : newPassword // ignore: cast_nullable_to_non_nullable
@@ -1289,16 +1282,16 @@ class __$$ChangePasswordImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$ChangePasswordImpl extends _ChangePassword {
-  const _$ChangePasswordImpl(
+class _$_ChangePassword extends _ChangePassword {
+  const _$_ChangePassword(
       {required this.newPassword,
       required this.newPasswordVerify,
       required this.oldPassword,
       required this.auth})
       : super._();
 
-  factory _$ChangePasswordImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ChangePasswordImplFromJson(json);
+  factory _$_ChangePassword.fromJson(Map<String, dynamic> json) =>
+      _$$_ChangePasswordFromJson(json);
 
   @override
   final String newPassword;
@@ -1318,7 +1311,7 @@ class _$ChangePasswordImpl extends _ChangePassword {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ChangePasswordImpl &&
+            other is _$_ChangePassword &&
             (identical(other.newPassword, newPassword) ||
                 other.newPassword == newPassword) &&
             (identical(other.newPasswordVerify, newPasswordVerify) ||
@@ -1336,13 +1329,12 @@ class _$ChangePasswordImpl extends _ChangePassword {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ChangePasswordImplCopyWith<_$ChangePasswordImpl> get copyWith =>
-      __$$ChangePasswordImplCopyWithImpl<_$ChangePasswordImpl>(
-          this, _$identity);
+  _$$_ChangePasswordCopyWith<_$_ChangePassword> get copyWith =>
+      __$$_ChangePasswordCopyWithImpl<_$_ChangePassword>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ChangePasswordImplToJson(
+    return _$$_ChangePasswordToJson(
       this,
     );
   }
@@ -1353,11 +1345,11 @@ abstract class _ChangePassword extends ChangePassword {
       {required final String newPassword,
       required final String newPasswordVerify,
       required final String oldPassword,
-      required final String auth}) = _$ChangePasswordImpl;
+      required final String auth}) = _$_ChangePassword;
   const _ChangePassword._() : super._();
 
   factory _ChangePassword.fromJson(Map<String, dynamic> json) =
-      _$ChangePasswordImpl.fromJson;
+      _$_ChangePassword.fromJson;
 
   @override
   String get newPassword;
@@ -1369,7 +1361,7 @@ abstract class _ChangePassword extends ChangePassword {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$ChangePasswordImplCopyWith<_$ChangePasswordImpl> get copyWith =>
+  _$$_ChangePasswordCopyWith<_$_ChangePassword> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1471,11 +1463,11 @@ class _$GetPersonDetailsCopyWithImpl<$Res, $Val extends GetPersonDetails>
 }
 
 /// @nodoc
-abstract class _$$GetPersonDetailsImplCopyWith<$Res>
+abstract class _$$_GetPersonDetailsCopyWith<$Res>
     implements $GetPersonDetailsCopyWith<$Res> {
-  factory _$$GetPersonDetailsImplCopyWith(_$GetPersonDetailsImpl value,
-          $Res Function(_$GetPersonDetailsImpl) then) =
-      __$$GetPersonDetailsImplCopyWithImpl<$Res>;
+  factory _$$_GetPersonDetailsCopyWith(
+          _$_GetPersonDetails value, $Res Function(_$_GetPersonDetails) then) =
+      __$$_GetPersonDetailsCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1490,11 +1482,11 @@ abstract class _$$GetPersonDetailsImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$GetPersonDetailsImplCopyWithImpl<$Res>
-    extends _$GetPersonDetailsCopyWithImpl<$Res, _$GetPersonDetailsImpl>
-    implements _$$GetPersonDetailsImplCopyWith<$Res> {
-  __$$GetPersonDetailsImplCopyWithImpl(_$GetPersonDetailsImpl _value,
-      $Res Function(_$GetPersonDetailsImpl) _then)
+class __$$_GetPersonDetailsCopyWithImpl<$Res>
+    extends _$GetPersonDetailsCopyWithImpl<$Res, _$_GetPersonDetails>
+    implements _$$_GetPersonDetailsCopyWith<$Res> {
+  __$$_GetPersonDetailsCopyWithImpl(
+      _$_GetPersonDetails _value, $Res Function(_$_GetPersonDetails) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1509,7 +1501,7 @@ class __$$GetPersonDetailsImplCopyWithImpl<$Res>
     Object? savedOnly = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$GetPersonDetailsImpl(
+    return _then(_$_GetPersonDetails(
       personId: freezed == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -1549,8 +1541,8 @@ class __$$GetPersonDetailsImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetPersonDetailsImpl extends _GetPersonDetails {
-  const _$GetPersonDetailsImpl(
+class _$_GetPersonDetails extends _GetPersonDetails {
+  const _$_GetPersonDetails(
       {this.personId,
       this.username,
       this.sort,
@@ -1561,8 +1553,8 @@ class _$GetPersonDetailsImpl extends _GetPersonDetails {
       this.auth})
       : super._();
 
-  factory _$GetPersonDetailsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetPersonDetailsImplFromJson(json);
+  factory _$_GetPersonDetails.fromJson(Map<String, dynamic> json) =>
+      _$$_GetPersonDetailsFromJson(json);
 
   @override
   final int? personId;
@@ -1590,7 +1582,7 @@ class _$GetPersonDetailsImpl extends _GetPersonDetails {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetPersonDetailsImpl &&
+            other is _$_GetPersonDetails &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.username, username) ||
@@ -1613,13 +1605,12 @@ class _$GetPersonDetailsImpl extends _GetPersonDetails {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetPersonDetailsImplCopyWith<_$GetPersonDetailsImpl> get copyWith =>
-      __$$GetPersonDetailsImplCopyWithImpl<_$GetPersonDetailsImpl>(
-          this, _$identity);
+  _$$_GetPersonDetailsCopyWith<_$_GetPersonDetails> get copyWith =>
+      __$$_GetPersonDetailsCopyWithImpl<_$_GetPersonDetails>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetPersonDetailsImplToJson(
+    return _$$_GetPersonDetailsToJson(
       this,
     );
   }
@@ -1634,11 +1625,11 @@ abstract class _GetPersonDetails extends GetPersonDetails {
       final int? limit,
       final int? communityId,
       final bool? savedOnly,
-      final String? auth}) = _$GetPersonDetailsImpl;
+      final String? auth}) = _$_GetPersonDetails;
   const _GetPersonDetails._() : super._();
 
   factory _GetPersonDetails.fromJson(Map<String, dynamic> json) =
-      _$GetPersonDetailsImpl.fromJson;
+      _$_GetPersonDetails.fromJson;
 
   @override
   int? get personId;
@@ -1658,7 +1649,7 @@ abstract class _GetPersonDetails extends GetPersonDetails {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetPersonDetailsImplCopyWith<_$GetPersonDetailsImpl> get copyWith =>
+  _$$_GetPersonDetailsCopyWith<_$_GetPersonDetails> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1710,22 +1701,22 @@ class _$MarkAllAsReadCopyWithImpl<$Res, $Val extends MarkAllAsRead>
 }
 
 /// @nodoc
-abstract class _$$MarkAllAsReadImplCopyWith<$Res>
+abstract class _$$_MarkAllAsReadCopyWith<$Res>
     implements $MarkAllAsReadCopyWith<$Res> {
-  factory _$$MarkAllAsReadImplCopyWith(
-          _$MarkAllAsReadImpl value, $Res Function(_$MarkAllAsReadImpl) then) =
-      __$$MarkAllAsReadImplCopyWithImpl<$Res>;
+  factory _$$_MarkAllAsReadCopyWith(
+          _$_MarkAllAsRead value, $Res Function(_$_MarkAllAsRead) then) =
+      __$$_MarkAllAsReadCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String auth});
 }
 
 /// @nodoc
-class __$$MarkAllAsReadImplCopyWithImpl<$Res>
-    extends _$MarkAllAsReadCopyWithImpl<$Res, _$MarkAllAsReadImpl>
-    implements _$$MarkAllAsReadImplCopyWith<$Res> {
-  __$$MarkAllAsReadImplCopyWithImpl(
-      _$MarkAllAsReadImpl _value, $Res Function(_$MarkAllAsReadImpl) _then)
+class __$$_MarkAllAsReadCopyWithImpl<$Res>
+    extends _$MarkAllAsReadCopyWithImpl<$Res, _$_MarkAllAsRead>
+    implements _$$_MarkAllAsReadCopyWith<$Res> {
+  __$$_MarkAllAsReadCopyWithImpl(
+      _$_MarkAllAsRead _value, $Res Function(_$_MarkAllAsRead) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1733,7 +1724,7 @@ class __$$MarkAllAsReadImplCopyWithImpl<$Res>
   $Res call({
     Object? auth = null,
   }) {
-    return _then(_$MarkAllAsReadImpl(
+    return _then(_$_MarkAllAsRead(
       auth: null == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -1745,11 +1736,11 @@ class __$$MarkAllAsReadImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$MarkAllAsReadImpl extends _MarkAllAsRead {
-  const _$MarkAllAsReadImpl({required this.auth}) : super._();
+class _$_MarkAllAsRead extends _MarkAllAsRead {
+  const _$_MarkAllAsRead({required this.auth}) : super._();
 
-  factory _$MarkAllAsReadImpl.fromJson(Map<String, dynamic> json) =>
-      _$$MarkAllAsReadImplFromJson(json);
+  factory _$_MarkAllAsRead.fromJson(Map<String, dynamic> json) =>
+      _$$_MarkAllAsReadFromJson(json);
 
   @override
   final String auth;
@@ -1763,7 +1754,7 @@ class _$MarkAllAsReadImpl extends _MarkAllAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$MarkAllAsReadImpl &&
+            other is _$_MarkAllAsRead &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -1774,30 +1765,29 @@ class _$MarkAllAsReadImpl extends _MarkAllAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$MarkAllAsReadImplCopyWith<_$MarkAllAsReadImpl> get copyWith =>
-      __$$MarkAllAsReadImplCopyWithImpl<_$MarkAllAsReadImpl>(this, _$identity);
+  _$$_MarkAllAsReadCopyWith<_$_MarkAllAsRead> get copyWith =>
+      __$$_MarkAllAsReadCopyWithImpl<_$_MarkAllAsRead>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$MarkAllAsReadImplToJson(
+    return _$$_MarkAllAsReadToJson(
       this,
     );
   }
 }
 
 abstract class _MarkAllAsRead extends MarkAllAsRead {
-  const factory _MarkAllAsRead({required final String auth}) =
-      _$MarkAllAsReadImpl;
+  const factory _MarkAllAsRead({required final String auth}) = _$_MarkAllAsRead;
   const _MarkAllAsRead._() : super._();
 
   factory _MarkAllAsRead.fromJson(Map<String, dynamic> json) =
-      _$MarkAllAsReadImpl.fromJson;
+      _$_MarkAllAsRead.fromJson;
 
   @override
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$MarkAllAsReadImplCopyWith<_$MarkAllAsReadImpl> get copyWith =>
+  _$$_MarkAllAsReadCopyWith<_$_MarkAllAsRead> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1860,22 +1850,21 @@ class _$AddAdminCopyWithImpl<$Res, $Val extends AddAdmin>
 }
 
 /// @nodoc
-abstract class _$$AddAdminImplCopyWith<$Res>
-    implements $AddAdminCopyWith<$Res> {
-  factory _$$AddAdminImplCopyWith(
-          _$AddAdminImpl value, $Res Function(_$AddAdminImpl) then) =
-      __$$AddAdminImplCopyWithImpl<$Res>;
+abstract class _$$_AddAdminCopyWith<$Res> implements $AddAdminCopyWith<$Res> {
+  factory _$$_AddAdminCopyWith(
+          _$_AddAdmin value, $Res Function(_$_AddAdmin) then) =
+      __$$_AddAdminCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int personId, bool added, String auth});
 }
 
 /// @nodoc
-class __$$AddAdminImplCopyWithImpl<$Res>
-    extends _$AddAdminCopyWithImpl<$Res, _$AddAdminImpl>
-    implements _$$AddAdminImplCopyWith<$Res> {
-  __$$AddAdminImplCopyWithImpl(
-      _$AddAdminImpl _value, $Res Function(_$AddAdminImpl) _then)
+class __$$_AddAdminCopyWithImpl<$Res>
+    extends _$AddAdminCopyWithImpl<$Res, _$_AddAdmin>
+    implements _$$_AddAdminCopyWith<$Res> {
+  __$$_AddAdminCopyWithImpl(
+      _$_AddAdmin _value, $Res Function(_$_AddAdmin) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1885,7 +1874,7 @@ class __$$AddAdminImplCopyWithImpl<$Res>
     Object? added = null,
     Object? auth = null,
   }) {
-    return _then(_$AddAdminImpl(
+    return _then(_$_AddAdmin(
       personId: null == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -1905,13 +1894,13 @@ class __$$AddAdminImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$AddAdminImpl extends _AddAdmin {
-  const _$AddAdminImpl(
+class _$_AddAdmin extends _AddAdmin {
+  const _$_AddAdmin(
       {required this.personId, required this.added, required this.auth})
       : super._();
 
-  factory _$AddAdminImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AddAdminImplFromJson(json);
+  factory _$_AddAdmin.fromJson(Map<String, dynamic> json) =>
+      _$$_AddAdminFromJson(json);
 
   @override
   final int personId;
@@ -1929,7 +1918,7 @@ class _$AddAdminImpl extends _AddAdmin {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AddAdminImpl &&
+            other is _$_AddAdmin &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.added, added) || other.added == added) &&
@@ -1943,12 +1932,12 @@ class _$AddAdminImpl extends _AddAdmin {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$AddAdminImplCopyWith<_$AddAdminImpl> get copyWith =>
-      __$$AddAdminImplCopyWithImpl<_$AddAdminImpl>(this, _$identity);
+  _$$_AddAdminCopyWith<_$_AddAdmin> get copyWith =>
+      __$$_AddAdminCopyWithImpl<_$_AddAdmin>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$AddAdminImplToJson(
+    return _$$_AddAdminToJson(
       this,
     );
   }
@@ -1958,11 +1947,10 @@ abstract class _AddAdmin extends AddAdmin {
   const factory _AddAdmin(
       {required final int personId,
       required final bool added,
-      required final String auth}) = _$AddAdminImpl;
+      required final String auth}) = _$_AddAdmin;
   const _AddAdmin._() : super._();
 
-  factory _AddAdmin.fromJson(Map<String, dynamic> json) =
-      _$AddAdminImpl.fromJson;
+  factory _AddAdmin.fromJson(Map<String, dynamic> json) = _$_AddAdmin.fromJson;
 
   @override
   int get personId;
@@ -1972,7 +1960,7 @@ abstract class _AddAdmin extends AddAdmin {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$AddAdminImplCopyWith<_$AddAdminImpl> get copyWith =>
+  _$$_AddAdminCopyWith<_$_AddAdmin> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2059,11 +2047,10 @@ class _$BanPersonCopyWithImpl<$Res, $Val extends BanPerson>
 }
 
 /// @nodoc
-abstract class _$$BanPersonImplCopyWith<$Res>
-    implements $BanPersonCopyWith<$Res> {
-  factory _$$BanPersonImplCopyWith(
-          _$BanPersonImpl value, $Res Function(_$BanPersonImpl) then) =
-      __$$BanPersonImplCopyWithImpl<$Res>;
+abstract class _$$_BanPersonCopyWith<$Res> implements $BanPersonCopyWith<$Res> {
+  factory _$$_BanPersonCopyWith(
+          _$_BanPerson value, $Res Function(_$_BanPerson) then) =
+      __$$_BanPersonCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2076,11 +2063,11 @@ abstract class _$$BanPersonImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$BanPersonImplCopyWithImpl<$Res>
-    extends _$BanPersonCopyWithImpl<$Res, _$BanPersonImpl>
-    implements _$$BanPersonImplCopyWith<$Res> {
-  __$$BanPersonImplCopyWithImpl(
-      _$BanPersonImpl _value, $Res Function(_$BanPersonImpl) _then)
+class __$$_BanPersonCopyWithImpl<$Res>
+    extends _$BanPersonCopyWithImpl<$Res, _$_BanPerson>
+    implements _$$_BanPersonCopyWith<$Res> {
+  __$$_BanPersonCopyWithImpl(
+      _$_BanPerson _value, $Res Function(_$_BanPerson) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2093,7 +2080,7 @@ class __$$BanPersonImplCopyWithImpl<$Res>
     Object? expires = freezed,
     Object? auth = null,
   }) {
-    return _then(_$BanPersonImpl(
+    return _then(_$_BanPerson(
       personId: null == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -2125,8 +2112,8 @@ class __$$BanPersonImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$BanPersonImpl extends _BanPerson {
-  const _$BanPersonImpl(
+class _$_BanPerson extends _BanPerson {
+  const _$_BanPerson(
       {required this.personId,
       required this.ban,
       this.removeData,
@@ -2135,8 +2122,8 @@ class _$BanPersonImpl extends _BanPerson {
       required this.auth})
       : super._();
 
-  factory _$BanPersonImpl.fromJson(Map<String, dynamic> json) =>
-      _$$BanPersonImplFromJson(json);
+  factory _$_BanPerson.fromJson(Map<String, dynamic> json) =>
+      _$$_BanPersonFromJson(json);
 
   @override
   final int personId;
@@ -2160,7 +2147,7 @@ class _$BanPersonImpl extends _BanPerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$BanPersonImpl &&
+            other is _$_BanPerson &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.ban, ban) || other.ban == ban) &&
@@ -2179,12 +2166,12 @@ class _$BanPersonImpl extends _BanPerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$BanPersonImplCopyWith<_$BanPersonImpl> get copyWith =>
-      __$$BanPersonImplCopyWithImpl<_$BanPersonImpl>(this, _$identity);
+  _$$_BanPersonCopyWith<_$_BanPerson> get copyWith =>
+      __$$_BanPersonCopyWithImpl<_$_BanPerson>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$BanPersonImplToJson(
+    return _$$_BanPersonToJson(
       this,
     );
   }
@@ -2197,11 +2184,11 @@ abstract class _BanPerson extends BanPerson {
       final bool? removeData,
       final String? reason,
       final int? expires,
-      required final String auth}) = _$BanPersonImpl;
+      required final String auth}) = _$_BanPerson;
   const _BanPerson._() : super._();
 
   factory _BanPerson.fromJson(Map<String, dynamic> json) =
-      _$BanPersonImpl.fromJson;
+      _$_BanPerson.fromJson;
 
   @override
   int get personId;
@@ -2217,7 +2204,7 @@ abstract class _BanPerson extends BanPerson {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$BanPersonImplCopyWith<_$BanPersonImpl> get copyWith =>
+  _$$_BanPersonCopyWith<_$_BanPerson> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2294,11 +2281,11 @@ class _$GetRepliesCopyWithImpl<$Res, $Val extends GetReplies>
 }
 
 /// @nodoc
-abstract class _$$GetRepliesImplCopyWith<$Res>
+abstract class _$$_GetRepliesCopyWith<$Res>
     implements $GetRepliesCopyWith<$Res> {
-  factory _$$GetRepliesImplCopyWith(
-          _$GetRepliesImpl value, $Res Function(_$GetRepliesImpl) then) =
-      __$$GetRepliesImplCopyWithImpl<$Res>;
+  factory _$$_GetRepliesCopyWith(
+          _$_GetReplies value, $Res Function(_$_GetReplies) then) =
+      __$$_GetRepliesCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2306,11 +2293,11 @@ abstract class _$$GetRepliesImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$GetRepliesImplCopyWithImpl<$Res>
-    extends _$GetRepliesCopyWithImpl<$Res, _$GetRepliesImpl>
-    implements _$$GetRepliesImplCopyWith<$Res> {
-  __$$GetRepliesImplCopyWithImpl(
-      _$GetRepliesImpl _value, $Res Function(_$GetRepliesImpl) _then)
+class __$$_GetRepliesCopyWithImpl<$Res>
+    extends _$GetRepliesCopyWithImpl<$Res, _$_GetReplies>
+    implements _$$_GetRepliesCopyWith<$Res> {
+  __$$_GetRepliesCopyWithImpl(
+      _$_GetReplies _value, $Res Function(_$_GetReplies) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2322,7 +2309,7 @@ class __$$GetRepliesImplCopyWithImpl<$Res>
     Object? unreadOnly = freezed,
     Object? auth = null,
   }) {
-    return _then(_$GetRepliesImpl(
+    return _then(_$_GetReplies(
       sort: freezed == sort
           ? _value.sort
           : sort // ignore: cast_nullable_to_non_nullable
@@ -2350,13 +2337,13 @@ class __$$GetRepliesImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetRepliesImpl extends _GetReplies {
-  const _$GetRepliesImpl(
+class _$_GetReplies extends _GetReplies {
+  const _$_GetReplies(
       {this.sort, this.page, this.limit, this.unreadOnly, required this.auth})
       : super._();
 
-  factory _$GetRepliesImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetRepliesImplFromJson(json);
+  factory _$_GetReplies.fromJson(Map<String, dynamic> json) =>
+      _$$_GetRepliesFromJson(json);
 
   @override
   final SortType? sort;
@@ -2378,7 +2365,7 @@ class _$GetRepliesImpl extends _GetReplies {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetRepliesImpl &&
+            other is _$_GetReplies &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
@@ -2395,12 +2382,12 @@ class _$GetRepliesImpl extends _GetReplies {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetRepliesImplCopyWith<_$GetRepliesImpl> get copyWith =>
-      __$$GetRepliesImplCopyWithImpl<_$GetRepliesImpl>(this, _$identity);
+  _$$_GetRepliesCopyWith<_$_GetReplies> get copyWith =>
+      __$$_GetRepliesCopyWithImpl<_$_GetReplies>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetRepliesImplToJson(
+    return _$$_GetRepliesToJson(
       this,
     );
   }
@@ -2412,11 +2399,11 @@ abstract class _GetReplies extends GetReplies {
       final int? page,
       final int? limit,
       final bool? unreadOnly,
-      required final String auth}) = _$GetRepliesImpl;
+      required final String auth}) = _$_GetReplies;
   const _GetReplies._() : super._();
 
   factory _GetReplies.fromJson(Map<String, dynamic> json) =
-      _$GetRepliesImpl.fromJson;
+      _$_GetReplies.fromJson;
 
   @override
   SortType? get sort;
@@ -2430,7 +2417,7 @@ abstract class _GetReplies extends GetReplies {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetRepliesImplCopyWith<_$GetRepliesImpl> get copyWith =>
+  _$$_GetRepliesCopyWith<_$_GetReplies> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2507,11 +2494,11 @@ class _$GetPersonMentionsCopyWithImpl<$Res, $Val extends GetPersonMentions>
 }
 
 /// @nodoc
-abstract class _$$GetPersonMentionsImplCopyWith<$Res>
+abstract class _$$_GetPersonMentionsCopyWith<$Res>
     implements $GetPersonMentionsCopyWith<$Res> {
-  factory _$$GetPersonMentionsImplCopyWith(_$GetPersonMentionsImpl value,
-          $Res Function(_$GetPersonMentionsImpl) then) =
-      __$$GetPersonMentionsImplCopyWithImpl<$Res>;
+  factory _$$_GetPersonMentionsCopyWith(_$_GetPersonMentions value,
+          $Res Function(_$_GetPersonMentions) then) =
+      __$$_GetPersonMentionsCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2519,11 +2506,11 @@ abstract class _$$GetPersonMentionsImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$GetPersonMentionsImplCopyWithImpl<$Res>
-    extends _$GetPersonMentionsCopyWithImpl<$Res, _$GetPersonMentionsImpl>
-    implements _$$GetPersonMentionsImplCopyWith<$Res> {
-  __$$GetPersonMentionsImplCopyWithImpl(_$GetPersonMentionsImpl _value,
-      $Res Function(_$GetPersonMentionsImpl) _then)
+class __$$_GetPersonMentionsCopyWithImpl<$Res>
+    extends _$GetPersonMentionsCopyWithImpl<$Res, _$_GetPersonMentions>
+    implements _$$_GetPersonMentionsCopyWith<$Res> {
+  __$$_GetPersonMentionsCopyWithImpl(
+      _$_GetPersonMentions _value, $Res Function(_$_GetPersonMentions) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2535,7 +2522,7 @@ class __$$GetPersonMentionsImplCopyWithImpl<$Res>
     Object? unreadOnly = freezed,
     Object? auth = null,
   }) {
-    return _then(_$GetPersonMentionsImpl(
+    return _then(_$_GetPersonMentions(
       sort: freezed == sort
           ? _value.sort
           : sort // ignore: cast_nullable_to_non_nullable
@@ -2563,13 +2550,13 @@ class __$$GetPersonMentionsImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetPersonMentionsImpl extends _GetPersonMentions {
-  const _$GetPersonMentionsImpl(
+class _$_GetPersonMentions extends _GetPersonMentions {
+  const _$_GetPersonMentions(
       {this.sort, this.page, this.limit, this.unreadOnly, required this.auth})
       : super._();
 
-  factory _$GetPersonMentionsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetPersonMentionsImplFromJson(json);
+  factory _$_GetPersonMentions.fromJson(Map<String, dynamic> json) =>
+      _$$_GetPersonMentionsFromJson(json);
 
   @override
   final SortType? sort;
@@ -2591,7 +2578,7 @@ class _$GetPersonMentionsImpl extends _GetPersonMentions {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetPersonMentionsImpl &&
+            other is _$_GetPersonMentions &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
@@ -2608,13 +2595,13 @@ class _$GetPersonMentionsImpl extends _GetPersonMentions {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetPersonMentionsImplCopyWith<_$GetPersonMentionsImpl> get copyWith =>
-      __$$GetPersonMentionsImplCopyWithImpl<_$GetPersonMentionsImpl>(
+  _$$_GetPersonMentionsCopyWith<_$_GetPersonMentions> get copyWith =>
+      __$$_GetPersonMentionsCopyWithImpl<_$_GetPersonMentions>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetPersonMentionsImplToJson(
+    return _$$_GetPersonMentionsToJson(
       this,
     );
   }
@@ -2626,11 +2613,11 @@ abstract class _GetPersonMentions extends GetPersonMentions {
       final int? page,
       final int? limit,
       final bool? unreadOnly,
-      required final String auth}) = _$GetPersonMentionsImpl;
+      required final String auth}) = _$_GetPersonMentions;
   const _GetPersonMentions._() : super._();
 
   factory _GetPersonMentions.fromJson(Map<String, dynamic> json) =
-      _$GetPersonMentionsImpl.fromJson;
+      _$_GetPersonMentions.fromJson;
 
   @override
   SortType? get sort;
@@ -2644,7 +2631,7 @@ abstract class _GetPersonMentions extends GetPersonMentions {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetPersonMentionsImplCopyWith<_$GetPersonMentionsImpl> get copyWith =>
+  _$$_GetPersonMentionsCopyWith<_$_GetPersonMentions> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2710,25 +2697,23 @@ class _$MarkPersonMentionAsReadCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$MarkPersonMentionAsReadImplCopyWith<$Res>
+abstract class _$$_MarkPersonMentionAsReadCopyWith<$Res>
     implements $MarkPersonMentionAsReadCopyWith<$Res> {
-  factory _$$MarkPersonMentionAsReadImplCopyWith(
-          _$MarkPersonMentionAsReadImpl value,
-          $Res Function(_$MarkPersonMentionAsReadImpl) then) =
-      __$$MarkPersonMentionAsReadImplCopyWithImpl<$Res>;
+  factory _$$_MarkPersonMentionAsReadCopyWith(_$_MarkPersonMentionAsRead value,
+          $Res Function(_$_MarkPersonMentionAsRead) then) =
+      __$$_MarkPersonMentionAsReadCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int personMentionId, bool read, String auth});
 }
 
 /// @nodoc
-class __$$MarkPersonMentionAsReadImplCopyWithImpl<$Res>
+class __$$_MarkPersonMentionAsReadCopyWithImpl<$Res>
     extends _$MarkPersonMentionAsReadCopyWithImpl<$Res,
-        _$MarkPersonMentionAsReadImpl>
-    implements _$$MarkPersonMentionAsReadImplCopyWith<$Res> {
-  __$$MarkPersonMentionAsReadImplCopyWithImpl(
-      _$MarkPersonMentionAsReadImpl _value,
-      $Res Function(_$MarkPersonMentionAsReadImpl) _then)
+        _$_MarkPersonMentionAsRead>
+    implements _$$_MarkPersonMentionAsReadCopyWith<$Res> {
+  __$$_MarkPersonMentionAsReadCopyWithImpl(_$_MarkPersonMentionAsRead _value,
+      $Res Function(_$_MarkPersonMentionAsRead) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2738,7 +2723,7 @@ class __$$MarkPersonMentionAsReadImplCopyWithImpl<$Res>
     Object? read = null,
     Object? auth = null,
   }) {
-    return _then(_$MarkPersonMentionAsReadImpl(
+    return _then(_$_MarkPersonMentionAsRead(
       personMentionId: null == personMentionId
           ? _value.personMentionId
           : personMentionId // ignore: cast_nullable_to_non_nullable
@@ -2758,13 +2743,13 @@ class __$$MarkPersonMentionAsReadImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$MarkPersonMentionAsReadImpl extends _MarkPersonMentionAsRead {
-  const _$MarkPersonMentionAsReadImpl(
+class _$_MarkPersonMentionAsRead extends _MarkPersonMentionAsRead {
+  const _$_MarkPersonMentionAsRead(
       {required this.personMentionId, required this.read, required this.auth})
       : super._();
 
-  factory _$MarkPersonMentionAsReadImpl.fromJson(Map<String, dynamic> json) =>
-      _$$MarkPersonMentionAsReadImplFromJson(json);
+  factory _$_MarkPersonMentionAsRead.fromJson(Map<String, dynamic> json) =>
+      _$$_MarkPersonMentionAsReadFromJson(json);
 
   @override
   final int personMentionId;
@@ -2782,7 +2767,7 @@ class _$MarkPersonMentionAsReadImpl extends _MarkPersonMentionAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$MarkPersonMentionAsReadImpl &&
+            other is _$_MarkPersonMentionAsRead &&
             (identical(other.personMentionId, personMentionId) ||
                 other.personMentionId == personMentionId) &&
             (identical(other.read, read) || other.read == read) &&
@@ -2796,13 +2781,14 @@ class _$MarkPersonMentionAsReadImpl extends _MarkPersonMentionAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$MarkPersonMentionAsReadImplCopyWith<_$MarkPersonMentionAsReadImpl>
-      get copyWith => __$$MarkPersonMentionAsReadImplCopyWithImpl<
-          _$MarkPersonMentionAsReadImpl>(this, _$identity);
+  _$$_MarkPersonMentionAsReadCopyWith<_$_MarkPersonMentionAsRead>
+      get copyWith =>
+          __$$_MarkPersonMentionAsReadCopyWithImpl<_$_MarkPersonMentionAsRead>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$MarkPersonMentionAsReadImplToJson(
+    return _$$_MarkPersonMentionAsReadToJson(
       this,
     );
   }
@@ -2812,11 +2798,11 @@ abstract class _MarkPersonMentionAsRead extends MarkPersonMentionAsRead {
   const factory _MarkPersonMentionAsRead(
       {required final int personMentionId,
       required final bool read,
-      required final String auth}) = _$MarkPersonMentionAsReadImpl;
+      required final String auth}) = _$_MarkPersonMentionAsRead;
   const _MarkPersonMentionAsRead._() : super._();
 
   factory _MarkPersonMentionAsRead.fromJson(Map<String, dynamic> json) =
-      _$MarkPersonMentionAsReadImpl.fromJson;
+      _$_MarkPersonMentionAsRead.fromJson;
 
   @override
   int get personMentionId;
@@ -2826,7 +2812,7 @@ abstract class _MarkPersonMentionAsRead extends MarkPersonMentionAsRead {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$MarkPersonMentionAsReadImplCopyWith<_$MarkPersonMentionAsReadImpl>
+  _$$_MarkPersonMentionAsReadCopyWith<_$_MarkPersonMentionAsRead>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -2884,22 +2870,22 @@ class _$DeleteAccountCopyWithImpl<$Res, $Val extends DeleteAccount>
 }
 
 /// @nodoc
-abstract class _$$DeleteAccountImplCopyWith<$Res>
+abstract class _$$_DeleteAccountCopyWith<$Res>
     implements $DeleteAccountCopyWith<$Res> {
-  factory _$$DeleteAccountImplCopyWith(
-          _$DeleteAccountImpl value, $Res Function(_$DeleteAccountImpl) then) =
-      __$$DeleteAccountImplCopyWithImpl<$Res>;
+  factory _$$_DeleteAccountCopyWith(
+          _$_DeleteAccount value, $Res Function(_$_DeleteAccount) then) =
+      __$$_DeleteAccountCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String password, String auth});
 }
 
 /// @nodoc
-class __$$DeleteAccountImplCopyWithImpl<$Res>
-    extends _$DeleteAccountCopyWithImpl<$Res, _$DeleteAccountImpl>
-    implements _$$DeleteAccountImplCopyWith<$Res> {
-  __$$DeleteAccountImplCopyWithImpl(
-      _$DeleteAccountImpl _value, $Res Function(_$DeleteAccountImpl) _then)
+class __$$_DeleteAccountCopyWithImpl<$Res>
+    extends _$DeleteAccountCopyWithImpl<$Res, _$_DeleteAccount>
+    implements _$$_DeleteAccountCopyWith<$Res> {
+  __$$_DeleteAccountCopyWithImpl(
+      _$_DeleteAccount _value, $Res Function(_$_DeleteAccount) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2908,7 +2894,7 @@ class __$$DeleteAccountImplCopyWithImpl<$Res>
     Object? password = null,
     Object? auth = null,
   }) {
-    return _then(_$DeleteAccountImpl(
+    return _then(_$_DeleteAccount(
       password: null == password
           ? _value.password
           : password // ignore: cast_nullable_to_non_nullable
@@ -2924,12 +2910,12 @@ class __$$DeleteAccountImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$DeleteAccountImpl extends _DeleteAccount {
-  const _$DeleteAccountImpl({required this.password, required this.auth})
+class _$_DeleteAccount extends _DeleteAccount {
+  const _$_DeleteAccount({required this.password, required this.auth})
       : super._();
 
-  factory _$DeleteAccountImpl.fromJson(Map<String, dynamic> json) =>
-      _$$DeleteAccountImplFromJson(json);
+  factory _$_DeleteAccount.fromJson(Map<String, dynamic> json) =>
+      _$$_DeleteAccountFromJson(json);
 
   @override
   final String password;
@@ -2945,7 +2931,7 @@ class _$DeleteAccountImpl extends _DeleteAccount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$DeleteAccountImpl &&
+            other is _$_DeleteAccount &&
             (identical(other.password, password) ||
                 other.password == password) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -2958,12 +2944,12 @@ class _$DeleteAccountImpl extends _DeleteAccount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$DeleteAccountImplCopyWith<_$DeleteAccountImpl> get copyWith =>
-      __$$DeleteAccountImplCopyWithImpl<_$DeleteAccountImpl>(this, _$identity);
+  _$$_DeleteAccountCopyWith<_$_DeleteAccount> get copyWith =>
+      __$$_DeleteAccountCopyWithImpl<_$_DeleteAccount>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$DeleteAccountImplToJson(
+    return _$$_DeleteAccountToJson(
       this,
     );
   }
@@ -2972,11 +2958,11 @@ class _$DeleteAccountImpl extends _DeleteAccount {
 abstract class _DeleteAccount extends DeleteAccount {
   const factory _DeleteAccount(
       {required final String password,
-      required final String auth}) = _$DeleteAccountImpl;
+      required final String auth}) = _$_DeleteAccount;
   const _DeleteAccount._() : super._();
 
   factory _DeleteAccount.fromJson(Map<String, dynamic> json) =
-      _$DeleteAccountImpl.fromJson;
+      _$_DeleteAccount.fromJson;
 
   @override
   String get password;
@@ -2984,7 +2970,7 @@ abstract class _DeleteAccount extends DeleteAccount {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$DeleteAccountImplCopyWith<_$DeleteAccountImpl> get copyWith =>
+  _$$_DeleteAccountCopyWith<_$_DeleteAccount> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3036,22 +3022,22 @@ class _$PasswordResetCopyWithImpl<$Res, $Val extends PasswordReset>
 }
 
 /// @nodoc
-abstract class _$$PasswordResetImplCopyWith<$Res>
+abstract class _$$_PasswordResetCopyWith<$Res>
     implements $PasswordResetCopyWith<$Res> {
-  factory _$$PasswordResetImplCopyWith(
-          _$PasswordResetImpl value, $Res Function(_$PasswordResetImpl) then) =
-      __$$PasswordResetImplCopyWithImpl<$Res>;
+  factory _$$_PasswordResetCopyWith(
+          _$_PasswordReset value, $Res Function(_$_PasswordReset) then) =
+      __$$_PasswordResetCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String email});
 }
 
 /// @nodoc
-class __$$PasswordResetImplCopyWithImpl<$Res>
-    extends _$PasswordResetCopyWithImpl<$Res, _$PasswordResetImpl>
-    implements _$$PasswordResetImplCopyWith<$Res> {
-  __$$PasswordResetImplCopyWithImpl(
-      _$PasswordResetImpl _value, $Res Function(_$PasswordResetImpl) _then)
+class __$$_PasswordResetCopyWithImpl<$Res>
+    extends _$PasswordResetCopyWithImpl<$Res, _$_PasswordReset>
+    implements _$$_PasswordResetCopyWith<$Res> {
+  __$$_PasswordResetCopyWithImpl(
+      _$_PasswordReset _value, $Res Function(_$_PasswordReset) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3059,7 +3045,7 @@ class __$$PasswordResetImplCopyWithImpl<$Res>
   $Res call({
     Object? email = null,
   }) {
-    return _then(_$PasswordResetImpl(
+    return _then(_$_PasswordReset(
       email: null == email
           ? _value.email
           : email // ignore: cast_nullable_to_non_nullable
@@ -3071,11 +3057,11 @@ class __$$PasswordResetImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$PasswordResetImpl extends _PasswordReset {
-  const _$PasswordResetImpl({required this.email}) : super._();
+class _$_PasswordReset extends _PasswordReset {
+  const _$_PasswordReset({required this.email}) : super._();
 
-  factory _$PasswordResetImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PasswordResetImplFromJson(json);
+  factory _$_PasswordReset.fromJson(Map<String, dynamic> json) =>
+      _$$_PasswordResetFromJson(json);
 
   @override
   final String email;
@@ -3089,7 +3075,7 @@ class _$PasswordResetImpl extends _PasswordReset {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PasswordResetImpl &&
+            other is _$_PasswordReset &&
             (identical(other.email, email) || other.email == email));
   }
 
@@ -3100,12 +3086,12 @@ class _$PasswordResetImpl extends _PasswordReset {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PasswordResetImplCopyWith<_$PasswordResetImpl> get copyWith =>
-      __$$PasswordResetImplCopyWithImpl<_$PasswordResetImpl>(this, _$identity);
+  _$$_PasswordResetCopyWith<_$_PasswordReset> get copyWith =>
+      __$$_PasswordResetCopyWithImpl<_$_PasswordReset>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PasswordResetImplToJson(
+    return _$$_PasswordResetToJson(
       this,
     );
   }
@@ -3113,17 +3099,17 @@ class _$PasswordResetImpl extends _PasswordReset {
 
 abstract class _PasswordReset extends PasswordReset {
   const factory _PasswordReset({required final String email}) =
-      _$PasswordResetImpl;
+      _$_PasswordReset;
   const _PasswordReset._() : super._();
 
   factory _PasswordReset.fromJson(Map<String, dynamic> json) =
-      _$PasswordResetImpl.fromJson;
+      _$_PasswordReset.fromJson;
 
   @override
   String get email;
   @override
   @JsonKey(ignore: true)
-  _$$PasswordResetImplCopyWith<_$PasswordResetImpl> get copyWith =>
+  _$$_PasswordResetCopyWith<_$_PasswordReset> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3187,22 +3173,22 @@ class _$PasswordChangeCopyWithImpl<$Res, $Val extends PasswordChange>
 }
 
 /// @nodoc
-abstract class _$$PasswordChangeImplCopyWith<$Res>
+abstract class _$$_PasswordChangeCopyWith<$Res>
     implements $PasswordChangeCopyWith<$Res> {
-  factory _$$PasswordChangeImplCopyWith(_$PasswordChangeImpl value,
-          $Res Function(_$PasswordChangeImpl) then) =
-      __$$PasswordChangeImplCopyWithImpl<$Res>;
+  factory _$$_PasswordChangeCopyWith(
+          _$_PasswordChange value, $Res Function(_$_PasswordChange) then) =
+      __$$_PasswordChangeCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String token, String password, String passwordVerify});
 }
 
 /// @nodoc
-class __$$PasswordChangeImplCopyWithImpl<$Res>
-    extends _$PasswordChangeCopyWithImpl<$Res, _$PasswordChangeImpl>
-    implements _$$PasswordChangeImplCopyWith<$Res> {
-  __$$PasswordChangeImplCopyWithImpl(
-      _$PasswordChangeImpl _value, $Res Function(_$PasswordChangeImpl) _then)
+class __$$_PasswordChangeCopyWithImpl<$Res>
+    extends _$PasswordChangeCopyWithImpl<$Res, _$_PasswordChange>
+    implements _$$_PasswordChangeCopyWith<$Res> {
+  __$$_PasswordChangeCopyWithImpl(
+      _$_PasswordChange _value, $Res Function(_$_PasswordChange) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3212,7 +3198,7 @@ class __$$PasswordChangeImplCopyWithImpl<$Res>
     Object? password = null,
     Object? passwordVerify = null,
   }) {
-    return _then(_$PasswordChangeImpl(
+    return _then(_$_PasswordChange(
       token: null == token
           ? _value.token
           : token // ignore: cast_nullable_to_non_nullable
@@ -3232,15 +3218,15 @@ class __$$PasswordChangeImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$PasswordChangeImpl extends _PasswordChange {
-  const _$PasswordChangeImpl(
+class _$_PasswordChange extends _PasswordChange {
+  const _$_PasswordChange(
       {required this.token,
       required this.password,
       required this.passwordVerify})
       : super._();
 
-  factory _$PasswordChangeImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PasswordChangeImplFromJson(json);
+  factory _$_PasswordChange.fromJson(Map<String, dynamic> json) =>
+      _$$_PasswordChangeFromJson(json);
 
   @override
   final String token;
@@ -3258,7 +3244,7 @@ class _$PasswordChangeImpl extends _PasswordChange {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PasswordChangeImpl &&
+            other is _$_PasswordChange &&
             (identical(other.token, token) || other.token == token) &&
             (identical(other.password, password) ||
                 other.password == password) &&
@@ -3273,13 +3259,12 @@ class _$PasswordChangeImpl extends _PasswordChange {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PasswordChangeImplCopyWith<_$PasswordChangeImpl> get copyWith =>
-      __$$PasswordChangeImplCopyWithImpl<_$PasswordChangeImpl>(
-          this, _$identity);
+  _$$_PasswordChangeCopyWith<_$_PasswordChange> get copyWith =>
+      __$$_PasswordChangeCopyWithImpl<_$_PasswordChange>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PasswordChangeImplToJson(
+    return _$$_PasswordChangeToJson(
       this,
     );
   }
@@ -3289,11 +3274,11 @@ abstract class _PasswordChange extends PasswordChange {
   const factory _PasswordChange(
       {required final String token,
       required final String password,
-      required final String passwordVerify}) = _$PasswordChangeImpl;
+      required final String passwordVerify}) = _$_PasswordChange;
   const _PasswordChange._() : super._();
 
   factory _PasswordChange.fromJson(Map<String, dynamic> json) =
-      _$PasswordChangeImpl.fromJson;
+      _$_PasswordChange.fromJson;
 
   @override
   String get token;
@@ -3303,7 +3288,7 @@ abstract class _PasswordChange extends PasswordChange {
   String get passwordVerify;
   @override
   @JsonKey(ignore: true)
-  _$$PasswordChangeImplCopyWith<_$PasswordChangeImpl> get copyWith =>
+  _$$_PasswordChangeCopyWith<_$_PasswordChange> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3368,22 +3353,22 @@ class _$CreatePrivateMessageCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$CreatePrivateMessageImplCopyWith<$Res>
+abstract class _$$_CreatePrivateMessageCopyWith<$Res>
     implements $CreatePrivateMessageCopyWith<$Res> {
-  factory _$$CreatePrivateMessageImplCopyWith(_$CreatePrivateMessageImpl value,
-          $Res Function(_$CreatePrivateMessageImpl) then) =
-      __$$CreatePrivateMessageImplCopyWithImpl<$Res>;
+  factory _$$_CreatePrivateMessageCopyWith(_$_CreatePrivateMessage value,
+          $Res Function(_$_CreatePrivateMessage) then) =
+      __$$_CreatePrivateMessageCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String content, int recipientId, String auth});
 }
 
 /// @nodoc
-class __$$CreatePrivateMessageImplCopyWithImpl<$Res>
-    extends _$CreatePrivateMessageCopyWithImpl<$Res, _$CreatePrivateMessageImpl>
-    implements _$$CreatePrivateMessageImplCopyWith<$Res> {
-  __$$CreatePrivateMessageImplCopyWithImpl(_$CreatePrivateMessageImpl _value,
-      $Res Function(_$CreatePrivateMessageImpl) _then)
+class __$$_CreatePrivateMessageCopyWithImpl<$Res>
+    extends _$CreatePrivateMessageCopyWithImpl<$Res, _$_CreatePrivateMessage>
+    implements _$$_CreatePrivateMessageCopyWith<$Res> {
+  __$$_CreatePrivateMessageCopyWithImpl(_$_CreatePrivateMessage _value,
+      $Res Function(_$_CreatePrivateMessage) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3393,7 +3378,7 @@ class __$$CreatePrivateMessageImplCopyWithImpl<$Res>
     Object? recipientId = null,
     Object? auth = null,
   }) {
-    return _then(_$CreatePrivateMessageImpl(
+    return _then(_$_CreatePrivateMessage(
       content: null == content
           ? _value.content
           : content // ignore: cast_nullable_to_non_nullable
@@ -3413,13 +3398,13 @@ class __$$CreatePrivateMessageImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$CreatePrivateMessageImpl extends _CreatePrivateMessage {
-  const _$CreatePrivateMessageImpl(
+class _$_CreatePrivateMessage extends _CreatePrivateMessage {
+  const _$_CreatePrivateMessage(
       {required this.content, required this.recipientId, required this.auth})
       : super._();
 
-  factory _$CreatePrivateMessageImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CreatePrivateMessageImplFromJson(json);
+  factory _$_CreatePrivateMessage.fromJson(Map<String, dynamic> json) =>
+      _$$_CreatePrivateMessageFromJson(json);
 
   @override
   final String content;
@@ -3437,7 +3422,7 @@ class _$CreatePrivateMessageImpl extends _CreatePrivateMessage {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CreatePrivateMessageImpl &&
+            other is _$_CreatePrivateMessage &&
             (identical(other.content, content) || other.content == content) &&
             (identical(other.recipientId, recipientId) ||
                 other.recipientId == recipientId) &&
@@ -3451,14 +3436,13 @@ class _$CreatePrivateMessageImpl extends _CreatePrivateMessage {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CreatePrivateMessageImplCopyWith<_$CreatePrivateMessageImpl>
-      get copyWith =>
-          __$$CreatePrivateMessageImplCopyWithImpl<_$CreatePrivateMessageImpl>(
-              this, _$identity);
+  _$$_CreatePrivateMessageCopyWith<_$_CreatePrivateMessage> get copyWith =>
+      __$$_CreatePrivateMessageCopyWithImpl<_$_CreatePrivateMessage>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CreatePrivateMessageImplToJson(
+    return _$$_CreatePrivateMessageToJson(
       this,
     );
   }
@@ -3468,11 +3452,11 @@ abstract class _CreatePrivateMessage extends CreatePrivateMessage {
   const factory _CreatePrivateMessage(
       {required final String content,
       required final int recipientId,
-      required final String auth}) = _$CreatePrivateMessageImpl;
+      required final String auth}) = _$_CreatePrivateMessage;
   const _CreatePrivateMessage._() : super._();
 
   factory _CreatePrivateMessage.fromJson(Map<String, dynamic> json) =
-      _$CreatePrivateMessageImpl.fromJson;
+      _$_CreatePrivateMessage.fromJson;
 
   @override
   String get content;
@@ -3482,8 +3466,8 @@ abstract class _CreatePrivateMessage extends CreatePrivateMessage {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$CreatePrivateMessageImplCopyWith<_$CreatePrivateMessageImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_CreatePrivateMessageCopyWith<_$_CreatePrivateMessage> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 EditPrivateMessage _$EditPrivateMessageFromJson(Map<String, dynamic> json) {
@@ -3546,22 +3530,22 @@ class _$EditPrivateMessageCopyWithImpl<$Res, $Val extends EditPrivateMessage>
 }
 
 /// @nodoc
-abstract class _$$EditPrivateMessageImplCopyWith<$Res>
+abstract class _$$_EditPrivateMessageCopyWith<$Res>
     implements $EditPrivateMessageCopyWith<$Res> {
-  factory _$$EditPrivateMessageImplCopyWith(_$EditPrivateMessageImpl value,
-          $Res Function(_$EditPrivateMessageImpl) then) =
-      __$$EditPrivateMessageImplCopyWithImpl<$Res>;
+  factory _$$_EditPrivateMessageCopyWith(_$_EditPrivateMessage value,
+          $Res Function(_$_EditPrivateMessage) then) =
+      __$$_EditPrivateMessageCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int privateMessageId, String content, String auth});
 }
 
 /// @nodoc
-class __$$EditPrivateMessageImplCopyWithImpl<$Res>
-    extends _$EditPrivateMessageCopyWithImpl<$Res, _$EditPrivateMessageImpl>
-    implements _$$EditPrivateMessageImplCopyWith<$Res> {
-  __$$EditPrivateMessageImplCopyWithImpl(_$EditPrivateMessageImpl _value,
-      $Res Function(_$EditPrivateMessageImpl) _then)
+class __$$_EditPrivateMessageCopyWithImpl<$Res>
+    extends _$EditPrivateMessageCopyWithImpl<$Res, _$_EditPrivateMessage>
+    implements _$$_EditPrivateMessageCopyWith<$Res> {
+  __$$_EditPrivateMessageCopyWithImpl(
+      _$_EditPrivateMessage _value, $Res Function(_$_EditPrivateMessage) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3571,7 +3555,7 @@ class __$$EditPrivateMessageImplCopyWithImpl<$Res>
     Object? content = null,
     Object? auth = null,
   }) {
-    return _then(_$EditPrivateMessageImpl(
+    return _then(_$_EditPrivateMessage(
       privateMessageId: null == privateMessageId
           ? _value.privateMessageId
           : privateMessageId // ignore: cast_nullable_to_non_nullable
@@ -3591,15 +3575,15 @@ class __$$EditPrivateMessageImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$EditPrivateMessageImpl extends _EditPrivateMessage {
-  const _$EditPrivateMessageImpl(
+class _$_EditPrivateMessage extends _EditPrivateMessage {
+  const _$_EditPrivateMessage(
       {required this.privateMessageId,
       required this.content,
       required this.auth})
       : super._();
 
-  factory _$EditPrivateMessageImpl.fromJson(Map<String, dynamic> json) =>
-      _$$EditPrivateMessageImplFromJson(json);
+  factory _$_EditPrivateMessage.fromJson(Map<String, dynamic> json) =>
+      _$$_EditPrivateMessageFromJson(json);
 
   @override
   final int privateMessageId;
@@ -3617,7 +3601,7 @@ class _$EditPrivateMessageImpl extends _EditPrivateMessage {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$EditPrivateMessageImpl &&
+            other is _$_EditPrivateMessage &&
             (identical(other.privateMessageId, privateMessageId) ||
                 other.privateMessageId == privateMessageId) &&
             (identical(other.content, content) || other.content == content) &&
@@ -3631,13 +3615,13 @@ class _$EditPrivateMessageImpl extends _EditPrivateMessage {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$EditPrivateMessageImplCopyWith<_$EditPrivateMessageImpl> get copyWith =>
-      __$$EditPrivateMessageImplCopyWithImpl<_$EditPrivateMessageImpl>(
+  _$$_EditPrivateMessageCopyWith<_$_EditPrivateMessage> get copyWith =>
+      __$$_EditPrivateMessageCopyWithImpl<_$_EditPrivateMessage>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$EditPrivateMessageImplToJson(
+    return _$$_EditPrivateMessageToJson(
       this,
     );
   }
@@ -3647,11 +3631,11 @@ abstract class _EditPrivateMessage extends EditPrivateMessage {
   const factory _EditPrivateMessage(
       {required final int privateMessageId,
       required final String content,
-      required final String auth}) = _$EditPrivateMessageImpl;
+      required final String auth}) = _$_EditPrivateMessage;
   const _EditPrivateMessage._() : super._();
 
   factory _EditPrivateMessage.fromJson(Map<String, dynamic> json) =
-      _$EditPrivateMessageImpl.fromJson;
+      _$_EditPrivateMessage.fromJson;
 
   @override
   int get privateMessageId;
@@ -3661,7 +3645,7 @@ abstract class _EditPrivateMessage extends EditPrivateMessage {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$EditPrivateMessageImplCopyWith<_$EditPrivateMessageImpl> get copyWith =>
+  _$$_EditPrivateMessageCopyWith<_$_EditPrivateMessage> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3726,22 +3710,22 @@ class _$DeletePrivateMessageCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$DeletePrivateMessageImplCopyWith<$Res>
+abstract class _$$_DeletePrivateMessageCopyWith<$Res>
     implements $DeletePrivateMessageCopyWith<$Res> {
-  factory _$$DeletePrivateMessageImplCopyWith(_$DeletePrivateMessageImpl value,
-          $Res Function(_$DeletePrivateMessageImpl) then) =
-      __$$DeletePrivateMessageImplCopyWithImpl<$Res>;
+  factory _$$_DeletePrivateMessageCopyWith(_$_DeletePrivateMessage value,
+          $Res Function(_$_DeletePrivateMessage) then) =
+      __$$_DeletePrivateMessageCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int privateMessageId, bool deleted, String auth});
 }
 
 /// @nodoc
-class __$$DeletePrivateMessageImplCopyWithImpl<$Res>
-    extends _$DeletePrivateMessageCopyWithImpl<$Res, _$DeletePrivateMessageImpl>
-    implements _$$DeletePrivateMessageImplCopyWith<$Res> {
-  __$$DeletePrivateMessageImplCopyWithImpl(_$DeletePrivateMessageImpl _value,
-      $Res Function(_$DeletePrivateMessageImpl) _then)
+class __$$_DeletePrivateMessageCopyWithImpl<$Res>
+    extends _$DeletePrivateMessageCopyWithImpl<$Res, _$_DeletePrivateMessage>
+    implements _$$_DeletePrivateMessageCopyWith<$Res> {
+  __$$_DeletePrivateMessageCopyWithImpl(_$_DeletePrivateMessage _value,
+      $Res Function(_$_DeletePrivateMessage) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3751,7 +3735,7 @@ class __$$DeletePrivateMessageImplCopyWithImpl<$Res>
     Object? deleted = null,
     Object? auth = null,
   }) {
-    return _then(_$DeletePrivateMessageImpl(
+    return _then(_$_DeletePrivateMessage(
       privateMessageId: null == privateMessageId
           ? _value.privateMessageId
           : privateMessageId // ignore: cast_nullable_to_non_nullable
@@ -3771,15 +3755,15 @@ class __$$DeletePrivateMessageImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$DeletePrivateMessageImpl extends _DeletePrivateMessage {
-  const _$DeletePrivateMessageImpl(
+class _$_DeletePrivateMessage extends _DeletePrivateMessage {
+  const _$_DeletePrivateMessage(
       {required this.privateMessageId,
       required this.deleted,
       required this.auth})
       : super._();
 
-  factory _$DeletePrivateMessageImpl.fromJson(Map<String, dynamic> json) =>
-      _$$DeletePrivateMessageImplFromJson(json);
+  factory _$_DeletePrivateMessage.fromJson(Map<String, dynamic> json) =>
+      _$$_DeletePrivateMessageFromJson(json);
 
   @override
   final int privateMessageId;
@@ -3797,7 +3781,7 @@ class _$DeletePrivateMessageImpl extends _DeletePrivateMessage {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$DeletePrivateMessageImpl &&
+            other is _$_DeletePrivateMessage &&
             (identical(other.privateMessageId, privateMessageId) ||
                 other.privateMessageId == privateMessageId) &&
             (identical(other.deleted, deleted) || other.deleted == deleted) &&
@@ -3811,14 +3795,13 @@ class _$DeletePrivateMessageImpl extends _DeletePrivateMessage {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$DeletePrivateMessageImplCopyWith<_$DeletePrivateMessageImpl>
-      get copyWith =>
-          __$$DeletePrivateMessageImplCopyWithImpl<_$DeletePrivateMessageImpl>(
-              this, _$identity);
+  _$$_DeletePrivateMessageCopyWith<_$_DeletePrivateMessage> get copyWith =>
+      __$$_DeletePrivateMessageCopyWithImpl<_$_DeletePrivateMessage>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$DeletePrivateMessageImplToJson(
+    return _$$_DeletePrivateMessageToJson(
       this,
     );
   }
@@ -3828,11 +3811,11 @@ abstract class _DeletePrivateMessage extends DeletePrivateMessage {
   const factory _DeletePrivateMessage(
       {required final int privateMessageId,
       required final bool deleted,
-      required final String auth}) = _$DeletePrivateMessageImpl;
+      required final String auth}) = _$_DeletePrivateMessage;
   const _DeletePrivateMessage._() : super._();
 
   factory _DeletePrivateMessage.fromJson(Map<String, dynamic> json) =
-      _$DeletePrivateMessageImpl.fromJson;
+      _$_DeletePrivateMessage.fromJson;
 
   @override
   int get privateMessageId;
@@ -3842,8 +3825,8 @@ abstract class _DeletePrivateMessage extends DeletePrivateMessage {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$DeletePrivateMessageImplCopyWith<_$DeletePrivateMessageImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_DeletePrivateMessageCopyWith<_$_DeletePrivateMessage> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 MarkPrivateMessageAsRead _$MarkPrivateMessageAsReadFromJson(
@@ -3908,25 +3891,24 @@ class _$MarkPrivateMessageAsReadCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$MarkPrivateMessageAsReadImplCopyWith<$Res>
+abstract class _$$_MarkPrivateMessageAsReadCopyWith<$Res>
     implements $MarkPrivateMessageAsReadCopyWith<$Res> {
-  factory _$$MarkPrivateMessageAsReadImplCopyWith(
-          _$MarkPrivateMessageAsReadImpl value,
-          $Res Function(_$MarkPrivateMessageAsReadImpl) then) =
-      __$$MarkPrivateMessageAsReadImplCopyWithImpl<$Res>;
+  factory _$$_MarkPrivateMessageAsReadCopyWith(
+          _$_MarkPrivateMessageAsRead value,
+          $Res Function(_$_MarkPrivateMessageAsRead) then) =
+      __$$_MarkPrivateMessageAsReadCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int privateMessageId, bool read, String auth});
 }
 
 /// @nodoc
-class __$$MarkPrivateMessageAsReadImplCopyWithImpl<$Res>
+class __$$_MarkPrivateMessageAsReadCopyWithImpl<$Res>
     extends _$MarkPrivateMessageAsReadCopyWithImpl<$Res,
-        _$MarkPrivateMessageAsReadImpl>
-    implements _$$MarkPrivateMessageAsReadImplCopyWith<$Res> {
-  __$$MarkPrivateMessageAsReadImplCopyWithImpl(
-      _$MarkPrivateMessageAsReadImpl _value,
-      $Res Function(_$MarkPrivateMessageAsReadImpl) _then)
+        _$_MarkPrivateMessageAsRead>
+    implements _$$_MarkPrivateMessageAsReadCopyWith<$Res> {
+  __$$_MarkPrivateMessageAsReadCopyWithImpl(_$_MarkPrivateMessageAsRead _value,
+      $Res Function(_$_MarkPrivateMessageAsRead) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3936,7 +3918,7 @@ class __$$MarkPrivateMessageAsReadImplCopyWithImpl<$Res>
     Object? read = null,
     Object? auth = null,
   }) {
-    return _then(_$MarkPrivateMessageAsReadImpl(
+    return _then(_$_MarkPrivateMessageAsRead(
       privateMessageId: null == privateMessageId
           ? _value.privateMessageId
           : privateMessageId // ignore: cast_nullable_to_non_nullable
@@ -3956,13 +3938,13 @@ class __$$MarkPrivateMessageAsReadImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$MarkPrivateMessageAsReadImpl extends _MarkPrivateMessageAsRead {
-  const _$MarkPrivateMessageAsReadImpl(
+class _$_MarkPrivateMessageAsRead extends _MarkPrivateMessageAsRead {
+  const _$_MarkPrivateMessageAsRead(
       {required this.privateMessageId, required this.read, required this.auth})
       : super._();
 
-  factory _$MarkPrivateMessageAsReadImpl.fromJson(Map<String, dynamic> json) =>
-      _$$MarkPrivateMessageAsReadImplFromJson(json);
+  factory _$_MarkPrivateMessageAsRead.fromJson(Map<String, dynamic> json) =>
+      _$$_MarkPrivateMessageAsReadFromJson(json);
 
   @override
   final int privateMessageId;
@@ -3980,7 +3962,7 @@ class _$MarkPrivateMessageAsReadImpl extends _MarkPrivateMessageAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$MarkPrivateMessageAsReadImpl &&
+            other is _$_MarkPrivateMessageAsRead &&
             (identical(other.privateMessageId, privateMessageId) ||
                 other.privateMessageId == privateMessageId) &&
             (identical(other.read, read) || other.read == read) &&
@@ -3994,13 +3976,13 @@ class _$MarkPrivateMessageAsReadImpl extends _MarkPrivateMessageAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$MarkPrivateMessageAsReadImplCopyWith<_$MarkPrivateMessageAsReadImpl>
-      get copyWith => __$$MarkPrivateMessageAsReadImplCopyWithImpl<
-          _$MarkPrivateMessageAsReadImpl>(this, _$identity);
+  _$$_MarkPrivateMessageAsReadCopyWith<_$_MarkPrivateMessageAsRead>
+      get copyWith => __$$_MarkPrivateMessageAsReadCopyWithImpl<
+          _$_MarkPrivateMessageAsRead>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$MarkPrivateMessageAsReadImplToJson(
+    return _$$_MarkPrivateMessageAsReadToJson(
       this,
     );
   }
@@ -4010,11 +3992,11 @@ abstract class _MarkPrivateMessageAsRead extends MarkPrivateMessageAsRead {
   const factory _MarkPrivateMessageAsRead(
       {required final int privateMessageId,
       required final bool read,
-      required final String auth}) = _$MarkPrivateMessageAsReadImpl;
+      required final String auth}) = _$_MarkPrivateMessageAsRead;
   const _MarkPrivateMessageAsRead._() : super._();
 
   factory _MarkPrivateMessageAsRead.fromJson(Map<String, dynamic> json) =
-      _$MarkPrivateMessageAsReadImpl.fromJson;
+      _$_MarkPrivateMessageAsRead.fromJson;
 
   @override
   int get privateMessageId;
@@ -4024,7 +4006,7 @@ abstract class _MarkPrivateMessageAsRead extends MarkPrivateMessageAsRead {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$MarkPrivateMessageAsReadImplCopyWith<_$MarkPrivateMessageAsReadImpl>
+  _$$_MarkPrivateMessageAsReadCopyWith<_$_MarkPrivateMessageAsRead>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -4094,22 +4076,22 @@ class _$GetPrivateMessagesCopyWithImpl<$Res, $Val extends GetPrivateMessages>
 }
 
 /// @nodoc
-abstract class _$$GetPrivateMessagesImplCopyWith<$Res>
+abstract class _$$_GetPrivateMessagesCopyWith<$Res>
     implements $GetPrivateMessagesCopyWith<$Res> {
-  factory _$$GetPrivateMessagesImplCopyWith(_$GetPrivateMessagesImpl value,
-          $Res Function(_$GetPrivateMessagesImpl) then) =
-      __$$GetPrivateMessagesImplCopyWithImpl<$Res>;
+  factory _$$_GetPrivateMessagesCopyWith(_$_GetPrivateMessages value,
+          $Res Function(_$_GetPrivateMessages) then) =
+      __$$_GetPrivateMessagesCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool? unreadOnly, int? page, int? limit, String auth});
 }
 
 /// @nodoc
-class __$$GetPrivateMessagesImplCopyWithImpl<$Res>
-    extends _$GetPrivateMessagesCopyWithImpl<$Res, _$GetPrivateMessagesImpl>
-    implements _$$GetPrivateMessagesImplCopyWith<$Res> {
-  __$$GetPrivateMessagesImplCopyWithImpl(_$GetPrivateMessagesImpl _value,
-      $Res Function(_$GetPrivateMessagesImpl) _then)
+class __$$_GetPrivateMessagesCopyWithImpl<$Res>
+    extends _$GetPrivateMessagesCopyWithImpl<$Res, _$_GetPrivateMessages>
+    implements _$$_GetPrivateMessagesCopyWith<$Res> {
+  __$$_GetPrivateMessagesCopyWithImpl(
+      _$_GetPrivateMessages _value, $Res Function(_$_GetPrivateMessages) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4120,7 +4102,7 @@ class __$$GetPrivateMessagesImplCopyWithImpl<$Res>
     Object? limit = freezed,
     Object? auth = null,
   }) {
-    return _then(_$GetPrivateMessagesImpl(
+    return _then(_$_GetPrivateMessages(
       unreadOnly: freezed == unreadOnly
           ? _value.unreadOnly
           : unreadOnly // ignore: cast_nullable_to_non_nullable
@@ -4144,13 +4126,13 @@ class __$$GetPrivateMessagesImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetPrivateMessagesImpl extends _GetPrivateMessages {
-  const _$GetPrivateMessagesImpl(
+class _$_GetPrivateMessages extends _GetPrivateMessages {
+  const _$_GetPrivateMessages(
       {this.unreadOnly, this.page, this.limit, required this.auth})
       : super._();
 
-  factory _$GetPrivateMessagesImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetPrivateMessagesImplFromJson(json);
+  factory _$_GetPrivateMessages.fromJson(Map<String, dynamic> json) =>
+      _$$_GetPrivateMessagesFromJson(json);
 
   @override
   final bool? unreadOnly;
@@ -4170,7 +4152,7 @@ class _$GetPrivateMessagesImpl extends _GetPrivateMessages {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetPrivateMessagesImpl &&
+            other is _$_GetPrivateMessages &&
             (identical(other.unreadOnly, unreadOnly) ||
                 other.unreadOnly == unreadOnly) &&
             (identical(other.page, page) || other.page == page) &&
@@ -4185,13 +4167,13 @@ class _$GetPrivateMessagesImpl extends _GetPrivateMessages {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetPrivateMessagesImplCopyWith<_$GetPrivateMessagesImpl> get copyWith =>
-      __$$GetPrivateMessagesImplCopyWithImpl<_$GetPrivateMessagesImpl>(
+  _$$_GetPrivateMessagesCopyWith<_$_GetPrivateMessages> get copyWith =>
+      __$$_GetPrivateMessagesCopyWithImpl<_$_GetPrivateMessages>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetPrivateMessagesImplToJson(
+    return _$$_GetPrivateMessagesToJson(
       this,
     );
   }
@@ -4202,11 +4184,11 @@ abstract class _GetPrivateMessages extends GetPrivateMessages {
       {final bool? unreadOnly,
       final int? page,
       final int? limit,
-      required final String auth}) = _$GetPrivateMessagesImpl;
+      required final String auth}) = _$_GetPrivateMessages;
   const _GetPrivateMessages._() : super._();
 
   factory _GetPrivateMessages.fromJson(Map<String, dynamic> json) =
-      _$GetPrivateMessagesImpl.fromJson;
+      _$_GetPrivateMessages.fromJson;
 
   @override
   bool? get unreadOnly;
@@ -4218,7 +4200,7 @@ abstract class _GetPrivateMessages extends GetPrivateMessages {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetPrivateMessagesImplCopyWith<_$GetPrivateMessagesImpl> get copyWith =>
+  _$$_GetPrivateMessagesCopyWith<_$_GetPrivateMessages> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4282,22 +4264,22 @@ class _$BlockPersonCopyWithImpl<$Res, $Val extends BlockPerson>
 }
 
 /// @nodoc
-abstract class _$$BlockPersonImplCopyWith<$Res>
+abstract class _$$_BlockPersonCopyWith<$Res>
     implements $BlockPersonCopyWith<$Res> {
-  factory _$$BlockPersonImplCopyWith(
-          _$BlockPersonImpl value, $Res Function(_$BlockPersonImpl) then) =
-      __$$BlockPersonImplCopyWithImpl<$Res>;
+  factory _$$_BlockPersonCopyWith(
+          _$_BlockPerson value, $Res Function(_$_BlockPerson) then) =
+      __$$_BlockPersonCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int personId, bool block, String auth});
 }
 
 /// @nodoc
-class __$$BlockPersonImplCopyWithImpl<$Res>
-    extends _$BlockPersonCopyWithImpl<$Res, _$BlockPersonImpl>
-    implements _$$BlockPersonImplCopyWith<$Res> {
-  __$$BlockPersonImplCopyWithImpl(
-      _$BlockPersonImpl _value, $Res Function(_$BlockPersonImpl) _then)
+class __$$_BlockPersonCopyWithImpl<$Res>
+    extends _$BlockPersonCopyWithImpl<$Res, _$_BlockPerson>
+    implements _$$_BlockPersonCopyWith<$Res> {
+  __$$_BlockPersonCopyWithImpl(
+      _$_BlockPerson _value, $Res Function(_$_BlockPerson) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4307,7 +4289,7 @@ class __$$BlockPersonImplCopyWithImpl<$Res>
     Object? block = null,
     Object? auth = null,
   }) {
-    return _then(_$BlockPersonImpl(
+    return _then(_$_BlockPerson(
       personId: null == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -4327,13 +4309,13 @@ class __$$BlockPersonImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$BlockPersonImpl extends _BlockPerson {
-  const _$BlockPersonImpl(
+class _$_BlockPerson extends _BlockPerson {
+  const _$_BlockPerson(
       {required this.personId, required this.block, required this.auth})
       : super._();
 
-  factory _$BlockPersonImpl.fromJson(Map<String, dynamic> json) =>
-      _$$BlockPersonImplFromJson(json);
+  factory _$_BlockPerson.fromJson(Map<String, dynamic> json) =>
+      _$$_BlockPersonFromJson(json);
 
   @override
   final int personId;
@@ -4351,7 +4333,7 @@ class _$BlockPersonImpl extends _BlockPerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$BlockPersonImpl &&
+            other is _$_BlockPerson &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.block, block) || other.block == block) &&
@@ -4365,12 +4347,12 @@ class _$BlockPersonImpl extends _BlockPerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$BlockPersonImplCopyWith<_$BlockPersonImpl> get copyWith =>
-      __$$BlockPersonImplCopyWithImpl<_$BlockPersonImpl>(this, _$identity);
+  _$$_BlockPersonCopyWith<_$_BlockPerson> get copyWith =>
+      __$$_BlockPersonCopyWithImpl<_$_BlockPerson>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$BlockPersonImplToJson(
+    return _$$_BlockPersonToJson(
       this,
     );
   }
@@ -4380,11 +4362,11 @@ abstract class _BlockPerson extends BlockPerson {
   const factory _BlockPerson(
       {required final int personId,
       required final bool block,
-      required final String auth}) = _$BlockPersonImpl;
+      required final String auth}) = _$_BlockPerson;
   const _BlockPerson._() : super._();
 
   factory _BlockPerson.fromJson(Map<String, dynamic> json) =
-      _$BlockPersonImpl.fromJson;
+      _$_BlockPerson.fromJson;
 
   @override
   int get personId;
@@ -4394,7 +4376,7 @@ abstract class _BlockPerson extends BlockPerson {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$BlockPersonImplCopyWith<_$BlockPersonImpl> get copyWith =>
+  _$$_BlockPersonCopyWith<_$_BlockPerson> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4446,22 +4428,22 @@ class _$GetUnreadCountCopyWithImpl<$Res, $Val extends GetUnreadCount>
 }
 
 /// @nodoc
-abstract class _$$GetUnreadCountImplCopyWith<$Res>
+abstract class _$$_GetUnreadCountCopyWith<$Res>
     implements $GetUnreadCountCopyWith<$Res> {
-  factory _$$GetUnreadCountImplCopyWith(_$GetUnreadCountImpl value,
-          $Res Function(_$GetUnreadCountImpl) then) =
-      __$$GetUnreadCountImplCopyWithImpl<$Res>;
+  factory _$$_GetUnreadCountCopyWith(
+          _$_GetUnreadCount value, $Res Function(_$_GetUnreadCount) then) =
+      __$$_GetUnreadCountCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String auth});
 }
 
 /// @nodoc
-class __$$GetUnreadCountImplCopyWithImpl<$Res>
-    extends _$GetUnreadCountCopyWithImpl<$Res, _$GetUnreadCountImpl>
-    implements _$$GetUnreadCountImplCopyWith<$Res> {
-  __$$GetUnreadCountImplCopyWithImpl(
-      _$GetUnreadCountImpl _value, $Res Function(_$GetUnreadCountImpl) _then)
+class __$$_GetUnreadCountCopyWithImpl<$Res>
+    extends _$GetUnreadCountCopyWithImpl<$Res, _$_GetUnreadCount>
+    implements _$$_GetUnreadCountCopyWith<$Res> {
+  __$$_GetUnreadCountCopyWithImpl(
+      _$_GetUnreadCount _value, $Res Function(_$_GetUnreadCount) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4469,7 +4451,7 @@ class __$$GetUnreadCountImplCopyWithImpl<$Res>
   $Res call({
     Object? auth = null,
   }) {
-    return _then(_$GetUnreadCountImpl(
+    return _then(_$_GetUnreadCount(
       auth: null == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -4481,11 +4463,11 @@ class __$$GetUnreadCountImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetUnreadCountImpl extends _GetUnreadCount {
-  const _$GetUnreadCountImpl({required this.auth}) : super._();
+class _$_GetUnreadCount extends _GetUnreadCount {
+  const _$_GetUnreadCount({required this.auth}) : super._();
 
-  factory _$GetUnreadCountImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetUnreadCountImplFromJson(json);
+  factory _$_GetUnreadCount.fromJson(Map<String, dynamic> json) =>
+      _$$_GetUnreadCountFromJson(json);
 
   @override
   final String auth;
@@ -4499,7 +4481,7 @@ class _$GetUnreadCountImpl extends _GetUnreadCount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetUnreadCountImpl &&
+            other is _$_GetUnreadCount &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -4510,13 +4492,12 @@ class _$GetUnreadCountImpl extends _GetUnreadCount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetUnreadCountImplCopyWith<_$GetUnreadCountImpl> get copyWith =>
-      __$$GetUnreadCountImplCopyWithImpl<_$GetUnreadCountImpl>(
-          this, _$identity);
+  _$$_GetUnreadCountCopyWith<_$_GetUnreadCount> get copyWith =>
+      __$$_GetUnreadCountCopyWithImpl<_$_GetUnreadCount>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetUnreadCountImplToJson(
+    return _$$_GetUnreadCountToJson(
       this,
     );
   }
@@ -4524,17 +4505,17 @@ class _$GetUnreadCountImpl extends _GetUnreadCount {
 
 abstract class _GetUnreadCount extends GetUnreadCount {
   const factory _GetUnreadCount({required final String auth}) =
-      _$GetUnreadCountImpl;
+      _$_GetUnreadCount;
   const _GetUnreadCount._() : super._();
 
   factory _GetUnreadCount.fromJson(Map<String, dynamic> json) =
-      _$GetUnreadCountImpl.fromJson;
+      _$_GetUnreadCount.fromJson;
 
   @override
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetUnreadCountImplCopyWith<_$GetUnreadCountImpl> get copyWith =>
+  _$$_GetUnreadCountCopyWith<_$_GetUnreadCount> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4592,22 +4573,22 @@ class _$GetReportCountCopyWithImpl<$Res, $Val extends GetReportCount>
 }
 
 /// @nodoc
-abstract class _$$GetReportCountImplCopyWith<$Res>
+abstract class _$$_GetReportCountCopyWith<$Res>
     implements $GetReportCountCopyWith<$Res> {
-  factory _$$GetReportCountImplCopyWith(_$GetReportCountImpl value,
-          $Res Function(_$GetReportCountImpl) then) =
-      __$$GetReportCountImplCopyWithImpl<$Res>;
+  factory _$$_GetReportCountCopyWith(
+          _$_GetReportCount value, $Res Function(_$_GetReportCount) then) =
+      __$$_GetReportCountCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int? communityId, String auth});
 }
 
 /// @nodoc
-class __$$GetReportCountImplCopyWithImpl<$Res>
-    extends _$GetReportCountCopyWithImpl<$Res, _$GetReportCountImpl>
-    implements _$$GetReportCountImplCopyWith<$Res> {
-  __$$GetReportCountImplCopyWithImpl(
-      _$GetReportCountImpl _value, $Res Function(_$GetReportCountImpl) _then)
+class __$$_GetReportCountCopyWithImpl<$Res>
+    extends _$GetReportCountCopyWithImpl<$Res, _$_GetReportCount>
+    implements _$$_GetReportCountCopyWith<$Res> {
+  __$$_GetReportCountCopyWithImpl(
+      _$_GetReportCount _value, $Res Function(_$_GetReportCount) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4616,7 +4597,7 @@ class __$$GetReportCountImplCopyWithImpl<$Res>
     Object? communityId = freezed,
     Object? auth = null,
   }) {
-    return _then(_$GetReportCountImpl(
+    return _then(_$_GetReportCount(
       communityId: freezed == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -4632,12 +4613,11 @@ class __$$GetReportCountImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetReportCountImpl extends _GetReportCount {
-  const _$GetReportCountImpl({this.communityId, required this.auth})
-      : super._();
+class _$_GetReportCount extends _GetReportCount {
+  const _$_GetReportCount({this.communityId, required this.auth}) : super._();
 
-  factory _$GetReportCountImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetReportCountImplFromJson(json);
+  factory _$_GetReportCount.fromJson(Map<String, dynamic> json) =>
+      _$$_GetReportCountFromJson(json);
 
   @override
   final int? communityId;
@@ -4653,7 +4633,7 @@ class _$GetReportCountImpl extends _GetReportCount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetReportCountImpl &&
+            other is _$_GetReportCount &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -4666,13 +4646,12 @@ class _$GetReportCountImpl extends _GetReportCount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetReportCountImplCopyWith<_$GetReportCountImpl> get copyWith =>
-      __$$GetReportCountImplCopyWithImpl<_$GetReportCountImpl>(
-          this, _$identity);
+  _$$_GetReportCountCopyWith<_$_GetReportCount> get copyWith =>
+      __$$_GetReportCountCopyWithImpl<_$_GetReportCount>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetReportCountImplToJson(
+    return _$$_GetReportCountToJson(
       this,
     );
   }
@@ -4680,12 +4659,11 @@ class _$GetReportCountImpl extends _GetReportCount {
 
 abstract class _GetReportCount extends GetReportCount {
   const factory _GetReportCount(
-      {final int? communityId,
-      required final String auth}) = _$GetReportCountImpl;
+      {final int? communityId, required final String auth}) = _$_GetReportCount;
   const _GetReportCount._() : super._();
 
   factory _GetReportCount.fromJson(Map<String, dynamic> json) =
-      _$GetReportCountImpl.fromJson;
+      _$_GetReportCount.fromJson;
 
   @override
   int? get communityId;
@@ -4693,7 +4671,7 @@ abstract class _GetReportCount extends GetReportCount {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetReportCountImplCopyWith<_$GetReportCountImpl> get copyWith =>
+  _$$_GetReportCountCopyWith<_$_GetReportCount> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4745,22 +4723,22 @@ class _$GetBannedPersonsCopyWithImpl<$Res, $Val extends GetBannedPersons>
 }
 
 /// @nodoc
-abstract class _$$GetBannedPersonsImplCopyWith<$Res>
+abstract class _$$_GetBannedPersonsCopyWith<$Res>
     implements $GetBannedPersonsCopyWith<$Res> {
-  factory _$$GetBannedPersonsImplCopyWith(_$GetBannedPersonsImpl value,
-          $Res Function(_$GetBannedPersonsImpl) then) =
-      __$$GetBannedPersonsImplCopyWithImpl<$Res>;
+  factory _$$_GetBannedPersonsCopyWith(
+          _$_GetBannedPersons value, $Res Function(_$_GetBannedPersons) then) =
+      __$$_GetBannedPersonsCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String auth});
 }
 
 /// @nodoc
-class __$$GetBannedPersonsImplCopyWithImpl<$Res>
-    extends _$GetBannedPersonsCopyWithImpl<$Res, _$GetBannedPersonsImpl>
-    implements _$$GetBannedPersonsImplCopyWith<$Res> {
-  __$$GetBannedPersonsImplCopyWithImpl(_$GetBannedPersonsImpl _value,
-      $Res Function(_$GetBannedPersonsImpl) _then)
+class __$$_GetBannedPersonsCopyWithImpl<$Res>
+    extends _$GetBannedPersonsCopyWithImpl<$Res, _$_GetBannedPersons>
+    implements _$$_GetBannedPersonsCopyWith<$Res> {
+  __$$_GetBannedPersonsCopyWithImpl(
+      _$_GetBannedPersons _value, $Res Function(_$_GetBannedPersons) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4768,7 +4746,7 @@ class __$$GetBannedPersonsImplCopyWithImpl<$Res>
   $Res call({
     Object? auth = null,
   }) {
-    return _then(_$GetBannedPersonsImpl(
+    return _then(_$_GetBannedPersons(
       auth: null == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -4780,11 +4758,11 @@ class __$$GetBannedPersonsImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetBannedPersonsImpl extends _GetBannedPersons {
-  const _$GetBannedPersonsImpl({required this.auth}) : super._();
+class _$_GetBannedPersons extends _GetBannedPersons {
+  const _$_GetBannedPersons({required this.auth}) : super._();
 
-  factory _$GetBannedPersonsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetBannedPersonsImplFromJson(json);
+  factory _$_GetBannedPersons.fromJson(Map<String, dynamic> json) =>
+      _$$_GetBannedPersonsFromJson(json);
 
   @override
   final String auth;
@@ -4798,7 +4776,7 @@ class _$GetBannedPersonsImpl extends _GetBannedPersons {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetBannedPersonsImpl &&
+            other is _$_GetBannedPersons &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -4809,13 +4787,12 @@ class _$GetBannedPersonsImpl extends _GetBannedPersons {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetBannedPersonsImplCopyWith<_$GetBannedPersonsImpl> get copyWith =>
-      __$$GetBannedPersonsImplCopyWithImpl<_$GetBannedPersonsImpl>(
-          this, _$identity);
+  _$$_GetBannedPersonsCopyWith<_$_GetBannedPersons> get copyWith =>
+      __$$_GetBannedPersonsCopyWithImpl<_$_GetBannedPersons>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetBannedPersonsImplToJson(
+    return _$$_GetBannedPersonsToJson(
       this,
     );
   }
@@ -4823,17 +4800,17 @@ class _$GetBannedPersonsImpl extends _GetBannedPersons {
 
 abstract class _GetBannedPersons extends GetBannedPersons {
   const factory _GetBannedPersons({required final String auth}) =
-      _$GetBannedPersonsImpl;
+      _$_GetBannedPersons;
   const _GetBannedPersons._() : super._();
 
   factory _GetBannedPersons.fromJson(Map<String, dynamic> json) =
-      _$GetBannedPersonsImpl.fromJson;
+      _$_GetBannedPersons.fromJson;
 
   @override
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetBannedPersonsImplCopyWith<_$GetBannedPersonsImpl> get copyWith =>
+  _$$_GetBannedPersonsCopyWith<_$_GetBannedPersons> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4885,22 +4862,22 @@ class _$VerifyEmailCopyWithImpl<$Res, $Val extends VerifyEmail>
 }
 
 /// @nodoc
-abstract class _$$VerifyEmailImplCopyWith<$Res>
+abstract class _$$_VerifyEmailCopyWith<$Res>
     implements $VerifyEmailCopyWith<$Res> {
-  factory _$$VerifyEmailImplCopyWith(
-          _$VerifyEmailImpl value, $Res Function(_$VerifyEmailImpl) then) =
-      __$$VerifyEmailImplCopyWithImpl<$Res>;
+  factory _$$_VerifyEmailCopyWith(
+          _$_VerifyEmail value, $Res Function(_$_VerifyEmail) then) =
+      __$$_VerifyEmailCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String token});
 }
 
 /// @nodoc
-class __$$VerifyEmailImplCopyWithImpl<$Res>
-    extends _$VerifyEmailCopyWithImpl<$Res, _$VerifyEmailImpl>
-    implements _$$VerifyEmailImplCopyWith<$Res> {
-  __$$VerifyEmailImplCopyWithImpl(
-      _$VerifyEmailImpl _value, $Res Function(_$VerifyEmailImpl) _then)
+class __$$_VerifyEmailCopyWithImpl<$Res>
+    extends _$VerifyEmailCopyWithImpl<$Res, _$_VerifyEmail>
+    implements _$$_VerifyEmailCopyWith<$Res> {
+  __$$_VerifyEmailCopyWithImpl(
+      _$_VerifyEmail _value, $Res Function(_$_VerifyEmail) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4908,7 +4885,7 @@ class __$$VerifyEmailImplCopyWithImpl<$Res>
   $Res call({
     Object? token = null,
   }) {
-    return _then(_$VerifyEmailImpl(
+    return _then(_$_VerifyEmail(
       token: null == token
           ? _value.token
           : token // ignore: cast_nullable_to_non_nullable
@@ -4920,11 +4897,11 @@ class __$$VerifyEmailImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$VerifyEmailImpl extends _VerifyEmail {
-  const _$VerifyEmailImpl({required this.token}) : super._();
+class _$_VerifyEmail extends _VerifyEmail {
+  const _$_VerifyEmail({required this.token}) : super._();
 
-  factory _$VerifyEmailImpl.fromJson(Map<String, dynamic> json) =>
-      _$$VerifyEmailImplFromJson(json);
+  factory _$_VerifyEmail.fromJson(Map<String, dynamic> json) =>
+      _$$_VerifyEmailFromJson(json);
 
   @override
   final String token;
@@ -4938,7 +4915,7 @@ class _$VerifyEmailImpl extends _VerifyEmail {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$VerifyEmailImpl &&
+            other is _$_VerifyEmail &&
             (identical(other.token, token) || other.token == token));
   }
 
@@ -4949,28 +4926,28 @@ class _$VerifyEmailImpl extends _VerifyEmail {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$VerifyEmailImplCopyWith<_$VerifyEmailImpl> get copyWith =>
-      __$$VerifyEmailImplCopyWithImpl<_$VerifyEmailImpl>(this, _$identity);
+  _$$_VerifyEmailCopyWith<_$_VerifyEmail> get copyWith =>
+      __$$_VerifyEmailCopyWithImpl<_$_VerifyEmail>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$VerifyEmailImplToJson(
+    return _$$_VerifyEmailToJson(
       this,
     );
   }
 }
 
 abstract class _VerifyEmail extends VerifyEmail {
-  const factory _VerifyEmail({required final String token}) = _$VerifyEmailImpl;
+  const factory _VerifyEmail({required final String token}) = _$_VerifyEmail;
   const _VerifyEmail._() : super._();
 
   factory _VerifyEmail.fromJson(Map<String, dynamic> json) =
-      _$VerifyEmailImpl.fromJson;
+      _$_VerifyEmail.fromJson;
 
   @override
   String get token;
   @override
   @JsonKey(ignore: true)
-  _$$VerifyEmailImplCopyWith<_$VerifyEmailImpl> get copyWith =>
+  _$$_VerifyEmailCopyWith<_$_VerifyEmail> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/person.g.dart
+++ b/lib/src/v3/api/person.g.dart
@@ -6,13 +6,13 @@ part of 'person.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$LoginImpl _$$LoginImplFromJson(Map<String, dynamic> json) => _$LoginImpl(
+_$_Login _$$_LoginFromJson(Map<String, dynamic> json) => _$_Login(
       usernameOrEmail: json['username_or_email'] as String,
       password: json['password'] as String,
       totp2faToken: json['totp_2fa_token'] as String?,
     );
 
-Map<String, dynamic> _$$LoginImplToJson(_$LoginImpl instance) {
+Map<String, dynamic> _$$_LoginToJson(_$_Login instance) {
   final val = <String, dynamic>{
     'username_or_email': instance.usernameOrEmail,
     'password': instance.password,
@@ -28,8 +28,7 @@ Map<String, dynamic> _$$LoginImplToJson(_$LoginImpl instance) {
   return val;
 }
 
-_$RegisterImpl _$$RegisterImplFromJson(Map<String, dynamic> json) =>
-    _$RegisterImpl(
+_$_Register _$$_RegisterFromJson(Map<String, dynamic> json) => _$_Register(
       username: json['username'] as String,
       email: json['email'] as String?,
       password: json['password'] as String,
@@ -41,7 +40,7 @@ _$RegisterImpl _$$RegisterImplFromJson(Map<String, dynamic> json) =>
       answer: json['answer'] as String?,
     );
 
-Map<String, dynamic> _$$RegisterImplToJson(_$RegisterImpl instance) {
+Map<String, dynamic> _$$_RegisterToJson(_$_Register instance) {
   final val = <String, dynamic>{
     'username': instance.username,
   };
@@ -63,15 +62,14 @@ Map<String, dynamic> _$$RegisterImplToJson(_$RegisterImpl instance) {
   return val;
 }
 
-_$GetCaptchaImpl _$$GetCaptchaImplFromJson(Map<String, dynamic> json) =>
-    _$GetCaptchaImpl();
+_$_GetCaptcha _$$_GetCaptchaFromJson(Map<String, dynamic> json) =>
+    _$_GetCaptcha();
 
-Map<String, dynamic> _$$GetCaptchaImplToJson(_$GetCaptchaImpl instance) =>
+Map<String, dynamic> _$$_GetCaptchaToJson(_$_GetCaptcha instance) =>
     <String, dynamic>{};
 
-_$SaveUserSettingsImpl _$$SaveUserSettingsImplFromJson(
-        Map<String, dynamic> json) =>
-    _$SaveUserSettingsImpl(
+_$_SaveUserSettings _$$_SaveUserSettingsFromJson(Map<String, dynamic> json) =>
+    _$_SaveUserSettings(
       showNsfw: json['show_nsfw'] as bool?,
       theme: json['theme'] as String?,
       defaultSortType: json['default_sort_type'] == null
@@ -100,8 +98,7 @@ _$SaveUserSettingsImpl _$$SaveUserSettingsImplFromJson(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$SaveUserSettingsImplToJson(
-    _$SaveUserSettingsImpl instance) {
+Map<String, dynamic> _$$_SaveUserSettingsToJson(_$_SaveUserSettings instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -134,16 +131,15 @@ Map<String, dynamic> _$$SaveUserSettingsImplToJson(
   return val;
 }
 
-_$ChangePasswordImpl _$$ChangePasswordImplFromJson(Map<String, dynamic> json) =>
-    _$ChangePasswordImpl(
+_$_ChangePassword _$$_ChangePasswordFromJson(Map<String, dynamic> json) =>
+    _$_ChangePassword(
       newPassword: json['new_password'] as String,
       newPasswordVerify: json['new_password_verify'] as String,
       oldPassword: json['old_password'] as String,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$ChangePasswordImplToJson(
-        _$ChangePasswordImpl instance) =>
+Map<String, dynamic> _$$_ChangePasswordToJson(_$_ChangePassword instance) =>
     <String, dynamic>{
       'new_password': instance.newPassword,
       'new_password_verify': instance.newPasswordVerify,
@@ -151,9 +147,8 @@ Map<String, dynamic> _$$ChangePasswordImplToJson(
       'auth': instance.auth,
     };
 
-_$GetPersonDetailsImpl _$$GetPersonDetailsImplFromJson(
-        Map<String, dynamic> json) =>
-    _$GetPersonDetailsImpl(
+_$_GetPersonDetails _$$_GetPersonDetailsFromJson(Map<String, dynamic> json) =>
+    _$_GetPersonDetails(
       personId: json['person_id'] as int?,
       username: json['username'] as String?,
       sort: json['sort'] == null ? null : SortType.fromJson(json['sort']),
@@ -164,8 +159,7 @@ _$GetPersonDetailsImpl _$$GetPersonDetailsImplFromJson(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$GetPersonDetailsImplToJson(
-    _$GetPersonDetailsImpl instance) {
+Map<String, dynamic> _$$_GetPersonDetailsToJson(_$_GetPersonDetails instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -185,32 +179,30 @@ Map<String, dynamic> _$$GetPersonDetailsImplToJson(
   return val;
 }
 
-_$MarkAllAsReadImpl _$$MarkAllAsReadImplFromJson(Map<String, dynamic> json) =>
-    _$MarkAllAsReadImpl(
+_$_MarkAllAsRead _$$_MarkAllAsReadFromJson(Map<String, dynamic> json) =>
+    _$_MarkAllAsRead(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$MarkAllAsReadImplToJson(_$MarkAllAsReadImpl instance) =>
+Map<String, dynamic> _$$_MarkAllAsReadToJson(_$_MarkAllAsRead instance) =>
     <String, dynamic>{
       'auth': instance.auth,
     };
 
-_$AddAdminImpl _$$AddAdminImplFromJson(Map<String, dynamic> json) =>
-    _$AddAdminImpl(
+_$_AddAdmin _$$_AddAdminFromJson(Map<String, dynamic> json) => _$_AddAdmin(
       personId: json['person_id'] as int,
       added: json['added'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$AddAdminImplToJson(_$AddAdminImpl instance) =>
+Map<String, dynamic> _$$_AddAdminToJson(_$_AddAdmin instance) =>
     <String, dynamic>{
       'person_id': instance.personId,
       'added': instance.added,
       'auth': instance.auth,
     };
 
-_$BanPersonImpl _$$BanPersonImplFromJson(Map<String, dynamic> json) =>
-    _$BanPersonImpl(
+_$_BanPerson _$$_BanPersonFromJson(Map<String, dynamic> json) => _$_BanPerson(
       personId: json['person_id'] as int,
       ban: json['ban'] as bool,
       removeData: json['remove_data'] as bool?,
@@ -219,7 +211,7 @@ _$BanPersonImpl _$$BanPersonImplFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$BanPersonImplToJson(_$BanPersonImpl instance) {
+Map<String, dynamic> _$$_BanPersonToJson(_$_BanPerson instance) {
   final val = <String, dynamic>{
     'person_id': instance.personId,
     'ban': instance.ban,
@@ -238,8 +230,8 @@ Map<String, dynamic> _$$BanPersonImplToJson(_$BanPersonImpl instance) {
   return val;
 }
 
-_$GetRepliesImpl _$$GetRepliesImplFromJson(Map<String, dynamic> json) =>
-    _$GetRepliesImpl(
+_$_GetReplies _$$_GetRepliesFromJson(Map<String, dynamic> json) =>
+    _$_GetReplies(
       sort: json['sort'] == null ? null : SortType.fromJson(json['sort']),
       page: json['page'] as int?,
       limit: json['limit'] as int?,
@@ -247,7 +239,7 @@ _$GetRepliesImpl _$$GetRepliesImplFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$GetRepliesImplToJson(_$GetRepliesImpl instance) {
+Map<String, dynamic> _$$_GetRepliesToJson(_$_GetReplies instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -264,9 +256,8 @@ Map<String, dynamic> _$$GetRepliesImplToJson(_$GetRepliesImpl instance) {
   return val;
 }
 
-_$GetPersonMentionsImpl _$$GetPersonMentionsImplFromJson(
-        Map<String, dynamic> json) =>
-    _$GetPersonMentionsImpl(
+_$_GetPersonMentions _$$_GetPersonMentionsFromJson(Map<String, dynamic> json) =>
+    _$_GetPersonMentions(
       sort: json['sort'] == null ? null : SortType.fromJson(json['sort']),
       page: json['page'] as int?,
       limit: json['limit'] as int?,
@@ -274,8 +265,8 @@ _$GetPersonMentionsImpl _$$GetPersonMentionsImplFromJson(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$GetPersonMentionsImplToJson(
-    _$GetPersonMentionsImpl instance) {
+Map<String, dynamic> _$$_GetPersonMentionsToJson(
+    _$_GetPersonMentions instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -292,134 +283,133 @@ Map<String, dynamic> _$$GetPersonMentionsImplToJson(
   return val;
 }
 
-_$MarkPersonMentionAsReadImpl _$$MarkPersonMentionAsReadImplFromJson(
+_$_MarkPersonMentionAsRead _$$_MarkPersonMentionAsReadFromJson(
         Map<String, dynamic> json) =>
-    _$MarkPersonMentionAsReadImpl(
+    _$_MarkPersonMentionAsRead(
       personMentionId: json['person_mention_id'] as int,
       read: json['read'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$MarkPersonMentionAsReadImplToJson(
-        _$MarkPersonMentionAsReadImpl instance) =>
+Map<String, dynamic> _$$_MarkPersonMentionAsReadToJson(
+        _$_MarkPersonMentionAsRead instance) =>
     <String, dynamic>{
       'person_mention_id': instance.personMentionId,
       'read': instance.read,
       'auth': instance.auth,
     };
 
-_$DeleteAccountImpl _$$DeleteAccountImplFromJson(Map<String, dynamic> json) =>
-    _$DeleteAccountImpl(
+_$_DeleteAccount _$$_DeleteAccountFromJson(Map<String, dynamic> json) =>
+    _$_DeleteAccount(
       password: json['password'] as String,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$DeleteAccountImplToJson(_$DeleteAccountImpl instance) =>
+Map<String, dynamic> _$$_DeleteAccountToJson(_$_DeleteAccount instance) =>
     <String, dynamic>{
       'password': instance.password,
       'auth': instance.auth,
     };
 
-_$PasswordResetImpl _$$PasswordResetImplFromJson(Map<String, dynamic> json) =>
-    _$PasswordResetImpl(
+_$_PasswordReset _$$_PasswordResetFromJson(Map<String, dynamic> json) =>
+    _$_PasswordReset(
       email: json['email'] as String,
     );
 
-Map<String, dynamic> _$$PasswordResetImplToJson(_$PasswordResetImpl instance) =>
+Map<String, dynamic> _$$_PasswordResetToJson(_$_PasswordReset instance) =>
     <String, dynamic>{
       'email': instance.email,
     };
 
-_$PasswordChangeImpl _$$PasswordChangeImplFromJson(Map<String, dynamic> json) =>
-    _$PasswordChangeImpl(
+_$_PasswordChange _$$_PasswordChangeFromJson(Map<String, dynamic> json) =>
+    _$_PasswordChange(
       token: json['token'] as String,
       password: json['password'] as String,
       passwordVerify: json['password_verify'] as String,
     );
 
-Map<String, dynamic> _$$PasswordChangeImplToJson(
-        _$PasswordChangeImpl instance) =>
+Map<String, dynamic> _$$_PasswordChangeToJson(_$_PasswordChange instance) =>
     <String, dynamic>{
       'token': instance.token,
       'password': instance.password,
       'password_verify': instance.passwordVerify,
     };
 
-_$CreatePrivateMessageImpl _$$CreatePrivateMessageImplFromJson(
+_$_CreatePrivateMessage _$$_CreatePrivateMessageFromJson(
         Map<String, dynamic> json) =>
-    _$CreatePrivateMessageImpl(
+    _$_CreatePrivateMessage(
       content: json['content'] as String,
       recipientId: json['recipient_id'] as int,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$CreatePrivateMessageImplToJson(
-        _$CreatePrivateMessageImpl instance) =>
+Map<String, dynamic> _$$_CreatePrivateMessageToJson(
+        _$_CreatePrivateMessage instance) =>
     <String, dynamic>{
       'content': instance.content,
       'recipient_id': instance.recipientId,
       'auth': instance.auth,
     };
 
-_$EditPrivateMessageImpl _$$EditPrivateMessageImplFromJson(
+_$_EditPrivateMessage _$$_EditPrivateMessageFromJson(
         Map<String, dynamic> json) =>
-    _$EditPrivateMessageImpl(
+    _$_EditPrivateMessage(
       privateMessageId: json['private_message_id'] as int,
       content: json['content'] as String,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$EditPrivateMessageImplToJson(
-        _$EditPrivateMessageImpl instance) =>
+Map<String, dynamic> _$$_EditPrivateMessageToJson(
+        _$_EditPrivateMessage instance) =>
     <String, dynamic>{
       'private_message_id': instance.privateMessageId,
       'content': instance.content,
       'auth': instance.auth,
     };
 
-_$DeletePrivateMessageImpl _$$DeletePrivateMessageImplFromJson(
+_$_DeletePrivateMessage _$$_DeletePrivateMessageFromJson(
         Map<String, dynamic> json) =>
-    _$DeletePrivateMessageImpl(
+    _$_DeletePrivateMessage(
       privateMessageId: json['private_message_id'] as int,
       deleted: json['deleted'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$DeletePrivateMessageImplToJson(
-        _$DeletePrivateMessageImpl instance) =>
+Map<String, dynamic> _$$_DeletePrivateMessageToJson(
+        _$_DeletePrivateMessage instance) =>
     <String, dynamic>{
       'private_message_id': instance.privateMessageId,
       'deleted': instance.deleted,
       'auth': instance.auth,
     };
 
-_$MarkPrivateMessageAsReadImpl _$$MarkPrivateMessageAsReadImplFromJson(
+_$_MarkPrivateMessageAsRead _$$_MarkPrivateMessageAsReadFromJson(
         Map<String, dynamic> json) =>
-    _$MarkPrivateMessageAsReadImpl(
+    _$_MarkPrivateMessageAsRead(
       privateMessageId: json['private_message_id'] as int,
       read: json['read'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$MarkPrivateMessageAsReadImplToJson(
-        _$MarkPrivateMessageAsReadImpl instance) =>
+Map<String, dynamic> _$$_MarkPrivateMessageAsReadToJson(
+        _$_MarkPrivateMessageAsRead instance) =>
     <String, dynamic>{
       'private_message_id': instance.privateMessageId,
       'read': instance.read,
       'auth': instance.auth,
     };
 
-_$GetPrivateMessagesImpl _$$GetPrivateMessagesImplFromJson(
+_$_GetPrivateMessages _$$_GetPrivateMessagesFromJson(
         Map<String, dynamic> json) =>
-    _$GetPrivateMessagesImpl(
+    _$_GetPrivateMessages(
       unreadOnly: json['unread_only'] as bool?,
       page: json['page'] as int?,
       limit: json['limit'] as int?,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$GetPrivateMessagesImplToJson(
-    _$GetPrivateMessagesImpl instance) {
+Map<String, dynamic> _$$_GetPrivateMessagesToJson(
+    _$_GetPrivateMessages instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -435,39 +425,37 @@ Map<String, dynamic> _$$GetPrivateMessagesImplToJson(
   return val;
 }
 
-_$BlockPersonImpl _$$BlockPersonImplFromJson(Map<String, dynamic> json) =>
-    _$BlockPersonImpl(
+_$_BlockPerson _$$_BlockPersonFromJson(Map<String, dynamic> json) =>
+    _$_BlockPerson(
       personId: json['person_id'] as int,
       block: json['block'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$BlockPersonImplToJson(_$BlockPersonImpl instance) =>
+Map<String, dynamic> _$$_BlockPersonToJson(_$_BlockPerson instance) =>
     <String, dynamic>{
       'person_id': instance.personId,
       'block': instance.block,
       'auth': instance.auth,
     };
 
-_$GetUnreadCountImpl _$$GetUnreadCountImplFromJson(Map<String, dynamic> json) =>
-    _$GetUnreadCountImpl(
+_$_GetUnreadCount _$$_GetUnreadCountFromJson(Map<String, dynamic> json) =>
+    _$_GetUnreadCount(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$GetUnreadCountImplToJson(
-        _$GetUnreadCountImpl instance) =>
+Map<String, dynamic> _$$_GetUnreadCountToJson(_$_GetUnreadCount instance) =>
     <String, dynamic>{
       'auth': instance.auth,
     };
 
-_$GetReportCountImpl _$$GetReportCountImplFromJson(Map<String, dynamic> json) =>
-    _$GetReportCountImpl(
+_$_GetReportCount _$$_GetReportCountFromJson(Map<String, dynamic> json) =>
+    _$_GetReportCount(
       communityId: json['community_id'] as int?,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$GetReportCountImplToJson(
-    _$GetReportCountImpl instance) {
+Map<String, dynamic> _$$_GetReportCountToJson(_$_GetReportCount instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -481,24 +469,22 @@ Map<String, dynamic> _$$GetReportCountImplToJson(
   return val;
 }
 
-_$GetBannedPersonsImpl _$$GetBannedPersonsImplFromJson(
-        Map<String, dynamic> json) =>
-    _$GetBannedPersonsImpl(
+_$_GetBannedPersons _$$_GetBannedPersonsFromJson(Map<String, dynamic> json) =>
+    _$_GetBannedPersons(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$GetBannedPersonsImplToJson(
-        _$GetBannedPersonsImpl instance) =>
+Map<String, dynamic> _$$_GetBannedPersonsToJson(_$_GetBannedPersons instance) =>
     <String, dynamic>{
       'auth': instance.auth,
     };
 
-_$VerifyEmailImpl _$$VerifyEmailImplFromJson(Map<String, dynamic> json) =>
-    _$VerifyEmailImpl(
+_$_VerifyEmail _$$_VerifyEmailFromJson(Map<String, dynamic> json) =>
+    _$_VerifyEmail(
       token: json['token'] as String,
     );
 
-Map<String, dynamic> _$$VerifyEmailImplToJson(_$VerifyEmailImpl instance) =>
+Map<String, dynamic> _$$_VerifyEmailToJson(_$_VerifyEmail instance) =>
     <String, dynamic>{
       'token': instance.token,
     };

--- a/lib/src/v3/api/post.freezed.dart
+++ b/lib/src/v3/api/post.freezed.dart
@@ -66,21 +66,20 @@ class _$GetPostCopyWithImpl<$Res, $Val extends GetPost>
 }
 
 /// @nodoc
-abstract class _$$GetPostImplCopyWith<$Res> implements $GetPostCopyWith<$Res> {
-  factory _$$GetPostImplCopyWith(
-          _$GetPostImpl value, $Res Function(_$GetPostImpl) then) =
-      __$$GetPostImplCopyWithImpl<$Res>;
+abstract class _$$_GetPostCopyWith<$Res> implements $GetPostCopyWith<$Res> {
+  factory _$$_GetPostCopyWith(
+          _$_GetPost value, $Res Function(_$_GetPost) then) =
+      __$$_GetPostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int id, String? auth});
 }
 
 /// @nodoc
-class __$$GetPostImplCopyWithImpl<$Res>
-    extends _$GetPostCopyWithImpl<$Res, _$GetPostImpl>
-    implements _$$GetPostImplCopyWith<$Res> {
-  __$$GetPostImplCopyWithImpl(
-      _$GetPostImpl _value, $Res Function(_$GetPostImpl) _then)
+class __$$_GetPostCopyWithImpl<$Res>
+    extends _$GetPostCopyWithImpl<$Res, _$_GetPost>
+    implements _$$_GetPostCopyWith<$Res> {
+  __$$_GetPostCopyWithImpl(_$_GetPost _value, $Res Function(_$_GetPost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -89,7 +88,7 @@ class __$$GetPostImplCopyWithImpl<$Res>
     Object? id = null,
     Object? auth = freezed,
   }) {
-    return _then(_$GetPostImpl(
+    return _then(_$_GetPost(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -105,11 +104,11 @@ class __$$GetPostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetPostImpl extends _GetPost {
-  const _$GetPostImpl({required this.id, this.auth}) : super._();
+class _$_GetPost extends _GetPost {
+  const _$_GetPost({required this.id, this.auth}) : super._();
 
-  factory _$GetPostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetPostImplFromJson(json);
+  factory _$_GetPost.fromJson(Map<String, dynamic> json) =>
+      _$$_GetPostFromJson(json);
 
   @override
   final int id;
@@ -125,7 +124,7 @@ class _$GetPostImpl extends _GetPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetPostImpl &&
+            other is _$_GetPost &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.auth, auth) || other.auth == auth));
   }
@@ -137,12 +136,12 @@ class _$GetPostImpl extends _GetPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetPostImplCopyWith<_$GetPostImpl> get copyWith =>
-      __$$GetPostImplCopyWithImpl<_$GetPostImpl>(this, _$identity);
+  _$$_GetPostCopyWith<_$_GetPost> get copyWith =>
+      __$$_GetPostCopyWithImpl<_$_GetPost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetPostImplToJson(
+    return _$$_GetPostToJson(
       this,
     );
   }
@@ -150,10 +149,10 @@ class _$GetPostImpl extends _GetPost {
 
 abstract class _GetPost extends GetPost {
   const factory _GetPost({required final int id, final String? auth}) =
-      _$GetPostImpl;
+      _$_GetPost;
   const _GetPost._() : super._();
 
-  factory _GetPost.fromJson(Map<String, dynamic> json) = _$GetPostImpl.fromJson;
+  factory _GetPost.fromJson(Map<String, dynamic> json) = _$_GetPost.fromJson;
 
   @override
   int get id;
@@ -161,7 +160,7 @@ abstract class _GetPost extends GetPost {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetPostImplCopyWith<_$GetPostImpl> get copyWith =>
+  _$$_GetPostCopyWith<_$_GetPost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -256,11 +255,11 @@ class _$CreatePostCopyWithImpl<$Res, $Val extends CreatePost>
 }
 
 /// @nodoc
-abstract class _$$CreatePostImplCopyWith<$Res>
+abstract class _$$_CreatePostCopyWith<$Res>
     implements $CreatePostCopyWith<$Res> {
-  factory _$$CreatePostImplCopyWith(
-          _$CreatePostImpl value, $Res Function(_$CreatePostImpl) then) =
-      __$$CreatePostImplCopyWithImpl<$Res>;
+  factory _$$_CreatePostCopyWith(
+          _$_CreatePost value, $Res Function(_$_CreatePost) then) =
+      __$$_CreatePostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -274,11 +273,11 @@ abstract class _$$CreatePostImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CreatePostImplCopyWithImpl<$Res>
-    extends _$CreatePostCopyWithImpl<$Res, _$CreatePostImpl>
-    implements _$$CreatePostImplCopyWith<$Res> {
-  __$$CreatePostImplCopyWithImpl(
-      _$CreatePostImpl _value, $Res Function(_$CreatePostImpl) _then)
+class __$$_CreatePostCopyWithImpl<$Res>
+    extends _$CreatePostCopyWithImpl<$Res, _$_CreatePost>
+    implements _$$_CreatePostCopyWith<$Res> {
+  __$$_CreatePostCopyWithImpl(
+      _$_CreatePost _value, $Res Function(_$_CreatePost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -292,7 +291,7 @@ class __$$CreatePostImplCopyWithImpl<$Res>
     Object? auth = null,
     Object? honeypot = freezed,
   }) {
-    return _then(_$CreatePostImpl(
+    return _then(_$_CreatePost(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -328,8 +327,8 @@ class __$$CreatePostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$CreatePostImpl extends _CreatePost {
-  const _$CreatePostImpl(
+class _$_CreatePost extends _CreatePost {
+  const _$_CreatePost(
       {required this.name,
       this.url,
       this.body,
@@ -339,8 +338,8 @@ class _$CreatePostImpl extends _CreatePost {
       this.honeypot})
       : super._();
 
-  factory _$CreatePostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CreatePostImplFromJson(json);
+  factory _$_CreatePost.fromJson(Map<String, dynamic> json) =>
+      _$$_CreatePostFromJson(json);
 
   @override
   final String name;
@@ -366,7 +365,7 @@ class _$CreatePostImpl extends _CreatePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CreatePostImpl &&
+            other is _$_CreatePost &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.url, url) || other.url == url) &&
             (identical(other.body, body) || other.body == body) &&
@@ -386,12 +385,12 @@ class _$CreatePostImpl extends _CreatePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CreatePostImplCopyWith<_$CreatePostImpl> get copyWith =>
-      __$$CreatePostImplCopyWithImpl<_$CreatePostImpl>(this, _$identity);
+  _$$_CreatePostCopyWith<_$_CreatePost> get copyWith =>
+      __$$_CreatePostCopyWithImpl<_$_CreatePost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CreatePostImplToJson(
+    return _$$_CreatePostToJson(
       this,
     );
   }
@@ -405,11 +404,11 @@ abstract class _CreatePost extends CreatePost {
       final bool? nsfw,
       required final int communityId,
       required final String auth,
-      final String? honeypot}) = _$CreatePostImpl;
+      final String? honeypot}) = _$_CreatePost;
   const _CreatePost._() : super._();
 
   factory _CreatePost.fromJson(Map<String, dynamic> json) =
-      _$CreatePostImpl.fromJson;
+      _$_CreatePost.fromJson;
 
   @override
   String get name;
@@ -427,7 +426,7 @@ abstract class _CreatePost extends CreatePost {
   String? get honeypot;
   @override
   @JsonKey(ignore: true)
-  _$$CreatePostImplCopyWith<_$CreatePostImpl> get copyWith =>
+  _$$_CreatePostCopyWith<_$_CreatePost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -529,11 +528,10 @@ class _$GetPostsCopyWithImpl<$Res, $Val extends GetPosts>
 }
 
 /// @nodoc
-abstract class _$$GetPostsImplCopyWith<$Res>
-    implements $GetPostsCopyWith<$Res> {
-  factory _$$GetPostsImplCopyWith(
-          _$GetPostsImpl value, $Res Function(_$GetPostsImpl) then) =
-      __$$GetPostsImplCopyWithImpl<$Res>;
+abstract class _$$_GetPostsCopyWith<$Res> implements $GetPostsCopyWith<$Res> {
+  factory _$$_GetPostsCopyWith(
+          _$_GetPosts value, $Res Function(_$_GetPosts) then) =
+      __$$_GetPostsCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -548,11 +546,11 @@ abstract class _$$GetPostsImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$GetPostsImplCopyWithImpl<$Res>
-    extends _$GetPostsCopyWithImpl<$Res, _$GetPostsImpl>
-    implements _$$GetPostsImplCopyWith<$Res> {
-  __$$GetPostsImplCopyWithImpl(
-      _$GetPostsImpl _value, $Res Function(_$GetPostsImpl) _then)
+class __$$_GetPostsCopyWithImpl<$Res>
+    extends _$GetPostsCopyWithImpl<$Res, _$_GetPosts>
+    implements _$$_GetPostsCopyWith<$Res> {
+  __$$_GetPostsCopyWithImpl(
+      _$_GetPosts _value, $Res Function(_$_GetPosts) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -567,7 +565,7 @@ class __$$GetPostsImplCopyWithImpl<$Res>
     Object? savedOnly = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$GetPostsImpl(
+    return _then(_$_GetPosts(
       type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -607,8 +605,8 @@ class __$$GetPostsImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetPostsImpl extends _GetPosts {
-  const _$GetPostsImpl(
+class _$_GetPosts extends _GetPosts {
+  const _$_GetPosts(
       {@JsonKey(name: 'type_') this.type,
       this.sort,
       this.page,
@@ -619,8 +617,8 @@ class _$GetPostsImpl extends _GetPosts {
       this.auth})
       : super._();
 
-  factory _$GetPostsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetPostsImplFromJson(json);
+  factory _$_GetPosts.fromJson(Map<String, dynamic> json) =>
+      _$$_GetPostsFromJson(json);
 
   @override
   @JsonKey(name: 'type_')
@@ -649,7 +647,7 @@ class _$GetPostsImpl extends _GetPosts {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetPostsImpl &&
+            other is _$_GetPosts &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
@@ -671,12 +669,12 @@ class _$GetPostsImpl extends _GetPosts {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetPostsImplCopyWith<_$GetPostsImpl> get copyWith =>
-      __$$GetPostsImplCopyWithImpl<_$GetPostsImpl>(this, _$identity);
+  _$$_GetPostsCopyWith<_$_GetPosts> get copyWith =>
+      __$$_GetPostsCopyWithImpl<_$_GetPosts>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetPostsImplToJson(
+    return _$$_GetPostsToJson(
       this,
     );
   }
@@ -691,11 +689,10 @@ abstract class _GetPosts extends GetPosts {
       final int? communityId,
       final String? communityName,
       final bool? savedOnly,
-      final String? auth}) = _$GetPostsImpl;
+      final String? auth}) = _$_GetPosts;
   const _GetPosts._() : super._();
 
-  factory _GetPosts.fromJson(Map<String, dynamic> json) =
-      _$GetPostsImpl.fromJson;
+  factory _GetPosts.fromJson(Map<String, dynamic> json) = _$_GetPosts.fromJson;
 
   @override
   @JsonKey(name: 'type_')
@@ -716,7 +713,7 @@ abstract class _GetPosts extends GetPosts {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetPostsImplCopyWith<_$GetPostsImpl> get copyWith =>
+  _$$_GetPostsCopyWith<_$_GetPosts> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -780,22 +777,22 @@ class _$CreatePostLikeCopyWithImpl<$Res, $Val extends CreatePostLike>
 }
 
 /// @nodoc
-abstract class _$$CreatePostLikeImplCopyWith<$Res>
+abstract class _$$_CreatePostLikeCopyWith<$Res>
     implements $CreatePostLikeCopyWith<$Res> {
-  factory _$$CreatePostLikeImplCopyWith(_$CreatePostLikeImpl value,
-          $Res Function(_$CreatePostLikeImpl) then) =
-      __$$CreatePostLikeImplCopyWithImpl<$Res>;
+  factory _$$_CreatePostLikeCopyWith(
+          _$_CreatePostLike value, $Res Function(_$_CreatePostLike) then) =
+      __$$_CreatePostLikeCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, VoteType score, String auth});
 }
 
 /// @nodoc
-class __$$CreatePostLikeImplCopyWithImpl<$Res>
-    extends _$CreatePostLikeCopyWithImpl<$Res, _$CreatePostLikeImpl>
-    implements _$$CreatePostLikeImplCopyWith<$Res> {
-  __$$CreatePostLikeImplCopyWithImpl(
-      _$CreatePostLikeImpl _value, $Res Function(_$CreatePostLikeImpl) _then)
+class __$$_CreatePostLikeCopyWithImpl<$Res>
+    extends _$CreatePostLikeCopyWithImpl<$Res, _$_CreatePostLike>
+    implements _$$_CreatePostLikeCopyWith<$Res> {
+  __$$_CreatePostLikeCopyWithImpl(
+      _$_CreatePostLike _value, $Res Function(_$_CreatePostLike) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -805,7 +802,7 @@ class __$$CreatePostLikeImplCopyWithImpl<$Res>
     Object? score = null,
     Object? auth = null,
   }) {
-    return _then(_$CreatePostLikeImpl(
+    return _then(_$_CreatePostLike(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -825,13 +822,13 @@ class __$$CreatePostLikeImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$CreatePostLikeImpl extends _CreatePostLike {
-  const _$CreatePostLikeImpl(
+class _$_CreatePostLike extends _CreatePostLike {
+  const _$_CreatePostLike(
       {required this.postId, required this.score, required this.auth})
       : super._();
 
-  factory _$CreatePostLikeImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CreatePostLikeImplFromJson(json);
+  factory _$_CreatePostLike.fromJson(Map<String, dynamic> json) =>
+      _$$_CreatePostLikeFromJson(json);
 
   @override
   final int postId;
@@ -849,7 +846,7 @@ class _$CreatePostLikeImpl extends _CreatePostLike {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CreatePostLikeImpl &&
+            other is _$_CreatePostLike &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.score, score) || other.score == score) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -862,13 +859,12 @@ class _$CreatePostLikeImpl extends _CreatePostLike {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CreatePostLikeImplCopyWith<_$CreatePostLikeImpl> get copyWith =>
-      __$$CreatePostLikeImplCopyWithImpl<_$CreatePostLikeImpl>(
-          this, _$identity);
+  _$$_CreatePostLikeCopyWith<_$_CreatePostLike> get copyWith =>
+      __$$_CreatePostLikeCopyWithImpl<_$_CreatePostLike>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CreatePostLikeImplToJson(
+    return _$$_CreatePostLikeToJson(
       this,
     );
   }
@@ -878,11 +874,11 @@ abstract class _CreatePostLike extends CreatePostLike {
   const factory _CreatePostLike(
       {required final int postId,
       required final VoteType score,
-      required final String auth}) = _$CreatePostLikeImpl;
+      required final String auth}) = _$_CreatePostLike;
   const _CreatePostLike._() : super._();
 
   factory _CreatePostLike.fromJson(Map<String, dynamic> json) =
-      _$CreatePostLikeImpl.fromJson;
+      _$_CreatePostLike.fromJson;
 
   @override
   int get postId;
@@ -892,7 +888,7 @@ abstract class _CreatePostLike extends CreatePostLike {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$CreatePostLikeImplCopyWith<_$CreatePostLikeImpl> get copyWith =>
+  _$$_CreatePostLikeCopyWith<_$_CreatePostLike> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -979,11 +975,10 @@ class _$EditPostCopyWithImpl<$Res, $Val extends EditPost>
 }
 
 /// @nodoc
-abstract class _$$EditPostImplCopyWith<$Res>
-    implements $EditPostCopyWith<$Res> {
-  factory _$$EditPostImplCopyWith(
-          _$EditPostImpl value, $Res Function(_$EditPostImpl) then) =
-      __$$EditPostImplCopyWithImpl<$Res>;
+abstract class _$$_EditPostCopyWith<$Res> implements $EditPostCopyWith<$Res> {
+  factory _$$_EditPostCopyWith(
+          _$_EditPost value, $Res Function(_$_EditPost) then) =
+      __$$_EditPostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -996,11 +991,11 @@ abstract class _$$EditPostImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$EditPostImplCopyWithImpl<$Res>
-    extends _$EditPostCopyWithImpl<$Res, _$EditPostImpl>
-    implements _$$EditPostImplCopyWith<$Res> {
-  __$$EditPostImplCopyWithImpl(
-      _$EditPostImpl _value, $Res Function(_$EditPostImpl) _then)
+class __$$_EditPostCopyWithImpl<$Res>
+    extends _$EditPostCopyWithImpl<$Res, _$_EditPost>
+    implements _$$_EditPostCopyWith<$Res> {
+  __$$_EditPostCopyWithImpl(
+      _$_EditPost _value, $Res Function(_$_EditPost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1013,7 +1008,7 @@ class __$$EditPostImplCopyWithImpl<$Res>
     Object? nsfw = freezed,
     Object? auth = null,
   }) {
-    return _then(_$EditPostImpl(
+    return _then(_$_EditPost(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1045,8 +1040,8 @@ class __$$EditPostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$EditPostImpl extends _EditPost {
-  const _$EditPostImpl(
+class _$_EditPost extends _EditPost {
+  const _$_EditPost(
       {required this.postId,
       this.name,
       this.url,
@@ -1055,8 +1050,8 @@ class _$EditPostImpl extends _EditPost {
       required this.auth})
       : super._();
 
-  factory _$EditPostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$EditPostImplFromJson(json);
+  factory _$_EditPost.fromJson(Map<String, dynamic> json) =>
+      _$$_EditPostFromJson(json);
 
   @override
   final int postId;
@@ -1080,7 +1075,7 @@ class _$EditPostImpl extends _EditPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$EditPostImpl &&
+            other is _$_EditPost &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.url, url) || other.url == url) &&
@@ -1097,12 +1092,12 @@ class _$EditPostImpl extends _EditPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$EditPostImplCopyWith<_$EditPostImpl> get copyWith =>
-      __$$EditPostImplCopyWithImpl<_$EditPostImpl>(this, _$identity);
+  _$$_EditPostCopyWith<_$_EditPost> get copyWith =>
+      __$$_EditPostCopyWithImpl<_$_EditPost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$EditPostImplToJson(
+    return _$$_EditPostToJson(
       this,
     );
   }
@@ -1115,11 +1110,10 @@ abstract class _EditPost extends EditPost {
       final String? url,
       final String? body,
       final bool? nsfw,
-      required final String auth}) = _$EditPostImpl;
+      required final String auth}) = _$_EditPost;
   const _EditPost._() : super._();
 
-  factory _EditPost.fromJson(Map<String, dynamic> json) =
-      _$EditPostImpl.fromJson;
+  factory _EditPost.fromJson(Map<String, dynamic> json) = _$_EditPost.fromJson;
 
   @override
   int get postId;
@@ -1135,7 +1129,7 @@ abstract class _EditPost extends EditPost {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$EditPostImplCopyWith<_$EditPostImpl> get copyWith =>
+  _$$_EditPostCopyWith<_$_EditPost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1199,22 +1193,22 @@ class _$DeletePostCopyWithImpl<$Res, $Val extends DeletePost>
 }
 
 /// @nodoc
-abstract class _$$DeletePostImplCopyWith<$Res>
+abstract class _$$_DeletePostCopyWith<$Res>
     implements $DeletePostCopyWith<$Res> {
-  factory _$$DeletePostImplCopyWith(
-          _$DeletePostImpl value, $Res Function(_$DeletePostImpl) then) =
-      __$$DeletePostImplCopyWithImpl<$Res>;
+  factory _$$_DeletePostCopyWith(
+          _$_DeletePost value, $Res Function(_$_DeletePost) then) =
+      __$$_DeletePostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool deleted, String auth});
 }
 
 /// @nodoc
-class __$$DeletePostImplCopyWithImpl<$Res>
-    extends _$DeletePostCopyWithImpl<$Res, _$DeletePostImpl>
-    implements _$$DeletePostImplCopyWith<$Res> {
-  __$$DeletePostImplCopyWithImpl(
-      _$DeletePostImpl _value, $Res Function(_$DeletePostImpl) _then)
+class __$$_DeletePostCopyWithImpl<$Res>
+    extends _$DeletePostCopyWithImpl<$Res, _$_DeletePost>
+    implements _$$_DeletePostCopyWith<$Res> {
+  __$$_DeletePostCopyWithImpl(
+      _$_DeletePost _value, $Res Function(_$_DeletePost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1224,7 +1218,7 @@ class __$$DeletePostImplCopyWithImpl<$Res>
     Object? deleted = null,
     Object? auth = null,
   }) {
-    return _then(_$DeletePostImpl(
+    return _then(_$_DeletePost(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1244,13 +1238,13 @@ class __$$DeletePostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$DeletePostImpl extends _DeletePost {
-  const _$DeletePostImpl(
+class _$_DeletePost extends _DeletePost {
+  const _$_DeletePost(
       {required this.postId, required this.deleted, required this.auth})
       : super._();
 
-  factory _$DeletePostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$DeletePostImplFromJson(json);
+  factory _$_DeletePost.fromJson(Map<String, dynamic> json) =>
+      _$$_DeletePostFromJson(json);
 
   @override
   final int postId;
@@ -1268,7 +1262,7 @@ class _$DeletePostImpl extends _DeletePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$DeletePostImpl &&
+            other is _$_DeletePost &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.deleted, deleted) || other.deleted == deleted) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -1281,12 +1275,12 @@ class _$DeletePostImpl extends _DeletePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$DeletePostImplCopyWith<_$DeletePostImpl> get copyWith =>
-      __$$DeletePostImplCopyWithImpl<_$DeletePostImpl>(this, _$identity);
+  _$$_DeletePostCopyWith<_$_DeletePost> get copyWith =>
+      __$$_DeletePostCopyWithImpl<_$_DeletePost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$DeletePostImplToJson(
+    return _$$_DeletePostToJson(
       this,
     );
   }
@@ -1296,11 +1290,11 @@ abstract class _DeletePost extends DeletePost {
   const factory _DeletePost(
       {required final int postId,
       required final bool deleted,
-      required final String auth}) = _$DeletePostImpl;
+      required final String auth}) = _$_DeletePost;
   const _DeletePost._() : super._();
 
   factory _DeletePost.fromJson(Map<String, dynamic> json) =
-      _$DeletePostImpl.fromJson;
+      _$_DeletePost.fromJson;
 
   @override
   int get postId;
@@ -1310,7 +1304,7 @@ abstract class _DeletePost extends DeletePost {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$DeletePostImplCopyWith<_$DeletePostImpl> get copyWith =>
+  _$$_DeletePostCopyWith<_$_DeletePost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1380,22 +1374,22 @@ class _$RemovePostCopyWithImpl<$Res, $Val extends RemovePost>
 }
 
 /// @nodoc
-abstract class _$$RemovePostImplCopyWith<$Res>
+abstract class _$$_RemovePostCopyWith<$Res>
     implements $RemovePostCopyWith<$Res> {
-  factory _$$RemovePostImplCopyWith(
-          _$RemovePostImpl value, $Res Function(_$RemovePostImpl) then) =
-      __$$RemovePostImplCopyWithImpl<$Res>;
+  factory _$$_RemovePostCopyWith(
+          _$_RemovePost value, $Res Function(_$_RemovePost) then) =
+      __$$_RemovePostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool removed, String? reason, String auth});
 }
 
 /// @nodoc
-class __$$RemovePostImplCopyWithImpl<$Res>
-    extends _$RemovePostCopyWithImpl<$Res, _$RemovePostImpl>
-    implements _$$RemovePostImplCopyWith<$Res> {
-  __$$RemovePostImplCopyWithImpl(
-      _$RemovePostImpl _value, $Res Function(_$RemovePostImpl) _then)
+class __$$_RemovePostCopyWithImpl<$Res>
+    extends _$RemovePostCopyWithImpl<$Res, _$_RemovePost>
+    implements _$$_RemovePostCopyWith<$Res> {
+  __$$_RemovePostCopyWithImpl(
+      _$_RemovePost _value, $Res Function(_$_RemovePost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1406,7 +1400,7 @@ class __$$RemovePostImplCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? auth = null,
   }) {
-    return _then(_$RemovePostImpl(
+    return _then(_$_RemovePost(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1430,16 +1424,16 @@ class __$$RemovePostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$RemovePostImpl extends _RemovePost {
-  const _$RemovePostImpl(
+class _$_RemovePost extends _RemovePost {
+  const _$_RemovePost(
       {required this.postId,
       required this.removed,
       this.reason,
       required this.auth})
       : super._();
 
-  factory _$RemovePostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$RemovePostImplFromJson(json);
+  factory _$_RemovePost.fromJson(Map<String, dynamic> json) =>
+      _$$_RemovePostFromJson(json);
 
   @override
   final int postId;
@@ -1459,7 +1453,7 @@ class _$RemovePostImpl extends _RemovePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$RemovePostImpl &&
+            other is _$_RemovePost &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.removed, removed) || other.removed == removed) &&
             (identical(other.reason, reason) || other.reason == reason) &&
@@ -1473,12 +1467,12 @@ class _$RemovePostImpl extends _RemovePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$RemovePostImplCopyWith<_$RemovePostImpl> get copyWith =>
-      __$$RemovePostImplCopyWithImpl<_$RemovePostImpl>(this, _$identity);
+  _$$_RemovePostCopyWith<_$_RemovePost> get copyWith =>
+      __$$_RemovePostCopyWithImpl<_$_RemovePost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$RemovePostImplToJson(
+    return _$$_RemovePostToJson(
       this,
     );
   }
@@ -1489,11 +1483,11 @@ abstract class _RemovePost extends RemovePost {
       {required final int postId,
       required final bool removed,
       final String? reason,
-      required final String auth}) = _$RemovePostImpl;
+      required final String auth}) = _$_RemovePost;
   const _RemovePost._() : super._();
 
   factory _RemovePost.fromJson(Map<String, dynamic> json) =
-      _$RemovePostImpl.fromJson;
+      _$_RemovePost.fromJson;
 
   @override
   int get postId;
@@ -1505,7 +1499,7 @@ abstract class _RemovePost extends RemovePost {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$RemovePostImplCopyWith<_$RemovePostImpl> get copyWith =>
+  _$$_RemovePostCopyWith<_$_RemovePost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1568,22 +1562,21 @@ class _$LockPostCopyWithImpl<$Res, $Val extends LockPost>
 }
 
 /// @nodoc
-abstract class _$$LockPostImplCopyWith<$Res>
-    implements $LockPostCopyWith<$Res> {
-  factory _$$LockPostImplCopyWith(
-          _$LockPostImpl value, $Res Function(_$LockPostImpl) then) =
-      __$$LockPostImplCopyWithImpl<$Res>;
+abstract class _$$_LockPostCopyWith<$Res> implements $LockPostCopyWith<$Res> {
+  factory _$$_LockPostCopyWith(
+          _$_LockPost value, $Res Function(_$_LockPost) then) =
+      __$$_LockPostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool locked, String auth});
 }
 
 /// @nodoc
-class __$$LockPostImplCopyWithImpl<$Res>
-    extends _$LockPostCopyWithImpl<$Res, _$LockPostImpl>
-    implements _$$LockPostImplCopyWith<$Res> {
-  __$$LockPostImplCopyWithImpl(
-      _$LockPostImpl _value, $Res Function(_$LockPostImpl) _then)
+class __$$_LockPostCopyWithImpl<$Res>
+    extends _$LockPostCopyWithImpl<$Res, _$_LockPost>
+    implements _$$_LockPostCopyWith<$Res> {
+  __$$_LockPostCopyWithImpl(
+      _$_LockPost _value, $Res Function(_$_LockPost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1593,7 +1586,7 @@ class __$$LockPostImplCopyWithImpl<$Res>
     Object? locked = null,
     Object? auth = null,
   }) {
-    return _then(_$LockPostImpl(
+    return _then(_$_LockPost(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1613,13 +1606,13 @@ class __$$LockPostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$LockPostImpl extends _LockPost {
-  const _$LockPostImpl(
+class _$_LockPost extends _LockPost {
+  const _$_LockPost(
       {required this.postId, required this.locked, required this.auth})
       : super._();
 
-  factory _$LockPostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$LockPostImplFromJson(json);
+  factory _$_LockPost.fromJson(Map<String, dynamic> json) =>
+      _$$_LockPostFromJson(json);
 
   @override
   final int postId;
@@ -1637,7 +1630,7 @@ class _$LockPostImpl extends _LockPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$LockPostImpl &&
+            other is _$_LockPost &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.locked, locked) || other.locked == locked) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -1650,12 +1643,12 @@ class _$LockPostImpl extends _LockPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$LockPostImplCopyWith<_$LockPostImpl> get copyWith =>
-      __$$LockPostImplCopyWithImpl<_$LockPostImpl>(this, _$identity);
+  _$$_LockPostCopyWith<_$_LockPost> get copyWith =>
+      __$$_LockPostCopyWithImpl<_$_LockPost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$LockPostImplToJson(
+    return _$$_LockPostToJson(
       this,
     );
   }
@@ -1665,11 +1658,10 @@ abstract class _LockPost extends LockPost {
   const factory _LockPost(
       {required final int postId,
       required final bool locked,
-      required final String auth}) = _$LockPostImpl;
+      required final String auth}) = _$_LockPost;
   const _LockPost._() : super._();
 
-  factory _LockPost.fromJson(Map<String, dynamic> json) =
-      _$LockPostImpl.fromJson;
+  factory _LockPost.fromJson(Map<String, dynamic> json) = _$_LockPost.fromJson;
 
   @override
   int get postId;
@@ -1679,7 +1671,7 @@ abstract class _LockPost extends LockPost {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$LockPostImplCopyWith<_$LockPostImpl> get copyWith =>
+  _$$_LockPostCopyWith<_$_LockPost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1743,22 +1735,22 @@ class _$StickyPostCopyWithImpl<$Res, $Val extends StickyPost>
 }
 
 /// @nodoc
-abstract class _$$StickyPostImplCopyWith<$Res>
+abstract class _$$_StickyPostCopyWith<$Res>
     implements $StickyPostCopyWith<$Res> {
-  factory _$$StickyPostImplCopyWith(
-          _$StickyPostImpl value, $Res Function(_$StickyPostImpl) then) =
-      __$$StickyPostImplCopyWithImpl<$Res>;
+  factory _$$_StickyPostCopyWith(
+          _$_StickyPost value, $Res Function(_$_StickyPost) then) =
+      __$$_StickyPostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool stickied, String auth});
 }
 
 /// @nodoc
-class __$$StickyPostImplCopyWithImpl<$Res>
-    extends _$StickyPostCopyWithImpl<$Res, _$StickyPostImpl>
-    implements _$$StickyPostImplCopyWith<$Res> {
-  __$$StickyPostImplCopyWithImpl(
-      _$StickyPostImpl _value, $Res Function(_$StickyPostImpl) _then)
+class __$$_StickyPostCopyWithImpl<$Res>
+    extends _$StickyPostCopyWithImpl<$Res, _$_StickyPost>
+    implements _$$_StickyPostCopyWith<$Res> {
+  __$$_StickyPostCopyWithImpl(
+      _$_StickyPost _value, $Res Function(_$_StickyPost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1768,7 +1760,7 @@ class __$$StickyPostImplCopyWithImpl<$Res>
     Object? stickied = null,
     Object? auth = null,
   }) {
-    return _then(_$StickyPostImpl(
+    return _then(_$_StickyPost(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1788,13 +1780,13 @@ class __$$StickyPostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$StickyPostImpl extends _StickyPost {
-  const _$StickyPostImpl(
+class _$_StickyPost extends _StickyPost {
+  const _$_StickyPost(
       {required this.postId, required this.stickied, required this.auth})
       : super._();
 
-  factory _$StickyPostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$StickyPostImplFromJson(json);
+  factory _$_StickyPost.fromJson(Map<String, dynamic> json) =>
+      _$$_StickyPostFromJson(json);
 
   @override
   final int postId;
@@ -1812,7 +1804,7 @@ class _$StickyPostImpl extends _StickyPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$StickyPostImpl &&
+            other is _$_StickyPost &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.stickied, stickied) ||
                 other.stickied == stickied) &&
@@ -1826,12 +1818,12 @@ class _$StickyPostImpl extends _StickyPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$StickyPostImplCopyWith<_$StickyPostImpl> get copyWith =>
-      __$$StickyPostImplCopyWithImpl<_$StickyPostImpl>(this, _$identity);
+  _$$_StickyPostCopyWith<_$_StickyPost> get copyWith =>
+      __$$_StickyPostCopyWithImpl<_$_StickyPost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$StickyPostImplToJson(
+    return _$$_StickyPostToJson(
       this,
     );
   }
@@ -1841,11 +1833,11 @@ abstract class _StickyPost extends StickyPost {
   const factory _StickyPost(
       {required final int postId,
       required final bool stickied,
-      required final String auth}) = _$StickyPostImpl;
+      required final String auth}) = _$_StickyPost;
   const _StickyPost._() : super._();
 
   factory _StickyPost.fromJson(Map<String, dynamic> json) =
-      _$StickyPostImpl.fromJson;
+      _$_StickyPost.fromJson;
 
   @override
   int get postId;
@@ -1855,7 +1847,7 @@ abstract class _StickyPost extends StickyPost {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$StickyPostImplCopyWith<_$StickyPostImpl> get copyWith =>
+  _$$_StickyPostCopyWith<_$_StickyPost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1918,22 +1910,21 @@ class _$SavePostCopyWithImpl<$Res, $Val extends SavePost>
 }
 
 /// @nodoc
-abstract class _$$SavePostImplCopyWith<$Res>
-    implements $SavePostCopyWith<$Res> {
-  factory _$$SavePostImplCopyWith(
-          _$SavePostImpl value, $Res Function(_$SavePostImpl) then) =
-      __$$SavePostImplCopyWithImpl<$Res>;
+abstract class _$$_SavePostCopyWith<$Res> implements $SavePostCopyWith<$Res> {
+  factory _$$_SavePostCopyWith(
+          _$_SavePost value, $Res Function(_$_SavePost) then) =
+      __$$_SavePostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool save, String auth});
 }
 
 /// @nodoc
-class __$$SavePostImplCopyWithImpl<$Res>
-    extends _$SavePostCopyWithImpl<$Res, _$SavePostImpl>
-    implements _$$SavePostImplCopyWith<$Res> {
-  __$$SavePostImplCopyWithImpl(
-      _$SavePostImpl _value, $Res Function(_$SavePostImpl) _then)
+class __$$_SavePostCopyWithImpl<$Res>
+    extends _$SavePostCopyWithImpl<$Res, _$_SavePost>
+    implements _$$_SavePostCopyWith<$Res> {
+  __$$_SavePostCopyWithImpl(
+      _$_SavePost _value, $Res Function(_$_SavePost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1943,7 +1934,7 @@ class __$$SavePostImplCopyWithImpl<$Res>
     Object? save = null,
     Object? auth = null,
   }) {
-    return _then(_$SavePostImpl(
+    return _then(_$_SavePost(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1963,13 +1954,13 @@ class __$$SavePostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$SavePostImpl extends _SavePost {
-  const _$SavePostImpl(
+class _$_SavePost extends _SavePost {
+  const _$_SavePost(
       {required this.postId, required this.save, required this.auth})
       : super._();
 
-  factory _$SavePostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SavePostImplFromJson(json);
+  factory _$_SavePost.fromJson(Map<String, dynamic> json) =>
+      _$$_SavePostFromJson(json);
 
   @override
   final int postId;
@@ -1987,7 +1978,7 @@ class _$SavePostImpl extends _SavePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SavePostImpl &&
+            other is _$_SavePost &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.save, save) || other.save == save) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -2000,12 +1991,12 @@ class _$SavePostImpl extends _SavePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SavePostImplCopyWith<_$SavePostImpl> get copyWith =>
-      __$$SavePostImplCopyWithImpl<_$SavePostImpl>(this, _$identity);
+  _$$_SavePostCopyWith<_$_SavePost> get copyWith =>
+      __$$_SavePostCopyWithImpl<_$_SavePost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$SavePostImplToJson(
+    return _$$_SavePostToJson(
       this,
     );
   }
@@ -2015,11 +2006,10 @@ abstract class _SavePost extends SavePost {
   const factory _SavePost(
       {required final int postId,
       required final bool save,
-      required final String auth}) = _$SavePostImpl;
+      required final String auth}) = _$_SavePost;
   const _SavePost._() : super._();
 
-  factory _SavePost.fromJson(Map<String, dynamic> json) =
-      _$SavePostImpl.fromJson;
+  factory _SavePost.fromJson(Map<String, dynamic> json) = _$_SavePost.fromJson;
 
   @override
   int get postId;
@@ -2029,7 +2019,7 @@ abstract class _SavePost extends SavePost {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$SavePostImplCopyWith<_$SavePostImpl> get copyWith =>
+  _$$_SavePostCopyWith<_$_SavePost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2081,22 +2071,22 @@ class _$GetSiteMetadataCopyWithImpl<$Res, $Val extends GetSiteMetadata>
 }
 
 /// @nodoc
-abstract class _$$GetSiteMetadataImplCopyWith<$Res>
+abstract class _$$_GetSiteMetadataCopyWith<$Res>
     implements $GetSiteMetadataCopyWith<$Res> {
-  factory _$$GetSiteMetadataImplCopyWith(_$GetSiteMetadataImpl value,
-          $Res Function(_$GetSiteMetadataImpl) then) =
-      __$$GetSiteMetadataImplCopyWithImpl<$Res>;
+  factory _$$_GetSiteMetadataCopyWith(
+          _$_GetSiteMetadata value, $Res Function(_$_GetSiteMetadata) then) =
+      __$$_GetSiteMetadataCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String url});
 }
 
 /// @nodoc
-class __$$GetSiteMetadataImplCopyWithImpl<$Res>
-    extends _$GetSiteMetadataCopyWithImpl<$Res, _$GetSiteMetadataImpl>
-    implements _$$GetSiteMetadataImplCopyWith<$Res> {
-  __$$GetSiteMetadataImplCopyWithImpl(
-      _$GetSiteMetadataImpl _value, $Res Function(_$GetSiteMetadataImpl) _then)
+class __$$_GetSiteMetadataCopyWithImpl<$Res>
+    extends _$GetSiteMetadataCopyWithImpl<$Res, _$_GetSiteMetadata>
+    implements _$$_GetSiteMetadataCopyWith<$Res> {
+  __$$_GetSiteMetadataCopyWithImpl(
+      _$_GetSiteMetadata _value, $Res Function(_$_GetSiteMetadata) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2104,7 +2094,7 @@ class __$$GetSiteMetadataImplCopyWithImpl<$Res>
   $Res call({
     Object? url = null,
   }) {
-    return _then(_$GetSiteMetadataImpl(
+    return _then(_$_GetSiteMetadata(
       url: null == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
@@ -2116,11 +2106,11 @@ class __$$GetSiteMetadataImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetSiteMetadataImpl extends _GetSiteMetadata {
-  const _$GetSiteMetadataImpl({required this.url}) : super._();
+class _$_GetSiteMetadata extends _GetSiteMetadata {
+  const _$_GetSiteMetadata({required this.url}) : super._();
 
-  factory _$GetSiteMetadataImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetSiteMetadataImplFromJson(json);
+  factory _$_GetSiteMetadata.fromJson(Map<String, dynamic> json) =>
+      _$$_GetSiteMetadataFromJson(json);
 
   @override
   final String url;
@@ -2134,7 +2124,7 @@ class _$GetSiteMetadataImpl extends _GetSiteMetadata {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetSiteMetadataImpl &&
+            other is _$_GetSiteMetadata &&
             (identical(other.url, url) || other.url == url));
   }
 
@@ -2145,13 +2135,12 @@ class _$GetSiteMetadataImpl extends _GetSiteMetadata {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetSiteMetadataImplCopyWith<_$GetSiteMetadataImpl> get copyWith =>
-      __$$GetSiteMetadataImplCopyWithImpl<_$GetSiteMetadataImpl>(
-          this, _$identity);
+  _$$_GetSiteMetadataCopyWith<_$_GetSiteMetadata> get copyWith =>
+      __$$_GetSiteMetadataCopyWithImpl<_$_GetSiteMetadata>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetSiteMetadataImplToJson(
+    return _$$_GetSiteMetadataToJson(
       this,
     );
   }
@@ -2159,17 +2148,17 @@ class _$GetSiteMetadataImpl extends _GetSiteMetadata {
 
 abstract class _GetSiteMetadata extends GetSiteMetadata {
   const factory _GetSiteMetadata({required final String url}) =
-      _$GetSiteMetadataImpl;
+      _$_GetSiteMetadata;
   const _GetSiteMetadata._() : super._();
 
   factory _GetSiteMetadata.fromJson(Map<String, dynamic> json) =
-      _$GetSiteMetadataImpl.fromJson;
+      _$_GetSiteMetadata.fromJson;
 
   @override
   String get url;
   @override
   @JsonKey(ignore: true)
-  _$$GetSiteMetadataImplCopyWith<_$GetSiteMetadataImpl> get copyWith =>
+  _$$_GetSiteMetadataCopyWith<_$_GetSiteMetadata> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2233,22 +2222,22 @@ class _$CreatePostReportCopyWithImpl<$Res, $Val extends CreatePostReport>
 }
 
 /// @nodoc
-abstract class _$$CreatePostReportImplCopyWith<$Res>
+abstract class _$$_CreatePostReportCopyWith<$Res>
     implements $CreatePostReportCopyWith<$Res> {
-  factory _$$CreatePostReportImplCopyWith(_$CreatePostReportImpl value,
-          $Res Function(_$CreatePostReportImpl) then) =
-      __$$CreatePostReportImplCopyWithImpl<$Res>;
+  factory _$$_CreatePostReportCopyWith(
+          _$_CreatePostReport value, $Res Function(_$_CreatePostReport) then) =
+      __$$_CreatePostReportCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, String reason, String auth});
 }
 
 /// @nodoc
-class __$$CreatePostReportImplCopyWithImpl<$Res>
-    extends _$CreatePostReportCopyWithImpl<$Res, _$CreatePostReportImpl>
-    implements _$$CreatePostReportImplCopyWith<$Res> {
-  __$$CreatePostReportImplCopyWithImpl(_$CreatePostReportImpl _value,
-      $Res Function(_$CreatePostReportImpl) _then)
+class __$$_CreatePostReportCopyWithImpl<$Res>
+    extends _$CreatePostReportCopyWithImpl<$Res, _$_CreatePostReport>
+    implements _$$_CreatePostReportCopyWith<$Res> {
+  __$$_CreatePostReportCopyWithImpl(
+      _$_CreatePostReport _value, $Res Function(_$_CreatePostReport) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2258,7 +2247,7 @@ class __$$CreatePostReportImplCopyWithImpl<$Res>
     Object? reason = null,
     Object? auth = null,
   }) {
-    return _then(_$CreatePostReportImpl(
+    return _then(_$_CreatePostReport(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -2278,13 +2267,13 @@ class __$$CreatePostReportImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$CreatePostReportImpl extends _CreatePostReport {
-  const _$CreatePostReportImpl(
+class _$_CreatePostReport extends _CreatePostReport {
+  const _$_CreatePostReport(
       {required this.postId, required this.reason, required this.auth})
       : super._();
 
-  factory _$CreatePostReportImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CreatePostReportImplFromJson(json);
+  factory _$_CreatePostReport.fromJson(Map<String, dynamic> json) =>
+      _$$_CreatePostReportFromJson(json);
 
   @override
   final int postId;
@@ -2302,7 +2291,7 @@ class _$CreatePostReportImpl extends _CreatePostReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CreatePostReportImpl &&
+            other is _$_CreatePostReport &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.reason, reason) || other.reason == reason) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -2315,13 +2304,12 @@ class _$CreatePostReportImpl extends _CreatePostReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CreatePostReportImplCopyWith<_$CreatePostReportImpl> get copyWith =>
-      __$$CreatePostReportImplCopyWithImpl<_$CreatePostReportImpl>(
-          this, _$identity);
+  _$$_CreatePostReportCopyWith<_$_CreatePostReport> get copyWith =>
+      __$$_CreatePostReportCopyWithImpl<_$_CreatePostReport>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CreatePostReportImplToJson(
+    return _$$_CreatePostReportToJson(
       this,
     );
   }
@@ -2331,11 +2319,11 @@ abstract class _CreatePostReport extends CreatePostReport {
   const factory _CreatePostReport(
       {required final int postId,
       required final String reason,
-      required final String auth}) = _$CreatePostReportImpl;
+      required final String auth}) = _$_CreatePostReport;
   const _CreatePostReport._() : super._();
 
   factory _CreatePostReport.fromJson(Map<String, dynamic> json) =
-      _$CreatePostReportImpl.fromJson;
+      _$_CreatePostReport.fromJson;
 
   @override
   int get postId;
@@ -2345,7 +2333,7 @@ abstract class _CreatePostReport extends CreatePostReport {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$CreatePostReportImplCopyWith<_$CreatePostReportImpl> get copyWith =>
+  _$$_CreatePostReportCopyWith<_$_CreatePostReport> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2409,22 +2397,22 @@ class _$ResolvePostReportCopyWithImpl<$Res, $Val extends ResolvePostReport>
 }
 
 /// @nodoc
-abstract class _$$ResolvePostReportImplCopyWith<$Res>
+abstract class _$$_ResolvePostReportCopyWith<$Res>
     implements $ResolvePostReportCopyWith<$Res> {
-  factory _$$ResolvePostReportImplCopyWith(_$ResolvePostReportImpl value,
-          $Res Function(_$ResolvePostReportImpl) then) =
-      __$$ResolvePostReportImplCopyWithImpl<$Res>;
+  factory _$$_ResolvePostReportCopyWith(_$_ResolvePostReport value,
+          $Res Function(_$_ResolvePostReport) then) =
+      __$$_ResolvePostReportCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int reportId, bool resolved, String auth});
 }
 
 /// @nodoc
-class __$$ResolvePostReportImplCopyWithImpl<$Res>
-    extends _$ResolvePostReportCopyWithImpl<$Res, _$ResolvePostReportImpl>
-    implements _$$ResolvePostReportImplCopyWith<$Res> {
-  __$$ResolvePostReportImplCopyWithImpl(_$ResolvePostReportImpl _value,
-      $Res Function(_$ResolvePostReportImpl) _then)
+class __$$_ResolvePostReportCopyWithImpl<$Res>
+    extends _$ResolvePostReportCopyWithImpl<$Res, _$_ResolvePostReport>
+    implements _$$_ResolvePostReportCopyWith<$Res> {
+  __$$_ResolvePostReportCopyWithImpl(
+      _$_ResolvePostReport _value, $Res Function(_$_ResolvePostReport) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2434,7 +2422,7 @@ class __$$ResolvePostReportImplCopyWithImpl<$Res>
     Object? resolved = null,
     Object? auth = null,
   }) {
-    return _then(_$ResolvePostReportImpl(
+    return _then(_$_ResolvePostReport(
       reportId: null == reportId
           ? _value.reportId
           : reportId // ignore: cast_nullable_to_non_nullable
@@ -2454,13 +2442,13 @@ class __$$ResolvePostReportImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$ResolvePostReportImpl extends _ResolvePostReport {
-  const _$ResolvePostReportImpl(
+class _$_ResolvePostReport extends _ResolvePostReport {
+  const _$_ResolvePostReport(
       {required this.reportId, required this.resolved, required this.auth})
       : super._();
 
-  factory _$ResolvePostReportImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ResolvePostReportImplFromJson(json);
+  factory _$_ResolvePostReport.fromJson(Map<String, dynamic> json) =>
+      _$$_ResolvePostReportFromJson(json);
 
   @override
   final int reportId;
@@ -2478,7 +2466,7 @@ class _$ResolvePostReportImpl extends _ResolvePostReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ResolvePostReportImpl &&
+            other is _$_ResolvePostReport &&
             (identical(other.reportId, reportId) ||
                 other.reportId == reportId) &&
             (identical(other.resolved, resolved) ||
@@ -2493,13 +2481,13 @@ class _$ResolvePostReportImpl extends _ResolvePostReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ResolvePostReportImplCopyWith<_$ResolvePostReportImpl> get copyWith =>
-      __$$ResolvePostReportImplCopyWithImpl<_$ResolvePostReportImpl>(
+  _$$_ResolvePostReportCopyWith<_$_ResolvePostReport> get copyWith =>
+      __$$_ResolvePostReportCopyWithImpl<_$_ResolvePostReport>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ResolvePostReportImplToJson(
+    return _$$_ResolvePostReportToJson(
       this,
     );
   }
@@ -2509,11 +2497,11 @@ abstract class _ResolvePostReport extends ResolvePostReport {
   const factory _ResolvePostReport(
       {required final int reportId,
       required final bool resolved,
-      required final String auth}) = _$ResolvePostReportImpl;
+      required final String auth}) = _$_ResolvePostReport;
   const _ResolvePostReport._() : super._();
 
   factory _ResolvePostReport.fromJson(Map<String, dynamic> json) =
-      _$ResolvePostReportImpl.fromJson;
+      _$_ResolvePostReport.fromJson;
 
   @override
   int get reportId;
@@ -2523,7 +2511,7 @@ abstract class _ResolvePostReport extends ResolvePostReport {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$ResolvePostReportImplCopyWith<_$ResolvePostReportImpl> get copyWith =>
+  _$$_ResolvePostReportCopyWith<_$_ResolvePostReport> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2604,11 +2592,11 @@ class _$ListPostReportsCopyWithImpl<$Res, $Val extends ListPostReports>
 }
 
 /// @nodoc
-abstract class _$$ListPostReportsImplCopyWith<$Res>
+abstract class _$$_ListPostReportsCopyWith<$Res>
     implements $ListPostReportsCopyWith<$Res> {
-  factory _$$ListPostReportsImplCopyWith(_$ListPostReportsImpl value,
-          $Res Function(_$ListPostReportsImpl) then) =
-      __$$ListPostReportsImplCopyWithImpl<$Res>;
+  factory _$$_ListPostReportsCopyWith(
+          _$_ListPostReports value, $Res Function(_$_ListPostReports) then) =
+      __$$_ListPostReportsCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2620,11 +2608,11 @@ abstract class _$$ListPostReportsImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ListPostReportsImplCopyWithImpl<$Res>
-    extends _$ListPostReportsCopyWithImpl<$Res, _$ListPostReportsImpl>
-    implements _$$ListPostReportsImplCopyWith<$Res> {
-  __$$ListPostReportsImplCopyWithImpl(
-      _$ListPostReportsImpl _value, $Res Function(_$ListPostReportsImpl) _then)
+class __$$_ListPostReportsCopyWithImpl<$Res>
+    extends _$ListPostReportsCopyWithImpl<$Res, _$_ListPostReports>
+    implements _$$_ListPostReportsCopyWith<$Res> {
+  __$$_ListPostReportsCopyWithImpl(
+      _$_ListPostReports _value, $Res Function(_$_ListPostReports) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2636,7 +2624,7 @@ class __$$ListPostReportsImplCopyWithImpl<$Res>
     Object? unresolvedOnly = freezed,
     Object? auth = null,
   }) {
-    return _then(_$ListPostReportsImpl(
+    return _then(_$_ListPostReports(
       page: freezed == page
           ? _value.page
           : page // ignore: cast_nullable_to_non_nullable
@@ -2664,8 +2652,8 @@ class __$$ListPostReportsImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$ListPostReportsImpl extends _ListPostReports {
-  const _$ListPostReportsImpl(
+class _$_ListPostReports extends _ListPostReports {
+  const _$_ListPostReports(
       {this.page,
       this.limit,
       this.communityId,
@@ -2673,8 +2661,8 @@ class _$ListPostReportsImpl extends _ListPostReports {
       required this.auth})
       : super._();
 
-  factory _$ListPostReportsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ListPostReportsImplFromJson(json);
+  factory _$_ListPostReports.fromJson(Map<String, dynamic> json) =>
+      _$$_ListPostReportsFromJson(json);
 
   @override
   final int? page;
@@ -2696,7 +2684,7 @@ class _$ListPostReportsImpl extends _ListPostReports {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ListPostReportsImpl &&
+            other is _$_ListPostReports &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
             (identical(other.communityId, communityId) ||
@@ -2714,13 +2702,12 @@ class _$ListPostReportsImpl extends _ListPostReports {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ListPostReportsImplCopyWith<_$ListPostReportsImpl> get copyWith =>
-      __$$ListPostReportsImplCopyWithImpl<_$ListPostReportsImpl>(
-          this, _$identity);
+  _$$_ListPostReportsCopyWith<_$_ListPostReports> get copyWith =>
+      __$$_ListPostReportsCopyWithImpl<_$_ListPostReports>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ListPostReportsImplToJson(
+    return _$$_ListPostReportsToJson(
       this,
     );
   }
@@ -2732,11 +2719,11 @@ abstract class _ListPostReports extends ListPostReports {
       final int? limit,
       final int? communityId,
       final bool? unresolvedOnly,
-      required final String auth}) = _$ListPostReportsImpl;
+      required final String auth}) = _$_ListPostReports;
   const _ListPostReports._() : super._();
 
   factory _ListPostReports.fromJson(Map<String, dynamic> json) =
-      _$ListPostReportsImpl.fromJson;
+      _$_ListPostReports.fromJson;
 
   @override
   int? get page;
@@ -2750,7 +2737,7 @@ abstract class _ListPostReports extends ListPostReports {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$ListPostReportsImplCopyWith<_$ListPostReportsImpl> get copyWith =>
+  _$$_ListPostReportsCopyWith<_$_ListPostReports> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2814,22 +2801,22 @@ class _$MarkPostAsReadCopyWithImpl<$Res, $Val extends MarkPostAsRead>
 }
 
 /// @nodoc
-abstract class _$$MarkPostAsReadImplCopyWith<$Res>
+abstract class _$$_MarkPostAsReadCopyWith<$Res>
     implements $MarkPostAsReadCopyWith<$Res> {
-  factory _$$MarkPostAsReadImplCopyWith(_$MarkPostAsReadImpl value,
-          $Res Function(_$MarkPostAsReadImpl) then) =
-      __$$MarkPostAsReadImplCopyWithImpl<$Res>;
+  factory _$$_MarkPostAsReadCopyWith(
+          _$_MarkPostAsRead value, $Res Function(_$_MarkPostAsRead) then) =
+      __$$_MarkPostAsReadCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool read, String auth});
 }
 
 /// @nodoc
-class __$$MarkPostAsReadImplCopyWithImpl<$Res>
-    extends _$MarkPostAsReadCopyWithImpl<$Res, _$MarkPostAsReadImpl>
-    implements _$$MarkPostAsReadImplCopyWith<$Res> {
-  __$$MarkPostAsReadImplCopyWithImpl(
-      _$MarkPostAsReadImpl _value, $Res Function(_$MarkPostAsReadImpl) _then)
+class __$$_MarkPostAsReadCopyWithImpl<$Res>
+    extends _$MarkPostAsReadCopyWithImpl<$Res, _$_MarkPostAsRead>
+    implements _$$_MarkPostAsReadCopyWith<$Res> {
+  __$$_MarkPostAsReadCopyWithImpl(
+      _$_MarkPostAsRead _value, $Res Function(_$_MarkPostAsRead) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2839,7 +2826,7 @@ class __$$MarkPostAsReadImplCopyWithImpl<$Res>
     Object? read = null,
     Object? auth = null,
   }) {
-    return _then(_$MarkPostAsReadImpl(
+    return _then(_$_MarkPostAsRead(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -2859,13 +2846,13 @@ class __$$MarkPostAsReadImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$MarkPostAsReadImpl extends _MarkPostAsRead {
-  const _$MarkPostAsReadImpl(
+class _$_MarkPostAsRead extends _MarkPostAsRead {
+  const _$_MarkPostAsRead(
       {required this.postId, required this.read, required this.auth})
       : super._();
 
-  factory _$MarkPostAsReadImpl.fromJson(Map<String, dynamic> json) =>
-      _$$MarkPostAsReadImplFromJson(json);
+  factory _$_MarkPostAsRead.fromJson(Map<String, dynamic> json) =>
+      _$$_MarkPostAsReadFromJson(json);
 
   @override
   final int postId;
@@ -2883,7 +2870,7 @@ class _$MarkPostAsReadImpl extends _MarkPostAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$MarkPostAsReadImpl &&
+            other is _$_MarkPostAsRead &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.read, read) || other.read == read) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -2896,13 +2883,12 @@ class _$MarkPostAsReadImpl extends _MarkPostAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$MarkPostAsReadImplCopyWith<_$MarkPostAsReadImpl> get copyWith =>
-      __$$MarkPostAsReadImplCopyWithImpl<_$MarkPostAsReadImpl>(
-          this, _$identity);
+  _$$_MarkPostAsReadCopyWith<_$_MarkPostAsRead> get copyWith =>
+      __$$_MarkPostAsReadCopyWithImpl<_$_MarkPostAsRead>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$MarkPostAsReadImplToJson(
+    return _$$_MarkPostAsReadToJson(
       this,
     );
   }
@@ -2912,11 +2898,11 @@ abstract class _MarkPostAsRead extends MarkPostAsRead {
   const factory _MarkPostAsRead(
       {required final int postId,
       required final bool read,
-      required final String auth}) = _$MarkPostAsReadImpl;
+      required final String auth}) = _$_MarkPostAsRead;
   const _MarkPostAsRead._() : super._();
 
   factory _MarkPostAsRead.fromJson(Map<String, dynamic> json) =
-      _$MarkPostAsReadImpl.fromJson;
+      _$_MarkPostAsRead.fromJson;
 
   @override
   int get postId;
@@ -2926,6 +2912,6 @@ abstract class _MarkPostAsRead extends MarkPostAsRead {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$MarkPostAsReadImplCopyWith<_$MarkPostAsReadImpl> get copyWith =>
+  _$$_MarkPostAsReadCopyWith<_$_MarkPostAsRead> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/post.g.dart
+++ b/lib/src/v3/api/post.g.dart
@@ -6,13 +6,12 @@ part of 'post.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$GetPostImpl _$$GetPostImplFromJson(Map<String, dynamic> json) =>
-    _$GetPostImpl(
+_$_GetPost _$$_GetPostFromJson(Map<String, dynamic> json) => _$_GetPost(
       id: json['id'] as int,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$GetPostImplToJson(_$GetPostImpl instance) {
+Map<String, dynamic> _$$_GetPostToJson(_$_GetPost instance) {
   final val = <String, dynamic>{
     'id': instance.id,
   };
@@ -27,8 +26,8 @@ Map<String, dynamic> _$$GetPostImplToJson(_$GetPostImpl instance) {
   return val;
 }
 
-_$CreatePostImpl _$$CreatePostImplFromJson(Map<String, dynamic> json) =>
-    _$CreatePostImpl(
+_$_CreatePost _$$_CreatePostFromJson(Map<String, dynamic> json) =>
+    _$_CreatePost(
       name: json['name'] as String,
       url: json['url'] as String?,
       body: json['body'] as String?,
@@ -38,7 +37,7 @@ _$CreatePostImpl _$$CreatePostImplFromJson(Map<String, dynamic> json) =>
       honeypot: json['honeypot'] as String?,
     );
 
-Map<String, dynamic> _$$CreatePostImplToJson(_$CreatePostImpl instance) {
+Map<String, dynamic> _$$_CreatePostToJson(_$_CreatePost instance) {
   final val = <String, dynamic>{
     'name': instance.name,
   };
@@ -58,8 +57,7 @@ Map<String, dynamic> _$$CreatePostImplToJson(_$CreatePostImpl instance) {
   return val;
 }
 
-_$GetPostsImpl _$$GetPostsImplFromJson(Map<String, dynamic> json) =>
-    _$GetPostsImpl(
+_$_GetPosts _$$_GetPostsFromJson(Map<String, dynamic> json) => _$_GetPosts(
       type: json['type_'] == null
           ? null
           : PostListingType.fromJson(json['type_']),
@@ -72,7 +70,7 @@ _$GetPostsImpl _$$GetPostsImplFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$GetPostsImplToJson(_$GetPostsImpl instance) {
+Map<String, dynamic> _$$_GetPostsToJson(_$_GetPosts instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -92,23 +90,21 @@ Map<String, dynamic> _$$GetPostsImplToJson(_$GetPostsImpl instance) {
   return val;
 }
 
-_$CreatePostLikeImpl _$$CreatePostLikeImplFromJson(Map<String, dynamic> json) =>
-    _$CreatePostLikeImpl(
+_$_CreatePostLike _$$_CreatePostLikeFromJson(Map<String, dynamic> json) =>
+    _$_CreatePostLike(
       postId: json['post_id'] as int,
       score: VoteType.fromJson(json['score'] as int),
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$CreatePostLikeImplToJson(
-        _$CreatePostLikeImpl instance) =>
+Map<String, dynamic> _$$_CreatePostLikeToJson(_$_CreatePostLike instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'score': instance.score.toJson(),
       'auth': instance.auth,
     };
 
-_$EditPostImpl _$$EditPostImplFromJson(Map<String, dynamic> json) =>
-    _$EditPostImpl(
+_$_EditPost _$$_EditPostFromJson(Map<String, dynamic> json) => _$_EditPost(
       postId: json['post_id'] as int,
       name: json['name'] as String?,
       url: json['url'] as String?,
@@ -117,7 +113,7 @@ _$EditPostImpl _$$EditPostImplFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$EditPostImplToJson(_$EditPostImpl instance) {
+Map<String, dynamic> _$$_EditPostToJson(_$_EditPost instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
   };
@@ -136,29 +132,29 @@ Map<String, dynamic> _$$EditPostImplToJson(_$EditPostImpl instance) {
   return val;
 }
 
-_$DeletePostImpl _$$DeletePostImplFromJson(Map<String, dynamic> json) =>
-    _$DeletePostImpl(
+_$_DeletePost _$$_DeletePostFromJson(Map<String, dynamic> json) =>
+    _$_DeletePost(
       postId: json['post_id'] as int,
       deleted: json['deleted'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$DeletePostImplToJson(_$DeletePostImpl instance) =>
+Map<String, dynamic> _$$_DeletePostToJson(_$_DeletePost instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'deleted': instance.deleted,
       'auth': instance.auth,
     };
 
-_$RemovePostImpl _$$RemovePostImplFromJson(Map<String, dynamic> json) =>
-    _$RemovePostImpl(
+_$_RemovePost _$$_RemovePostFromJson(Map<String, dynamic> json) =>
+    _$_RemovePost(
       postId: json['post_id'] as int,
       removed: json['removed'] as bool,
       reason: json['reason'] as String?,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$RemovePostImplToJson(_$RemovePostImpl instance) {
+Map<String, dynamic> _$$_RemovePostToJson(_$_RemovePost instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
     'removed': instance.removed,
@@ -175,95 +171,87 @@ Map<String, dynamic> _$$RemovePostImplToJson(_$RemovePostImpl instance) {
   return val;
 }
 
-_$LockPostImpl _$$LockPostImplFromJson(Map<String, dynamic> json) =>
-    _$LockPostImpl(
+_$_LockPost _$$_LockPostFromJson(Map<String, dynamic> json) => _$_LockPost(
       postId: json['post_id'] as int,
       locked: json['locked'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$LockPostImplToJson(_$LockPostImpl instance) =>
+Map<String, dynamic> _$$_LockPostToJson(_$_LockPost instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'locked': instance.locked,
       'auth': instance.auth,
     };
 
-_$StickyPostImpl _$$StickyPostImplFromJson(Map<String, dynamic> json) =>
-    _$StickyPostImpl(
+_$_StickyPost _$$_StickyPostFromJson(Map<String, dynamic> json) =>
+    _$_StickyPost(
       postId: json['post_id'] as int,
       stickied: json['stickied'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$StickyPostImplToJson(_$StickyPostImpl instance) =>
+Map<String, dynamic> _$$_StickyPostToJson(_$_StickyPost instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'stickied': instance.stickied,
       'auth': instance.auth,
     };
 
-_$SavePostImpl _$$SavePostImplFromJson(Map<String, dynamic> json) =>
-    _$SavePostImpl(
+_$_SavePost _$$_SavePostFromJson(Map<String, dynamic> json) => _$_SavePost(
       postId: json['post_id'] as int,
       save: json['save'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$SavePostImplToJson(_$SavePostImpl instance) =>
+Map<String, dynamic> _$$_SavePostToJson(_$_SavePost instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'save': instance.save,
       'auth': instance.auth,
     };
 
-_$GetSiteMetadataImpl _$$GetSiteMetadataImplFromJson(
-        Map<String, dynamic> json) =>
-    _$GetSiteMetadataImpl(
+_$_GetSiteMetadata _$$_GetSiteMetadataFromJson(Map<String, dynamic> json) =>
+    _$_GetSiteMetadata(
       url: json['url'] as String,
     );
 
-Map<String, dynamic> _$$GetSiteMetadataImplToJson(
-        _$GetSiteMetadataImpl instance) =>
+Map<String, dynamic> _$$_GetSiteMetadataToJson(_$_GetSiteMetadata instance) =>
     <String, dynamic>{
       'url': instance.url,
     };
 
-_$CreatePostReportImpl _$$CreatePostReportImplFromJson(
-        Map<String, dynamic> json) =>
-    _$CreatePostReportImpl(
+_$_CreatePostReport _$$_CreatePostReportFromJson(Map<String, dynamic> json) =>
+    _$_CreatePostReport(
       postId: json['post_id'] as int,
       reason: json['reason'] as String,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$CreatePostReportImplToJson(
-        _$CreatePostReportImpl instance) =>
+Map<String, dynamic> _$$_CreatePostReportToJson(_$_CreatePostReport instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'reason': instance.reason,
       'auth': instance.auth,
     };
 
-_$ResolvePostReportImpl _$$ResolvePostReportImplFromJson(
-        Map<String, dynamic> json) =>
-    _$ResolvePostReportImpl(
+_$_ResolvePostReport _$$_ResolvePostReportFromJson(Map<String, dynamic> json) =>
+    _$_ResolvePostReport(
       reportId: json['report_id'] as int,
       resolved: json['resolved'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$ResolvePostReportImplToJson(
-        _$ResolvePostReportImpl instance) =>
+Map<String, dynamic> _$$_ResolvePostReportToJson(
+        _$_ResolvePostReport instance) =>
     <String, dynamic>{
       'report_id': instance.reportId,
       'resolved': instance.resolved,
       'auth': instance.auth,
     };
 
-_$ListPostReportsImpl _$$ListPostReportsImplFromJson(
-        Map<String, dynamic> json) =>
-    _$ListPostReportsImpl(
+_$_ListPostReports _$$_ListPostReportsFromJson(Map<String, dynamic> json) =>
+    _$_ListPostReports(
       page: json['page'] as int?,
       limit: json['limit'] as int?,
       communityId: json['community_id'] as int?,
@@ -271,8 +259,7 @@ _$ListPostReportsImpl _$$ListPostReportsImplFromJson(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$ListPostReportsImplToJson(
-    _$ListPostReportsImpl instance) {
+Map<String, dynamic> _$$_ListPostReportsToJson(_$_ListPostReports instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -289,15 +276,14 @@ Map<String, dynamic> _$$ListPostReportsImplToJson(
   return val;
 }
 
-_$MarkPostAsReadImpl _$$MarkPostAsReadImplFromJson(Map<String, dynamic> json) =>
-    _$MarkPostAsReadImpl(
+_$_MarkPostAsRead _$$_MarkPostAsReadFromJson(Map<String, dynamic> json) =>
+    _$_MarkPostAsRead(
       postId: json['post_id'] as int,
       read: json['read'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$MarkPostAsReadImplToJson(
-        _$MarkPostAsReadImpl instance) =>
+Map<String, dynamic> _$$_MarkPostAsReadToJson(_$_MarkPostAsRead instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'read': instance.read,

--- a/lib/src/v3/api/site.dart
+++ b/lib/src/v3/api/site.dart
@@ -87,7 +87,7 @@ class BlockInstance
     /// Whether to block or unblock the given instance
     required bool block,
 
-    /// The auth token. This only works if auth is set within the header
+    /// The auth token. This parameter is passed in the header
     String? auth,
   }) = _BlockInstance;
 

--- a/lib/src/v3/api/site.dart
+++ b/lib/src/v3/api/site.dart
@@ -70,6 +70,41 @@ class GetModlog
   Modlog responseFactory(Map<String, dynamic> json) => Modlog.fromJson(json);
 }
 
+/// Blocks an instance given its instance id.
+///
+/// This function is only supported on lemmy instances version 0.19.0 and above.
+@freezed
+class BlockInstance
+    with _$BlockInstance
+    implements
+        LemmyApiQuery<BlockInstanceResponse>,
+        LemmyApiAuthenticatedQuery {
+  @apiSerde
+  const factory BlockInstance({
+    /// The ID of the instance
+    required int instanceId,
+
+    /// Whether to block or unblock the given instance
+    required bool block,
+
+    /// The auth token. This only works if auth is set within the header
+    String? auth,
+  }) = _BlockInstance;
+
+  const BlockInstance._();
+
+  factory BlockInstance.fromJson(Map<String, dynamic> json) =>
+      _$BlockInstanceFromJson(json);
+
+  final path = '/site/block';
+
+  final httpMethod = HttpMethod.post;
+
+  @override
+  BlockInstanceResponse responseFactory(Map<String, dynamic> json) =>
+      BlockInstanceResponse.fromJson(json);
+}
+
 @freezed
 class CreateSite
     with _$CreateSite

--- a/lib/src/v3/api/site.freezed.dart
+++ b/lib/src/v3/api/site.freezed.dart
@@ -125,10 +125,9 @@ class _$SearchCopyWithImpl<$Res, $Val extends Search>
 }
 
 /// @nodoc
-abstract class _$$SearchImplCopyWith<$Res> implements $SearchCopyWith<$Res> {
-  factory _$$SearchImplCopyWith(
-          _$SearchImpl value, $Res Function(_$SearchImpl) then) =
-      __$$SearchImplCopyWithImpl<$Res>;
+abstract class _$$_SearchCopyWith<$Res> implements $SearchCopyWith<$Res> {
+  factory _$$_SearchCopyWith(_$_Search value, $Res Function(_$_Search) then) =
+      __$$_SearchCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -145,11 +144,10 @@ abstract class _$$SearchImplCopyWith<$Res> implements $SearchCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$SearchImplCopyWithImpl<$Res>
-    extends _$SearchCopyWithImpl<$Res, _$SearchImpl>
-    implements _$$SearchImplCopyWith<$Res> {
-  __$$SearchImplCopyWithImpl(
-      _$SearchImpl _value, $Res Function(_$SearchImpl) _then)
+class __$$_SearchCopyWithImpl<$Res>
+    extends _$SearchCopyWithImpl<$Res, _$_Search>
+    implements _$$_SearchCopyWith<$Res> {
+  __$$_SearchCopyWithImpl(_$_Search _value, $Res Function(_$_Search) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -166,7 +164,7 @@ class __$$SearchImplCopyWithImpl<$Res>
     Object? creatorId = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$SearchImpl(
+    return _then(_$_Search(
       q: null == q
           ? _value.q
           : q // ignore: cast_nullable_to_non_nullable
@@ -214,8 +212,8 @@ class __$$SearchImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$SearchImpl extends _Search {
-  const _$SearchImpl(
+class _$_Search extends _Search {
+  const _$_Search(
       {required this.q,
       @JsonKey(name: 'type_') this.type,
       this.listingType,
@@ -228,8 +226,8 @@ class _$SearchImpl extends _Search {
       this.auth})
       : super._();
 
-  factory _$SearchImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SearchImplFromJson(json);
+  factory _$_Search.fromJson(Map<String, dynamic> json) =>
+      _$$_SearchFromJson(json);
 
   @override
   final String q;
@@ -262,7 +260,7 @@ class _$SearchImpl extends _Search {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SearchImpl &&
+            other is _$_Search &&
             (identical(other.q, q) || other.q == q) &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.listingType, listingType) ||
@@ -287,12 +285,12 @@ class _$SearchImpl extends _Search {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SearchImplCopyWith<_$SearchImpl> get copyWith =>
-      __$$SearchImplCopyWithImpl<_$SearchImpl>(this, _$identity);
+  _$$_SearchCopyWith<_$_Search> get copyWith =>
+      __$$_SearchCopyWithImpl<_$_Search>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$SearchImplToJson(
+    return _$$_SearchToJson(
       this,
     );
   }
@@ -309,10 +307,10 @@ abstract class _Search extends Search {
       final int? page,
       final int? limit,
       final int? creatorId,
-      final String? auth}) = _$SearchImpl;
+      final String? auth}) = _$_Search;
   const _Search._() : super._();
 
-  factory _Search.fromJson(Map<String, dynamic> json) = _$SearchImpl.fromJson;
+  factory _Search.fromJson(Map<String, dynamic> json) = _$_Search.fromJson;
 
   @override
   String get q;
@@ -337,7 +335,7 @@ abstract class _Search extends Search {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$SearchImplCopyWith<_$SearchImpl> get copyWith =>
+  _$$_SearchCopyWith<_$_Search> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -432,11 +430,10 @@ class _$GetModlogCopyWithImpl<$Res, $Val extends GetModlog>
 }
 
 /// @nodoc
-abstract class _$$GetModlogImplCopyWith<$Res>
-    implements $GetModlogCopyWith<$Res> {
-  factory _$$GetModlogImplCopyWith(
-          _$GetModlogImpl value, $Res Function(_$GetModlogImpl) then) =
-      __$$GetModlogImplCopyWithImpl<$Res>;
+abstract class _$$_GetModlogCopyWith<$Res> implements $GetModlogCopyWith<$Res> {
+  factory _$$_GetModlogCopyWith(
+          _$_GetModlog value, $Res Function(_$_GetModlog) then) =
+      __$$_GetModlogCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -450,11 +447,11 @@ abstract class _$$GetModlogImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$GetModlogImplCopyWithImpl<$Res>
-    extends _$GetModlogCopyWithImpl<$Res, _$GetModlogImpl>
-    implements _$$GetModlogImplCopyWith<$Res> {
-  __$$GetModlogImplCopyWithImpl(
-      _$GetModlogImpl _value, $Res Function(_$GetModlogImpl) _then)
+class __$$_GetModlogCopyWithImpl<$Res>
+    extends _$GetModlogCopyWithImpl<$Res, _$_GetModlog>
+    implements _$$_GetModlogCopyWith<$Res> {
+  __$$_GetModlogCopyWithImpl(
+      _$_GetModlog _value, $Res Function(_$_GetModlog) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -468,7 +465,7 @@ class __$$GetModlogImplCopyWithImpl<$Res>
     Object? auth = freezed,
     Object? type = freezed,
   }) {
-    return _then(_$GetModlogImpl(
+    return _then(_$_GetModlog(
       modPersonId: freezed == modPersonId
           ? _value.modPersonId
           : modPersonId // ignore: cast_nullable_to_non_nullable
@@ -504,8 +501,8 @@ class __$$GetModlogImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetModlogImpl extends _GetModlog {
-  const _$GetModlogImpl(
+class _$_GetModlog extends _GetModlog {
+  const _$_GetModlog(
       {this.modPersonId,
       this.communityId,
       this.otherPersonId,
@@ -515,8 +512,8 @@ class _$GetModlogImpl extends _GetModlog {
       @JsonKey(name: 'type_') this.type})
       : super._();
 
-  factory _$GetModlogImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetModlogImplFromJson(json);
+  factory _$_GetModlog.fromJson(Map<String, dynamic> json) =>
+      _$$_GetModlogFromJson(json);
 
   @override
   final int? modPersonId;
@@ -543,7 +540,7 @@ class _$GetModlogImpl extends _GetModlog {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetModlogImpl &&
+            other is _$_GetModlog &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
             (identical(other.communityId, communityId) ||
@@ -564,12 +561,12 @@ class _$GetModlogImpl extends _GetModlog {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetModlogImplCopyWith<_$GetModlogImpl> get copyWith =>
-      __$$GetModlogImplCopyWithImpl<_$GetModlogImpl>(this, _$identity);
+  _$$_GetModlogCopyWith<_$_GetModlog> get copyWith =>
+      __$$_GetModlogCopyWithImpl<_$_GetModlog>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetModlogImplToJson(
+    return _$$_GetModlogToJson(
       this,
     );
   }
@@ -583,11 +580,11 @@ abstract class _GetModlog extends GetModlog {
       final int? page,
       final int? limit,
       final String? auth,
-      @JsonKey(name: 'type_') final ModlogActionType? type}) = _$GetModlogImpl;
+      @JsonKey(name: 'type_') final ModlogActionType? type}) = _$_GetModlog;
   const _GetModlog._() : super._();
 
   factory _GetModlog.fromJson(Map<String, dynamic> json) =
-      _$GetModlogImpl.fromJson;
+      _$_GetModlog.fromJson;
 
   @override
   int? get modPersonId;
@@ -606,7 +603,199 @@ abstract class _GetModlog extends GetModlog {
   ModlogActionType? get type;
   @override
   @JsonKey(ignore: true)
-  _$$GetModlogImplCopyWith<_$GetModlogImpl> get copyWith =>
+  _$$_GetModlogCopyWith<_$_GetModlog> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+BlockInstance _$BlockInstanceFromJson(Map<String, dynamic> json) {
+  return _BlockInstance.fromJson(json);
+}
+
+/// @nodoc
+mixin _$BlockInstance {
+  /// The ID of the instance
+  int get instanceId => throw _privateConstructorUsedError;
+
+  /// Whether to block or unblock the given instance
+  bool get block => throw _privateConstructorUsedError;
+
+  /// The auth token. This only works if auth is set within the header
+  String? get auth => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $BlockInstanceCopyWith<BlockInstance> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BlockInstanceCopyWith<$Res> {
+  factory $BlockInstanceCopyWith(
+          BlockInstance value, $Res Function(BlockInstance) then) =
+      _$BlockInstanceCopyWithImpl<$Res, BlockInstance>;
+  @useResult
+  $Res call({int instanceId, bool block, String? auth});
+}
+
+/// @nodoc
+class _$BlockInstanceCopyWithImpl<$Res, $Val extends BlockInstance>
+    implements $BlockInstanceCopyWith<$Res> {
+  _$BlockInstanceCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? instanceId = null,
+    Object? block = null,
+    Object? auth = freezed,
+  }) {
+    return _then(_value.copyWith(
+      instanceId: null == instanceId
+          ? _value.instanceId
+          : instanceId // ignore: cast_nullable_to_non_nullable
+              as int,
+      block: null == block
+          ? _value.block
+          : block // ignore: cast_nullable_to_non_nullable
+              as bool,
+      auth: freezed == auth
+          ? _value.auth
+          : auth // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_BlockInstanceCopyWith<$Res>
+    implements $BlockInstanceCopyWith<$Res> {
+  factory _$$_BlockInstanceCopyWith(
+          _$_BlockInstance value, $Res Function(_$_BlockInstance) then) =
+      __$$_BlockInstanceCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int instanceId, bool block, String? auth});
+}
+
+/// @nodoc
+class __$$_BlockInstanceCopyWithImpl<$Res>
+    extends _$BlockInstanceCopyWithImpl<$Res, _$_BlockInstance>
+    implements _$$_BlockInstanceCopyWith<$Res> {
+  __$$_BlockInstanceCopyWithImpl(
+      _$_BlockInstance _value, $Res Function(_$_BlockInstance) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? instanceId = null,
+    Object? block = null,
+    Object? auth = freezed,
+  }) {
+    return _then(_$_BlockInstance(
+      instanceId: null == instanceId
+          ? _value.instanceId
+          : instanceId // ignore: cast_nullable_to_non_nullable
+              as int,
+      block: null == block
+          ? _value.block
+          : block // ignore: cast_nullable_to_non_nullable
+              as bool,
+      auth: freezed == auth
+          ? _value.auth
+          : auth // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+@apiSerde
+class _$_BlockInstance extends _BlockInstance {
+  const _$_BlockInstance(
+      {required this.instanceId, required this.block, this.auth})
+      : super._();
+
+  factory _$_BlockInstance.fromJson(Map<String, dynamic> json) =>
+      _$$_BlockInstanceFromJson(json);
+
+  /// The ID of the instance
+  @override
+  final int instanceId;
+
+  /// Whether to block or unblock the given instance
+  @override
+  final bool block;
+
+  /// The auth token. This only works if auth is set within the header
+  @override
+  final String? auth;
+
+  @override
+  String toString() {
+    return 'BlockInstance(instanceId: $instanceId, block: $block, auth: $auth)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_BlockInstance &&
+            (identical(other.instanceId, instanceId) ||
+                other.instanceId == instanceId) &&
+            (identical(other.block, block) || other.block == block) &&
+            (identical(other.auth, auth) || other.auth == auth));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, instanceId, block, auth);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_BlockInstanceCopyWith<_$_BlockInstance> get copyWith =>
+      __$$_BlockInstanceCopyWithImpl<_$_BlockInstance>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_BlockInstanceToJson(
+      this,
+    );
+  }
+}
+
+abstract class _BlockInstance extends BlockInstance {
+  const factory _BlockInstance(
+      {required final int instanceId,
+      required final bool block,
+      final String? auth}) = _$_BlockInstance;
+  const _BlockInstance._() : super._();
+
+  factory _BlockInstance.fromJson(Map<String, dynamic> json) =
+      _$_BlockInstance.fromJson;
+
+  @override
+
+  /// The ID of the instance
+  int get instanceId;
+  @override
+
+  /// Whether to block or unblock the given instance
+  bool get block;
+  @override
+
+  /// The auth token. This only works if auth is set within the header
+  String? get auth;
+  @override
+  @JsonKey(ignore: true)
+  _$$_BlockInstanceCopyWith<_$_BlockInstance> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -757,11 +946,11 @@ class _$CreateSiteCopyWithImpl<$Res, $Val extends CreateSite>
 }
 
 /// @nodoc
-abstract class _$$CreateSiteImplCopyWith<$Res>
+abstract class _$$_CreateSiteCopyWith<$Res>
     implements $CreateSiteCopyWith<$Res> {
-  factory _$$CreateSiteImplCopyWith(
-          _$CreateSiteImpl value, $Res Function(_$CreateSiteImpl) then) =
-      __$$CreateSiteImplCopyWithImpl<$Res>;
+  factory _$$_CreateSiteCopyWith(
+          _$_CreateSite value, $Res Function(_$_CreateSite) then) =
+      __$$_CreateSiteCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -783,11 +972,11 @@ abstract class _$$CreateSiteImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CreateSiteImplCopyWithImpl<$Res>
-    extends _$CreateSiteCopyWithImpl<$Res, _$CreateSiteImpl>
-    implements _$$CreateSiteImplCopyWith<$Res> {
-  __$$CreateSiteImplCopyWithImpl(
-      _$CreateSiteImpl _value, $Res Function(_$CreateSiteImpl) _then)
+class __$$_CreateSiteCopyWithImpl<$Res>
+    extends _$CreateSiteCopyWithImpl<$Res, _$_CreateSite>
+    implements _$$_CreateSiteCopyWith<$Res> {
+  __$$_CreateSiteCopyWithImpl(
+      _$_CreateSite _value, $Res Function(_$_CreateSite) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -809,7 +998,7 @@ class __$$CreateSiteImplCopyWithImpl<$Res>
     Object? auth = null,
     Object? defaultTheme = freezed,
   }) {
-    return _then(_$CreateSiteImpl(
+    return _then(_$_CreateSite(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -877,8 +1066,8 @@ class __$$CreateSiteImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$CreateSiteImpl extends _CreateSite {
-  const _$CreateSiteImpl(
+class _$_CreateSite extends _CreateSite {
+  const _$_CreateSite(
       {required this.name,
       this.sidebar,
       this.description,
@@ -896,8 +1085,8 @@ class _$CreateSiteImpl extends _CreateSite {
       this.defaultTheme})
       : super._();
 
-  factory _$CreateSiteImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CreateSiteImplFromJson(json);
+  factory _$_CreateSite.fromJson(Map<String, dynamic> json) =>
+      _$$_CreateSiteFromJson(json);
 
   @override
   final String name;
@@ -939,7 +1128,7 @@ class _$CreateSiteImpl extends _CreateSite {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CreateSiteImpl &&
+            other is _$_CreateSite &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.sidebar, sidebar) || other.sidebar == sidebar) &&
             (identical(other.description, description) ||
@@ -993,12 +1182,12 @@ class _$CreateSiteImpl extends _CreateSite {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CreateSiteImplCopyWith<_$CreateSiteImpl> get copyWith =>
-      __$$CreateSiteImplCopyWithImpl<_$CreateSiteImpl>(this, _$identity);
+  _$$_CreateSiteCopyWith<_$_CreateSite> get copyWith =>
+      __$$_CreateSiteCopyWithImpl<_$_CreateSite>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CreateSiteImplToJson(
+    return _$$_CreateSiteToJson(
       this,
     );
   }
@@ -1020,11 +1209,11 @@ abstract class _CreateSite extends CreateSite {
       final String? applicationQuestion,
       final bool? privateInstance,
       required final String auth,
-      final String? defaultTheme}) = _$CreateSiteImpl;
+      final String? defaultTheme}) = _$_CreateSite;
   const _CreateSite._() : super._();
 
   factory _CreateSite.fromJson(Map<String, dynamic> json) =
-      _$CreateSiteImpl.fromJson;
+      _$_CreateSite.fromJson;
 
   @override
   String get name;
@@ -1058,7 +1247,7 @@ abstract class _CreateSite extends CreateSite {
   String? get defaultTheme;
   @override
   @JsonKey(ignore: true)
-  _$$CreateSiteImplCopyWith<_$CreateSiteImpl> get copyWith =>
+  _$$_CreateSiteCopyWith<_$_CreateSite> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1208,11 +1397,10 @@ class _$EditSiteCopyWithImpl<$Res, $Val extends EditSite>
 }
 
 /// @nodoc
-abstract class _$$EditSiteImplCopyWith<$Res>
-    implements $EditSiteCopyWith<$Res> {
-  factory _$$EditSiteImplCopyWith(
-          _$EditSiteImpl value, $Res Function(_$EditSiteImpl) then) =
-      __$$EditSiteImplCopyWithImpl<$Res>;
+abstract class _$$_EditSiteCopyWith<$Res> implements $EditSiteCopyWith<$Res> {
+  factory _$$_EditSiteCopyWith(
+          _$_EditSite value, $Res Function(_$_EditSite) then) =
+      __$$_EditSiteCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1234,11 +1422,11 @@ abstract class _$$EditSiteImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$EditSiteImplCopyWithImpl<$Res>
-    extends _$EditSiteCopyWithImpl<$Res, _$EditSiteImpl>
-    implements _$$EditSiteImplCopyWith<$Res> {
-  __$$EditSiteImplCopyWithImpl(
-      _$EditSiteImpl _value, $Res Function(_$EditSiteImpl) _then)
+class __$$_EditSiteCopyWithImpl<$Res>
+    extends _$EditSiteCopyWithImpl<$Res, _$_EditSite>
+    implements _$$_EditSiteCopyWith<$Res> {
+  __$$_EditSiteCopyWithImpl(
+      _$_EditSite _value, $Res Function(_$_EditSite) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1260,7 +1448,7 @@ class __$$EditSiteImplCopyWithImpl<$Res>
     Object? auth = null,
     Object? defaultTheme = freezed,
   }) {
-    return _then(_$EditSiteImpl(
+    return _then(_$_EditSite(
       name: freezed == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -1328,8 +1516,8 @@ class __$$EditSiteImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$EditSiteImpl extends _EditSite {
-  const _$EditSiteImpl(
+class _$_EditSite extends _EditSite {
+  const _$_EditSite(
       {this.name,
       this.sidebar,
       this.description,
@@ -1347,8 +1535,8 @@ class _$EditSiteImpl extends _EditSite {
       this.defaultTheme})
       : super._();
 
-  factory _$EditSiteImpl.fromJson(Map<String, dynamic> json) =>
-      _$$EditSiteImplFromJson(json);
+  factory _$_EditSite.fromJson(Map<String, dynamic> json) =>
+      _$$_EditSiteFromJson(json);
 
   @override
   final String? name;
@@ -1390,7 +1578,7 @@ class _$EditSiteImpl extends _EditSite {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$EditSiteImpl &&
+            other is _$_EditSite &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.sidebar, sidebar) || other.sidebar == sidebar) &&
             (identical(other.description, description) ||
@@ -1444,12 +1632,12 @@ class _$EditSiteImpl extends _EditSite {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$EditSiteImplCopyWith<_$EditSiteImpl> get copyWith =>
-      __$$EditSiteImplCopyWithImpl<_$EditSiteImpl>(this, _$identity);
+  _$$_EditSiteCopyWith<_$_EditSite> get copyWith =>
+      __$$_EditSiteCopyWithImpl<_$_EditSite>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$EditSiteImplToJson(
+    return _$$_EditSiteToJson(
       this,
     );
   }
@@ -1471,11 +1659,10 @@ abstract class _EditSite extends EditSite {
       final String? applicationQuestion,
       final bool? privateInstance,
       required final String auth,
-      final String? defaultTheme}) = _$EditSiteImpl;
+      final String? defaultTheme}) = _$_EditSite;
   const _EditSite._() : super._();
 
-  factory _EditSite.fromJson(Map<String, dynamic> json) =
-      _$EditSiteImpl.fromJson;
+  factory _EditSite.fromJson(Map<String, dynamic> json) = _$_EditSite.fromJson;
 
   @override
   String? get name;
@@ -1509,7 +1696,7 @@ abstract class _EditSite extends EditSite {
   String? get defaultTheme;
   @override
   @JsonKey(ignore: true)
-  _$$EditSiteImplCopyWith<_$EditSiteImpl> get copyWith =>
+  _$$_EditSiteCopyWith<_$_EditSite> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1559,21 +1746,20 @@ class _$GetSiteCopyWithImpl<$Res, $Val extends GetSite>
 }
 
 /// @nodoc
-abstract class _$$GetSiteImplCopyWith<$Res> implements $GetSiteCopyWith<$Res> {
-  factory _$$GetSiteImplCopyWith(
-          _$GetSiteImpl value, $Res Function(_$GetSiteImpl) then) =
-      __$$GetSiteImplCopyWithImpl<$Res>;
+abstract class _$$_GetSiteCopyWith<$Res> implements $GetSiteCopyWith<$Res> {
+  factory _$$_GetSiteCopyWith(
+          _$_GetSite value, $Res Function(_$_GetSite) then) =
+      __$$_GetSiteCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$GetSiteImplCopyWithImpl<$Res>
-    extends _$GetSiteCopyWithImpl<$Res, _$GetSiteImpl>
-    implements _$$GetSiteImplCopyWith<$Res> {
-  __$$GetSiteImplCopyWithImpl(
-      _$GetSiteImpl _value, $Res Function(_$GetSiteImpl) _then)
+class __$$_GetSiteCopyWithImpl<$Res>
+    extends _$GetSiteCopyWithImpl<$Res, _$_GetSite>
+    implements _$$_GetSiteCopyWith<$Res> {
+  __$$_GetSiteCopyWithImpl(_$_GetSite _value, $Res Function(_$_GetSite) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1581,7 +1767,7 @@ class __$$GetSiteImplCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$GetSiteImpl(
+    return _then(_$_GetSite(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -1593,11 +1779,11 @@ class __$$GetSiteImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetSiteImpl extends _GetSite {
-  const _$GetSiteImpl({this.auth}) : super._();
+class _$_GetSite extends _GetSite {
+  const _$_GetSite({this.auth}) : super._();
 
-  factory _$GetSiteImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetSiteImplFromJson(json);
+  factory _$_GetSite.fromJson(Map<String, dynamic> json) =>
+      _$$_GetSiteFromJson(json);
 
   @override
   final String? auth;
@@ -1611,7 +1797,7 @@ class _$GetSiteImpl extends _GetSite {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetSiteImpl &&
+            other is _$_GetSite &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -1622,28 +1808,28 @@ class _$GetSiteImpl extends _GetSite {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetSiteImplCopyWith<_$GetSiteImpl> get copyWith =>
-      __$$GetSiteImplCopyWithImpl<_$GetSiteImpl>(this, _$identity);
+  _$$_GetSiteCopyWith<_$_GetSite> get copyWith =>
+      __$$_GetSiteCopyWithImpl<_$_GetSite>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetSiteImplToJson(
+    return _$$_GetSiteToJson(
       this,
     );
   }
 }
 
 abstract class _GetSite extends GetSite {
-  const factory _GetSite({final String? auth}) = _$GetSiteImpl;
+  const factory _GetSite({final String? auth}) = _$_GetSite;
   const _GetSite._() : super._();
 
-  factory _GetSite.fromJson(Map<String, dynamic> json) = _$GetSiteImpl.fromJson;
+  factory _GetSite.fromJson(Map<String, dynamic> json) = _$_GetSite.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetSiteImplCopyWith<_$GetSiteImpl> get copyWith =>
+  _$$_GetSiteCopyWith<_$_GetSite> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1695,22 +1881,22 @@ class _$LeaveAdminCopyWithImpl<$Res, $Val extends LeaveAdmin>
 }
 
 /// @nodoc
-abstract class _$$LeaveAdminImplCopyWith<$Res>
+abstract class _$$_LeaveAdminCopyWith<$Res>
     implements $LeaveAdminCopyWith<$Res> {
-  factory _$$LeaveAdminImplCopyWith(
-          _$LeaveAdminImpl value, $Res Function(_$LeaveAdminImpl) then) =
-      __$$LeaveAdminImplCopyWithImpl<$Res>;
+  factory _$$_LeaveAdminCopyWith(
+          _$_LeaveAdmin value, $Res Function(_$_LeaveAdmin) then) =
+      __$$_LeaveAdminCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String auth});
 }
 
 /// @nodoc
-class __$$LeaveAdminImplCopyWithImpl<$Res>
-    extends _$LeaveAdminCopyWithImpl<$Res, _$LeaveAdminImpl>
-    implements _$$LeaveAdminImplCopyWith<$Res> {
-  __$$LeaveAdminImplCopyWithImpl(
-      _$LeaveAdminImpl _value, $Res Function(_$LeaveAdminImpl) _then)
+class __$$_LeaveAdminCopyWithImpl<$Res>
+    extends _$LeaveAdminCopyWithImpl<$Res, _$_LeaveAdmin>
+    implements _$$_LeaveAdminCopyWith<$Res> {
+  __$$_LeaveAdminCopyWithImpl(
+      _$_LeaveAdmin _value, $Res Function(_$_LeaveAdmin) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1718,7 +1904,7 @@ class __$$LeaveAdminImplCopyWithImpl<$Res>
   $Res call({
     Object? auth = null,
   }) {
-    return _then(_$LeaveAdminImpl(
+    return _then(_$_LeaveAdmin(
       auth: null == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -1730,11 +1916,11 @@ class __$$LeaveAdminImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$LeaveAdminImpl extends _LeaveAdmin {
-  const _$LeaveAdminImpl({required this.auth}) : super._();
+class _$_LeaveAdmin extends _LeaveAdmin {
+  const _$_LeaveAdmin({required this.auth}) : super._();
 
-  factory _$LeaveAdminImpl.fromJson(Map<String, dynamic> json) =>
-      _$$LeaveAdminImplFromJson(json);
+  factory _$_LeaveAdmin.fromJson(Map<String, dynamic> json) =>
+      _$$_LeaveAdminFromJson(json);
 
   @override
   final String auth;
@@ -1748,7 +1934,7 @@ class _$LeaveAdminImpl extends _LeaveAdmin {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$LeaveAdminImpl &&
+            other is _$_LeaveAdmin &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -1759,29 +1945,29 @@ class _$LeaveAdminImpl extends _LeaveAdmin {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$LeaveAdminImplCopyWith<_$LeaveAdminImpl> get copyWith =>
-      __$$LeaveAdminImplCopyWithImpl<_$LeaveAdminImpl>(this, _$identity);
+  _$$_LeaveAdminCopyWith<_$_LeaveAdmin> get copyWith =>
+      __$$_LeaveAdminCopyWithImpl<_$_LeaveAdmin>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$LeaveAdminImplToJson(
+    return _$$_LeaveAdminToJson(
       this,
     );
   }
 }
 
 abstract class _LeaveAdmin extends LeaveAdmin {
-  const factory _LeaveAdmin({required final String auth}) = _$LeaveAdminImpl;
+  const factory _LeaveAdmin({required final String auth}) = _$_LeaveAdmin;
   const _LeaveAdmin._() : super._();
 
   factory _LeaveAdmin.fromJson(Map<String, dynamic> json) =
-      _$LeaveAdminImpl.fromJson;
+      _$_LeaveAdmin.fromJson;
 
   @override
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$LeaveAdminImplCopyWith<_$LeaveAdminImpl> get copyWith =>
+  _$$_LeaveAdminCopyWith<_$_LeaveAdmin> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1833,22 +2019,22 @@ class _$GetSiteConfigCopyWithImpl<$Res, $Val extends GetSiteConfig>
 }
 
 /// @nodoc
-abstract class _$$GetSiteConfigImplCopyWith<$Res>
+abstract class _$$_GetSiteConfigCopyWith<$Res>
     implements $GetSiteConfigCopyWith<$Res> {
-  factory _$$GetSiteConfigImplCopyWith(
-          _$GetSiteConfigImpl value, $Res Function(_$GetSiteConfigImpl) then) =
-      __$$GetSiteConfigImplCopyWithImpl<$Res>;
+  factory _$$_GetSiteConfigCopyWith(
+          _$_GetSiteConfig value, $Res Function(_$_GetSiteConfig) then) =
+      __$$_GetSiteConfigCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String auth});
 }
 
 /// @nodoc
-class __$$GetSiteConfigImplCopyWithImpl<$Res>
-    extends _$GetSiteConfigCopyWithImpl<$Res, _$GetSiteConfigImpl>
-    implements _$$GetSiteConfigImplCopyWith<$Res> {
-  __$$GetSiteConfigImplCopyWithImpl(
-      _$GetSiteConfigImpl _value, $Res Function(_$GetSiteConfigImpl) _then)
+class __$$_GetSiteConfigCopyWithImpl<$Res>
+    extends _$GetSiteConfigCopyWithImpl<$Res, _$_GetSiteConfig>
+    implements _$$_GetSiteConfigCopyWith<$Res> {
+  __$$_GetSiteConfigCopyWithImpl(
+      _$_GetSiteConfig _value, $Res Function(_$_GetSiteConfig) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1856,7 +2042,7 @@ class __$$GetSiteConfigImplCopyWithImpl<$Res>
   $Res call({
     Object? auth = null,
   }) {
-    return _then(_$GetSiteConfigImpl(
+    return _then(_$_GetSiteConfig(
       auth: null == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -1868,11 +2054,11 @@ class __$$GetSiteConfigImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetSiteConfigImpl extends _GetSiteConfig {
-  const _$GetSiteConfigImpl({required this.auth}) : super._();
+class _$_GetSiteConfig extends _GetSiteConfig {
+  const _$_GetSiteConfig({required this.auth}) : super._();
 
-  factory _$GetSiteConfigImpl.fromJson(Map<String, dynamic> json) =>
-      _$$GetSiteConfigImplFromJson(json);
+  factory _$_GetSiteConfig.fromJson(Map<String, dynamic> json) =>
+      _$$_GetSiteConfigFromJson(json);
 
   @override
   final String auth;
@@ -1886,7 +2072,7 @@ class _$GetSiteConfigImpl extends _GetSiteConfig {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetSiteConfigImpl &&
+            other is _$_GetSiteConfig &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -1897,30 +2083,29 @@ class _$GetSiteConfigImpl extends _GetSiteConfig {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetSiteConfigImplCopyWith<_$GetSiteConfigImpl> get copyWith =>
-      __$$GetSiteConfigImplCopyWithImpl<_$GetSiteConfigImpl>(this, _$identity);
+  _$$_GetSiteConfigCopyWith<_$_GetSiteConfig> get copyWith =>
+      __$$_GetSiteConfigCopyWithImpl<_$_GetSiteConfig>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetSiteConfigImplToJson(
+    return _$$_GetSiteConfigToJson(
       this,
     );
   }
 }
 
 abstract class _GetSiteConfig extends GetSiteConfig {
-  const factory _GetSiteConfig({required final String auth}) =
-      _$GetSiteConfigImpl;
+  const factory _GetSiteConfig({required final String auth}) = _$_GetSiteConfig;
   const _GetSiteConfig._() : super._();
 
   factory _GetSiteConfig.fromJson(Map<String, dynamic> json) =
-      _$GetSiteConfigImpl.fromJson;
+      _$_GetSiteConfig.fromJson;
 
   @override
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetSiteConfigImplCopyWith<_$GetSiteConfigImpl> get copyWith =>
+  _$$_GetSiteConfigCopyWith<_$_GetSiteConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1978,22 +2163,22 @@ class _$SaveSiteConfigCopyWithImpl<$Res, $Val extends SaveSiteConfig>
 }
 
 /// @nodoc
-abstract class _$$SaveSiteConfigImplCopyWith<$Res>
+abstract class _$$_SaveSiteConfigCopyWith<$Res>
     implements $SaveSiteConfigCopyWith<$Res> {
-  factory _$$SaveSiteConfigImplCopyWith(_$SaveSiteConfigImpl value,
-          $Res Function(_$SaveSiteConfigImpl) then) =
-      __$$SaveSiteConfigImplCopyWithImpl<$Res>;
+  factory _$$_SaveSiteConfigCopyWith(
+          _$_SaveSiteConfig value, $Res Function(_$_SaveSiteConfig) then) =
+      __$$_SaveSiteConfigCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String configHjson, String auth});
 }
 
 /// @nodoc
-class __$$SaveSiteConfigImplCopyWithImpl<$Res>
-    extends _$SaveSiteConfigCopyWithImpl<$Res, _$SaveSiteConfigImpl>
-    implements _$$SaveSiteConfigImplCopyWith<$Res> {
-  __$$SaveSiteConfigImplCopyWithImpl(
-      _$SaveSiteConfigImpl _value, $Res Function(_$SaveSiteConfigImpl) _then)
+class __$$_SaveSiteConfigCopyWithImpl<$Res>
+    extends _$SaveSiteConfigCopyWithImpl<$Res, _$_SaveSiteConfig>
+    implements _$$_SaveSiteConfigCopyWith<$Res> {
+  __$$_SaveSiteConfigCopyWithImpl(
+      _$_SaveSiteConfig _value, $Res Function(_$_SaveSiteConfig) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2002,7 +2187,7 @@ class __$$SaveSiteConfigImplCopyWithImpl<$Res>
     Object? configHjson = null,
     Object? auth = null,
   }) {
-    return _then(_$SaveSiteConfigImpl(
+    return _then(_$_SaveSiteConfig(
       configHjson: null == configHjson
           ? _value.configHjson
           : configHjson // ignore: cast_nullable_to_non_nullable
@@ -2018,12 +2203,12 @@ class __$$SaveSiteConfigImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$SaveSiteConfigImpl extends _SaveSiteConfig {
-  const _$SaveSiteConfigImpl({required this.configHjson, required this.auth})
+class _$_SaveSiteConfig extends _SaveSiteConfig {
+  const _$_SaveSiteConfig({required this.configHjson, required this.auth})
       : super._();
 
-  factory _$SaveSiteConfigImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SaveSiteConfigImplFromJson(json);
+  factory _$_SaveSiteConfig.fromJson(Map<String, dynamic> json) =>
+      _$$_SaveSiteConfigFromJson(json);
 
   @override
   final String configHjson;
@@ -2039,7 +2224,7 @@ class _$SaveSiteConfigImpl extends _SaveSiteConfig {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SaveSiteConfigImpl &&
+            other is _$_SaveSiteConfig &&
             (identical(other.configHjson, configHjson) ||
                 other.configHjson == configHjson) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -2052,13 +2237,12 @@ class _$SaveSiteConfigImpl extends _SaveSiteConfig {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SaveSiteConfigImplCopyWith<_$SaveSiteConfigImpl> get copyWith =>
-      __$$SaveSiteConfigImplCopyWithImpl<_$SaveSiteConfigImpl>(
-          this, _$identity);
+  _$$_SaveSiteConfigCopyWith<_$_SaveSiteConfig> get copyWith =>
+      __$$_SaveSiteConfigCopyWithImpl<_$_SaveSiteConfig>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$SaveSiteConfigImplToJson(
+    return _$$_SaveSiteConfigToJson(
       this,
     );
   }
@@ -2067,11 +2251,11 @@ class _$SaveSiteConfigImpl extends _SaveSiteConfig {
 abstract class _SaveSiteConfig extends SaveSiteConfig {
   const factory _SaveSiteConfig(
       {required final String configHjson,
-      required final String auth}) = _$SaveSiteConfigImpl;
+      required final String auth}) = _$_SaveSiteConfig;
   const _SaveSiteConfig._() : super._();
 
   factory _SaveSiteConfig.fromJson(Map<String, dynamic> json) =
-      _$SaveSiteConfigImpl.fromJson;
+      _$_SaveSiteConfig.fromJson;
 
   @override
   String get configHjson;
@@ -2079,7 +2263,7 @@ abstract class _SaveSiteConfig extends SaveSiteConfig {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$SaveSiteConfigImplCopyWith<_$SaveSiteConfigImpl> get copyWith =>
+  _$$_SaveSiteConfigCopyWith<_$_SaveSiteConfig> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2137,22 +2321,22 @@ class _$ResolveObjectCopyWithImpl<$Res, $Val extends ResolveObject>
 }
 
 /// @nodoc
-abstract class _$$ResolveObjectImplCopyWith<$Res>
+abstract class _$$_ResolveObjectCopyWith<$Res>
     implements $ResolveObjectCopyWith<$Res> {
-  factory _$$ResolveObjectImplCopyWith(
-          _$ResolveObjectImpl value, $Res Function(_$ResolveObjectImpl) then) =
-      __$$ResolveObjectImplCopyWithImpl<$Res>;
+  factory _$$_ResolveObjectCopyWith(
+          _$_ResolveObject value, $Res Function(_$_ResolveObject) then) =
+      __$$_ResolveObjectCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String q, String? auth});
 }
 
 /// @nodoc
-class __$$ResolveObjectImplCopyWithImpl<$Res>
-    extends _$ResolveObjectCopyWithImpl<$Res, _$ResolveObjectImpl>
-    implements _$$ResolveObjectImplCopyWith<$Res> {
-  __$$ResolveObjectImplCopyWithImpl(
-      _$ResolveObjectImpl _value, $Res Function(_$ResolveObjectImpl) _then)
+class __$$_ResolveObjectCopyWithImpl<$Res>
+    extends _$ResolveObjectCopyWithImpl<$Res, _$_ResolveObject>
+    implements _$$_ResolveObjectCopyWith<$Res> {
+  __$$_ResolveObjectCopyWithImpl(
+      _$_ResolveObject _value, $Res Function(_$_ResolveObject) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2161,7 +2345,7 @@ class __$$ResolveObjectImplCopyWithImpl<$Res>
     Object? q = null,
     Object? auth = freezed,
   }) {
-    return _then(_$ResolveObjectImpl(
+    return _then(_$_ResolveObject(
       q: null == q
           ? _value.q
           : q // ignore: cast_nullable_to_non_nullable
@@ -2177,11 +2361,11 @@ class __$$ResolveObjectImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$ResolveObjectImpl extends _ResolveObject {
-  const _$ResolveObjectImpl({required this.q, this.auth}) : super._();
+class _$_ResolveObject extends _ResolveObject {
+  const _$_ResolveObject({required this.q, this.auth}) : super._();
 
-  factory _$ResolveObjectImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ResolveObjectImplFromJson(json);
+  factory _$_ResolveObject.fromJson(Map<String, dynamic> json) =>
+      _$$_ResolveObjectFromJson(json);
 
   @override
   final String q;
@@ -2197,7 +2381,7 @@ class _$ResolveObjectImpl extends _ResolveObject {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ResolveObjectImpl &&
+            other is _$_ResolveObject &&
             (identical(other.q, q) || other.q == q) &&
             (identical(other.auth, auth) || other.auth == auth));
   }
@@ -2209,12 +2393,12 @@ class _$ResolveObjectImpl extends _ResolveObject {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ResolveObjectImplCopyWith<_$ResolveObjectImpl> get copyWith =>
-      __$$ResolveObjectImplCopyWithImpl<_$ResolveObjectImpl>(this, _$identity);
+  _$$_ResolveObjectCopyWith<_$_ResolveObject> get copyWith =>
+      __$$_ResolveObjectCopyWithImpl<_$_ResolveObject>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ResolveObjectImplToJson(
+    return _$$_ResolveObjectToJson(
       this,
     );
   }
@@ -2222,11 +2406,11 @@ class _$ResolveObjectImpl extends _ResolveObject {
 
 abstract class _ResolveObject extends ResolveObject {
   const factory _ResolveObject({required final String q, final String? auth}) =
-      _$ResolveObjectImpl;
+      _$_ResolveObject;
   const _ResolveObject._() : super._();
 
   factory _ResolveObject.fromJson(Map<String, dynamic> json) =
-      _$ResolveObjectImpl.fromJson;
+      _$_ResolveObject.fromJson;
 
   @override
   String get q;
@@ -2234,7 +2418,7 @@ abstract class _ResolveObject extends ResolveObject {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$ResolveObjectImplCopyWith<_$ResolveObjectImpl> get copyWith =>
+  _$$_ResolveObjectCopyWith<_$_ResolveObject> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2291,25 +2475,25 @@ class _$GetUnreadRegistrationApplicationCountCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$GetUnreadRegistrationApplicationCountImplCopyWith<$Res>
+abstract class _$$_GetUnreadRegistrationApplicationCountCopyWith<$Res>
     implements $GetUnreadRegistrationApplicationCountCopyWith<$Res> {
-  factory _$$GetUnreadRegistrationApplicationCountImplCopyWith(
-          _$GetUnreadRegistrationApplicationCountImpl value,
-          $Res Function(_$GetUnreadRegistrationApplicationCountImpl) then) =
-      __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl<$Res>;
+  factory _$$_GetUnreadRegistrationApplicationCountCopyWith(
+          _$_GetUnreadRegistrationApplicationCount value,
+          $Res Function(_$_GetUnreadRegistrationApplicationCount) then) =
+      __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String auth});
 }
 
 /// @nodoc
-class __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl<$Res>
+class __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<$Res>
     extends _$GetUnreadRegistrationApplicationCountCopyWithImpl<$Res,
-        _$GetUnreadRegistrationApplicationCountImpl>
-    implements _$$GetUnreadRegistrationApplicationCountImplCopyWith<$Res> {
-  __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl(
-      _$GetUnreadRegistrationApplicationCountImpl _value,
-      $Res Function(_$GetUnreadRegistrationApplicationCountImpl) _then)
+        _$_GetUnreadRegistrationApplicationCount>
+    implements _$$_GetUnreadRegistrationApplicationCountCopyWith<$Res> {
+  __$$_GetUnreadRegistrationApplicationCountCopyWithImpl(
+      _$_GetUnreadRegistrationApplicationCount _value,
+      $Res Function(_$_GetUnreadRegistrationApplicationCount) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2317,7 +2501,7 @@ class __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl<$Res>
   $Res call({
     Object? auth = null,
   }) {
-    return _then(_$GetUnreadRegistrationApplicationCountImpl(
+    return _then(_$_GetUnreadRegistrationApplicationCount(
       auth: null == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -2329,14 +2513,14 @@ class __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$GetUnreadRegistrationApplicationCountImpl
+class _$_GetUnreadRegistrationApplicationCount
     extends _GetUnreadRegistrationApplicationCount {
-  const _$GetUnreadRegistrationApplicationCountImpl({required this.auth})
+  const _$_GetUnreadRegistrationApplicationCount({required this.auth})
       : super._();
 
-  factory _$GetUnreadRegistrationApplicationCountImpl.fromJson(
+  factory _$_GetUnreadRegistrationApplicationCount.fromJson(
           Map<String, dynamic> json) =>
-      _$$GetUnreadRegistrationApplicationCountImplFromJson(json);
+      _$$_GetUnreadRegistrationApplicationCountFromJson(json);
 
   @override
   final String auth;
@@ -2350,7 +2534,7 @@ class _$GetUnreadRegistrationApplicationCountImpl
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$GetUnreadRegistrationApplicationCountImpl &&
+            other is _$_GetUnreadRegistrationApplicationCount &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -2361,14 +2545,14 @@ class _$GetUnreadRegistrationApplicationCountImpl
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$GetUnreadRegistrationApplicationCountImplCopyWith<
-          _$GetUnreadRegistrationApplicationCountImpl>
-      get copyWith => __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl<
-          _$GetUnreadRegistrationApplicationCountImpl>(this, _$identity);
+  _$$_GetUnreadRegistrationApplicationCountCopyWith<
+          _$_GetUnreadRegistrationApplicationCount>
+      get copyWith => __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<
+          _$_GetUnreadRegistrationApplicationCount>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$GetUnreadRegistrationApplicationCountImplToJson(
+    return _$$_GetUnreadRegistrationApplicationCountToJson(
       this,
     );
   }
@@ -2377,20 +2561,19 @@ class _$GetUnreadRegistrationApplicationCountImpl
 abstract class _GetUnreadRegistrationApplicationCount
     extends GetUnreadRegistrationApplicationCount {
   const factory _GetUnreadRegistrationApplicationCount(
-          {required final String auth}) =
-      _$GetUnreadRegistrationApplicationCountImpl;
+      {required final String auth}) = _$_GetUnreadRegistrationApplicationCount;
   const _GetUnreadRegistrationApplicationCount._() : super._();
 
   factory _GetUnreadRegistrationApplicationCount.fromJson(
           Map<String, dynamic> json) =
-      _$GetUnreadRegistrationApplicationCountImpl.fromJson;
+      _$_GetUnreadRegistrationApplicationCount.fromJson;
 
   @override
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$GetUnreadRegistrationApplicationCountImplCopyWith<
-          _$GetUnreadRegistrationApplicationCountImpl>
+  _$$_GetUnreadRegistrationApplicationCountCopyWith<
+          _$_GetUnreadRegistrationApplicationCount>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -2464,25 +2647,25 @@ class _$ListRegistrationApplicationsCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$ListRegistrationApplicationsImplCopyWith<$Res>
+abstract class _$$_ListRegistrationApplicationsCopyWith<$Res>
     implements $ListRegistrationApplicationsCopyWith<$Res> {
-  factory _$$ListRegistrationApplicationsImplCopyWith(
-          _$ListRegistrationApplicationsImpl value,
-          $Res Function(_$ListRegistrationApplicationsImpl) then) =
-      __$$ListRegistrationApplicationsImplCopyWithImpl<$Res>;
+  factory _$$_ListRegistrationApplicationsCopyWith(
+          _$_ListRegistrationApplications value,
+          $Res Function(_$_ListRegistrationApplications) then) =
+      __$$_ListRegistrationApplicationsCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool? unreadOnly, int? page, int? limit, String auth});
 }
 
 /// @nodoc
-class __$$ListRegistrationApplicationsImplCopyWithImpl<$Res>
+class __$$_ListRegistrationApplicationsCopyWithImpl<$Res>
     extends _$ListRegistrationApplicationsCopyWithImpl<$Res,
-        _$ListRegistrationApplicationsImpl>
-    implements _$$ListRegistrationApplicationsImplCopyWith<$Res> {
-  __$$ListRegistrationApplicationsImplCopyWithImpl(
-      _$ListRegistrationApplicationsImpl _value,
-      $Res Function(_$ListRegistrationApplicationsImpl) _then)
+        _$_ListRegistrationApplications>
+    implements _$$_ListRegistrationApplicationsCopyWith<$Res> {
+  __$$_ListRegistrationApplicationsCopyWithImpl(
+      _$_ListRegistrationApplications _value,
+      $Res Function(_$_ListRegistrationApplications) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2493,7 +2676,7 @@ class __$$ListRegistrationApplicationsImplCopyWithImpl<$Res>
     Object? limit = freezed,
     Object? auth = null,
   }) {
-    return _then(_$ListRegistrationApplicationsImpl(
+    return _then(_$_ListRegistrationApplications(
       unreadOnly: freezed == unreadOnly
           ? _value.unreadOnly
           : unreadOnly // ignore: cast_nullable_to_non_nullable
@@ -2517,14 +2700,13 @@ class __$$ListRegistrationApplicationsImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$ListRegistrationApplicationsImpl extends _ListRegistrationApplications {
-  const _$ListRegistrationApplicationsImpl(
+class _$_ListRegistrationApplications extends _ListRegistrationApplications {
+  const _$_ListRegistrationApplications(
       {this.unreadOnly, this.page, this.limit, required this.auth})
       : super._();
 
-  factory _$ListRegistrationApplicationsImpl.fromJson(
-          Map<String, dynamic> json) =>
-      _$$ListRegistrationApplicationsImplFromJson(json);
+  factory _$_ListRegistrationApplications.fromJson(Map<String, dynamic> json) =>
+      _$$_ListRegistrationApplicationsFromJson(json);
 
   @override
   final bool? unreadOnly;
@@ -2544,7 +2726,7 @@ class _$ListRegistrationApplicationsImpl extends _ListRegistrationApplications {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ListRegistrationApplicationsImpl &&
+            other is _$_ListRegistrationApplications &&
             (identical(other.unreadOnly, unreadOnly) ||
                 other.unreadOnly == unreadOnly) &&
             (identical(other.page, page) || other.page == page) &&
@@ -2559,14 +2741,13 @@ class _$ListRegistrationApplicationsImpl extends _ListRegistrationApplications {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ListRegistrationApplicationsImplCopyWith<
-          _$ListRegistrationApplicationsImpl>
-      get copyWith => __$$ListRegistrationApplicationsImplCopyWithImpl<
-          _$ListRegistrationApplicationsImpl>(this, _$identity);
+  _$$_ListRegistrationApplicationsCopyWith<_$_ListRegistrationApplications>
+      get copyWith => __$$_ListRegistrationApplicationsCopyWithImpl<
+          _$_ListRegistrationApplications>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ListRegistrationApplicationsImplToJson(
+    return _$$_ListRegistrationApplicationsToJson(
       this,
     );
   }
@@ -2578,11 +2759,11 @@ abstract class _ListRegistrationApplications
       {final bool? unreadOnly,
       final int? page,
       final int? limit,
-      required final String auth}) = _$ListRegistrationApplicationsImpl;
+      required final String auth}) = _$_ListRegistrationApplications;
   const _ListRegistrationApplications._() : super._();
 
   factory _ListRegistrationApplications.fromJson(Map<String, dynamic> json) =
-      _$ListRegistrationApplicationsImpl.fromJson;
+      _$_ListRegistrationApplications.fromJson;
 
   @override
   bool? get unreadOnly;
@@ -2594,8 +2775,7 @@ abstract class _ListRegistrationApplications
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$ListRegistrationApplicationsImplCopyWith<
-          _$ListRegistrationApplicationsImpl>
+  _$$_ListRegistrationApplicationsCopyWith<_$_ListRegistrationApplications>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -2669,25 +2849,25 @@ class _$ApproveRegistrationApplicationCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$ApproveRegistrationApplicationImplCopyWith<$Res>
+abstract class _$$_ApproveRegistrationApplicationCopyWith<$Res>
     implements $ApproveRegistrationApplicationCopyWith<$Res> {
-  factory _$$ApproveRegistrationApplicationImplCopyWith(
-          _$ApproveRegistrationApplicationImpl value,
-          $Res Function(_$ApproveRegistrationApplicationImpl) then) =
-      __$$ApproveRegistrationApplicationImplCopyWithImpl<$Res>;
+  factory _$$_ApproveRegistrationApplicationCopyWith(
+          _$_ApproveRegistrationApplication value,
+          $Res Function(_$_ApproveRegistrationApplication) then) =
+      __$$_ApproveRegistrationApplicationCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int id, bool approve, String? denyReason, String auth});
 }
 
 /// @nodoc
-class __$$ApproveRegistrationApplicationImplCopyWithImpl<$Res>
+class __$$_ApproveRegistrationApplicationCopyWithImpl<$Res>
     extends _$ApproveRegistrationApplicationCopyWithImpl<$Res,
-        _$ApproveRegistrationApplicationImpl>
-    implements _$$ApproveRegistrationApplicationImplCopyWith<$Res> {
-  __$$ApproveRegistrationApplicationImplCopyWithImpl(
-      _$ApproveRegistrationApplicationImpl _value,
-      $Res Function(_$ApproveRegistrationApplicationImpl) _then)
+        _$_ApproveRegistrationApplication>
+    implements _$$_ApproveRegistrationApplicationCopyWith<$Res> {
+  __$$_ApproveRegistrationApplicationCopyWithImpl(
+      _$_ApproveRegistrationApplication _value,
+      $Res Function(_$_ApproveRegistrationApplication) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2698,7 +2878,7 @@ class __$$ApproveRegistrationApplicationImplCopyWithImpl<$Res>
     Object? denyReason = freezed,
     Object? auth = null,
   }) {
-    return _then(_$ApproveRegistrationApplicationImpl(
+    return _then(_$_ApproveRegistrationApplication(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -2722,18 +2902,18 @@ class __$$ApproveRegistrationApplicationImplCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$ApproveRegistrationApplicationImpl
+class _$_ApproveRegistrationApplication
     extends _ApproveRegistrationApplication {
-  const _$ApproveRegistrationApplicationImpl(
+  const _$_ApproveRegistrationApplication(
       {required this.id,
       required this.approve,
       this.denyReason,
       required this.auth})
       : super._();
 
-  factory _$ApproveRegistrationApplicationImpl.fromJson(
+  factory _$_ApproveRegistrationApplication.fromJson(
           Map<String, dynamic> json) =>
-      _$$ApproveRegistrationApplicationImplFromJson(json);
+      _$$_ApproveRegistrationApplicationFromJson(json);
 
   @override
   final int id;
@@ -2753,7 +2933,7 @@ class _$ApproveRegistrationApplicationImpl
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ApproveRegistrationApplicationImpl &&
+            other is _$_ApproveRegistrationApplication &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.approve, approve) || other.approve == approve) &&
             (identical(other.denyReason, denyReason) ||
@@ -2768,14 +2948,13 @@ class _$ApproveRegistrationApplicationImpl
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ApproveRegistrationApplicationImplCopyWith<
-          _$ApproveRegistrationApplicationImpl>
-      get copyWith => __$$ApproveRegistrationApplicationImplCopyWithImpl<
-          _$ApproveRegistrationApplicationImpl>(this, _$identity);
+  _$$_ApproveRegistrationApplicationCopyWith<_$_ApproveRegistrationApplication>
+      get copyWith => __$$_ApproveRegistrationApplicationCopyWithImpl<
+          _$_ApproveRegistrationApplication>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ApproveRegistrationApplicationImplToJson(
+    return _$$_ApproveRegistrationApplicationToJson(
       this,
     );
   }
@@ -2787,11 +2966,11 @@ abstract class _ApproveRegistrationApplication
       {required final int id,
       required final bool approve,
       final String? denyReason,
-      required final String auth}) = _$ApproveRegistrationApplicationImpl;
+      required final String auth}) = _$_ApproveRegistrationApplication;
   const _ApproveRegistrationApplication._() : super._();
 
   factory _ApproveRegistrationApplication.fromJson(Map<String, dynamic> json) =
-      _$ApproveRegistrationApplicationImpl.fromJson;
+      _$_ApproveRegistrationApplication.fromJson;
 
   @override
   int get id;
@@ -2803,7 +2982,6 @@ abstract class _ApproveRegistrationApplication
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$ApproveRegistrationApplicationImplCopyWith<
-          _$ApproveRegistrationApplicationImpl>
+  _$$_ApproveRegistrationApplicationCopyWith<_$_ApproveRegistrationApplication>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/site.g.dart
+++ b/lib/src/v3/api/site.g.dart
@@ -6,7 +6,7 @@ part of 'site.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$SearchImpl _$$SearchImplFromJson(Map<String, dynamic> json) => _$SearchImpl(
+_$_Search _$$_SearchFromJson(Map<String, dynamic> json) => _$_Search(
       q: json['q'] as String,
       type: json['type_'] == null
           ? null
@@ -23,7 +23,7 @@ _$SearchImpl _$$SearchImplFromJson(Map<String, dynamic> json) => _$SearchImpl(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$SearchImplToJson(_$SearchImpl instance) {
+Map<String, dynamic> _$$_SearchToJson(_$_Search instance) {
   final val = <String, dynamic>{
     'q': instance.q,
   };
@@ -46,8 +46,7 @@ Map<String, dynamic> _$$SearchImplToJson(_$SearchImpl instance) {
   return val;
 }
 
-_$GetModlogImpl _$$GetModlogImplFromJson(Map<String, dynamic> json) =>
-    _$GetModlogImpl(
+_$_GetModlog _$$_GetModlogFromJson(Map<String, dynamic> json) => _$_GetModlog(
       modPersonId: json['mod_person_id'] as int?,
       communityId: json['community_id'] as int?,
       otherPersonId: json['other_person_id'] as int?,
@@ -59,7 +58,7 @@ _$GetModlogImpl _$$GetModlogImplFromJson(Map<String, dynamic> json) =>
           : ModlogActionType.fromJson(json['type_'] as String),
     );
 
-Map<String, dynamic> _$$GetModlogImplToJson(_$GetModlogImpl instance) {
+Map<String, dynamic> _$$_GetModlogToJson(_$_GetModlog instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -78,8 +77,31 @@ Map<String, dynamic> _$$GetModlogImplToJson(_$GetModlogImpl instance) {
   return val;
 }
 
-_$CreateSiteImpl _$$CreateSiteImplFromJson(Map<String, dynamic> json) =>
-    _$CreateSiteImpl(
+_$_BlockInstance _$$_BlockInstanceFromJson(Map<String, dynamic> json) =>
+    _$_BlockInstance(
+      instanceId: json['instance_id'] as int,
+      block: json['block'] as bool,
+      auth: json['auth'] as String?,
+    );
+
+Map<String, dynamic> _$$_BlockInstanceToJson(_$_BlockInstance instance) {
+  final val = <String, dynamic>{
+    'instance_id': instance.instanceId,
+    'block': instance.block,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('auth', instance.auth);
+  return val;
+}
+
+_$_CreateSite _$$_CreateSiteFromJson(Map<String, dynamic> json) =>
+    _$_CreateSite(
       name: json['name'] as String,
       sidebar: json['sidebar'] as String?,
       description: json['description'] as String?,
@@ -98,7 +120,7 @@ _$CreateSiteImpl _$$CreateSiteImplFromJson(Map<String, dynamic> json) =>
       defaultTheme: json['default_theme'] as String?,
     );
 
-Map<String, dynamic> _$$CreateSiteImplToJson(_$CreateSiteImpl instance) {
+Map<String, dynamic> _$$_CreateSiteToJson(_$_CreateSite instance) {
   final val = <String, dynamic>{
     'name': instance.name,
   };
@@ -127,8 +149,7 @@ Map<String, dynamic> _$$CreateSiteImplToJson(_$CreateSiteImpl instance) {
   return val;
 }
 
-_$EditSiteImpl _$$EditSiteImplFromJson(Map<String, dynamic> json) =>
-    _$EditSiteImpl(
+_$_EditSite _$$_EditSiteFromJson(Map<String, dynamic> json) => _$_EditSite(
       name: json['name'] as String?,
       sidebar: json['sidebar'] as String?,
       description: json['description'] as String?,
@@ -147,7 +168,7 @@ _$EditSiteImpl _$$EditSiteImplFromJson(Map<String, dynamic> json) =>
       defaultTheme: json['default_theme'] as String?,
     );
 
-Map<String, dynamic> _$$EditSiteImplToJson(_$EditSiteImpl instance) {
+Map<String, dynamic> _$$_EditSiteToJson(_$_EditSite instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -175,12 +196,11 @@ Map<String, dynamic> _$$EditSiteImplToJson(_$EditSiteImpl instance) {
   return val;
 }
 
-_$GetSiteImpl _$$GetSiteImplFromJson(Map<String, dynamic> json) =>
-    _$GetSiteImpl(
+_$_GetSite _$$_GetSiteFromJson(Map<String, dynamic> json) => _$_GetSite(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$GetSiteImplToJson(_$GetSiteImpl instance) {
+Map<String, dynamic> _$$_GetSiteToJson(_$_GetSite instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -193,46 +213,45 @@ Map<String, dynamic> _$$GetSiteImplToJson(_$GetSiteImpl instance) {
   return val;
 }
 
-_$LeaveAdminImpl _$$LeaveAdminImplFromJson(Map<String, dynamic> json) =>
-    _$LeaveAdminImpl(
+_$_LeaveAdmin _$$_LeaveAdminFromJson(Map<String, dynamic> json) =>
+    _$_LeaveAdmin(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$LeaveAdminImplToJson(_$LeaveAdminImpl instance) =>
+Map<String, dynamic> _$$_LeaveAdminToJson(_$_LeaveAdmin instance) =>
     <String, dynamic>{
       'auth': instance.auth,
     };
 
-_$GetSiteConfigImpl _$$GetSiteConfigImplFromJson(Map<String, dynamic> json) =>
-    _$GetSiteConfigImpl(
+_$_GetSiteConfig _$$_GetSiteConfigFromJson(Map<String, dynamic> json) =>
+    _$_GetSiteConfig(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$GetSiteConfigImplToJson(_$GetSiteConfigImpl instance) =>
+Map<String, dynamic> _$$_GetSiteConfigToJson(_$_GetSiteConfig instance) =>
     <String, dynamic>{
       'auth': instance.auth,
     };
 
-_$SaveSiteConfigImpl _$$SaveSiteConfigImplFromJson(Map<String, dynamic> json) =>
-    _$SaveSiteConfigImpl(
+_$_SaveSiteConfig _$$_SaveSiteConfigFromJson(Map<String, dynamic> json) =>
+    _$_SaveSiteConfig(
       configHjson: json['config_hjson'] as String,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$SaveSiteConfigImplToJson(
-        _$SaveSiteConfigImpl instance) =>
+Map<String, dynamic> _$$_SaveSiteConfigToJson(_$_SaveSiteConfig instance) =>
     <String, dynamic>{
       'config_hjson': instance.configHjson,
       'auth': instance.auth,
     };
 
-_$ResolveObjectImpl _$$ResolveObjectImplFromJson(Map<String, dynamic> json) =>
-    _$ResolveObjectImpl(
+_$_ResolveObject _$$_ResolveObjectFromJson(Map<String, dynamic> json) =>
+    _$_ResolveObject(
       q: json['q'] as String,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$ResolveObjectImplToJson(_$ResolveObjectImpl instance) {
+Map<String, dynamic> _$$_ResolveObjectToJson(_$_ResolveObject instance) {
   final val = <String, dynamic>{
     'q': instance.q,
   };
@@ -247,30 +266,30 @@ Map<String, dynamic> _$$ResolveObjectImplToJson(_$ResolveObjectImpl instance) {
   return val;
 }
 
-_$GetUnreadRegistrationApplicationCountImpl
-    _$$GetUnreadRegistrationApplicationCountImplFromJson(
+_$_GetUnreadRegistrationApplicationCount
+    _$$_GetUnreadRegistrationApplicationCountFromJson(
             Map<String, dynamic> json) =>
-        _$GetUnreadRegistrationApplicationCountImpl(
+        _$_GetUnreadRegistrationApplicationCount(
           auth: json['auth'] as String,
         );
 
-Map<String, dynamic> _$$GetUnreadRegistrationApplicationCountImplToJson(
-        _$GetUnreadRegistrationApplicationCountImpl instance) =>
+Map<String, dynamic> _$$_GetUnreadRegistrationApplicationCountToJson(
+        _$_GetUnreadRegistrationApplicationCount instance) =>
     <String, dynamic>{
       'auth': instance.auth,
     };
 
-_$ListRegistrationApplicationsImpl _$$ListRegistrationApplicationsImplFromJson(
+_$_ListRegistrationApplications _$$_ListRegistrationApplicationsFromJson(
         Map<String, dynamic> json) =>
-    _$ListRegistrationApplicationsImpl(
+    _$_ListRegistrationApplications(
       unreadOnly: json['unread_only'] as bool?,
       page: json['page'] as int?,
       limit: json['limit'] as int?,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$ListRegistrationApplicationsImplToJson(
-    _$ListRegistrationApplicationsImpl instance) {
+Map<String, dynamic> _$$_ListRegistrationApplicationsToJson(
+    _$_ListRegistrationApplications instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -286,17 +305,17 @@ Map<String, dynamic> _$$ListRegistrationApplicationsImplToJson(
   return val;
 }
 
-_$ApproveRegistrationApplicationImpl
-    _$$ApproveRegistrationApplicationImplFromJson(Map<String, dynamic> json) =>
-        _$ApproveRegistrationApplicationImpl(
-          id: json['id'] as int,
-          approve: json['approve'] as bool,
-          denyReason: json['deny_reason'] as String?,
-          auth: json['auth'] as String,
-        );
+_$_ApproveRegistrationApplication _$$_ApproveRegistrationApplicationFromJson(
+        Map<String, dynamic> json) =>
+    _$_ApproveRegistrationApplication(
+      id: json['id'] as int,
+      approve: json['approve'] as bool,
+      denyReason: json['deny_reason'] as String?,
+      auth: json['auth'] as String,
+    );
 
-Map<String, dynamic> _$$ApproveRegistrationApplicationImplToJson(
-    _$ApproveRegistrationApplicationImpl instance) {
+Map<String, dynamic> _$$_ApproveRegistrationApplicationToJson(
+    _$_ApproveRegistrationApplication instance) {
   final val = <String, dynamic>{
     'id': instance.id,
     'approve': instance.approve,

--- a/lib/src/v3/models/api.dart
+++ b/lib/src/v3/models/api.dart
@@ -351,3 +351,15 @@ class LoginResponse with _$LoginResponse {
   factory LoginResponse.fromJson(Map<String, dynamic> json) =>
       _$LoginResponseFromJson(json);
 }
+
+@freezed
+class BlockInstanceResponse with _$BlockInstanceResponse {
+  @modelSerde
+  const factory BlockInstanceResponse({
+    required bool blocked,
+  }) = _BlockInstanceResponse;
+
+  const BlockInstanceResponse._();
+  factory BlockInstanceResponse.fromJson(Map<String, dynamic> json) =>
+      _$BlockInstanceResponseFromJson(json);
+}

--- a/lib/src/v3/models/api.freezed.dart
+++ b/lib/src/v3/models/api.freezed.dart
@@ -115,11 +115,11 @@ class _$FullCommunityViewCopyWithImpl<$Res, $Val extends FullCommunityView>
 }
 
 /// @nodoc
-abstract class _$$FullCommunityViewImplCopyWith<$Res>
+abstract class _$$_FullCommunityViewCopyWith<$Res>
     implements $FullCommunityViewCopyWith<$Res> {
-  factory _$$FullCommunityViewImplCopyWith(_$FullCommunityViewImpl value,
-          $Res Function(_$FullCommunityViewImpl) then) =
-      __$$FullCommunityViewImplCopyWithImpl<$Res>;
+  factory _$$_FullCommunityViewCopyWith(_$_FullCommunityView value,
+          $Res Function(_$_FullCommunityView) then) =
+      __$$_FullCommunityViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -136,11 +136,11 @@ abstract class _$$FullCommunityViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$FullCommunityViewImplCopyWithImpl<$Res>
-    extends _$FullCommunityViewCopyWithImpl<$Res, _$FullCommunityViewImpl>
-    implements _$$FullCommunityViewImplCopyWith<$Res> {
-  __$$FullCommunityViewImplCopyWithImpl(_$FullCommunityViewImpl _value,
-      $Res Function(_$FullCommunityViewImpl) _then)
+class __$$_FullCommunityViewCopyWithImpl<$Res>
+    extends _$FullCommunityViewCopyWithImpl<$Res, _$_FullCommunityView>
+    implements _$$_FullCommunityViewCopyWith<$Res> {
+  __$$_FullCommunityViewCopyWithImpl(
+      _$_FullCommunityView _value, $Res Function(_$_FullCommunityView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -152,7 +152,7 @@ class __$$FullCommunityViewImplCopyWithImpl<$Res>
     Object? online = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$FullCommunityViewImpl(
+    return _then(_$_FullCommunityView(
       communityView: null == communityView
           ? _value.communityView
           : communityView // ignore: cast_nullable_to_non_nullable
@@ -180,8 +180,8 @@ class __$$FullCommunityViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$FullCommunityViewImpl extends _FullCommunityView {
-  const _$FullCommunityViewImpl(
+class _$_FullCommunityView extends _FullCommunityView {
+  const _$_FullCommunityView(
       {required this.communityView,
       required this.site,
       required final List<CommunityModeratorView> moderators,
@@ -190,8 +190,8 @@ class _$FullCommunityViewImpl extends _FullCommunityView {
       : _moderators = moderators,
         super._();
 
-  factory _$FullCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FullCommunityViewImplFromJson(json);
+  factory _$_FullCommunityView.fromJson(Map<String, dynamic> json) =>
+      _$$_FullCommunityViewFromJson(json);
 
   @override
   final CommunityView communityView;
@@ -219,7 +219,7 @@ class _$FullCommunityViewImpl extends _FullCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$FullCommunityViewImpl &&
+            other is _$_FullCommunityView &&
             (identical(other.communityView, communityView) ||
                 other.communityView == communityView) &&
             (identical(other.site, site) || other.site == site) &&
@@ -238,13 +238,13 @@ class _$FullCommunityViewImpl extends _FullCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$FullCommunityViewImplCopyWith<_$FullCommunityViewImpl> get copyWith =>
-      __$$FullCommunityViewImplCopyWithImpl<_$FullCommunityViewImpl>(
+  _$$_FullCommunityViewCopyWith<_$_FullCommunityView> get copyWith =>
+      __$$_FullCommunityViewCopyWithImpl<_$_FullCommunityView>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$FullCommunityViewImplToJson(
+    return _$$_FullCommunityViewToJson(
       this,
     );
   }
@@ -256,11 +256,11 @@ abstract class _FullCommunityView extends FullCommunityView {
       required final Site? site,
       required final List<CommunityModeratorView> moderators,
       final int? online,
-      required final String instanceHost}) = _$FullCommunityViewImpl;
+      required final String instanceHost}) = _$_FullCommunityView;
   const _FullCommunityView._() : super._();
 
   factory _FullCommunityView.fromJson(Map<String, dynamic> json) =
-      _$FullCommunityViewImpl.fromJson;
+      _$_FullCommunityView.fromJson;
 
   @override
   CommunityView get communityView;
@@ -274,7 +274,7 @@ abstract class _FullCommunityView extends FullCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$FullCommunityViewImplCopyWith<_$FullCommunityViewImpl> get copyWith =>
+  _$$_FullCommunityViewCopyWith<_$_FullCommunityView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -375,11 +375,11 @@ class _$FullPostViewCopyWithImpl<$Res, $Val extends FullPostView>
 }
 
 /// @nodoc
-abstract class _$$FullPostViewImplCopyWith<$Res>
+abstract class _$$_FullPostViewCopyWith<$Res>
     implements $FullPostViewCopyWith<$Res> {
-  factory _$$FullPostViewImplCopyWith(
-          _$FullPostViewImpl value, $Res Function(_$FullPostViewImpl) then) =
-      __$$FullPostViewImplCopyWithImpl<$Res>;
+  factory _$$_FullPostViewCopyWith(
+          _$_FullPostView value, $Res Function(_$_FullPostView) then) =
+      __$$_FullPostViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -396,11 +396,11 @@ abstract class _$$FullPostViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$FullPostViewImplCopyWithImpl<$Res>
-    extends _$FullPostViewCopyWithImpl<$Res, _$FullPostViewImpl>
-    implements _$$FullPostViewImplCopyWith<$Res> {
-  __$$FullPostViewImplCopyWithImpl(
-      _$FullPostViewImpl _value, $Res Function(_$FullPostViewImpl) _then)
+class __$$_FullPostViewCopyWithImpl<$Res>
+    extends _$FullPostViewCopyWithImpl<$Res, _$_FullPostView>
+    implements _$$_FullPostViewCopyWith<$Res> {
+  __$$_FullPostViewCopyWithImpl(
+      _$_FullPostView _value, $Res Function(_$_FullPostView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -412,7 +412,7 @@ class __$$FullPostViewImplCopyWithImpl<$Res>
     Object? online = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$FullPostViewImpl(
+    return _then(_$_FullPostView(
       postView: null == postView
           ? _value.postView
           : postView // ignore: cast_nullable_to_non_nullable
@@ -440,8 +440,8 @@ class __$$FullPostViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$FullPostViewImpl extends _FullPostView {
-  const _$FullPostViewImpl(
+class _$_FullPostView extends _FullPostView {
+  const _$_FullPostView(
       {required this.postView,
       required this.communityView,
       required final List<CommunityModeratorView> moderators,
@@ -450,8 +450,8 @@ class _$FullPostViewImpl extends _FullPostView {
       : _moderators = moderators,
         super._();
 
-  factory _$FullPostViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FullPostViewImplFromJson(json);
+  factory _$_FullPostView.fromJson(Map<String, dynamic> json) =>
+      _$$_FullPostViewFromJson(json);
 
   @override
   final PostView postView;
@@ -479,7 +479,7 @@ class _$FullPostViewImpl extends _FullPostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$FullPostViewImpl &&
+            other is _$_FullPostView &&
             (identical(other.postView, postView) ||
                 other.postView == postView) &&
             (identical(other.communityView, communityView) ||
@@ -499,12 +499,12 @@ class _$FullPostViewImpl extends _FullPostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$FullPostViewImplCopyWith<_$FullPostViewImpl> get copyWith =>
-      __$$FullPostViewImplCopyWithImpl<_$FullPostViewImpl>(this, _$identity);
+  _$$_FullPostViewCopyWith<_$_FullPostView> get copyWith =>
+      __$$_FullPostViewCopyWithImpl<_$_FullPostView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$FullPostViewImplToJson(
+    return _$$_FullPostViewToJson(
       this,
     );
   }
@@ -516,11 +516,11 @@ abstract class _FullPostView extends FullPostView {
       required final CommunityView communityView,
       required final List<CommunityModeratorView> moderators,
       final int? online,
-      required final String instanceHost}) = _$FullPostViewImpl;
+      required final String instanceHost}) = _$_FullPostView;
   const _FullPostView._() : super._();
 
   factory _FullPostView.fromJson(Map<String, dynamic> json) =
-      _$FullPostViewImpl.fromJson;
+      _$_FullPostView.fromJson;
 
   @override
   PostView get postView;
@@ -534,7 +534,7 @@ abstract class _FullPostView extends FullPostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$FullPostViewImplCopyWith<_$FullPostViewImpl> get copyWith =>
+  _$$_FullPostViewCopyWith<_$_FullPostView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -623,11 +623,11 @@ class _$SearchResultsCopyWithImpl<$Res, $Val extends SearchResults>
 }
 
 /// @nodoc
-abstract class _$$SearchResultsImplCopyWith<$Res>
+abstract class _$$_SearchResultsCopyWith<$Res>
     implements $SearchResultsCopyWith<$Res> {
-  factory _$$SearchResultsImplCopyWith(
-          _$SearchResultsImpl value, $Res Function(_$SearchResultsImpl) then) =
-      __$$SearchResultsImplCopyWithImpl<$Res>;
+  factory _$$_SearchResultsCopyWith(
+          _$_SearchResults value, $Res Function(_$_SearchResults) then) =
+      __$$_SearchResultsCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -640,11 +640,11 @@ abstract class _$$SearchResultsImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$SearchResultsImplCopyWithImpl<$Res>
-    extends _$SearchResultsCopyWithImpl<$Res, _$SearchResultsImpl>
-    implements _$$SearchResultsImplCopyWith<$Res> {
-  __$$SearchResultsImplCopyWithImpl(
-      _$SearchResultsImpl _value, $Res Function(_$SearchResultsImpl) _then)
+class __$$_SearchResultsCopyWithImpl<$Res>
+    extends _$SearchResultsCopyWithImpl<$Res, _$_SearchResults>
+    implements _$$_SearchResultsCopyWith<$Res> {
+  __$$_SearchResultsCopyWithImpl(
+      _$_SearchResults _value, $Res Function(_$_SearchResults) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -657,7 +657,7 @@ class __$$SearchResultsImplCopyWithImpl<$Res>
     Object? users = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$SearchResultsImpl(
+    return _then(_$_SearchResults(
       type: null == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -689,8 +689,8 @@ class __$$SearchResultsImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$SearchResultsImpl extends _SearchResults {
-  const _$SearchResultsImpl(
+class _$_SearchResults extends _SearchResults {
+  const _$_SearchResults(
       {@JsonKey(name: 'type_') required this.type,
       required final List<CommentView> comments,
       required final List<PostView> posts,
@@ -703,8 +703,8 @@ class _$SearchResultsImpl extends _SearchResults {
         _users = users,
         super._();
 
-  factory _$SearchResultsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SearchResultsImplFromJson(json);
+  factory _$_SearchResults.fromJson(Map<String, dynamic> json) =>
+      _$$_SearchResultsFromJson(json);
 
   @override
   @JsonKey(name: 'type_')
@@ -753,7 +753,7 @@ class _$SearchResultsImpl extends _SearchResults {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SearchResultsImpl &&
+            other is _$_SearchResults &&
             (identical(other.type, type) || other.type == type) &&
             const DeepCollectionEquality().equals(other._comments, _comments) &&
             const DeepCollectionEquality().equals(other._posts, _posts) &&
@@ -778,12 +778,12 @@ class _$SearchResultsImpl extends _SearchResults {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SearchResultsImplCopyWith<_$SearchResultsImpl> get copyWith =>
-      __$$SearchResultsImplCopyWithImpl<_$SearchResultsImpl>(this, _$identity);
+  _$$_SearchResultsCopyWith<_$_SearchResults> get copyWith =>
+      __$$_SearchResultsCopyWithImpl<_$_SearchResults>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$SearchResultsImplToJson(
+    return _$$_SearchResultsToJson(
       this,
     );
   }
@@ -796,11 +796,11 @@ abstract class _SearchResults extends SearchResults {
       required final List<PostView> posts,
       required final List<CommunityView> communities,
       required final List<PersonViewSafe> users,
-      required final String instanceHost}) = _$SearchResultsImpl;
+      required final String instanceHost}) = _$_SearchResults;
   const _SearchResults._() : super._();
 
   factory _SearchResults.fromJson(Map<String, dynamic> json) =
-      _$SearchResultsImpl.fromJson;
+      _$_SearchResults.fromJson;
 
   @override
   @JsonKey(name: 'type_')
@@ -817,7 +817,7 @@ abstract class _SearchResults extends SearchResults {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$SearchResultsImplCopyWith<_$SearchResultsImpl> get copyWith =>
+  _$$_SearchResultsCopyWith<_$_SearchResults> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -985,10 +985,9 @@ class _$ModlogCopyWithImpl<$Res, $Val extends Modlog>
 }
 
 /// @nodoc
-abstract class _$$ModlogImplCopyWith<$Res> implements $ModlogCopyWith<$Res> {
-  factory _$$ModlogImplCopyWith(
-          _$ModlogImpl value, $Res Function(_$ModlogImpl) then) =
-      __$$ModlogImplCopyWithImpl<$Res>;
+abstract class _$$_ModlogCopyWith<$Res> implements $ModlogCopyWith<$Res> {
+  factory _$$_ModlogCopyWith(_$_Modlog value, $Res Function(_$_Modlog) then) =
+      __$$_ModlogCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1011,11 +1010,10 @@ abstract class _$$ModlogImplCopyWith<$Res> implements $ModlogCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$ModlogImplCopyWithImpl<$Res>
-    extends _$ModlogCopyWithImpl<$Res, _$ModlogImpl>
-    implements _$$ModlogImplCopyWith<$Res> {
-  __$$ModlogImplCopyWithImpl(
-      _$ModlogImpl _value, $Res Function(_$ModlogImpl) _then)
+class __$$_ModlogCopyWithImpl<$Res>
+    extends _$ModlogCopyWithImpl<$Res, _$_Modlog>
+    implements _$$_ModlogCopyWith<$Res> {
+  __$$_ModlogCopyWithImpl(_$_Modlog _value, $Res Function(_$_Modlog) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1038,7 +1036,7 @@ class __$$ModlogImplCopyWithImpl<$Res>
     Object? adminPurgedPosts = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModlogImpl(
+    return _then(_$_Modlog(
       removedPosts: null == removedPosts
           ? _value._removedPosts
           : removedPosts // ignore: cast_nullable_to_non_nullable
@@ -1110,8 +1108,8 @@ class __$$ModlogImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModlogImpl extends _Modlog {
-  const _$ModlogImpl(
+class _$_Modlog extends _Modlog {
+  const _$_Modlog(
       {required final List<ModRemovePostView> removedPosts,
       required final List<ModLockPostView> lockedPosts,
       required final List<ModFeaturePostView> featuredPosts,
@@ -1145,8 +1143,8 @@ class _$ModlogImpl extends _Modlog {
         _adminPurgedPosts = adminPurgedPosts,
         super._();
 
-  factory _$ModlogImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModlogImplFromJson(json);
+  factory _$_Modlog.fromJson(Map<String, dynamic> json) =>
+      _$$_ModlogFromJson(json);
 
   final List<ModRemovePostView> _removedPosts;
   @override
@@ -1289,7 +1287,7 @@ class _$ModlogImpl extends _Modlog {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModlogImpl &&
+            other is _$_Modlog &&
             const DeepCollectionEquality()
                 .equals(other._removedPosts, _removedPosts) &&
             const DeepCollectionEquality()
@@ -1346,12 +1344,12 @@ class _$ModlogImpl extends _Modlog {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModlogImplCopyWith<_$ModlogImpl> get copyWith =>
-      __$$ModlogImplCopyWithImpl<_$ModlogImpl>(this, _$identity);
+  _$$_ModlogCopyWith<_$_Modlog> get copyWith =>
+      __$$_ModlogCopyWithImpl<_$_Modlog>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModlogImplToJson(
+    return _$$_ModlogToJson(
       this,
     );
   }
@@ -1374,10 +1372,10 @@ abstract class _Modlog extends Modlog {
       required final List<AdminPurgePersonView> adminPurgedPersons,
       required final List<AdminPurgeCommunityView> adminPurgedCommunities,
       required final List<AdminPurgePostView> adminPurgedPosts,
-      required final String instanceHost}) = _$ModlogImpl;
+      required final String instanceHost}) = _$_Modlog;
   const _Modlog._() : super._();
 
-  factory _Modlog.fromJson(Map<String, dynamic> json) = _$ModlogImpl.fromJson;
+  factory _Modlog.fromJson(Map<String, dynamic> json) = _$_Modlog.fromJson;
 
   @override
   List<ModRemovePostView> get removedPosts;
@@ -1413,7 +1411,7 @@ abstract class _Modlog extends Modlog {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModlogImplCopyWith<_$ModlogImpl> get copyWith =>
+  _$$_ModlogCopyWith<_$_Modlog> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1497,11 +1495,11 @@ class _$FullCommentViewCopyWithImpl<$Res, $Val extends FullCommentView>
 }
 
 /// @nodoc
-abstract class _$$FullCommentViewImplCopyWith<$Res>
+abstract class _$$_FullCommentViewCopyWith<$Res>
     implements $FullCommentViewCopyWith<$Res> {
-  factory _$$FullCommentViewImplCopyWith(_$FullCommentViewImpl value,
-          $Res Function(_$FullCommentViewImpl) then) =
-      __$$FullCommentViewImplCopyWithImpl<$Res>;
+  factory _$$_FullCommentViewCopyWith(
+          _$_FullCommentView value, $Res Function(_$_FullCommentView) then) =
+      __$$_FullCommentViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1515,11 +1513,11 @@ abstract class _$$FullCommentViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$FullCommentViewImplCopyWithImpl<$Res>
-    extends _$FullCommentViewCopyWithImpl<$Res, _$FullCommentViewImpl>
-    implements _$$FullCommentViewImplCopyWith<$Res> {
-  __$$FullCommentViewImplCopyWithImpl(
-      _$FullCommentViewImpl _value, $Res Function(_$FullCommentViewImpl) _then)
+class __$$_FullCommentViewCopyWithImpl<$Res>
+    extends _$FullCommentViewCopyWithImpl<$Res, _$_FullCommentView>
+    implements _$$_FullCommentViewCopyWith<$Res> {
+  __$$_FullCommentViewCopyWithImpl(
+      _$_FullCommentView _value, $Res Function(_$_FullCommentView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1530,7 +1528,7 @@ class __$$FullCommentViewImplCopyWithImpl<$Res>
     Object? formId = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$FullCommentViewImpl(
+    return _then(_$_FullCommentView(
       commentView: null == commentView
           ? _value.commentView
           : commentView // ignore: cast_nullable_to_non_nullable
@@ -1554,8 +1552,8 @@ class __$$FullCommentViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$FullCommentViewImpl extends _FullCommentView {
-  const _$FullCommentViewImpl(
+class _$_FullCommentView extends _FullCommentView {
+  const _$_FullCommentView(
       {required this.commentView,
       required final List<int> recipientIds,
       this.formId,
@@ -1563,8 +1561,8 @@ class _$FullCommentViewImpl extends _FullCommentView {
       : _recipientIds = recipientIds,
         super._();
 
-  factory _$FullCommentViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FullCommentViewImplFromJson(json);
+  factory _$_FullCommentView.fromJson(Map<String, dynamic> json) =>
+      _$$_FullCommentViewFromJson(json);
 
   @override
   final CommentView commentView;
@@ -1590,7 +1588,7 @@ class _$FullCommentViewImpl extends _FullCommentView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$FullCommentViewImpl &&
+            other is _$_FullCommentView &&
             (identical(other.commentView, commentView) ||
                 other.commentView == commentView) &&
             const DeepCollectionEquality()
@@ -1608,13 +1606,12 @@ class _$FullCommentViewImpl extends _FullCommentView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$FullCommentViewImplCopyWith<_$FullCommentViewImpl> get copyWith =>
-      __$$FullCommentViewImplCopyWithImpl<_$FullCommentViewImpl>(
-          this, _$identity);
+  _$$_FullCommentViewCopyWith<_$_FullCommentView> get copyWith =>
+      __$$_FullCommentViewCopyWithImpl<_$_FullCommentView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$FullCommentViewImplToJson(
+    return _$$_FullCommentViewToJson(
       this,
     );
   }
@@ -1625,11 +1622,11 @@ abstract class _FullCommentView extends FullCommentView {
       {required final CommentView commentView,
       required final List<int> recipientIds,
       final String? formId,
-      required final String instanceHost}) = _$FullCommentViewImpl;
+      required final String instanceHost}) = _$_FullCommentView;
   const _FullCommentView._() : super._();
 
   factory _FullCommentView.fromJson(Map<String, dynamic> json) =
-      _$FullCommentViewImpl.fromJson;
+      _$_FullCommentView.fromJson;
 
   @override
   CommentView get commentView;
@@ -1641,7 +1638,7 @@ abstract class _FullCommentView extends FullCommentView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$FullCommentViewImplCopyWith<_$FullCommentViewImpl> get copyWith =>
+  _$$_FullCommentViewCopyWith<_$_FullCommentView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1710,11 +1707,11 @@ class _$FullCommentReplyViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$FullCommentReplyViewImplCopyWith<$Res>
+abstract class _$$_FullCommentReplyViewCopyWith<$Res>
     implements $FullCommentReplyViewCopyWith<$Res> {
-  factory _$$FullCommentReplyViewImplCopyWith(_$FullCommentReplyViewImpl value,
-          $Res Function(_$FullCommentReplyViewImpl) then) =
-      __$$FullCommentReplyViewImplCopyWithImpl<$Res>;
+  factory _$$_FullCommentReplyViewCopyWith(_$_FullCommentReplyView value,
+          $Res Function(_$_FullCommentReplyView) then) =
+      __$$_FullCommentReplyViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CommentReplyView commentReplyView, String instanceHost});
@@ -1724,11 +1721,11 @@ abstract class _$$FullCommentReplyViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$FullCommentReplyViewImplCopyWithImpl<$Res>
-    extends _$FullCommentReplyViewCopyWithImpl<$Res, _$FullCommentReplyViewImpl>
-    implements _$$FullCommentReplyViewImplCopyWith<$Res> {
-  __$$FullCommentReplyViewImplCopyWithImpl(_$FullCommentReplyViewImpl _value,
-      $Res Function(_$FullCommentReplyViewImpl) _then)
+class __$$_FullCommentReplyViewCopyWithImpl<$Res>
+    extends _$FullCommentReplyViewCopyWithImpl<$Res, _$_FullCommentReplyView>
+    implements _$$_FullCommentReplyViewCopyWith<$Res> {
+  __$$_FullCommentReplyViewCopyWithImpl(_$_FullCommentReplyView _value,
+      $Res Function(_$_FullCommentReplyView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1737,7 +1734,7 @@ class __$$FullCommentReplyViewImplCopyWithImpl<$Res>
     Object? commentReplyView = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$FullCommentReplyViewImpl(
+    return _then(_$_FullCommentReplyView(
       commentReplyView: null == commentReplyView
           ? _value.commentReplyView
           : commentReplyView // ignore: cast_nullable_to_non_nullable
@@ -1753,13 +1750,13 @@ class __$$FullCommentReplyViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$FullCommentReplyViewImpl extends _FullCommentReplyView {
-  const _$FullCommentReplyViewImpl(
+class _$_FullCommentReplyView extends _FullCommentReplyView {
+  const _$_FullCommentReplyView(
       {required this.commentReplyView, required this.instanceHost})
       : super._();
 
-  factory _$FullCommentReplyViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FullCommentReplyViewImplFromJson(json);
+  factory _$_FullCommentReplyView.fromJson(Map<String, dynamic> json) =>
+      _$$_FullCommentReplyViewFromJson(json);
 
   @override
   final CommentReplyView commentReplyView;
@@ -1775,7 +1772,7 @@ class _$FullCommentReplyViewImpl extends _FullCommentReplyView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$FullCommentReplyViewImpl &&
+            other is _$_FullCommentReplyView &&
             (identical(other.commentReplyView, commentReplyView) ||
                 other.commentReplyView == commentReplyView) &&
             (identical(other.instanceHost, instanceHost) ||
@@ -1789,14 +1786,13 @@ class _$FullCommentReplyViewImpl extends _FullCommentReplyView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$FullCommentReplyViewImplCopyWith<_$FullCommentReplyViewImpl>
-      get copyWith =>
-          __$$FullCommentReplyViewImplCopyWithImpl<_$FullCommentReplyViewImpl>(
-              this, _$identity);
+  _$$_FullCommentReplyViewCopyWith<_$_FullCommentReplyView> get copyWith =>
+      __$$_FullCommentReplyViewCopyWithImpl<_$_FullCommentReplyView>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$FullCommentReplyViewImplToJson(
+    return _$$_FullCommentReplyViewToJson(
       this,
     );
   }
@@ -1805,11 +1801,11 @@ class _$FullCommentReplyViewImpl extends _FullCommentReplyView {
 abstract class _FullCommentReplyView extends FullCommentReplyView {
   const factory _FullCommentReplyView(
       {required final CommentReplyView commentReplyView,
-      required final String instanceHost}) = _$FullCommentReplyViewImpl;
+      required final String instanceHost}) = _$_FullCommentReplyView;
   const _FullCommentReplyView._() : super._();
 
   factory _FullCommentReplyView.fromJson(Map<String, dynamic> json) =
-      _$FullCommentReplyViewImpl.fromJson;
+      _$_FullCommentReplyView.fromJson;
 
   @override
   CommentReplyView get commentReplyView;
@@ -1817,8 +1813,8 @@ abstract class _FullCommentReplyView extends FullCommentReplyView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$FullCommentReplyViewImplCopyWith<_$FullCommentReplyViewImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_FullCommentReplyViewCopyWith<_$_FullCommentReplyView> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 FullSiteView _$FullSiteViewFromJson(Map<String, dynamic> json) {
@@ -1961,11 +1957,11 @@ class _$FullSiteViewCopyWithImpl<$Res, $Val extends FullSiteView>
 }
 
 /// @nodoc
-abstract class _$$FullSiteViewImplCopyWith<$Res>
+abstract class _$$_FullSiteViewCopyWith<$Res>
     implements $FullSiteViewCopyWith<$Res> {
-  factory _$$FullSiteViewImplCopyWith(
-          _$FullSiteViewImpl value, $Res Function(_$FullSiteViewImpl) then) =
-      __$$FullSiteViewImplCopyWithImpl<$Res>;
+  factory _$$_FullSiteViewCopyWith(
+          _$_FullSiteView value, $Res Function(_$_FullSiteView) then) =
+      __$$_FullSiteViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1987,11 +1983,11 @@ abstract class _$$FullSiteViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$FullSiteViewImplCopyWithImpl<$Res>
-    extends _$FullSiteViewCopyWithImpl<$Res, _$FullSiteViewImpl>
-    implements _$$FullSiteViewImplCopyWith<$Res> {
-  __$$FullSiteViewImplCopyWithImpl(
-      _$FullSiteViewImpl _value, $Res Function(_$FullSiteViewImpl) _then)
+class __$$_FullSiteViewCopyWithImpl<$Res>
+    extends _$FullSiteViewCopyWithImpl<$Res, _$_FullSiteView>
+    implements _$$_FullSiteViewCopyWith<$Res> {
+  __$$_FullSiteViewCopyWithImpl(
+      _$_FullSiteView _value, $Res Function(_$_FullSiteView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2006,7 +2002,7 @@ class __$$FullSiteViewImplCopyWithImpl<$Res>
     Object? instanceHost = null,
     Object? taglines = null,
   }) {
-    return _then(_$FullSiteViewImpl(
+    return _then(_$_FullSiteView(
       siteView: freezed == siteView
           ? _value.siteView
           : siteView // ignore: cast_nullable_to_non_nullable
@@ -2046,8 +2042,8 @@ class __$$FullSiteViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$FullSiteViewImpl extends _FullSiteView {
-  const _$FullSiteViewImpl(
+class _$_FullSiteView extends _FullSiteView {
+  const _$_FullSiteView(
       {this.siteView,
       required final List<PersonViewSafe> admins,
       this.online,
@@ -2060,8 +2056,8 @@ class _$FullSiteViewImpl extends _FullSiteView {
         _taglines = taglines,
         super._();
 
-  factory _$FullSiteViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FullSiteViewImplFromJson(json);
+  factory _$_FullSiteView.fromJson(Map<String, dynamic> json) =>
+      _$$_FullSiteViewFromJson(json);
 
   @override
   final SiteView? siteView;
@@ -2100,7 +2096,7 @@ class _$FullSiteViewImpl extends _FullSiteView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$FullSiteViewImpl &&
+            other is _$_FullSiteView &&
             (identical(other.siteView, siteView) ||
                 other.siteView == siteView) &&
             const DeepCollectionEquality().equals(other._admins, _admins) &&
@@ -2130,12 +2126,12 @@ class _$FullSiteViewImpl extends _FullSiteView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$FullSiteViewImplCopyWith<_$FullSiteViewImpl> get copyWith =>
-      __$$FullSiteViewImplCopyWithImpl<_$FullSiteViewImpl>(this, _$identity);
+  _$$_FullSiteViewCopyWith<_$_FullSiteView> get copyWith =>
+      __$$_FullSiteViewCopyWithImpl<_$_FullSiteView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$FullSiteViewImplToJson(
+    return _$$_FullSiteViewToJson(
       this,
     );
   }
@@ -2150,11 +2146,11 @@ abstract class _FullSiteView extends FullSiteView {
       final MyUserInfo? myUser,
       final FederatedInstances? federatedInstances,
       required final String instanceHost,
-      required final List<Tagline> taglines}) = _$FullSiteViewImpl;
+      required final List<Tagline> taglines}) = _$_FullSiteView;
   const _FullSiteView._() : super._();
 
   factory _FullSiteView.fromJson(Map<String, dynamic> json) =
-      _$FullSiteViewImpl.fromJson;
+      _$_FullSiteView.fromJson;
 
   @override
   SiteView? get siteView;
@@ -2174,7 +2170,7 @@ abstract class _FullSiteView extends FullSiteView {
   List<Tagline> get taglines;
   @override
   @JsonKey(ignore: true)
-  _$$FullSiteViewImplCopyWith<_$FullSiteViewImpl> get copyWith =>
+  _$$_FullSiteViewCopyWith<_$_FullSiteView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2260,10 +2256,10 @@ class _$TaglineCopyWithImpl<$Res, $Val extends Tagline>
 }
 
 /// @nodoc
-abstract class _$$TaglineImplCopyWith<$Res> implements $TaglineCopyWith<$Res> {
-  factory _$$TaglineImplCopyWith(
-          _$TaglineImpl value, $Res Function(_$TaglineImpl) then) =
-      __$$TaglineImplCopyWithImpl<$Res>;
+abstract class _$$_TaglineCopyWith<$Res> implements $TaglineCopyWith<$Res> {
+  factory _$$_TaglineCopyWith(
+          _$_Tagline value, $Res Function(_$_Tagline) then) =
+      __$$_TaglineCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2276,11 +2272,10 @@ abstract class _$$TaglineImplCopyWith<$Res> implements $TaglineCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$TaglineImplCopyWithImpl<$Res>
-    extends _$TaglineCopyWithImpl<$Res, _$TaglineImpl>
-    implements _$$TaglineImplCopyWith<$Res> {
-  __$$TaglineImplCopyWithImpl(
-      _$TaglineImpl _value, $Res Function(_$TaglineImpl) _then)
+class __$$_TaglineCopyWithImpl<$Res>
+    extends _$TaglineCopyWithImpl<$Res, _$_Tagline>
+    implements _$$_TaglineCopyWith<$Res> {
+  __$$_TaglineCopyWithImpl(_$_Tagline _value, $Res Function(_$_Tagline) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2293,7 +2288,7 @@ class __$$TaglineImplCopyWithImpl<$Res>
     Object? instanceHost = null,
     Object? updated = freezed,
   }) {
-    return _then(_$TaglineImpl(
+    return _then(_$_Tagline(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -2325,8 +2320,8 @@ class __$$TaglineImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$TaglineImpl extends _Tagline {
-  const _$TaglineImpl(
+class _$_Tagline extends _Tagline {
+  const _$_Tagline(
       {required this.id,
       required this.localSiteId,
       required this.content,
@@ -2335,8 +2330,8 @@ class _$TaglineImpl extends _Tagline {
       this.updated})
       : super._();
 
-  factory _$TaglineImpl.fromJson(Map<String, dynamic> json) =>
-      _$$TaglineImplFromJson(json);
+  factory _$_Tagline.fromJson(Map<String, dynamic> json) =>
+      _$$_TaglineFromJson(json);
 
   @override
   final int id;
@@ -2360,7 +2355,7 @@ class _$TaglineImpl extends _Tagline {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$TaglineImpl &&
+            other is _$_Tagline &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.localSiteId, localSiteId) ||
                 other.localSiteId == localSiteId) &&
@@ -2380,12 +2375,12 @@ class _$TaglineImpl extends _Tagline {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$TaglineImplCopyWith<_$TaglineImpl> get copyWith =>
-      __$$TaglineImplCopyWithImpl<_$TaglineImpl>(this, _$identity);
+  _$$_TaglineCopyWith<_$_Tagline> get copyWith =>
+      __$$_TaglineCopyWithImpl<_$_Tagline>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$TaglineImplToJson(
+    return _$$_TaglineToJson(
       this,
     );
   }
@@ -2398,10 +2393,10 @@ abstract class _Tagline extends Tagline {
       required final String content,
       required final DateTime published,
       required final String instanceHost,
-      final DateTime? updated}) = _$TaglineImpl;
+      final DateTime? updated}) = _$_Tagline;
   const _Tagline._() : super._();
 
-  factory _Tagline.fromJson(Map<String, dynamic> json) = _$TaglineImpl.fromJson;
+  factory _Tagline.fromJson(Map<String, dynamic> json) = _$_Tagline.fromJson;
 
   @override
   int get id;
@@ -2417,7 +2412,7 @@ abstract class _Tagline extends Tagline {
   DateTime? get updated;
   @override
   @JsonKey(ignore: true)
-  _$$TaglineImplCopyWith<_$TaglineImpl> get copyWith =>
+  _$$_TaglineCopyWith<_$_Tagline> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2517,11 +2512,11 @@ class _$MyUserInfoCopyWithImpl<$Res, $Val extends MyUserInfo>
 }
 
 /// @nodoc
-abstract class _$$MyUserInfoImplCopyWith<$Res>
+abstract class _$$_MyUserInfoCopyWith<$Res>
     implements $MyUserInfoCopyWith<$Res> {
-  factory _$$MyUserInfoImplCopyWith(
-          _$MyUserInfoImpl value, $Res Function(_$MyUserInfoImpl) then) =
-      __$$MyUserInfoImplCopyWithImpl<$Res>;
+  factory _$$_MyUserInfoCopyWith(
+          _$_MyUserInfo value, $Res Function(_$_MyUserInfo) then) =
+      __$$_MyUserInfoCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2537,11 +2532,11 @@ abstract class _$$MyUserInfoImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$MyUserInfoImplCopyWithImpl<$Res>
-    extends _$MyUserInfoCopyWithImpl<$Res, _$MyUserInfoImpl>
-    implements _$$MyUserInfoImplCopyWith<$Res> {
-  __$$MyUserInfoImplCopyWithImpl(
-      _$MyUserInfoImpl _value, $Res Function(_$MyUserInfoImpl) _then)
+class __$$_MyUserInfoCopyWithImpl<$Res>
+    extends _$MyUserInfoCopyWithImpl<$Res, _$_MyUserInfo>
+    implements _$$_MyUserInfoCopyWith<$Res> {
+  __$$_MyUserInfoCopyWithImpl(
+      _$_MyUserInfo _value, $Res Function(_$_MyUserInfo) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2554,7 +2549,7 @@ class __$$MyUserInfoImplCopyWithImpl<$Res>
     Object? personBlocks = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$MyUserInfoImpl(
+    return _then(_$_MyUserInfo(
       localUserView: null == localUserView
           ? _value.localUserView
           : localUserView // ignore: cast_nullable_to_non_nullable
@@ -2586,8 +2581,8 @@ class __$$MyUserInfoImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$MyUserInfoImpl extends _MyUserInfo {
-  const _$MyUserInfoImpl(
+class _$_MyUserInfo extends _MyUserInfo {
+  const _$_MyUserInfo(
       {required this.localUserView,
       required final List<CommunityFollowerView> follows,
       required final List<CommunityModeratorView> moderates,
@@ -2600,8 +2595,8 @@ class _$MyUserInfoImpl extends _MyUserInfo {
         _personBlocks = personBlocks,
         super._();
 
-  factory _$MyUserInfoImpl.fromJson(Map<String, dynamic> json) =>
-      _$$MyUserInfoImplFromJson(json);
+  factory _$_MyUserInfo.fromJson(Map<String, dynamic> json) =>
+      _$$_MyUserInfoFromJson(json);
 
   @override
   final LocalUserSettingsView localUserView;
@@ -2649,7 +2644,7 @@ class _$MyUserInfoImpl extends _MyUserInfo {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$MyUserInfoImpl &&
+            other is _$_MyUserInfo &&
             (identical(other.localUserView, localUserView) ||
                 other.localUserView == localUserView) &&
             const DeepCollectionEquality().equals(other._follows, _follows) &&
@@ -2677,12 +2672,12 @@ class _$MyUserInfoImpl extends _MyUserInfo {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$MyUserInfoImplCopyWith<_$MyUserInfoImpl> get copyWith =>
-      __$$MyUserInfoImplCopyWithImpl<_$MyUserInfoImpl>(this, _$identity);
+  _$$_MyUserInfoCopyWith<_$_MyUserInfo> get copyWith =>
+      __$$_MyUserInfoCopyWithImpl<_$_MyUserInfo>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$MyUserInfoImplToJson(
+    return _$$_MyUserInfoToJson(
       this,
     );
   }
@@ -2695,11 +2690,11 @@ abstract class _MyUserInfo extends MyUserInfo {
       required final List<CommunityModeratorView> moderates,
       required final List<CommunityBlockView> communityBlocks,
       required final List<PersonBlockView> personBlocks,
-      required final String instanceHost}) = _$MyUserInfoImpl;
+      required final String instanceHost}) = _$_MyUserInfo;
   const _MyUserInfo._() : super._();
 
   factory _MyUserInfo.fromJson(Map<String, dynamic> json) =
-      _$MyUserInfoImpl.fromJson;
+      _$_MyUserInfo.fromJson;
 
   @override
   LocalUserSettingsView get localUserView;
@@ -2715,7 +2710,7 @@ abstract class _MyUserInfo extends MyUserInfo {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$MyUserInfoImplCopyWith<_$MyUserInfoImpl> get copyWith =>
+  _$$_MyUserInfoCopyWith<_$_MyUserInfo> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2789,11 +2784,11 @@ class _$FederatedInstancesCopyWithImpl<$Res, $Val extends FederatedInstances>
 }
 
 /// @nodoc
-abstract class _$$FederatedInstancesImplCopyWith<$Res>
+abstract class _$$_FederatedInstancesCopyWith<$Res>
     implements $FederatedInstancesCopyWith<$Res> {
-  factory _$$FederatedInstancesImplCopyWith(_$FederatedInstancesImpl value,
-          $Res Function(_$FederatedInstancesImpl) then) =
-      __$$FederatedInstancesImplCopyWithImpl<$Res>;
+  factory _$$_FederatedInstancesCopyWith(_$_FederatedInstances value,
+          $Res Function(_$_FederatedInstances) then) =
+      __$$_FederatedInstancesCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2804,11 +2799,11 @@ abstract class _$$FederatedInstancesImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$FederatedInstancesImplCopyWithImpl<$Res>
-    extends _$FederatedInstancesCopyWithImpl<$Res, _$FederatedInstancesImpl>
-    implements _$$FederatedInstancesImplCopyWith<$Res> {
-  __$$FederatedInstancesImplCopyWithImpl(_$FederatedInstancesImpl _value,
-      $Res Function(_$FederatedInstancesImpl) _then)
+class __$$_FederatedInstancesCopyWithImpl<$Res>
+    extends _$FederatedInstancesCopyWithImpl<$Res, _$_FederatedInstances>
+    implements _$$_FederatedInstancesCopyWith<$Res> {
+  __$$_FederatedInstancesCopyWithImpl(
+      _$_FederatedInstances _value, $Res Function(_$_FederatedInstances) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2819,7 +2814,7 @@ class __$$FederatedInstancesImplCopyWithImpl<$Res>
     Object? blocked = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$FederatedInstancesImpl(
+    return _then(_$_FederatedInstances(
       linked: null == linked
           ? _value._linked
           : linked // ignore: cast_nullable_to_non_nullable
@@ -2843,8 +2838,8 @@ class __$$FederatedInstancesImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$FederatedInstancesImpl extends _FederatedInstances {
-  const _$FederatedInstancesImpl(
+class _$_FederatedInstances extends _FederatedInstances {
+  const _$_FederatedInstances(
       {required final List<String> linked,
       final List<String>? allowed,
       final List<String>? blocked,
@@ -2854,8 +2849,8 @@ class _$FederatedInstancesImpl extends _FederatedInstances {
         _blocked = blocked,
         super._();
 
-  factory _$FederatedInstancesImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FederatedInstancesImplFromJson(json);
+  factory _$_FederatedInstances.fromJson(Map<String, dynamic> json) =>
+      _$$_FederatedInstancesFromJson(json);
 
   final List<String> _linked;
   @override
@@ -2897,7 +2892,7 @@ class _$FederatedInstancesImpl extends _FederatedInstances {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$FederatedInstancesImpl &&
+            other is _$_FederatedInstances &&
             const DeepCollectionEquality().equals(other._linked, _linked) &&
             const DeepCollectionEquality().equals(other._allowed, _allowed) &&
             const DeepCollectionEquality().equals(other._blocked, _blocked) &&
@@ -2917,13 +2912,13 @@ class _$FederatedInstancesImpl extends _FederatedInstances {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$FederatedInstancesImplCopyWith<_$FederatedInstancesImpl> get copyWith =>
-      __$$FederatedInstancesImplCopyWithImpl<_$FederatedInstancesImpl>(
+  _$$_FederatedInstancesCopyWith<_$_FederatedInstances> get copyWith =>
+      __$$_FederatedInstancesCopyWithImpl<_$_FederatedInstances>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$FederatedInstancesImplToJson(
+    return _$$_FederatedInstancesToJson(
       this,
     );
   }
@@ -2934,11 +2929,11 @@ abstract class _FederatedInstances extends FederatedInstances {
       {required final List<String> linked,
       final List<String>? allowed,
       final List<String>? blocked,
-      required final String instanceHost}) = _$FederatedInstancesImpl;
+      required final String instanceHost}) = _$_FederatedInstances;
   const _FederatedInstances._() : super._();
 
   factory _FederatedInstances.fromJson(Map<String, dynamic> json) =
-      _$FederatedInstancesImpl.fromJson;
+      _$_FederatedInstances.fromJson;
 
   @override
   List<String> get linked;
@@ -2950,7 +2945,7 @@ abstract class _FederatedInstances extends FederatedInstances {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$FederatedInstancesImplCopyWith<_$FederatedInstancesImpl> get copyWith =>
+  _$$_FederatedInstancesCopyWith<_$_FederatedInstances> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3015,21 +3010,20 @@ class _$CaptchaCopyWithImpl<$Res, $Val extends Captcha>
 }
 
 /// @nodoc
-abstract class _$$CaptchaImplCopyWith<$Res> implements $CaptchaCopyWith<$Res> {
-  factory _$$CaptchaImplCopyWith(
-          _$CaptchaImpl value, $Res Function(_$CaptchaImpl) then) =
-      __$$CaptchaImplCopyWithImpl<$Res>;
+abstract class _$$_CaptchaCopyWith<$Res> implements $CaptchaCopyWith<$Res> {
+  factory _$$_CaptchaCopyWith(
+          _$_Captcha value, $Res Function(_$_Captcha) then) =
+      __$$_CaptchaCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String png, String? wav, String uuid});
 }
 
 /// @nodoc
-class __$$CaptchaImplCopyWithImpl<$Res>
-    extends _$CaptchaCopyWithImpl<$Res, _$CaptchaImpl>
-    implements _$$CaptchaImplCopyWith<$Res> {
-  __$$CaptchaImplCopyWithImpl(
-      _$CaptchaImpl _value, $Res Function(_$CaptchaImpl) _then)
+class __$$_CaptchaCopyWithImpl<$Res>
+    extends _$CaptchaCopyWithImpl<$Res, _$_Captcha>
+    implements _$$_CaptchaCopyWith<$Res> {
+  __$$_CaptchaCopyWithImpl(_$_Captcha _value, $Res Function(_$_Captcha) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3039,7 +3033,7 @@ class __$$CaptchaImplCopyWithImpl<$Res>
     Object? wav = freezed,
     Object? uuid = null,
   }) {
-    return _then(_$CaptchaImpl(
+    return _then(_$_Captcha(
       png: null == png
           ? _value.png
           : png // ignore: cast_nullable_to_non_nullable
@@ -3059,12 +3053,12 @@ class __$$CaptchaImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CaptchaImpl extends _Captcha {
-  const _$CaptchaImpl({required this.png, this.wav, required this.uuid})
+class _$_Captcha extends _Captcha {
+  const _$_Captcha({required this.png, this.wav, required this.uuid})
       : super._();
 
-  factory _$CaptchaImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CaptchaImplFromJson(json);
+  factory _$_Captcha.fromJson(Map<String, dynamic> json) =>
+      _$$_CaptchaFromJson(json);
 
   /// A Base64 encoded png
   @override
@@ -3085,7 +3079,7 @@ class _$CaptchaImpl extends _Captcha {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CaptchaImpl &&
+            other is _$_Captcha &&
             (identical(other.png, png) || other.png == png) &&
             (identical(other.wav, wav) || other.wav == wav) &&
             (identical(other.uuid, uuid) || other.uuid == uuid));
@@ -3098,12 +3092,12 @@ class _$CaptchaImpl extends _Captcha {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CaptchaImplCopyWith<_$CaptchaImpl> get copyWith =>
-      __$$CaptchaImplCopyWithImpl<_$CaptchaImpl>(this, _$identity);
+  _$$_CaptchaCopyWith<_$_Captcha> get copyWith =>
+      __$$_CaptchaCopyWithImpl<_$_Captcha>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CaptchaImplToJson(
+    return _$$_CaptchaToJson(
       this,
     );
   }
@@ -3113,10 +3107,10 @@ abstract class _Captcha extends Captcha {
   const factory _Captcha(
       {required final String png,
       final String? wav,
-      required final String uuid}) = _$CaptchaImpl;
+      required final String uuid}) = _$_Captcha;
   const _Captcha._() : super._();
 
-  factory _Captcha.fromJson(Map<String, dynamic> json) = _$CaptchaImpl.fromJson;
+  factory _Captcha.fromJson(Map<String, dynamic> json) = _$_Captcha.fromJson;
 
   @override
 
@@ -3130,7 +3124,7 @@ abstract class _Captcha extends Captcha {
   String get uuid;
   @override
   @JsonKey(ignore: true)
-  _$$CaptchaImplCopyWith<_$CaptchaImpl> get copyWith =>
+  _$$_CaptchaCopyWith<_$_Captcha> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3222,11 +3216,11 @@ class _$FullPersonViewCopyWithImpl<$Res, $Val extends FullPersonView>
 }
 
 /// @nodoc
-abstract class _$$FullPersonViewImplCopyWith<$Res>
+abstract class _$$_FullPersonViewCopyWith<$Res>
     implements $FullPersonViewCopyWith<$Res> {
-  factory _$$FullPersonViewImplCopyWith(_$FullPersonViewImpl value,
-          $Res Function(_$FullPersonViewImpl) then) =
-      __$$FullPersonViewImplCopyWithImpl<$Res>;
+  factory _$$_FullPersonViewCopyWith(
+          _$_FullPersonView value, $Res Function(_$_FullPersonView) then) =
+      __$$_FullPersonViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3241,11 +3235,11 @@ abstract class _$$FullPersonViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$FullPersonViewImplCopyWithImpl<$Res>
-    extends _$FullPersonViewCopyWithImpl<$Res, _$FullPersonViewImpl>
-    implements _$$FullPersonViewImplCopyWith<$Res> {
-  __$$FullPersonViewImplCopyWithImpl(
-      _$FullPersonViewImpl _value, $Res Function(_$FullPersonViewImpl) _then)
+class __$$_FullPersonViewCopyWithImpl<$Res>
+    extends _$FullPersonViewCopyWithImpl<$Res, _$_FullPersonView>
+    implements _$$_FullPersonViewCopyWith<$Res> {
+  __$$_FullPersonViewCopyWithImpl(
+      _$_FullPersonView _value, $Res Function(_$_FullPersonView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3257,7 +3251,7 @@ class __$$FullPersonViewImplCopyWithImpl<$Res>
     Object? posts = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$FullPersonViewImpl(
+    return _then(_$_FullPersonView(
       personView: null == personView
           ? _value.personView
           : personView // ignore: cast_nullable_to_non_nullable
@@ -3285,8 +3279,8 @@ class __$$FullPersonViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$FullPersonViewImpl extends _FullPersonView {
-  const _$FullPersonViewImpl(
+class _$_FullPersonView extends _FullPersonView {
+  const _$_FullPersonView(
       {required this.personView,
       required final List<CommunityModeratorView> moderates,
       required final List<CommentView> comments,
@@ -3297,8 +3291,8 @@ class _$FullPersonViewImpl extends _FullPersonView {
         _posts = posts,
         super._();
 
-  factory _$FullPersonViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FullPersonViewImplFromJson(json);
+  factory _$_FullPersonView.fromJson(Map<String, dynamic> json) =>
+      _$$_FullPersonViewFromJson(json);
 
   @override
   final PersonViewSafe personView;
@@ -3338,7 +3332,7 @@ class _$FullPersonViewImpl extends _FullPersonView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$FullPersonViewImpl &&
+            other is _$_FullPersonView &&
             (identical(other.personView, personView) ||
                 other.personView == personView) &&
             const DeepCollectionEquality()
@@ -3362,13 +3356,12 @@ class _$FullPersonViewImpl extends _FullPersonView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$FullPersonViewImplCopyWith<_$FullPersonViewImpl> get copyWith =>
-      __$$FullPersonViewImplCopyWithImpl<_$FullPersonViewImpl>(
-          this, _$identity);
+  _$$_FullPersonViewCopyWith<_$_FullPersonView> get copyWith =>
+      __$$_FullPersonViewCopyWithImpl<_$_FullPersonView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$FullPersonViewImplToJson(
+    return _$$_FullPersonViewToJson(
       this,
     );
   }
@@ -3380,11 +3373,11 @@ abstract class _FullPersonView extends FullPersonView {
       required final List<CommunityModeratorView> moderates,
       required final List<CommentView> comments,
       required final List<PostView> posts,
-      required final String instanceHost}) = _$FullPersonViewImpl;
+      required final String instanceHost}) = _$_FullPersonView;
   const _FullPersonView._() : super._();
 
   factory _FullPersonView.fromJson(Map<String, dynamic> json) =
-      _$FullPersonViewImpl.fromJson;
+      _$_FullPersonView.fromJson;
 
   @override
   PersonViewSafe get personView;
@@ -3398,7 +3391,7 @@ abstract class _FullPersonView extends FullPersonView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$FullPersonViewImplCopyWith<_$FullPersonViewImpl> get copyWith =>
+  _$$_FullPersonViewCopyWith<_$_FullPersonView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3472,11 +3465,11 @@ class _$BannedCommunityUserCopyWithImpl<$Res, $Val extends BannedCommunityUser>
 }
 
 /// @nodoc
-abstract class _$$BannedCommunityUserImplCopyWith<$Res>
+abstract class _$$_BannedCommunityUserCopyWith<$Res>
     implements $BannedCommunityUserCopyWith<$Res> {
-  factory _$$BannedCommunityUserImplCopyWith(_$BannedCommunityUserImpl value,
-          $Res Function(_$BannedCommunityUserImpl) then) =
-      __$$BannedCommunityUserImplCopyWithImpl<$Res>;
+  factory _$$_BannedCommunityUserCopyWith(_$_BannedCommunityUser value,
+          $Res Function(_$_BannedCommunityUser) then) =
+      __$$_BannedCommunityUserCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonViewSafe personView, bool banned, String instanceHost});
@@ -3486,11 +3479,11 @@ abstract class _$$BannedCommunityUserImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$BannedCommunityUserImplCopyWithImpl<$Res>
-    extends _$BannedCommunityUserCopyWithImpl<$Res, _$BannedCommunityUserImpl>
-    implements _$$BannedCommunityUserImplCopyWith<$Res> {
-  __$$BannedCommunityUserImplCopyWithImpl(_$BannedCommunityUserImpl _value,
-      $Res Function(_$BannedCommunityUserImpl) _then)
+class __$$_BannedCommunityUserCopyWithImpl<$Res>
+    extends _$BannedCommunityUserCopyWithImpl<$Res, _$_BannedCommunityUser>
+    implements _$$_BannedCommunityUserCopyWith<$Res> {
+  __$$_BannedCommunityUserCopyWithImpl(_$_BannedCommunityUser _value,
+      $Res Function(_$_BannedCommunityUser) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3500,7 +3493,7 @@ class __$$BannedCommunityUserImplCopyWithImpl<$Res>
     Object? banned = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$BannedCommunityUserImpl(
+    return _then(_$_BannedCommunityUser(
       personView: null == personView
           ? _value.personView
           : personView // ignore: cast_nullable_to_non_nullable
@@ -3520,15 +3513,15 @@ class __$$BannedCommunityUserImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$BannedCommunityUserImpl extends _BannedCommunityUser {
-  const _$BannedCommunityUserImpl(
+class _$_BannedCommunityUser extends _BannedCommunityUser {
+  const _$_BannedCommunityUser(
       {required this.personView,
       required this.banned,
       required this.instanceHost})
       : super._();
 
-  factory _$BannedCommunityUserImpl.fromJson(Map<String, dynamic> json) =>
-      _$$BannedCommunityUserImplFromJson(json);
+  factory _$_BannedCommunityUser.fromJson(Map<String, dynamic> json) =>
+      _$$_BannedCommunityUserFromJson(json);
 
   @override
   final PersonViewSafe personView;
@@ -3546,7 +3539,7 @@ class _$BannedCommunityUserImpl extends _BannedCommunityUser {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$BannedCommunityUserImpl &&
+            other is _$_BannedCommunityUser &&
             (identical(other.personView, personView) ||
                 other.personView == personView) &&
             (identical(other.banned, banned) || other.banned == banned) &&
@@ -3562,13 +3555,13 @@ class _$BannedCommunityUserImpl extends _BannedCommunityUser {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$BannedCommunityUserImplCopyWith<_$BannedCommunityUserImpl> get copyWith =>
-      __$$BannedCommunityUserImplCopyWithImpl<_$BannedCommunityUserImpl>(
+  _$$_BannedCommunityUserCopyWith<_$_BannedCommunityUser> get copyWith =>
+      __$$_BannedCommunityUserCopyWithImpl<_$_BannedCommunityUser>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$BannedCommunityUserImplToJson(
+    return _$$_BannedCommunityUserToJson(
       this,
     );
   }
@@ -3578,11 +3571,11 @@ abstract class _BannedCommunityUser extends BannedCommunityUser {
   const factory _BannedCommunityUser(
       {required final PersonViewSafe personView,
       required final bool banned,
-      required final String instanceHost}) = _$BannedCommunityUserImpl;
+      required final String instanceHost}) = _$_BannedCommunityUser;
   const _BannedCommunityUser._() : super._();
 
   factory _BannedCommunityUser.fromJson(Map<String, dynamic> json) =
-      _$BannedCommunityUserImpl.fromJson;
+      _$_BannedCommunityUser.fromJson;
 
   @override
   PersonViewSafe get personView;
@@ -3592,7 +3585,7 @@ abstract class _BannedCommunityUser extends BannedCommunityUser {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$BannedCommunityUserImplCopyWith<_$BannedCommunityUserImpl> get copyWith =>
+  _$$_BannedCommunityUserCopyWith<_$_BannedCommunityUser> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3666,11 +3659,11 @@ class _$BannedPersonCopyWithImpl<$Res, $Val extends BannedPerson>
 }
 
 /// @nodoc
-abstract class _$$BannedPersonImplCopyWith<$Res>
+abstract class _$$_BannedPersonCopyWith<$Res>
     implements $BannedPersonCopyWith<$Res> {
-  factory _$$BannedPersonImplCopyWith(
-          _$BannedPersonImpl value, $Res Function(_$BannedPersonImpl) then) =
-      __$$BannedPersonImplCopyWithImpl<$Res>;
+  factory _$$_BannedPersonCopyWith(
+          _$_BannedPerson value, $Res Function(_$_BannedPerson) then) =
+      __$$_BannedPersonCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonViewSafe personView, bool banned, String instanceHost});
@@ -3680,11 +3673,11 @@ abstract class _$$BannedPersonImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$BannedPersonImplCopyWithImpl<$Res>
-    extends _$BannedPersonCopyWithImpl<$Res, _$BannedPersonImpl>
-    implements _$$BannedPersonImplCopyWith<$Res> {
-  __$$BannedPersonImplCopyWithImpl(
-      _$BannedPersonImpl _value, $Res Function(_$BannedPersonImpl) _then)
+class __$$_BannedPersonCopyWithImpl<$Res>
+    extends _$BannedPersonCopyWithImpl<$Res, _$_BannedPerson>
+    implements _$$_BannedPersonCopyWith<$Res> {
+  __$$_BannedPersonCopyWithImpl(
+      _$_BannedPerson _value, $Res Function(_$_BannedPerson) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3694,7 +3687,7 @@ class __$$BannedPersonImplCopyWithImpl<$Res>
     Object? banned = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$BannedPersonImpl(
+    return _then(_$_BannedPerson(
       personView: null == personView
           ? _value.personView
           : personView // ignore: cast_nullable_to_non_nullable
@@ -3714,15 +3707,15 @@ class __$$BannedPersonImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$BannedPersonImpl extends _BannedPerson {
-  const _$BannedPersonImpl(
+class _$_BannedPerson extends _BannedPerson {
+  const _$_BannedPerson(
       {required this.personView,
       required this.banned,
       required this.instanceHost})
       : super._();
 
-  factory _$BannedPersonImpl.fromJson(Map<String, dynamic> json) =>
-      _$$BannedPersonImplFromJson(json);
+  factory _$_BannedPerson.fromJson(Map<String, dynamic> json) =>
+      _$$_BannedPersonFromJson(json);
 
   @override
   final PersonViewSafe personView;
@@ -3740,7 +3733,7 @@ class _$BannedPersonImpl extends _BannedPerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$BannedPersonImpl &&
+            other is _$_BannedPerson &&
             (identical(other.personView, personView) ||
                 other.personView == personView) &&
             (identical(other.banned, banned) || other.banned == banned) &&
@@ -3756,12 +3749,12 @@ class _$BannedPersonImpl extends _BannedPerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$BannedPersonImplCopyWith<_$BannedPersonImpl> get copyWith =>
-      __$$BannedPersonImplCopyWithImpl<_$BannedPersonImpl>(this, _$identity);
+  _$$_BannedPersonCopyWith<_$_BannedPerson> get copyWith =>
+      __$$_BannedPersonCopyWithImpl<_$_BannedPerson>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$BannedPersonImplToJson(
+    return _$$_BannedPersonToJson(
       this,
     );
   }
@@ -3771,11 +3764,11 @@ abstract class _BannedPerson extends BannedPerson {
   const factory _BannedPerson(
       {required final PersonViewSafe personView,
       required final bool banned,
-      required final String instanceHost}) = _$BannedPersonImpl;
+      required final String instanceHost}) = _$_BannedPerson;
   const _BannedPerson._() : super._();
 
   factory _BannedPerson.fromJson(Map<String, dynamic> json) =
-      _$BannedPersonImpl.fromJson;
+      _$_BannedPerson.fromJson;
 
   @override
   PersonViewSafe get personView;
@@ -3785,7 +3778,7 @@ abstract class _BannedPerson extends BannedPerson {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$BannedPersonImplCopyWith<_$BannedPersonImpl> get copyWith =>
+  _$$_BannedPersonCopyWith<_$_BannedPerson> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3921,12 +3914,11 @@ class _$ResolveObjectResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$ResolveObjectResponseImplCopyWith<$Res>
+abstract class _$$_ResolveObjectResponseCopyWith<$Res>
     implements $ResolveObjectResponseCopyWith<$Res> {
-  factory _$$ResolveObjectResponseImplCopyWith(
-          _$ResolveObjectResponseImpl value,
-          $Res Function(_$ResolveObjectResponseImpl) then) =
-      __$$ResolveObjectResponseImplCopyWithImpl<$Res>;
+  factory _$$_ResolveObjectResponseCopyWith(_$_ResolveObjectResponse value,
+          $Res Function(_$_ResolveObjectResponse) then) =
+      __$$_ResolveObjectResponseCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3947,12 +3939,11 @@ abstract class _$$ResolveObjectResponseImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ResolveObjectResponseImplCopyWithImpl<$Res>
-    extends _$ResolveObjectResponseCopyWithImpl<$Res,
-        _$ResolveObjectResponseImpl>
-    implements _$$ResolveObjectResponseImplCopyWith<$Res> {
-  __$$ResolveObjectResponseImplCopyWithImpl(_$ResolveObjectResponseImpl _value,
-      $Res Function(_$ResolveObjectResponseImpl) _then)
+class __$$_ResolveObjectResponseCopyWithImpl<$Res>
+    extends _$ResolveObjectResponseCopyWithImpl<$Res, _$_ResolveObjectResponse>
+    implements _$$_ResolveObjectResponseCopyWith<$Res> {
+  __$$_ResolveObjectResponseCopyWithImpl(_$_ResolveObjectResponse _value,
+      $Res Function(_$_ResolveObjectResponse) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3964,7 +3955,7 @@ class __$$ResolveObjectResponseImplCopyWithImpl<$Res>
     Object? person = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$ResolveObjectResponseImpl(
+    return _then(_$_ResolveObjectResponse(
       comment: freezed == comment
           ? _value.comment
           : comment // ignore: cast_nullable_to_non_nullable
@@ -3992,8 +3983,8 @@ class __$$ResolveObjectResponseImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ResolveObjectResponseImpl extends _ResolveObjectResponse {
-  const _$ResolveObjectResponseImpl(
+class _$_ResolveObjectResponse extends _ResolveObjectResponse {
+  const _$_ResolveObjectResponse(
       {this.comment,
       this.post,
       this.community,
@@ -4001,8 +3992,8 @@ class _$ResolveObjectResponseImpl extends _ResolveObjectResponse {
       required this.instanceHost})
       : super._();
 
-  factory _$ResolveObjectResponseImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ResolveObjectResponseImplFromJson(json);
+  factory _$_ResolveObjectResponse.fromJson(Map<String, dynamic> json) =>
+      _$$_ResolveObjectResponseFromJson(json);
 
   @override
   final CommentView? comment;
@@ -4024,7 +4015,7 @@ class _$ResolveObjectResponseImpl extends _ResolveObjectResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ResolveObjectResponseImpl &&
+            other is _$_ResolveObjectResponse &&
             (identical(other.comment, comment) || other.comment == comment) &&
             (identical(other.post, post) || other.post == post) &&
             (identical(other.community, community) ||
@@ -4042,13 +4033,13 @@ class _$ResolveObjectResponseImpl extends _ResolveObjectResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ResolveObjectResponseImplCopyWith<_$ResolveObjectResponseImpl>
-      get copyWith => __$$ResolveObjectResponseImplCopyWithImpl<
-          _$ResolveObjectResponseImpl>(this, _$identity);
+  _$$_ResolveObjectResponseCopyWith<_$_ResolveObjectResponse> get copyWith =>
+      __$$_ResolveObjectResponseCopyWithImpl<_$_ResolveObjectResponse>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ResolveObjectResponseImplToJson(
+    return _$$_ResolveObjectResponseToJson(
       this,
     );
   }
@@ -4060,11 +4051,11 @@ abstract class _ResolveObjectResponse extends ResolveObjectResponse {
       final PostView? post,
       final CommunityView? community,
       final PersonViewSafe? person,
-      required final String instanceHost}) = _$ResolveObjectResponseImpl;
+      required final String instanceHost}) = _$_ResolveObjectResponse;
   const _ResolveObjectResponse._() : super._();
 
   factory _ResolveObjectResponse.fromJson(Map<String, dynamic> json) =
-      _$ResolveObjectResponseImpl.fromJson;
+      _$_ResolveObjectResponse.fromJson;
 
   @override
   CommentView? get comment;
@@ -4078,8 +4069,8 @@ abstract class _ResolveObjectResponse extends ResolveObjectResponse {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ResolveObjectResponseImplCopyWith<_$ResolveObjectResponseImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_ResolveObjectResponseCopyWith<_$_ResolveObjectResponse> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 SiteMetadata _$SiteMetadataFromJson(Map<String, dynamic> json) {
@@ -4159,11 +4150,11 @@ class _$SiteMetadataCopyWithImpl<$Res, $Val extends SiteMetadata>
 }
 
 /// @nodoc
-abstract class _$$SiteMetadataImplCopyWith<$Res>
+abstract class _$$_SiteMetadataCopyWith<$Res>
     implements $SiteMetadataCopyWith<$Res> {
-  factory _$$SiteMetadataImplCopyWith(
-          _$SiteMetadataImpl value, $Res Function(_$SiteMetadataImpl) then) =
-      __$$SiteMetadataImplCopyWithImpl<$Res>;
+  factory _$$_SiteMetadataCopyWith(
+          _$_SiteMetadata value, $Res Function(_$_SiteMetadata) then) =
+      __$$_SiteMetadataCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4175,11 +4166,11 @@ abstract class _$$SiteMetadataImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$SiteMetadataImplCopyWithImpl<$Res>
-    extends _$SiteMetadataCopyWithImpl<$Res, _$SiteMetadataImpl>
-    implements _$$SiteMetadataImplCopyWith<$Res> {
-  __$$SiteMetadataImplCopyWithImpl(
-      _$SiteMetadataImpl _value, $Res Function(_$SiteMetadataImpl) _then)
+class __$$_SiteMetadataCopyWithImpl<$Res>
+    extends _$SiteMetadataCopyWithImpl<$Res, _$_SiteMetadata>
+    implements _$$_SiteMetadataCopyWith<$Res> {
+  __$$_SiteMetadataCopyWithImpl(
+      _$_SiteMetadata _value, $Res Function(_$_SiteMetadata) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4191,7 +4182,7 @@ class __$$SiteMetadataImplCopyWithImpl<$Res>
     Object? html = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$SiteMetadataImpl(
+    return _then(_$_SiteMetadata(
       title: freezed == title
           ? _value.title
           : title // ignore: cast_nullable_to_non_nullable
@@ -4219,8 +4210,8 @@ class __$$SiteMetadataImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$SiteMetadataImpl extends _SiteMetadata {
-  const _$SiteMetadataImpl(
+class _$_SiteMetadata extends _SiteMetadata {
+  const _$_SiteMetadata(
       {this.title,
       this.description,
       this.image,
@@ -4228,8 +4219,8 @@ class _$SiteMetadataImpl extends _SiteMetadata {
       required this.instanceHost})
       : super._();
 
-  factory _$SiteMetadataImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SiteMetadataImplFromJson(json);
+  factory _$_SiteMetadata.fromJson(Map<String, dynamic> json) =>
+      _$$_SiteMetadataFromJson(json);
 
   @override
   final String? title;
@@ -4251,7 +4242,7 @@ class _$SiteMetadataImpl extends _SiteMetadata {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SiteMetadataImpl &&
+            other is _$_SiteMetadata &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.description, description) ||
                 other.description == description) &&
@@ -4269,12 +4260,12 @@ class _$SiteMetadataImpl extends _SiteMetadata {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SiteMetadataImplCopyWith<_$SiteMetadataImpl> get copyWith =>
-      __$$SiteMetadataImplCopyWithImpl<_$SiteMetadataImpl>(this, _$identity);
+  _$$_SiteMetadataCopyWith<_$_SiteMetadata> get copyWith =>
+      __$$_SiteMetadataCopyWithImpl<_$_SiteMetadata>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$SiteMetadataImplToJson(
+    return _$$_SiteMetadataToJson(
       this,
     );
   }
@@ -4286,11 +4277,11 @@ abstract class _SiteMetadata extends SiteMetadata {
       final String? description,
       final String? image,
       final String? html,
-      required final String instanceHost}) = _$SiteMetadataImpl;
+      required final String instanceHost}) = _$_SiteMetadata;
   const _SiteMetadata._() : super._();
 
   factory _SiteMetadata.fromJson(Map<String, dynamic> json) =
-      _$SiteMetadataImpl.fromJson;
+      _$_SiteMetadata.fromJson;
 
   @override
   String? get title;
@@ -4304,7 +4295,7 @@ abstract class _SiteMetadata extends SiteMetadata {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$SiteMetadataImplCopyWith<_$SiteMetadataImpl> get copyWith =>
+  _$$_SiteMetadataCopyWith<_$_SiteMetadata> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4378,11 +4369,11 @@ class _$BlockedPersonCopyWithImpl<$Res, $Val extends BlockedPerson>
 }
 
 /// @nodoc
-abstract class _$$BlockedPersonImplCopyWith<$Res>
+abstract class _$$_BlockedPersonCopyWith<$Res>
     implements $BlockedPersonCopyWith<$Res> {
-  factory _$$BlockedPersonImplCopyWith(
-          _$BlockedPersonImpl value, $Res Function(_$BlockedPersonImpl) then) =
-      __$$BlockedPersonImplCopyWithImpl<$Res>;
+  factory _$$_BlockedPersonCopyWith(
+          _$_BlockedPerson value, $Res Function(_$_BlockedPerson) then) =
+      __$$_BlockedPersonCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonViewSafe personView, bool blocked, String instanceHost});
@@ -4392,11 +4383,11 @@ abstract class _$$BlockedPersonImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$BlockedPersonImplCopyWithImpl<$Res>
-    extends _$BlockedPersonCopyWithImpl<$Res, _$BlockedPersonImpl>
-    implements _$$BlockedPersonImplCopyWith<$Res> {
-  __$$BlockedPersonImplCopyWithImpl(
-      _$BlockedPersonImpl _value, $Res Function(_$BlockedPersonImpl) _then)
+class __$$_BlockedPersonCopyWithImpl<$Res>
+    extends _$BlockedPersonCopyWithImpl<$Res, _$_BlockedPerson>
+    implements _$$_BlockedPersonCopyWith<$Res> {
+  __$$_BlockedPersonCopyWithImpl(
+      _$_BlockedPerson _value, $Res Function(_$_BlockedPerson) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4406,7 +4397,7 @@ class __$$BlockedPersonImplCopyWithImpl<$Res>
     Object? blocked = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$BlockedPersonImpl(
+    return _then(_$_BlockedPerson(
       personView: null == personView
           ? _value.personView
           : personView // ignore: cast_nullable_to_non_nullable
@@ -4426,15 +4417,15 @@ class __$$BlockedPersonImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$BlockedPersonImpl extends _BlockedPerson {
-  const _$BlockedPersonImpl(
+class _$_BlockedPerson extends _BlockedPerson {
+  const _$_BlockedPerson(
       {required this.personView,
       required this.blocked,
       required this.instanceHost})
       : super._();
 
-  factory _$BlockedPersonImpl.fromJson(Map<String, dynamic> json) =>
-      _$$BlockedPersonImplFromJson(json);
+  factory _$_BlockedPerson.fromJson(Map<String, dynamic> json) =>
+      _$$_BlockedPersonFromJson(json);
 
   @override
   final PersonViewSafe personView;
@@ -4452,7 +4443,7 @@ class _$BlockedPersonImpl extends _BlockedPerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$BlockedPersonImpl &&
+            other is _$_BlockedPerson &&
             (identical(other.personView, personView) ||
                 other.personView == personView) &&
             (identical(other.blocked, blocked) || other.blocked == blocked) &&
@@ -4468,12 +4459,12 @@ class _$BlockedPersonImpl extends _BlockedPerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$BlockedPersonImplCopyWith<_$BlockedPersonImpl> get copyWith =>
-      __$$BlockedPersonImplCopyWithImpl<_$BlockedPersonImpl>(this, _$identity);
+  _$$_BlockedPersonCopyWith<_$_BlockedPerson> get copyWith =>
+      __$$_BlockedPersonCopyWithImpl<_$_BlockedPerson>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$BlockedPersonImplToJson(
+    return _$$_BlockedPersonToJson(
       this,
     );
   }
@@ -4483,11 +4474,11 @@ abstract class _BlockedPerson extends BlockedPerson {
   const factory _BlockedPerson(
       {required final PersonViewSafe personView,
       required final bool blocked,
-      required final String instanceHost}) = _$BlockedPersonImpl;
+      required final String instanceHost}) = _$_BlockedPerson;
   const _BlockedPerson._() : super._();
 
   factory _BlockedPerson.fromJson(Map<String, dynamic> json) =
-      _$BlockedPersonImpl.fromJson;
+      _$_BlockedPerson.fromJson;
 
   @override
   PersonViewSafe get personView;
@@ -4497,7 +4488,7 @@ abstract class _BlockedPerson extends BlockedPerson {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$BlockedPersonImplCopyWith<_$BlockedPersonImpl> get copyWith =>
+  _$$_BlockedPersonCopyWith<_$_BlockedPerson> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4571,11 +4562,11 @@ class _$BlockedCommunityCopyWithImpl<$Res, $Val extends BlockedCommunity>
 }
 
 /// @nodoc
-abstract class _$$BlockedCommunityImplCopyWith<$Res>
+abstract class _$$_BlockedCommunityCopyWith<$Res>
     implements $BlockedCommunityCopyWith<$Res> {
-  factory _$$BlockedCommunityImplCopyWith(_$BlockedCommunityImpl value,
-          $Res Function(_$BlockedCommunityImpl) then) =
-      __$$BlockedCommunityImplCopyWithImpl<$Res>;
+  factory _$$_BlockedCommunityCopyWith(
+          _$_BlockedCommunity value, $Res Function(_$_BlockedCommunity) then) =
+      __$$_BlockedCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CommunityView communityView, bool blocked, String instanceHost});
@@ -4585,11 +4576,11 @@ abstract class _$$BlockedCommunityImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$BlockedCommunityImplCopyWithImpl<$Res>
-    extends _$BlockedCommunityCopyWithImpl<$Res, _$BlockedCommunityImpl>
-    implements _$$BlockedCommunityImplCopyWith<$Res> {
-  __$$BlockedCommunityImplCopyWithImpl(_$BlockedCommunityImpl _value,
-      $Res Function(_$BlockedCommunityImpl) _then)
+class __$$_BlockedCommunityCopyWithImpl<$Res>
+    extends _$BlockedCommunityCopyWithImpl<$Res, _$_BlockedCommunity>
+    implements _$$_BlockedCommunityCopyWith<$Res> {
+  __$$_BlockedCommunityCopyWithImpl(
+      _$_BlockedCommunity _value, $Res Function(_$_BlockedCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4599,7 +4590,7 @@ class __$$BlockedCommunityImplCopyWithImpl<$Res>
     Object? blocked = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$BlockedCommunityImpl(
+    return _then(_$_BlockedCommunity(
       communityView: null == communityView
           ? _value.communityView
           : communityView // ignore: cast_nullable_to_non_nullable
@@ -4619,15 +4610,15 @@ class __$$BlockedCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$BlockedCommunityImpl extends _BlockedCommunity {
-  const _$BlockedCommunityImpl(
+class _$_BlockedCommunity extends _BlockedCommunity {
+  const _$_BlockedCommunity(
       {required this.communityView,
       required this.blocked,
       required this.instanceHost})
       : super._();
 
-  factory _$BlockedCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$BlockedCommunityImplFromJson(json);
+  factory _$_BlockedCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_BlockedCommunityFromJson(json);
 
   @override
   final CommunityView communityView;
@@ -4645,7 +4636,7 @@ class _$BlockedCommunityImpl extends _BlockedCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$BlockedCommunityImpl &&
+            other is _$_BlockedCommunity &&
             (identical(other.communityView, communityView) ||
                 other.communityView == communityView) &&
             (identical(other.blocked, blocked) || other.blocked == blocked) &&
@@ -4661,13 +4652,12 @@ class _$BlockedCommunityImpl extends _BlockedCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$BlockedCommunityImplCopyWith<_$BlockedCommunityImpl> get copyWith =>
-      __$$BlockedCommunityImplCopyWithImpl<_$BlockedCommunityImpl>(
-          this, _$identity);
+  _$$_BlockedCommunityCopyWith<_$_BlockedCommunity> get copyWith =>
+      __$$_BlockedCommunityCopyWithImpl<_$_BlockedCommunity>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$BlockedCommunityImplToJson(
+    return _$$_BlockedCommunityToJson(
       this,
     );
   }
@@ -4677,11 +4667,11 @@ abstract class _BlockedCommunity extends BlockedCommunity {
   const factory _BlockedCommunity(
       {required final CommunityView communityView,
       required final bool blocked,
-      required final String instanceHost}) = _$BlockedCommunityImpl;
+      required final String instanceHost}) = _$_BlockedCommunity;
   const _BlockedCommunity._() : super._();
 
   factory _BlockedCommunity.fromJson(Map<String, dynamic> json) =
-      _$BlockedCommunityImpl.fromJson;
+      _$_BlockedCommunity.fromJson;
 
   @override
   CommunityView get communityView;
@@ -4691,7 +4681,7 @@ abstract class _BlockedCommunity extends BlockedCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$BlockedCommunityImplCopyWith<_$BlockedCommunityImpl> get copyWith =>
+  _$$_BlockedCommunityCopyWith<_$_BlockedCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4765,11 +4755,11 @@ class _$ReportCountCopyWithImpl<$Res, $Val extends ReportCount>
 }
 
 /// @nodoc
-abstract class _$$ReportCountImplCopyWith<$Res>
+abstract class _$$_ReportCountCopyWith<$Res>
     implements $ReportCountCopyWith<$Res> {
-  factory _$$ReportCountImplCopyWith(
-          _$ReportCountImpl value, $Res Function(_$ReportCountImpl) then) =
-      __$$ReportCountImplCopyWithImpl<$Res>;
+  factory _$$_ReportCountCopyWith(
+          _$_ReportCount value, $Res Function(_$_ReportCount) then) =
+      __$$_ReportCountCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4780,11 +4770,11 @@ abstract class _$$ReportCountImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ReportCountImplCopyWithImpl<$Res>
-    extends _$ReportCountCopyWithImpl<$Res, _$ReportCountImpl>
-    implements _$$ReportCountImplCopyWith<$Res> {
-  __$$ReportCountImplCopyWithImpl(
-      _$ReportCountImpl _value, $Res Function(_$ReportCountImpl) _then)
+class __$$_ReportCountCopyWithImpl<$Res>
+    extends _$ReportCountCopyWithImpl<$Res, _$_ReportCount>
+    implements _$$_ReportCountCopyWith<$Res> {
+  __$$_ReportCountCopyWithImpl(
+      _$_ReportCount _value, $Res Function(_$_ReportCount) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4795,7 +4785,7 @@ class __$$ReportCountImplCopyWithImpl<$Res>
     Object? postReports = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ReportCountImpl(
+    return _then(_$_ReportCount(
       communityId: freezed == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -4819,16 +4809,16 @@ class __$$ReportCountImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ReportCountImpl extends _ReportCount {
-  const _$ReportCountImpl(
+class _$_ReportCount extends _ReportCount {
+  const _$_ReportCount(
       {this.communityId,
       required this.commentReports,
       required this.postReports,
       required this.instanceHost})
       : super._();
 
-  factory _$ReportCountImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ReportCountImplFromJson(json);
+  factory _$_ReportCount.fromJson(Map<String, dynamic> json) =>
+      _$$_ReportCountFromJson(json);
 
   @override
   final int? communityId;
@@ -4848,7 +4838,7 @@ class _$ReportCountImpl extends _ReportCount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ReportCountImpl &&
+            other is _$_ReportCount &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.commentReports, commentReports) ||
@@ -4867,12 +4857,12 @@ class _$ReportCountImpl extends _ReportCount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ReportCountImplCopyWith<_$ReportCountImpl> get copyWith =>
-      __$$ReportCountImplCopyWithImpl<_$ReportCountImpl>(this, _$identity);
+  _$$_ReportCountCopyWith<_$_ReportCount> get copyWith =>
+      __$$_ReportCountCopyWithImpl<_$_ReportCount>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ReportCountImplToJson(
+    return _$$_ReportCountToJson(
       this,
     );
   }
@@ -4883,11 +4873,11 @@ abstract class _ReportCount extends ReportCount {
       {final int? communityId,
       required final int commentReports,
       required final int postReports,
-      required final String instanceHost}) = _$ReportCountImpl;
+      required final String instanceHost}) = _$_ReportCount;
   const _ReportCount._() : super._();
 
   factory _ReportCount.fromJson(Map<String, dynamic> json) =
-      _$ReportCountImpl.fromJson;
+      _$_ReportCount.fromJson;
 
   @override
   int? get communityId;
@@ -4899,7 +4889,7 @@ abstract class _ReportCount extends ReportCount {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ReportCountImplCopyWith<_$ReportCountImpl> get copyWith =>
+  _$$_ReportCountCopyWith<_$_ReportCount> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4970,11 +4960,11 @@ class _$UnreadCountCopyWithImpl<$Res, $Val extends UnreadCount>
 }
 
 /// @nodoc
-abstract class _$$UnreadCountImplCopyWith<$Res>
+abstract class _$$_UnreadCountCopyWith<$Res>
     implements $UnreadCountCopyWith<$Res> {
-  factory _$$UnreadCountImplCopyWith(
-          _$UnreadCountImpl value, $Res Function(_$UnreadCountImpl) then) =
-      __$$UnreadCountImplCopyWithImpl<$Res>;
+  factory _$$_UnreadCountCopyWith(
+          _$_UnreadCount value, $Res Function(_$_UnreadCount) then) =
+      __$$_UnreadCountCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4982,11 +4972,11 @@ abstract class _$$UnreadCountImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$UnreadCountImplCopyWithImpl<$Res>
-    extends _$UnreadCountCopyWithImpl<$Res, _$UnreadCountImpl>
-    implements _$$UnreadCountImplCopyWith<$Res> {
-  __$$UnreadCountImplCopyWithImpl(
-      _$UnreadCountImpl _value, $Res Function(_$UnreadCountImpl) _then)
+class __$$_UnreadCountCopyWithImpl<$Res>
+    extends _$UnreadCountCopyWithImpl<$Res, _$_UnreadCount>
+    implements _$$_UnreadCountCopyWith<$Res> {
+  __$$_UnreadCountCopyWithImpl(
+      _$_UnreadCount _value, $Res Function(_$_UnreadCount) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4997,7 +4987,7 @@ class __$$UnreadCountImplCopyWithImpl<$Res>
     Object? privateMessages = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$UnreadCountImpl(
+    return _then(_$_UnreadCount(
       replies: null == replies
           ? _value.replies
           : replies // ignore: cast_nullable_to_non_nullable
@@ -5021,16 +5011,16 @@ class __$$UnreadCountImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$UnreadCountImpl extends _UnreadCount {
-  const _$UnreadCountImpl(
+class _$_UnreadCount extends _UnreadCount {
+  const _$_UnreadCount(
       {required this.replies,
       required this.mentions,
       required this.privateMessages,
       required this.instanceHost})
       : super._();
 
-  factory _$UnreadCountImpl.fromJson(Map<String, dynamic> json) =>
-      _$$UnreadCountImplFromJson(json);
+  factory _$_UnreadCount.fromJson(Map<String, dynamic> json) =>
+      _$$_UnreadCountFromJson(json);
 
   @override
   final int replies;
@@ -5050,7 +5040,7 @@ class _$UnreadCountImpl extends _UnreadCount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$UnreadCountImpl &&
+            other is _$_UnreadCount &&
             (identical(other.replies, replies) || other.replies == replies) &&
             (identical(other.mentions, mentions) ||
                 other.mentions == mentions) &&
@@ -5068,12 +5058,12 @@ class _$UnreadCountImpl extends _UnreadCount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$UnreadCountImplCopyWith<_$UnreadCountImpl> get copyWith =>
-      __$$UnreadCountImplCopyWithImpl<_$UnreadCountImpl>(this, _$identity);
+  _$$_UnreadCountCopyWith<_$_UnreadCount> get copyWith =>
+      __$$_UnreadCountCopyWithImpl<_$_UnreadCount>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$UnreadCountImplToJson(
+    return _$$_UnreadCountToJson(
       this,
     );
   }
@@ -5084,11 +5074,11 @@ abstract class _UnreadCount extends UnreadCount {
       {required final int replies,
       required final int mentions,
       required final int privateMessages,
-      required final String instanceHost}) = _$UnreadCountImpl;
+      required final String instanceHost}) = _$_UnreadCount;
   const _UnreadCount._() : super._();
 
   factory _UnreadCount.fromJson(Map<String, dynamic> json) =
-      _$UnreadCountImpl.fromJson;
+      _$_UnreadCount.fromJson;
 
   @override
   int get replies;
@@ -5100,7 +5090,7 @@ abstract class _UnreadCount extends UnreadCount {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$UnreadCountImplCopyWith<_$UnreadCountImpl> get copyWith =>
+  _$$_UnreadCountCopyWith<_$_UnreadCount> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5174,11 +5164,11 @@ class _$LoginResponseCopyWithImpl<$Res, $Val extends LoginResponse>
 }
 
 /// @nodoc
-abstract class _$$LoginResponseImplCopyWith<$Res>
+abstract class _$$_LoginResponseCopyWith<$Res>
     implements $LoginResponseCopyWith<$Res> {
-  factory _$$LoginResponseImplCopyWith(
-          _$LoginResponseImpl value, $Res Function(_$LoginResponseImpl) then) =
-      __$$LoginResponseImplCopyWithImpl<$Res>;
+  factory _$$_LoginResponseCopyWith(
+          _$_LoginResponse value, $Res Function(_$_LoginResponse) then) =
+      __$$_LoginResponseCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5189,11 +5179,11 @@ abstract class _$$LoginResponseImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$LoginResponseImplCopyWithImpl<$Res>
-    extends _$LoginResponseCopyWithImpl<$Res, _$LoginResponseImpl>
-    implements _$$LoginResponseImplCopyWith<$Res> {
-  __$$LoginResponseImplCopyWithImpl(
-      _$LoginResponseImpl _value, $Res Function(_$LoginResponseImpl) _then)
+class __$$_LoginResponseCopyWithImpl<$Res>
+    extends _$LoginResponseCopyWithImpl<$Res, _$_LoginResponse>
+    implements _$$_LoginResponseCopyWith<$Res> {
+  __$$_LoginResponseCopyWithImpl(
+      _$_LoginResponse _value, $Res Function(_$_LoginResponse) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5204,7 +5194,7 @@ class __$$LoginResponseImplCopyWithImpl<$Res>
     Object? registrationCreated = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$LoginResponseImpl(
+    return _then(_$_LoginResponse(
       jwt: freezed == jwt
           ? _value.jwt
           : jwt // ignore: cast_nullable_to_non_nullable
@@ -5228,16 +5218,16 @@ class __$$LoginResponseImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$LoginResponseImpl extends _LoginResponse {
-  const _$LoginResponseImpl(
+class _$_LoginResponse extends _LoginResponse {
+  const _$_LoginResponse(
       {this.jwt,
       required this.verifyEmailSent,
       required this.registrationCreated,
       required this.instanceHost})
       : super._();
 
-  factory _$LoginResponseImpl.fromJson(Map<String, dynamic> json) =>
-      _$$LoginResponseImplFromJson(json);
+  factory _$_LoginResponse.fromJson(Map<String, dynamic> json) =>
+      _$$_LoginResponseFromJson(json);
 
   @override
   final Jwt? jwt;
@@ -5257,7 +5247,7 @@ class _$LoginResponseImpl extends _LoginResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$LoginResponseImpl &&
+            other is _$_LoginResponse &&
             (identical(other.jwt, jwt) || other.jwt == jwt) &&
             (identical(other.verifyEmailSent, verifyEmailSent) ||
                 other.verifyEmailSent == verifyEmailSent) &&
@@ -5275,12 +5265,12 @@ class _$LoginResponseImpl extends _LoginResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$LoginResponseImplCopyWith<_$LoginResponseImpl> get copyWith =>
-      __$$LoginResponseImplCopyWithImpl<_$LoginResponseImpl>(this, _$identity);
+  _$$_LoginResponseCopyWith<_$_LoginResponse> get copyWith =>
+      __$$_LoginResponseCopyWithImpl<_$_LoginResponse>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$LoginResponseImplToJson(
+    return _$$_LoginResponseToJson(
       this,
     );
   }
@@ -5291,11 +5281,11 @@ abstract class _LoginResponse extends LoginResponse {
       {final Jwt? jwt,
       required final bool verifyEmailSent,
       required final bool registrationCreated,
-      required final String instanceHost}) = _$LoginResponseImpl;
+      required final String instanceHost}) = _$_LoginResponse;
   const _LoginResponse._() : super._();
 
   factory _LoginResponse.fromJson(Map<String, dynamic> json) =
-      _$LoginResponseImpl.fromJson;
+      _$_LoginResponse.fromJson;
 
   @override
   Jwt? get jwt;
@@ -5307,6 +5297,148 @@ abstract class _LoginResponse extends LoginResponse {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$LoginResponseImplCopyWith<_$LoginResponseImpl> get copyWith =>
+  _$$_LoginResponseCopyWith<_$_LoginResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+BlockInstanceResponse _$BlockInstanceResponseFromJson(
+    Map<String, dynamic> json) {
+  return _BlockInstanceResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$BlockInstanceResponse {
+  bool get blocked => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $BlockInstanceResponseCopyWith<BlockInstanceResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BlockInstanceResponseCopyWith<$Res> {
+  factory $BlockInstanceResponseCopyWith(BlockInstanceResponse value,
+          $Res Function(BlockInstanceResponse) then) =
+      _$BlockInstanceResponseCopyWithImpl<$Res, BlockInstanceResponse>;
+  @useResult
+  $Res call({bool blocked});
+}
+
+/// @nodoc
+class _$BlockInstanceResponseCopyWithImpl<$Res,
+        $Val extends BlockInstanceResponse>
+    implements $BlockInstanceResponseCopyWith<$Res> {
+  _$BlockInstanceResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? blocked = null,
+  }) {
+    return _then(_value.copyWith(
+      blocked: null == blocked
+          ? _value.blocked
+          : blocked // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_BlockInstanceResponseCopyWith<$Res>
+    implements $BlockInstanceResponseCopyWith<$Res> {
+  factory _$$_BlockInstanceResponseCopyWith(_$_BlockInstanceResponse value,
+          $Res Function(_$_BlockInstanceResponse) then) =
+      __$$_BlockInstanceResponseCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool blocked});
+}
+
+/// @nodoc
+class __$$_BlockInstanceResponseCopyWithImpl<$Res>
+    extends _$BlockInstanceResponseCopyWithImpl<$Res, _$_BlockInstanceResponse>
+    implements _$$_BlockInstanceResponseCopyWith<$Res> {
+  __$$_BlockInstanceResponseCopyWithImpl(_$_BlockInstanceResponse _value,
+      $Res Function(_$_BlockInstanceResponse) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? blocked = null,
+  }) {
+    return _then(_$_BlockInstanceResponse(
+      blocked: null == blocked
+          ? _value.blocked
+          : blocked // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+@modelSerde
+class _$_BlockInstanceResponse extends _BlockInstanceResponse {
+  const _$_BlockInstanceResponse({required this.blocked}) : super._();
+
+  factory _$_BlockInstanceResponse.fromJson(Map<String, dynamic> json) =>
+      _$$_BlockInstanceResponseFromJson(json);
+
+  @override
+  final bool blocked;
+
+  @override
+  String toString() {
+    return 'BlockInstanceResponse(blocked: $blocked)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_BlockInstanceResponse &&
+            (identical(other.blocked, blocked) || other.blocked == blocked));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, blocked);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_BlockInstanceResponseCopyWith<_$_BlockInstanceResponse> get copyWith =>
+      __$$_BlockInstanceResponseCopyWithImpl<_$_BlockInstanceResponse>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_BlockInstanceResponseToJson(
+      this,
+    );
+  }
+}
+
+abstract class _BlockInstanceResponse extends BlockInstanceResponse {
+  const factory _BlockInstanceResponse({required final bool blocked}) =
+      _$_BlockInstanceResponse;
+  const _BlockInstanceResponse._() : super._();
+
+  factory _BlockInstanceResponse.fromJson(Map<String, dynamic> json) =
+      _$_BlockInstanceResponse.fromJson;
+
+  @override
+  bool get blocked;
+  @override
+  @JsonKey(ignore: true)
+  _$$_BlockInstanceResponseCopyWith<_$_BlockInstanceResponse> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/api.g.dart
+++ b/lib/src/v3/models/api.g.dart
@@ -6,9 +6,8 @@ part of 'api.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$FullCommunityViewImpl _$$FullCommunityViewImplFromJson(
-        Map<String, dynamic> json) =>
-    _$FullCommunityViewImpl(
+_$_FullCommunityView _$$_FullCommunityViewFromJson(Map<String, dynamic> json) =>
+    _$_FullCommunityView(
       communityView: CommunityView.fromJson(
           json['community_view'] as Map<String, dynamic>),
       site: json['site'] == null
@@ -22,8 +21,8 @@ _$FullCommunityViewImpl _$$FullCommunityViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$FullCommunityViewImplToJson(
-        _$FullCommunityViewImpl instance) =>
+Map<String, dynamic> _$$_FullCommunityViewToJson(
+        _$_FullCommunityView instance) =>
     <String, dynamic>{
       'community_view': instance.communityView.toJson(),
       'site': instance.site?.toJson(),
@@ -32,8 +31,8 @@ Map<String, dynamic> _$$FullCommunityViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$FullPostViewImpl _$$FullPostViewImplFromJson(Map<String, dynamic> json) =>
-    _$FullPostViewImpl(
+_$_FullPostView _$$_FullPostViewFromJson(Map<String, dynamic> json) =>
+    _$_FullPostView(
       postView: PostView.fromJson(json['post_view'] as Map<String, dynamic>),
       communityView: CommunityView.fromJson(
           json['community_view'] as Map<String, dynamic>),
@@ -45,7 +44,7 @@ _$FullPostViewImpl _$$FullPostViewImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$FullPostViewImplToJson(_$FullPostViewImpl instance) =>
+Map<String, dynamic> _$$_FullPostViewToJson(_$_FullPostView instance) =>
     <String, dynamic>{
       'post_view': instance.postView.toJson(),
       'community_view': instance.communityView.toJson(),
@@ -54,8 +53,8 @@ Map<String, dynamic> _$$FullPostViewImplToJson(_$FullPostViewImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$SearchResultsImpl _$$SearchResultsImplFromJson(Map<String, dynamic> json) =>
-    _$SearchResultsImpl(
+_$_SearchResults _$$_SearchResultsFromJson(Map<String, dynamic> json) =>
+    _$_SearchResults(
       type: SearchType.fromJson(json['type_'] as String),
       comments: (json['comments'] as List<dynamic>)
           .map((e) => CommentView.fromJson(e as Map<String, dynamic>))
@@ -72,7 +71,7 @@ _$SearchResultsImpl _$$SearchResultsImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$SearchResultsImplToJson(_$SearchResultsImpl instance) =>
+Map<String, dynamic> _$$_SearchResultsToJson(_$_SearchResults instance) =>
     <String, dynamic>{
       'type_': instance.type.toJson(),
       'comments': instance.comments.map((e) => e.toJson()).toList(),
@@ -82,7 +81,7 @@ Map<String, dynamic> _$$SearchResultsImplToJson(_$SearchResultsImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$ModlogImpl _$$ModlogImplFromJson(Map<String, dynamic> json) => _$ModlogImpl(
+_$_Modlog _$$_ModlogFromJson(Map<String, dynamic> json) => _$_Modlog(
       removedPosts: (json['removed_posts'] as List<dynamic>)
           .map((e) => ModRemovePostView.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -137,8 +136,7 @@ _$ModlogImpl _$$ModlogImplFromJson(Map<String, dynamic> json) => _$ModlogImpl(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModlogImplToJson(_$ModlogImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$$_ModlogToJson(_$_Modlog instance) => <String, dynamic>{
       'removed_posts': instance.removedPosts.map((e) => e.toJson()).toList(),
       'locked_posts': instance.lockedPosts.map((e) => e.toJson()).toList(),
       'featured_posts': instance.featuredPosts.map((e) => e.toJson()).toList(),
@@ -167,9 +165,8 @@ Map<String, dynamic> _$$ModlogImplToJson(_$ModlogImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$FullCommentViewImpl _$$FullCommentViewImplFromJson(
-        Map<String, dynamic> json) =>
-    _$FullCommentViewImpl(
+_$_FullCommentView _$$_FullCommentViewFromJson(Map<String, dynamic> json) =>
+    _$_FullCommentView(
       commentView:
           CommentView.fromJson(json['comment_view'] as Map<String, dynamic>),
       recipientIds: (json['recipient_ids'] as List<dynamic>)
@@ -179,8 +176,7 @@ _$FullCommentViewImpl _$$FullCommentViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$FullCommentViewImplToJson(
-        _$FullCommentViewImpl instance) =>
+Map<String, dynamic> _$$_FullCommentViewToJson(_$_FullCommentView instance) =>
     <String, dynamic>{
       'comment_view': instance.commentView.toJson(),
       'recipient_ids': instance.recipientIds,
@@ -188,23 +184,23 @@ Map<String, dynamic> _$$FullCommentViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$FullCommentReplyViewImpl _$$FullCommentReplyViewImplFromJson(
+_$_FullCommentReplyView _$$_FullCommentReplyViewFromJson(
         Map<String, dynamic> json) =>
-    _$FullCommentReplyViewImpl(
+    _$_FullCommentReplyView(
       commentReplyView: CommentReplyView.fromJson(
           json['comment_reply_view'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$FullCommentReplyViewImplToJson(
-        _$FullCommentReplyViewImpl instance) =>
+Map<String, dynamic> _$$_FullCommentReplyViewToJson(
+        _$_FullCommentReplyView instance) =>
     <String, dynamic>{
       'comment_reply_view': instance.commentReplyView.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$FullSiteViewImpl _$$FullSiteViewImplFromJson(Map<String, dynamic> json) =>
-    _$FullSiteViewImpl(
+_$_FullSiteView _$$_FullSiteViewFromJson(Map<String, dynamic> json) =>
+    _$_FullSiteView(
       siteView: json['site_view'] == null
           ? null
           : SiteView.fromJson(json['site_view'] as Map<String, dynamic>),
@@ -226,7 +222,7 @@ _$FullSiteViewImpl _$$FullSiteViewImplFromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
-Map<String, dynamic> _$$FullSiteViewImplToJson(_$FullSiteViewImpl instance) =>
+Map<String, dynamic> _$$_FullSiteViewToJson(_$_FullSiteView instance) =>
     <String, dynamic>{
       'site_view': instance.siteView?.toJson(),
       'admins': instance.admins.map((e) => e.toJson()).toList(),
@@ -238,8 +234,7 @@ Map<String, dynamic> _$$FullSiteViewImplToJson(_$FullSiteViewImpl instance) =>
       'taglines': instance.taglines.map((e) => e.toJson()).toList(),
     };
 
-_$TaglineImpl _$$TaglineImplFromJson(Map<String, dynamic> json) =>
-    _$TaglineImpl(
+_$_Tagline _$$_TaglineFromJson(Map<String, dynamic> json) => _$_Tagline(
       id: json['id'] as int,
       localSiteId: json['local_site_id'] as int,
       content: json['content'] as String,
@@ -249,7 +244,7 @@ _$TaglineImpl _$$TaglineImplFromJson(Map<String, dynamic> json) =>
           json['updated'], const ForceUtcDateTime().fromJson),
     );
 
-Map<String, dynamic> _$$TaglineImplToJson(_$TaglineImpl instance) =>
+Map<String, dynamic> _$$_TaglineToJson(_$_Tagline instance) =>
     <String, dynamic>{
       'id': instance.id,
       'local_site_id': instance.localSiteId,
@@ -272,8 +267,8 @@ Json? _$JsonConverterToJson<Json, Value>(
 ) =>
     value == null ? null : toJson(value);
 
-_$MyUserInfoImpl _$$MyUserInfoImplFromJson(Map<String, dynamic> json) =>
-    _$MyUserInfoImpl(
+_$_MyUserInfo _$$_MyUserInfoFromJson(Map<String, dynamic> json) =>
+    _$_MyUserInfo(
       localUserView: LocalUserSettingsView.fromJson(
           json['local_user_view'] as Map<String, dynamic>),
       follows: (json['follows'] as List<dynamic>)
@@ -292,7 +287,7 @@ _$MyUserInfoImpl _$$MyUserInfoImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$MyUserInfoImplToJson(_$MyUserInfoImpl instance) =>
+Map<String, dynamic> _$$_MyUserInfoToJson(_$_MyUserInfo instance) =>
     <String, dynamic>{
       'local_user_view': instance.localUserView.toJson(),
       'follows': instance.follows.map((e) => e.toJson()).toList(),
@@ -303,9 +298,9 @@ Map<String, dynamic> _$$MyUserInfoImplToJson(_$MyUserInfoImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$FederatedInstancesImpl _$$FederatedInstancesImplFromJson(
+_$_FederatedInstances _$$_FederatedInstancesFromJson(
         Map<String, dynamic> json) =>
-    _$FederatedInstancesImpl(
+    _$_FederatedInstances(
       linked:
           (json['linked'] as List<dynamic>).map((e) => e as String).toList(),
       allowed:
@@ -315,8 +310,8 @@ _$FederatedInstancesImpl _$$FederatedInstancesImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$FederatedInstancesImplToJson(
-        _$FederatedInstancesImpl instance) =>
+Map<String, dynamic> _$$_FederatedInstancesToJson(
+        _$_FederatedInstances instance) =>
     <String, dynamic>{
       'linked': instance.linked,
       'allowed': instance.allowed,
@@ -324,22 +319,21 @@ Map<String, dynamic> _$$FederatedInstancesImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$CaptchaImpl _$$CaptchaImplFromJson(Map<String, dynamic> json) =>
-    _$CaptchaImpl(
+_$_Captcha _$$_CaptchaFromJson(Map<String, dynamic> json) => _$_Captcha(
       png: json['png'] as String,
       wav: json['wav'] as String?,
       uuid: json['uuid'] as String,
     );
 
-Map<String, dynamic> _$$CaptchaImplToJson(_$CaptchaImpl instance) =>
+Map<String, dynamic> _$$_CaptchaToJson(_$_Captcha instance) =>
     <String, dynamic>{
       'png': instance.png,
       'wav': instance.wav,
       'uuid': instance.uuid,
     };
 
-_$FullPersonViewImpl _$$FullPersonViewImplFromJson(Map<String, dynamic> json) =>
-    _$FullPersonViewImpl(
+_$_FullPersonView _$$_FullPersonViewFromJson(Map<String, dynamic> json) =>
+    _$_FullPersonView(
       personView:
           PersonViewSafe.fromJson(json['person_view'] as Map<String, dynamic>),
       moderates: (json['moderates'] as List<dynamic>)
@@ -355,8 +349,7 @@ _$FullPersonViewImpl _$$FullPersonViewImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$FullPersonViewImplToJson(
-        _$FullPersonViewImpl instance) =>
+Map<String, dynamic> _$$_FullPersonViewToJson(_$_FullPersonView instance) =>
     <String, dynamic>{
       'person_view': instance.personView.toJson(),
       'moderates': instance.moderates.map((e) => e.toJson()).toList(),
@@ -365,41 +358,41 @@ Map<String, dynamic> _$$FullPersonViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$BannedCommunityUserImpl _$$BannedCommunityUserImplFromJson(
+_$_BannedCommunityUser _$$_BannedCommunityUserFromJson(
         Map<String, dynamic> json) =>
-    _$BannedCommunityUserImpl(
+    _$_BannedCommunityUser(
       personView:
           PersonViewSafe.fromJson(json['person_view'] as Map<String, dynamic>),
       banned: json['banned'] as bool,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$BannedCommunityUserImplToJson(
-        _$BannedCommunityUserImpl instance) =>
+Map<String, dynamic> _$$_BannedCommunityUserToJson(
+        _$_BannedCommunityUser instance) =>
     <String, dynamic>{
       'person_view': instance.personView.toJson(),
       'banned': instance.banned,
       'instance_host': instance.instanceHost,
     };
 
-_$BannedPersonImpl _$$BannedPersonImplFromJson(Map<String, dynamic> json) =>
-    _$BannedPersonImpl(
+_$_BannedPerson _$$_BannedPersonFromJson(Map<String, dynamic> json) =>
+    _$_BannedPerson(
       personView:
           PersonViewSafe.fromJson(json['person_view'] as Map<String, dynamic>),
       banned: json['banned'] as bool,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$BannedPersonImplToJson(_$BannedPersonImpl instance) =>
+Map<String, dynamic> _$$_BannedPersonToJson(_$_BannedPerson instance) =>
     <String, dynamic>{
       'person_view': instance.personView.toJson(),
       'banned': instance.banned,
       'instance_host': instance.instanceHost,
     };
 
-_$ResolveObjectResponseImpl _$$ResolveObjectResponseImplFromJson(
+_$_ResolveObjectResponse _$$_ResolveObjectResponseFromJson(
         Map<String, dynamic> json) =>
-    _$ResolveObjectResponseImpl(
+    _$_ResolveObjectResponse(
       comment: json['comment'] == null
           ? null
           : CommentView.fromJson(json['comment'] as Map<String, dynamic>),
@@ -415,8 +408,8 @@ _$ResolveObjectResponseImpl _$$ResolveObjectResponseImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ResolveObjectResponseImplToJson(
-        _$ResolveObjectResponseImpl instance) =>
+Map<String, dynamic> _$$_ResolveObjectResponseToJson(
+        _$_ResolveObjectResponse instance) =>
     <String, dynamic>{
       'comment': instance.comment?.toJson(),
       'post': instance.post?.toJson(),
@@ -425,8 +418,8 @@ Map<String, dynamic> _$$ResolveObjectResponseImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$SiteMetadataImpl _$$SiteMetadataImplFromJson(Map<String, dynamic> json) =>
-    _$SiteMetadataImpl(
+_$_SiteMetadata _$$_SiteMetadataFromJson(Map<String, dynamic> json) =>
+    _$_SiteMetadata(
       title: json['title'] as String?,
       description: json['description'] as String?,
       image: json['image'] as String?,
@@ -434,7 +427,7 @@ _$SiteMetadataImpl _$$SiteMetadataImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$SiteMetadataImplToJson(_$SiteMetadataImpl instance) =>
+Map<String, dynamic> _$$_SiteMetadataToJson(_$_SiteMetadata instance) =>
     <String, dynamic>{
       'title': instance.title,
       'description': instance.description,
@@ -443,47 +436,45 @@ Map<String, dynamic> _$$SiteMetadataImplToJson(_$SiteMetadataImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$BlockedPersonImpl _$$BlockedPersonImplFromJson(Map<String, dynamic> json) =>
-    _$BlockedPersonImpl(
+_$_BlockedPerson _$$_BlockedPersonFromJson(Map<String, dynamic> json) =>
+    _$_BlockedPerson(
       personView:
           PersonViewSafe.fromJson(json['person_view'] as Map<String, dynamic>),
       blocked: json['blocked'] as bool,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$BlockedPersonImplToJson(_$BlockedPersonImpl instance) =>
+Map<String, dynamic> _$$_BlockedPersonToJson(_$_BlockedPerson instance) =>
     <String, dynamic>{
       'person_view': instance.personView.toJson(),
       'blocked': instance.blocked,
       'instance_host': instance.instanceHost,
     };
 
-_$BlockedCommunityImpl _$$BlockedCommunityImplFromJson(
-        Map<String, dynamic> json) =>
-    _$BlockedCommunityImpl(
+_$_BlockedCommunity _$$_BlockedCommunityFromJson(Map<String, dynamic> json) =>
+    _$_BlockedCommunity(
       communityView: CommunityView.fromJson(
           json['community_view'] as Map<String, dynamic>),
       blocked: json['blocked'] as bool,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$BlockedCommunityImplToJson(
-        _$BlockedCommunityImpl instance) =>
+Map<String, dynamic> _$$_BlockedCommunityToJson(_$_BlockedCommunity instance) =>
     <String, dynamic>{
       'community_view': instance.communityView.toJson(),
       'blocked': instance.blocked,
       'instance_host': instance.instanceHost,
     };
 
-_$ReportCountImpl _$$ReportCountImplFromJson(Map<String, dynamic> json) =>
-    _$ReportCountImpl(
+_$_ReportCount _$$_ReportCountFromJson(Map<String, dynamic> json) =>
+    _$_ReportCount(
       communityId: json['community_id'] as int?,
       commentReports: json['comment_reports'] as int,
       postReports: json['post_reports'] as int,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ReportCountImplToJson(_$ReportCountImpl instance) =>
+Map<String, dynamic> _$$_ReportCountToJson(_$_ReportCount instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'comment_reports': instance.commentReports,
@@ -491,15 +482,15 @@ Map<String, dynamic> _$$ReportCountImplToJson(_$ReportCountImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$UnreadCountImpl _$$UnreadCountImplFromJson(Map<String, dynamic> json) =>
-    _$UnreadCountImpl(
+_$_UnreadCount _$$_UnreadCountFromJson(Map<String, dynamic> json) =>
+    _$_UnreadCount(
       replies: json['replies'] as int,
       mentions: json['mentions'] as int,
       privateMessages: json['private_messages'] as int,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$UnreadCountImplToJson(_$UnreadCountImpl instance) =>
+Map<String, dynamic> _$$_UnreadCountToJson(_$_UnreadCount instance) =>
     <String, dynamic>{
       'replies': instance.replies,
       'mentions': instance.mentions,
@@ -507,18 +498,30 @@ Map<String, dynamic> _$$UnreadCountImplToJson(_$UnreadCountImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$LoginResponseImpl _$$LoginResponseImplFromJson(Map<String, dynamic> json) =>
-    _$LoginResponseImpl(
+_$_LoginResponse _$$_LoginResponseFromJson(Map<String, dynamic> json) =>
+    _$_LoginResponse(
       jwt: json['jwt'] == null ? null : Jwt.fromJson(json['jwt'] as String),
       verifyEmailSent: json['verify_email_sent'] as bool,
       registrationCreated: json['registration_created'] as bool,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$LoginResponseImplToJson(_$LoginResponseImpl instance) =>
+Map<String, dynamic> _$$_LoginResponseToJson(_$_LoginResponse instance) =>
     <String, dynamic>{
       'jwt': instance.jwt?.toJson(),
       'verify_email_sent': instance.verifyEmailSent,
       'registration_created': instance.registrationCreated,
       'instance_host': instance.instanceHost,
+    };
+
+_$_BlockInstanceResponse _$$_BlockInstanceResponseFromJson(
+        Map<String, dynamic> json) =>
+    _$_BlockInstanceResponse(
+      blocked: json['blocked'] as bool,
+    );
+
+Map<String, dynamic> _$$_BlockInstanceResponseToJson(
+        _$_BlockInstanceResponse instance) =>
+    <String, dynamic>{
+      'blocked': instance.blocked,
     };

--- a/lib/src/v3/models/source.freezed.dart
+++ b/lib/src/v3/models/source.freezed.dart
@@ -33,6 +33,8 @@ mixin _$PersonSafe {
   String? get banner => throw _privateConstructorUsedError;
   bool get deleted => throw _privateConstructorUsedError;
   String? get matrixUserId => throw _privateConstructorUsedError;
+
+  /// Removed in Lemmy 0.19
   bool? get admin => throw _privateConstructorUsedError;
   bool get botAccount => throw _privateConstructorUsedError;
   DateTime? get banExpires => throw _privateConstructorUsedError;
@@ -175,11 +177,11 @@ class _$PersonSafeCopyWithImpl<$Res, $Val extends PersonSafe>
 }
 
 /// @nodoc
-abstract class _$$PersonSafeImplCopyWith<$Res>
+abstract class _$$_PersonSafeCopyWith<$Res>
     implements $PersonSafeCopyWith<$Res> {
-  factory _$$PersonSafeImplCopyWith(
-          _$PersonSafeImpl value, $Res Function(_$PersonSafeImpl) then) =
-      __$$PersonSafeImplCopyWithImpl<$Res>;
+  factory _$$_PersonSafeCopyWith(
+          _$_PersonSafe value, $Res Function(_$_PersonSafe) then) =
+      __$$_PersonSafeCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -203,11 +205,11 @@ abstract class _$$PersonSafeImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$PersonSafeImplCopyWithImpl<$Res>
-    extends _$PersonSafeCopyWithImpl<$Res, _$PersonSafeImpl>
-    implements _$$PersonSafeImplCopyWith<$Res> {
-  __$$PersonSafeImplCopyWithImpl(
-      _$PersonSafeImpl _value, $Res Function(_$PersonSafeImpl) _then)
+class __$$_PersonSafeCopyWithImpl<$Res>
+    extends _$PersonSafeCopyWithImpl<$Res, _$_PersonSafe>
+    implements _$$_PersonSafeCopyWith<$Res> {
+  __$$_PersonSafeCopyWithImpl(
+      _$_PersonSafe _value, $Res Function(_$_PersonSafe) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -231,7 +233,7 @@ class __$$PersonSafeImplCopyWithImpl<$Res>
     Object? banExpires = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$PersonSafeImpl(
+    return _then(_$_PersonSafe(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -307,8 +309,8 @@ class __$$PersonSafeImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$PersonSafeImpl extends _PersonSafe {
-  const _$PersonSafeImpl(
+class _$_PersonSafe extends _PersonSafe {
+  const _$_PersonSafe(
       {required this.id,
       required this.name,
       this.displayName,
@@ -328,8 +330,8 @@ class _$PersonSafeImpl extends _PersonSafe {
       required this.instanceHost})
       : super._();
 
-  factory _$PersonSafeImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PersonSafeImplFromJson(json);
+  factory _$_PersonSafe.fromJson(Map<String, dynamic> json) =>
+      _$$_PersonSafeFromJson(json);
 
   @override
   final int id;
@@ -357,6 +359,8 @@ class _$PersonSafeImpl extends _PersonSafe {
   final bool deleted;
   @override
   final String? matrixUserId;
+
+  /// Removed in Lemmy 0.19
   @override
   final bool? admin;
   @override
@@ -375,7 +379,7 @@ class _$PersonSafeImpl extends _PersonSafe {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PersonSafeImpl &&
+            other is _$_PersonSafe &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.displayName, displayName) ||
@@ -426,12 +430,12 @@ class _$PersonSafeImpl extends _PersonSafe {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PersonSafeImplCopyWith<_$PersonSafeImpl> get copyWith =>
-      __$$PersonSafeImplCopyWithImpl<_$PersonSafeImpl>(this, _$identity);
+  _$$_PersonSafeCopyWith<_$_PersonSafe> get copyWith =>
+      __$$_PersonSafeCopyWithImpl<_$_PersonSafe>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PersonSafeImplToJson(
+    return _$$_PersonSafeToJson(
       this,
     );
   }
@@ -455,11 +459,11 @@ abstract class _PersonSafe extends PersonSafe {
       final bool? admin,
       required final bool botAccount,
       final DateTime? banExpires,
-      required final String instanceHost}) = _$PersonSafeImpl;
+      required final String instanceHost}) = _$_PersonSafe;
   const _PersonSafe._() : super._();
 
   factory _PersonSafe.fromJson(Map<String, dynamic> json) =
-      _$PersonSafeImpl.fromJson;
+      _$_PersonSafe.fromJson;
 
   @override
   int get id;
@@ -488,6 +492,8 @@ abstract class _PersonSafe extends PersonSafe {
   @override
   String? get matrixUserId;
   @override
+
+  /// Removed in Lemmy 0.19
   bool? get admin;
   @override
   bool get botAccount;
@@ -497,7 +503,7 @@ abstract class _PersonSafe extends PersonSafe {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$PersonSafeImplCopyWith<_$PersonSafeImpl> get copyWith =>
+  _$$_PersonSafeCopyWith<_$_PersonSafe> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -662,11 +668,11 @@ class _$LocalUserSettingsCopyWithImpl<$Res, $Val extends LocalUserSettings>
 }
 
 /// @nodoc
-abstract class _$$LocalUserSettingsImplCopyWith<$Res>
+abstract class _$$_LocalUserSettingsCopyWith<$Res>
     implements $LocalUserSettingsCopyWith<$Res> {
-  factory _$$LocalUserSettingsImplCopyWith(_$LocalUserSettingsImpl value,
-          $Res Function(_$LocalUserSettingsImpl) then) =
-      __$$LocalUserSettingsImplCopyWithImpl<$Res>;
+  factory _$$_LocalUserSettingsCopyWith(_$_LocalUserSettings value,
+          $Res Function(_$_LocalUserSettings) then) =
+      __$$_LocalUserSettingsCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -690,11 +696,11 @@ abstract class _$$LocalUserSettingsImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$LocalUserSettingsImplCopyWithImpl<$Res>
-    extends _$LocalUserSettingsCopyWithImpl<$Res, _$LocalUserSettingsImpl>
-    implements _$$LocalUserSettingsImplCopyWith<$Res> {
-  __$$LocalUserSettingsImplCopyWithImpl(_$LocalUserSettingsImpl _value,
-      $Res Function(_$LocalUserSettingsImpl) _then)
+class __$$_LocalUserSettingsCopyWithImpl<$Res>
+    extends _$LocalUserSettingsCopyWithImpl<$Res, _$_LocalUserSettings>
+    implements _$$_LocalUserSettingsCopyWith<$Res> {
+  __$$_LocalUserSettingsCopyWithImpl(
+      _$_LocalUserSettings _value, $Res Function(_$_LocalUserSettings) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -718,7 +724,7 @@ class __$$LocalUserSettingsImplCopyWithImpl<$Res>
     Object? acceptedApplication = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$LocalUserSettingsImpl(
+    return _then(_$_LocalUserSettings(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -794,8 +800,8 @@ class __$$LocalUserSettingsImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$LocalUserSettingsImpl extends _LocalUserSettings {
-  const _$LocalUserSettingsImpl(
+class _$_LocalUserSettings extends _LocalUserSettings {
+  const _$_LocalUserSettings(
       {required this.id,
       required this.personId,
       this.email,
@@ -815,8 +821,8 @@ class _$LocalUserSettingsImpl extends _LocalUserSettings {
       required this.instanceHost})
       : super._();
 
-  factory _$LocalUserSettingsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$LocalUserSettingsImplFromJson(json);
+  factory _$_LocalUserSettings.fromJson(Map<String, dynamic> json) =>
+      _$$_LocalUserSettingsFromJson(json);
 
   @override
   final int id;
@@ -862,7 +868,7 @@ class _$LocalUserSettingsImpl extends _LocalUserSettings {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$LocalUserSettingsImpl &&
+            other is _$_LocalUserSettings &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
@@ -922,13 +928,13 @@ class _$LocalUserSettingsImpl extends _LocalUserSettings {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$LocalUserSettingsImplCopyWith<_$LocalUserSettingsImpl> get copyWith =>
-      __$$LocalUserSettingsImplCopyWithImpl<_$LocalUserSettingsImpl>(
+  _$$_LocalUserSettingsCopyWith<_$_LocalUserSettings> get copyWith =>
+      __$$_LocalUserSettingsCopyWithImpl<_$_LocalUserSettings>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$LocalUserSettingsImplToJson(
+    return _$$_LocalUserSettingsToJson(
       this,
     );
   }
@@ -952,11 +958,11 @@ abstract class _LocalUserSettings extends LocalUserSettings {
       required final bool showNewPostNotifs,
       required final bool emailVerified,
       required final bool acceptedApplication,
-      required final String instanceHost}) = _$LocalUserSettingsImpl;
+      required final String instanceHost}) = _$_LocalUserSettings;
   const _LocalUserSettings._() : super._();
 
   factory _LocalUserSettings.fromJson(Map<String, dynamic> json) =
-      _$LocalUserSettingsImpl.fromJson;
+      _$_LocalUserSettings.fromJson;
 
   @override
   int get id;
@@ -994,7 +1000,7 @@ abstract class _LocalUserSettings extends LocalUserSettings {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$LocalUserSettingsImplCopyWith<_$LocalUserSettingsImpl> get copyWith =>
+  _$$_LocalUserSettingsCopyWith<_$_LocalUserSettings> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1136,10 +1142,9 @@ class _$SiteCopyWithImpl<$Res, $Val extends Site>
 }
 
 /// @nodoc
-abstract class _$$SiteImplCopyWith<$Res> implements $SiteCopyWith<$Res> {
-  factory _$$SiteImplCopyWith(
-          _$SiteImpl value, $Res Function(_$SiteImpl) then) =
-      __$$SiteImplCopyWithImpl<$Res>;
+abstract class _$$_SiteCopyWith<$Res> implements $SiteCopyWith<$Res> {
+  factory _$$_SiteCopyWith(_$_Site value, $Res Function(_$_Site) then) =
+      __$$_SiteCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1160,10 +1165,9 @@ abstract class _$$SiteImplCopyWith<$Res> implements $SiteCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$SiteImplCopyWithImpl<$Res>
-    extends _$SiteCopyWithImpl<$Res, _$SiteImpl>
-    implements _$$SiteImplCopyWith<$Res> {
-  __$$SiteImplCopyWithImpl(_$SiteImpl _value, $Res Function(_$SiteImpl) _then)
+class __$$_SiteCopyWithImpl<$Res> extends _$SiteCopyWithImpl<$Res, _$_Site>
+    implements _$$_SiteCopyWith<$Res> {
+  __$$_SiteCopyWithImpl(_$_Site _value, $Res Function(_$_Site) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1184,7 +1188,7 @@ class __$$SiteImplCopyWithImpl<$Res>
     Object? instanceId = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$SiteImpl(
+    return _then(_$_Site(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -1248,8 +1252,8 @@ class __$$SiteImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$SiteImpl extends _Site {
-  const _$SiteImpl(
+class _$_Site extends _Site {
+  const _$_Site(
       {required this.id,
       required this.name,
       this.sidebar,
@@ -1266,8 +1270,7 @@ class _$SiteImpl extends _Site {
       required this.instanceHost})
       : super._();
 
-  factory _$SiteImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SiteImplFromJson(json);
+  factory _$_Site.fromJson(Map<String, dynamic> json) => _$$_SiteFromJson(json);
 
   @override
   final int id;
@@ -1307,7 +1310,7 @@ class _$SiteImpl extends _Site {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SiteImpl &&
+            other is _$_Site &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.sidebar, sidebar) || other.sidebar == sidebar) &&
@@ -1353,12 +1356,12 @@ class _$SiteImpl extends _Site {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SiteImplCopyWith<_$SiteImpl> get copyWith =>
-      __$$SiteImplCopyWithImpl<_$SiteImpl>(this, _$identity);
+  _$$_SiteCopyWith<_$_Site> get copyWith =>
+      __$$_SiteCopyWithImpl<_$_Site>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$SiteImplToJson(
+    return _$$_SiteToJson(
       this,
     );
   }
@@ -1379,10 +1382,10 @@ abstract class _Site extends Site {
       required final String inboxUrl,
       required final String publicKey,
       required final int instanceId,
-      required final String instanceHost}) = _$SiteImpl;
+      required final String instanceHost}) = _$_Site;
   const _Site._() : super._();
 
-  factory _Site.fromJson(Map<String, dynamic> json) = _$SiteImpl.fromJson;
+  factory _Site.fromJson(Map<String, dynamic> json) = _$_Site.fromJson;
 
   @override
   int get id;
@@ -1414,8 +1417,7 @@ abstract class _Site extends Site {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$SiteImplCopyWith<_$SiteImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_SiteCopyWith<_$_Site> get copyWith => throw _privateConstructorUsedError;
 }
 
 LocalSite _$LocalSiteFromJson(Map<String, dynamic> json) {
@@ -1628,11 +1630,10 @@ class _$LocalSiteCopyWithImpl<$Res, $Val extends LocalSite>
 }
 
 /// @nodoc
-abstract class _$$LocalSiteImplCopyWith<$Res>
-    implements $LocalSiteCopyWith<$Res> {
-  factory _$$LocalSiteImplCopyWith(
-          _$LocalSiteImpl value, $Res Function(_$LocalSiteImpl) then) =
-      __$$LocalSiteImplCopyWithImpl<$Res>;
+abstract class _$$_LocalSiteCopyWith<$Res> implements $LocalSiteCopyWith<$Res> {
+  factory _$$_LocalSiteCopyWith(
+          _$_LocalSite value, $Res Function(_$_LocalSite) then) =
+      __$$_LocalSiteCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1663,11 +1664,11 @@ abstract class _$$LocalSiteImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$LocalSiteImplCopyWithImpl<$Res>
-    extends _$LocalSiteCopyWithImpl<$Res, _$LocalSiteImpl>
-    implements _$$LocalSiteImplCopyWith<$Res> {
-  __$$LocalSiteImplCopyWithImpl(
-      _$LocalSiteImpl _value, $Res Function(_$LocalSiteImpl) _then)
+class __$$_LocalSiteCopyWithImpl<$Res>
+    extends _$LocalSiteCopyWithImpl<$Res, _$_LocalSite>
+    implements _$$_LocalSiteCopyWith<$Res> {
+  __$$_LocalSiteCopyWithImpl(
+      _$_LocalSite _value, $Res Function(_$_LocalSite) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1698,7 +1699,7 @@ class __$$LocalSiteImplCopyWithImpl<$Res>
     Object? registrationMode = null,
     Object? reportsEmailAdmins = null,
   }) {
-    return _then(_$LocalSiteImpl(
+    return _then(_$_LocalSite(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -1802,8 +1803,8 @@ class __$$LocalSiteImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$LocalSiteImpl extends _LocalSite {
-  const _$LocalSiteImpl(
+class _$_LocalSite extends _LocalSite {
+  const _$_LocalSite(
       {required this.id,
       required this.siteId,
       required this.siteSetup,
@@ -1830,8 +1831,8 @@ class _$LocalSiteImpl extends _LocalSite {
       required this.reportsEmailAdmins})
       : super._();
 
-  factory _$LocalSiteImpl.fromJson(Map<String, dynamic> json) =>
-      _$$LocalSiteImplFromJson(json);
+  factory _$_LocalSite.fromJson(Map<String, dynamic> json) =>
+      _$$_LocalSiteFromJson(json);
 
   @override
   final int id;
@@ -1891,7 +1892,7 @@ class _$LocalSiteImpl extends _LocalSite {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$LocalSiteImpl &&
+            other is _$_LocalSite &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.siteId, siteId) || other.siteId == siteId) &&
             (identical(other.siteSetup, siteSetup) ||
@@ -1975,12 +1976,12 @@ class _$LocalSiteImpl extends _LocalSite {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$LocalSiteImplCopyWith<_$LocalSiteImpl> get copyWith =>
-      __$$LocalSiteImplCopyWithImpl<_$LocalSiteImpl>(this, _$identity);
+  _$$_LocalSiteCopyWith<_$_LocalSite> get copyWith =>
+      __$$_LocalSiteCopyWithImpl<_$_LocalSite>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$LocalSiteImplToJson(
+    return _$$_LocalSiteToJson(
       this,
     );
   }
@@ -2011,11 +2012,11 @@ abstract class _LocalSite extends LocalSite {
       required final String published,
       final DateTime? updated,
       required final String registrationMode,
-      required final bool reportsEmailAdmins}) = _$LocalSiteImpl;
+      required final bool reportsEmailAdmins}) = _$_LocalSite;
   const _LocalSite._() : super._();
 
   factory _LocalSite.fromJson(Map<String, dynamic> json) =
-      _$LocalSiteImpl.fromJson;
+      _$_LocalSite.fromJson;
 
   @override
   int get id;
@@ -2067,7 +2068,7 @@ abstract class _LocalSite extends LocalSite {
   bool get reportsEmailAdmins;
   @override
   @JsonKey(ignore: true)
-  _$$LocalSiteImplCopyWith<_$LocalSiteImpl> get copyWith =>
+  _$$_LocalSiteCopyWith<_$_LocalSite> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2190,11 +2191,11 @@ class _$PrivateMessageCopyWithImpl<$Res, $Val extends PrivateMessage>
 }
 
 /// @nodoc
-abstract class _$$PrivateMessageImplCopyWith<$Res>
+abstract class _$$_PrivateMessageCopyWith<$Res>
     implements $PrivateMessageCopyWith<$Res> {
-  factory _$$PrivateMessageImplCopyWith(_$PrivateMessageImpl value,
-          $Res Function(_$PrivateMessageImpl) then) =
-      __$$PrivateMessageImplCopyWithImpl<$Res>;
+  factory _$$_PrivateMessageCopyWith(
+          _$_PrivateMessage value, $Res Function(_$_PrivateMessage) then) =
+      __$$_PrivateMessageCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2212,11 +2213,11 @@ abstract class _$$PrivateMessageImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$PrivateMessageImplCopyWithImpl<$Res>
-    extends _$PrivateMessageCopyWithImpl<$Res, _$PrivateMessageImpl>
-    implements _$$PrivateMessageImplCopyWith<$Res> {
-  __$$PrivateMessageImplCopyWithImpl(
-      _$PrivateMessageImpl _value, $Res Function(_$PrivateMessageImpl) _then)
+class __$$_PrivateMessageCopyWithImpl<$Res>
+    extends _$PrivateMessageCopyWithImpl<$Res, _$_PrivateMessage>
+    implements _$$_PrivateMessageCopyWith<$Res> {
+  __$$_PrivateMessageCopyWithImpl(
+      _$_PrivateMessage _value, $Res Function(_$_PrivateMessage) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2234,7 +2235,7 @@ class __$$PrivateMessageImplCopyWithImpl<$Res>
     Object? local = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$PrivateMessageImpl(
+    return _then(_$_PrivateMessage(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -2286,8 +2287,8 @@ class __$$PrivateMessageImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$PrivateMessageImpl extends _PrivateMessage {
-  const _$PrivateMessageImpl(
+class _$_PrivateMessage extends _PrivateMessage {
+  const _$_PrivateMessage(
       {required this.id,
       required this.creatorId,
       required this.recipientId,
@@ -2301,8 +2302,8 @@ class _$PrivateMessageImpl extends _PrivateMessage {
       required this.instanceHost})
       : super._();
 
-  factory _$PrivateMessageImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PrivateMessageImplFromJson(json);
+  factory _$_PrivateMessage.fromJson(Map<String, dynamic> json) =>
+      _$$_PrivateMessageFromJson(json);
 
   @override
   final int id;
@@ -2336,7 +2337,7 @@ class _$PrivateMessageImpl extends _PrivateMessage {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PrivateMessageImpl &&
+            other is _$_PrivateMessage &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -2362,13 +2363,12 @@ class _$PrivateMessageImpl extends _PrivateMessage {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PrivateMessageImplCopyWith<_$PrivateMessageImpl> get copyWith =>
-      __$$PrivateMessageImplCopyWithImpl<_$PrivateMessageImpl>(
-          this, _$identity);
+  _$$_PrivateMessageCopyWith<_$_PrivateMessage> get copyWith =>
+      __$$_PrivateMessageCopyWithImpl<_$_PrivateMessage>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PrivateMessageImplToJson(
+    return _$$_PrivateMessageToJson(
       this,
     );
   }
@@ -2386,11 +2386,11 @@ abstract class _PrivateMessage extends PrivateMessage {
       final DateTime? updated,
       required final String apId,
       required final bool local,
-      required final String instanceHost}) = _$PrivateMessageImpl;
+      required final String instanceHost}) = _$_PrivateMessage;
   const _PrivateMessage._() : super._();
 
   factory _PrivateMessage.fromJson(Map<String, dynamic> json) =
-      _$PrivateMessageImpl.fromJson;
+      _$_PrivateMessage.fromJson;
 
   @override
   int get id;
@@ -2416,7 +2416,7 @@ abstract class _PrivateMessage extends PrivateMessage {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$PrivateMessageImplCopyWith<_$PrivateMessageImpl> get copyWith =>
+  _$$_PrivateMessageCopyWith<_$_PrivateMessage> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2546,11 +2546,11 @@ class _$PostReportCopyWithImpl<$Res, $Val extends PostReport>
 }
 
 /// @nodoc
-abstract class _$$PostReportImplCopyWith<$Res>
+abstract class _$$_PostReportCopyWith<$Res>
     implements $PostReportCopyWith<$Res> {
-  factory _$$PostReportImplCopyWith(
-          _$PostReportImpl value, $Res Function(_$PostReportImpl) then) =
-      __$$PostReportImplCopyWithImpl<$Res>;
+  factory _$$_PostReportCopyWith(
+          _$_PostReport value, $Res Function(_$_PostReport) then) =
+      __$$_PostReportCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2569,11 +2569,11 @@ abstract class _$$PostReportImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$PostReportImplCopyWithImpl<$Res>
-    extends _$PostReportCopyWithImpl<$Res, _$PostReportImpl>
-    implements _$$PostReportImplCopyWith<$Res> {
-  __$$PostReportImplCopyWithImpl(
-      _$PostReportImpl _value, $Res Function(_$PostReportImpl) _then)
+class __$$_PostReportCopyWithImpl<$Res>
+    extends _$PostReportCopyWithImpl<$Res, _$_PostReport>
+    implements _$$_PostReportCopyWith<$Res> {
+  __$$_PostReportCopyWithImpl(
+      _$_PostReport _value, $Res Function(_$_PostReport) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2592,7 +2592,7 @@ class __$$PostReportImplCopyWithImpl<$Res>
     Object? updated = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$PostReportImpl(
+    return _then(_$_PostReport(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -2648,8 +2648,8 @@ class __$$PostReportImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$PostReportImpl extends _PostReport {
-  const _$PostReportImpl(
+class _$_PostReport extends _PostReport {
+  const _$_PostReport(
       {required this.id,
       required this.creatorId,
       required this.postId,
@@ -2664,8 +2664,8 @@ class _$PostReportImpl extends _PostReport {
       required this.instanceHost})
       : super._();
 
-  factory _$PostReportImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PostReportImplFromJson(json);
+  factory _$_PostReport.fromJson(Map<String, dynamic> json) =>
+      _$$_PostReportFromJson(json);
 
   @override
   final int id;
@@ -2701,7 +2701,7 @@ class _$PostReportImpl extends _PostReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PostReportImpl &&
+            other is _$_PostReport &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -2744,12 +2744,12 @@ class _$PostReportImpl extends _PostReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PostReportImplCopyWith<_$PostReportImpl> get copyWith =>
-      __$$PostReportImplCopyWithImpl<_$PostReportImpl>(this, _$identity);
+  _$$_PostReportCopyWith<_$_PostReport> get copyWith =>
+      __$$_PostReportCopyWithImpl<_$_PostReport>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PostReportImplToJson(
+    return _$$_PostReportToJson(
       this,
     );
   }
@@ -2768,11 +2768,11 @@ abstract class _PostReport extends PostReport {
       final int? resolverId,
       required final DateTime published,
       final DateTime? updated,
-      required final String instanceHost}) = _$PostReportImpl;
+      required final String instanceHost}) = _$_PostReport;
   const _PostReport._() : super._();
 
   factory _PostReport.fromJson(Map<String, dynamic> json) =
-      _$PostReportImpl.fromJson;
+      _$_PostReport.fromJson;
 
   @override
   int get id;
@@ -2800,7 +2800,7 @@ abstract class _PostReport extends PostReport {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$PostReportImplCopyWith<_$PostReportImpl> get copyWith =>
+  _$$_PostReportCopyWith<_$_PostReport> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2991,10 +2991,9 @@ class _$PostCopyWithImpl<$Res, $Val extends Post>
 }
 
 /// @nodoc
-abstract class _$$PostImplCopyWith<$Res> implements $PostCopyWith<$Res> {
-  factory _$$PostImplCopyWith(
-          _$PostImpl value, $Res Function(_$PostImpl) then) =
-      __$$PostImplCopyWithImpl<$Res>;
+abstract class _$$_PostCopyWith<$Res> implements $PostCopyWith<$Res> {
+  factory _$$_PostCopyWith(_$_Post value, $Res Function(_$_Post) then) =
+      __$$_PostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3022,10 +3021,9 @@ abstract class _$$PostImplCopyWith<$Res> implements $PostCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$PostImplCopyWithImpl<$Res>
-    extends _$PostCopyWithImpl<$Res, _$PostImpl>
-    implements _$$PostImplCopyWith<$Res> {
-  __$$PostImplCopyWithImpl(_$PostImpl _value, $Res Function(_$PostImpl) _then)
+class __$$_PostCopyWithImpl<$Res> extends _$PostCopyWithImpl<$Res, _$_Post>
+    implements _$$_PostCopyWith<$Res> {
+  __$$_PostCopyWithImpl(_$_Post _value, $Res Function(_$_Post) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3053,7 +3051,7 @@ class __$$PostImplCopyWithImpl<$Res>
     Object? local = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$PostImpl(
+    return _then(_$_Post(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -3145,8 +3143,8 @@ class __$$PostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$PostImpl extends _Post {
-  const _$PostImpl(
+class _$_Post extends _Post {
+  const _$_Post(
       {required this.id,
       required this.name,
       this.url,
@@ -3170,8 +3168,7 @@ class _$PostImpl extends _Post {
       required this.instanceHost})
       : super._();
 
-  factory _$PostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PostImplFromJson(json);
+  factory _$_Post.fromJson(Map<String, dynamic> json) => _$$_PostFromJson(json);
 
   @override
   final int id;
@@ -3225,7 +3222,7 @@ class _$PostImpl extends _Post {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PostImpl &&
+            other is _$_Post &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.url, url) || other.url == url) &&
@@ -3289,12 +3286,12 @@ class _$PostImpl extends _Post {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PostImplCopyWith<_$PostImpl> get copyWith =>
-      __$$PostImplCopyWithImpl<_$PostImpl>(this, _$identity);
+  _$$_PostCopyWith<_$_Post> get copyWith =>
+      __$$_PostCopyWithImpl<_$_Post>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PostImplToJson(
+    return _$$_PostToJson(
       this,
     );
   }
@@ -3322,10 +3319,10 @@ abstract class _Post extends Post {
       final String? thumbnailUrl,
       required final String apId,
       required final bool local,
-      required final String instanceHost}) = _$PostImpl;
+      required final String instanceHost}) = _$_Post;
   const _Post._() : super._();
 
-  factory _Post.fromJson(Map<String, dynamic> json) = _$PostImpl.fromJson;
+  factory _Post.fromJson(Map<String, dynamic> json) = _$_Post.fromJson;
 
   @override
   int get id;
@@ -3371,8 +3368,7 @@ abstract class _Post extends Post {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$PostImplCopyWith<_$PostImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$_PostCopyWith<_$_Post> get copyWith => throw _privateConstructorUsedError;
 }
 
 PasswordResetRequest _$PasswordResetRequestFromJson(Map<String, dynamic> json) {
@@ -3453,11 +3449,11 @@ class _$PasswordResetRequestCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$PasswordResetRequestImplCopyWith<$Res>
+abstract class _$$_PasswordResetRequestCopyWith<$Res>
     implements $PasswordResetRequestCopyWith<$Res> {
-  factory _$$PasswordResetRequestImplCopyWith(_$PasswordResetRequestImpl value,
-          $Res Function(_$PasswordResetRequestImpl) then) =
-      __$$PasswordResetRequestImplCopyWithImpl<$Res>;
+  factory _$$_PasswordResetRequestCopyWith(_$_PasswordResetRequest value,
+          $Res Function(_$_PasswordResetRequest) then) =
+      __$$_PasswordResetRequestCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3469,11 +3465,11 @@ abstract class _$$PasswordResetRequestImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$PasswordResetRequestImplCopyWithImpl<$Res>
-    extends _$PasswordResetRequestCopyWithImpl<$Res, _$PasswordResetRequestImpl>
-    implements _$$PasswordResetRequestImplCopyWith<$Res> {
-  __$$PasswordResetRequestImplCopyWithImpl(_$PasswordResetRequestImpl _value,
-      $Res Function(_$PasswordResetRequestImpl) _then)
+class __$$_PasswordResetRequestCopyWithImpl<$Res>
+    extends _$PasswordResetRequestCopyWithImpl<$Res, _$_PasswordResetRequest>
+    implements _$$_PasswordResetRequestCopyWith<$Res> {
+  __$$_PasswordResetRequestCopyWithImpl(_$_PasswordResetRequest _value,
+      $Res Function(_$_PasswordResetRequest) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3485,7 +3481,7 @@ class __$$PasswordResetRequestImplCopyWithImpl<$Res>
     Object? published = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$PasswordResetRequestImpl(
+    return _then(_$_PasswordResetRequest(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -3513,8 +3509,8 @@ class __$$PasswordResetRequestImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$PasswordResetRequestImpl extends _PasswordResetRequest {
-  const _$PasswordResetRequestImpl(
+class _$_PasswordResetRequest extends _PasswordResetRequest {
+  const _$_PasswordResetRequest(
       {required this.id,
       required this.localUserId,
       required this.tokenEncrypted,
@@ -3522,8 +3518,8 @@ class _$PasswordResetRequestImpl extends _PasswordResetRequest {
       required this.instanceHost})
       : super._();
 
-  factory _$PasswordResetRequestImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PasswordResetRequestImplFromJson(json);
+  factory _$_PasswordResetRequest.fromJson(Map<String, dynamic> json) =>
+      _$$_PasswordResetRequestFromJson(json);
 
   @override
   final int id;
@@ -3545,7 +3541,7 @@ class _$PasswordResetRequestImpl extends _PasswordResetRequest {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PasswordResetRequestImpl &&
+            other is _$_PasswordResetRequest &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.localUserId, localUserId) ||
                 other.localUserId == localUserId) &&
@@ -3565,14 +3561,13 @@ class _$PasswordResetRequestImpl extends _PasswordResetRequest {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PasswordResetRequestImplCopyWith<_$PasswordResetRequestImpl>
-      get copyWith =>
-          __$$PasswordResetRequestImplCopyWithImpl<_$PasswordResetRequestImpl>(
-              this, _$identity);
+  _$$_PasswordResetRequestCopyWith<_$_PasswordResetRequest> get copyWith =>
+      __$$_PasswordResetRequestCopyWithImpl<_$_PasswordResetRequest>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PasswordResetRequestImplToJson(
+    return _$$_PasswordResetRequestToJson(
       this,
     );
   }
@@ -3584,11 +3579,11 @@ abstract class _PasswordResetRequest extends PasswordResetRequest {
       required final int localUserId,
       required final String tokenEncrypted,
       required final DateTime published,
-      required final String instanceHost}) = _$PasswordResetRequestImpl;
+      required final String instanceHost}) = _$_PasswordResetRequest;
   const _PasswordResetRequest._() : super._();
 
   factory _PasswordResetRequest.fromJson(Map<String, dynamic> json) =
-      _$PasswordResetRequestImpl.fromJson;
+      _$_PasswordResetRequest.fromJson;
 
   @override
   int get id;
@@ -3602,8 +3597,8 @@ abstract class _PasswordResetRequest extends PasswordResetRequest {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$PasswordResetRequestImplCopyWith<_$PasswordResetRequestImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_PasswordResetRequestCopyWith<_$_PasswordResetRequest> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 ModRemovePost _$ModRemovePostFromJson(Map<String, dynamic> json) {
@@ -3698,11 +3693,11 @@ class _$ModRemovePostCopyWithImpl<$Res, $Val extends ModRemovePost>
 }
 
 /// @nodoc
-abstract class _$$ModRemovePostImplCopyWith<$Res>
+abstract class _$$_ModRemovePostCopyWith<$Res>
     implements $ModRemovePostCopyWith<$Res> {
-  factory _$$ModRemovePostImplCopyWith(
-          _$ModRemovePostImpl value, $Res Function(_$ModRemovePostImpl) then) =
-      __$$ModRemovePostImplCopyWithImpl<$Res>;
+  factory _$$_ModRemovePostCopyWith(
+          _$_ModRemovePost value, $Res Function(_$_ModRemovePost) then) =
+      __$$_ModRemovePostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3716,11 +3711,11 @@ abstract class _$$ModRemovePostImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModRemovePostImplCopyWithImpl<$Res>
-    extends _$ModRemovePostCopyWithImpl<$Res, _$ModRemovePostImpl>
-    implements _$$ModRemovePostImplCopyWith<$Res> {
-  __$$ModRemovePostImplCopyWithImpl(
-      _$ModRemovePostImpl _value, $Res Function(_$ModRemovePostImpl) _then)
+class __$$_ModRemovePostCopyWithImpl<$Res>
+    extends _$ModRemovePostCopyWithImpl<$Res, _$_ModRemovePost>
+    implements _$$_ModRemovePostCopyWith<$Res> {
+  __$$_ModRemovePostCopyWithImpl(
+      _$_ModRemovePost _value, $Res Function(_$_ModRemovePost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3734,7 +3729,7 @@ class __$$ModRemovePostImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModRemovePostImpl(
+    return _then(_$_ModRemovePost(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -3770,8 +3765,8 @@ class __$$ModRemovePostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModRemovePostImpl extends _ModRemovePost {
-  const _$ModRemovePostImpl(
+class _$_ModRemovePost extends _ModRemovePost {
+  const _$_ModRemovePost(
       {required this.id,
       required this.modPersonId,
       required this.postId,
@@ -3781,8 +3776,8 @@ class _$ModRemovePostImpl extends _ModRemovePost {
       required this.instanceHost})
       : super._();
 
-  factory _$ModRemovePostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModRemovePostImplFromJson(json);
+  factory _$_ModRemovePost.fromJson(Map<String, dynamic> json) =>
+      _$$_ModRemovePostFromJson(json);
 
   @override
   final int id;
@@ -3809,7 +3804,7 @@ class _$ModRemovePostImpl extends _ModRemovePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModRemovePostImpl &&
+            other is _$_ModRemovePost &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -3829,12 +3824,12 @@ class _$ModRemovePostImpl extends _ModRemovePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModRemovePostImplCopyWith<_$ModRemovePostImpl> get copyWith =>
-      __$$ModRemovePostImplCopyWithImpl<_$ModRemovePostImpl>(this, _$identity);
+  _$$_ModRemovePostCopyWith<_$_ModRemovePost> get copyWith =>
+      __$$_ModRemovePostCopyWithImpl<_$_ModRemovePost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModRemovePostImplToJson(
+    return _$$_ModRemovePostToJson(
       this,
     );
   }
@@ -3848,11 +3843,11 @@ abstract class _ModRemovePost extends ModRemovePost {
       final String? reason,
       final bool? removed,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$ModRemovePostImpl;
+      required final String instanceHost}) = _$_ModRemovePost;
   const _ModRemovePost._() : super._();
 
   factory _ModRemovePost.fromJson(Map<String, dynamic> json) =
-      _$ModRemovePostImpl.fromJson;
+      _$_ModRemovePost.fromJson;
 
   @override
   int get id;
@@ -3871,7 +3866,7 @@ abstract class _ModRemovePost extends ModRemovePost {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModRemovePostImplCopyWith<_$ModRemovePostImpl> get copyWith =>
+  _$$_ModRemovePostCopyWith<_$_ModRemovePost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3960,11 +3955,11 @@ class _$ModLockPostCopyWithImpl<$Res, $Val extends ModLockPost>
 }
 
 /// @nodoc
-abstract class _$$ModLockPostImplCopyWith<$Res>
+abstract class _$$_ModLockPostCopyWith<$Res>
     implements $ModLockPostCopyWith<$Res> {
-  factory _$$ModLockPostImplCopyWith(
-          _$ModLockPostImpl value, $Res Function(_$ModLockPostImpl) then) =
-      __$$ModLockPostImplCopyWithImpl<$Res>;
+  factory _$$_ModLockPostCopyWith(
+          _$_ModLockPost value, $Res Function(_$_ModLockPost) then) =
+      __$$_ModLockPostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3977,11 +3972,11 @@ abstract class _$$ModLockPostImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModLockPostImplCopyWithImpl<$Res>
-    extends _$ModLockPostCopyWithImpl<$Res, _$ModLockPostImpl>
-    implements _$$ModLockPostImplCopyWith<$Res> {
-  __$$ModLockPostImplCopyWithImpl(
-      _$ModLockPostImpl _value, $Res Function(_$ModLockPostImpl) _then)
+class __$$_ModLockPostCopyWithImpl<$Res>
+    extends _$ModLockPostCopyWithImpl<$Res, _$_ModLockPost>
+    implements _$$_ModLockPostCopyWith<$Res> {
+  __$$_ModLockPostCopyWithImpl(
+      _$_ModLockPost _value, $Res Function(_$_ModLockPost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3994,7 +3989,7 @@ class __$$ModLockPostImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModLockPostImpl(
+    return _then(_$_ModLockPost(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -4026,8 +4021,8 @@ class __$$ModLockPostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModLockPostImpl extends _ModLockPost {
-  const _$ModLockPostImpl(
+class _$_ModLockPost extends _ModLockPost {
+  const _$_ModLockPost(
       {required this.id,
       required this.modPersonId,
       required this.postId,
@@ -4036,8 +4031,8 @@ class _$ModLockPostImpl extends _ModLockPost {
       required this.instanceHost})
       : super._();
 
-  factory _$ModLockPostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModLockPostImplFromJson(json);
+  factory _$_ModLockPost.fromJson(Map<String, dynamic> json) =>
+      _$$_ModLockPostFromJson(json);
 
   @override
   final int id;
@@ -4062,7 +4057,7 @@ class _$ModLockPostImpl extends _ModLockPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModLockPostImpl &&
+            other is _$_ModLockPost &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -4081,12 +4076,12 @@ class _$ModLockPostImpl extends _ModLockPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModLockPostImplCopyWith<_$ModLockPostImpl> get copyWith =>
-      __$$ModLockPostImplCopyWithImpl<_$ModLockPostImpl>(this, _$identity);
+  _$$_ModLockPostCopyWith<_$_ModLockPost> get copyWith =>
+      __$$_ModLockPostCopyWithImpl<_$_ModLockPost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModLockPostImplToJson(
+    return _$$_ModLockPostToJson(
       this,
     );
   }
@@ -4099,11 +4094,11 @@ abstract class _ModLockPost extends ModLockPost {
       required final int postId,
       final bool? locked,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$ModLockPostImpl;
+      required final String instanceHost}) = _$_ModLockPost;
   const _ModLockPost._() : super._();
 
   factory _ModLockPost.fromJson(Map<String, dynamic> json) =
-      _$ModLockPostImpl.fromJson;
+      _$_ModLockPost.fromJson;
 
   @override
   int get id;
@@ -4120,7 +4115,7 @@ abstract class _ModLockPost extends ModLockPost {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModLockPostImplCopyWith<_$ModLockPostImpl> get copyWith =>
+  _$$_ModLockPostCopyWith<_$_ModLockPost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4209,11 +4204,11 @@ class _$ModStickyPostCopyWithImpl<$Res, $Val extends ModStickyPost>
 }
 
 /// @nodoc
-abstract class _$$ModStickyPostImplCopyWith<$Res>
+abstract class _$$_ModStickyPostCopyWith<$Res>
     implements $ModStickyPostCopyWith<$Res> {
-  factory _$$ModStickyPostImplCopyWith(
-          _$ModStickyPostImpl value, $Res Function(_$ModStickyPostImpl) then) =
-      __$$ModStickyPostImplCopyWithImpl<$Res>;
+  factory _$$_ModStickyPostCopyWith(
+          _$_ModStickyPost value, $Res Function(_$_ModStickyPost) then) =
+      __$$_ModStickyPostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4226,11 +4221,11 @@ abstract class _$$ModStickyPostImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModStickyPostImplCopyWithImpl<$Res>
-    extends _$ModStickyPostCopyWithImpl<$Res, _$ModStickyPostImpl>
-    implements _$$ModStickyPostImplCopyWith<$Res> {
-  __$$ModStickyPostImplCopyWithImpl(
-      _$ModStickyPostImpl _value, $Res Function(_$ModStickyPostImpl) _then)
+class __$$_ModStickyPostCopyWithImpl<$Res>
+    extends _$ModStickyPostCopyWithImpl<$Res, _$_ModStickyPost>
+    implements _$$_ModStickyPostCopyWith<$Res> {
+  __$$_ModStickyPostCopyWithImpl(
+      _$_ModStickyPost _value, $Res Function(_$_ModStickyPost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4243,7 +4238,7 @@ class __$$ModStickyPostImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModStickyPostImpl(
+    return _then(_$_ModStickyPost(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -4275,8 +4270,8 @@ class __$$ModStickyPostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModStickyPostImpl extends _ModStickyPost {
-  const _$ModStickyPostImpl(
+class _$_ModStickyPost extends _ModStickyPost {
+  const _$_ModStickyPost(
       {required this.id,
       required this.modPersonId,
       required this.postId,
@@ -4285,8 +4280,8 @@ class _$ModStickyPostImpl extends _ModStickyPost {
       required this.instanceHost})
       : super._();
 
-  factory _$ModStickyPostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModStickyPostImplFromJson(json);
+  factory _$_ModStickyPost.fromJson(Map<String, dynamic> json) =>
+      _$$_ModStickyPostFromJson(json);
 
   @override
   final int id;
@@ -4311,7 +4306,7 @@ class _$ModStickyPostImpl extends _ModStickyPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModStickyPostImpl &&
+            other is _$_ModStickyPost &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -4331,12 +4326,12 @@ class _$ModStickyPostImpl extends _ModStickyPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModStickyPostImplCopyWith<_$ModStickyPostImpl> get copyWith =>
-      __$$ModStickyPostImplCopyWithImpl<_$ModStickyPostImpl>(this, _$identity);
+  _$$_ModStickyPostCopyWith<_$_ModStickyPost> get copyWith =>
+      __$$_ModStickyPostCopyWithImpl<_$_ModStickyPost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModStickyPostImplToJson(
+    return _$$_ModStickyPostToJson(
       this,
     );
   }
@@ -4349,11 +4344,11 @@ abstract class _ModStickyPost extends ModStickyPost {
       required final int postId,
       final bool? stickied,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$ModStickyPostImpl;
+      required final String instanceHost}) = _$_ModStickyPost;
   const _ModStickyPost._() : super._();
 
   factory _ModStickyPost.fromJson(Map<String, dynamic> json) =
-      _$ModStickyPostImpl.fromJson;
+      _$_ModStickyPost.fromJson;
 
   @override
   int get id;
@@ -4370,7 +4365,7 @@ abstract class _ModStickyPost extends ModStickyPost {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModStickyPostImplCopyWith<_$ModStickyPostImpl> get copyWith =>
+  _$$_ModStickyPostCopyWith<_$_ModStickyPost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4466,11 +4461,11 @@ class _$ModFeaturePostCopyWithImpl<$Res, $Val extends ModFeaturePost>
 }
 
 /// @nodoc
-abstract class _$$ModFeaturePostImplCopyWith<$Res>
+abstract class _$$_ModFeaturePostCopyWith<$Res>
     implements $ModFeaturePostCopyWith<$Res> {
-  factory _$$ModFeaturePostImplCopyWith(_$ModFeaturePostImpl value,
-          $Res Function(_$ModFeaturePostImpl) then) =
-      __$$ModFeaturePostImplCopyWithImpl<$Res>;
+  factory _$$_ModFeaturePostCopyWith(
+          _$_ModFeaturePost value, $Res Function(_$_ModFeaturePost) then) =
+      __$$_ModFeaturePostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4484,11 +4479,11 @@ abstract class _$$ModFeaturePostImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModFeaturePostImplCopyWithImpl<$Res>
-    extends _$ModFeaturePostCopyWithImpl<$Res, _$ModFeaturePostImpl>
-    implements _$$ModFeaturePostImplCopyWith<$Res> {
-  __$$ModFeaturePostImplCopyWithImpl(
-      _$ModFeaturePostImpl _value, $Res Function(_$ModFeaturePostImpl) _then)
+class __$$_ModFeaturePostCopyWithImpl<$Res>
+    extends _$ModFeaturePostCopyWithImpl<$Res, _$_ModFeaturePost>
+    implements _$$_ModFeaturePostCopyWith<$Res> {
+  __$$_ModFeaturePostCopyWithImpl(
+      _$_ModFeaturePost _value, $Res Function(_$_ModFeaturePost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4502,7 +4497,7 @@ class __$$ModFeaturePostImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModFeaturePostImpl(
+    return _then(_$_ModFeaturePost(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -4538,8 +4533,8 @@ class __$$ModFeaturePostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModFeaturePostImpl extends _ModFeaturePost {
-  const _$ModFeaturePostImpl(
+class _$_ModFeaturePost extends _ModFeaturePost {
+  const _$_ModFeaturePost(
       {required this.id,
       required this.modPersonId,
       required this.postId,
@@ -4549,8 +4544,8 @@ class _$ModFeaturePostImpl extends _ModFeaturePost {
       required this.instanceHost})
       : super._();
 
-  factory _$ModFeaturePostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModFeaturePostImplFromJson(json);
+  factory _$_ModFeaturePost.fromJson(Map<String, dynamic> json) =>
+      _$$_ModFeaturePostFromJson(json);
 
   @override
   final int id;
@@ -4577,7 +4572,7 @@ class _$ModFeaturePostImpl extends _ModFeaturePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModFeaturePostImpl &&
+            other is _$_ModFeaturePost &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -4599,13 +4594,12 @@ class _$ModFeaturePostImpl extends _ModFeaturePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModFeaturePostImplCopyWith<_$ModFeaturePostImpl> get copyWith =>
-      __$$ModFeaturePostImplCopyWithImpl<_$ModFeaturePostImpl>(
-          this, _$identity);
+  _$$_ModFeaturePostCopyWith<_$_ModFeaturePost> get copyWith =>
+      __$$_ModFeaturePostCopyWithImpl<_$_ModFeaturePost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModFeaturePostImplToJson(
+    return _$$_ModFeaturePostToJson(
       this,
     );
   }
@@ -4619,11 +4613,11 @@ abstract class _ModFeaturePost extends ModFeaturePost {
       required final bool featured,
       required final bool isFeaturedCommunity,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$ModFeaturePostImpl;
+      required final String instanceHost}) = _$_ModFeaturePost;
   const _ModFeaturePost._() : super._();
 
   factory _ModFeaturePost.fromJson(Map<String, dynamic> json) =
-      _$ModFeaturePostImpl.fromJson;
+      _$_ModFeaturePost.fromJson;
 
   @override
   int get id;
@@ -4642,7 +4636,7 @@ abstract class _ModFeaturePost extends ModFeaturePost {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModFeaturePostImplCopyWith<_$ModFeaturePostImpl> get copyWith =>
+  _$$_ModFeaturePostCopyWith<_$_ModFeaturePost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4738,11 +4732,11 @@ class _$ModRemoveCommentCopyWithImpl<$Res, $Val extends ModRemoveComment>
 }
 
 /// @nodoc
-abstract class _$$ModRemoveCommentImplCopyWith<$Res>
+abstract class _$$_ModRemoveCommentCopyWith<$Res>
     implements $ModRemoveCommentCopyWith<$Res> {
-  factory _$$ModRemoveCommentImplCopyWith(_$ModRemoveCommentImpl value,
-          $Res Function(_$ModRemoveCommentImpl) then) =
-      __$$ModRemoveCommentImplCopyWithImpl<$Res>;
+  factory _$$_ModRemoveCommentCopyWith(
+          _$_ModRemoveComment value, $Res Function(_$_ModRemoveComment) then) =
+      __$$_ModRemoveCommentCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4756,11 +4750,11 @@ abstract class _$$ModRemoveCommentImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModRemoveCommentImplCopyWithImpl<$Res>
-    extends _$ModRemoveCommentCopyWithImpl<$Res, _$ModRemoveCommentImpl>
-    implements _$$ModRemoveCommentImplCopyWith<$Res> {
-  __$$ModRemoveCommentImplCopyWithImpl(_$ModRemoveCommentImpl _value,
-      $Res Function(_$ModRemoveCommentImpl) _then)
+class __$$_ModRemoveCommentCopyWithImpl<$Res>
+    extends _$ModRemoveCommentCopyWithImpl<$Res, _$_ModRemoveComment>
+    implements _$$_ModRemoveCommentCopyWith<$Res> {
+  __$$_ModRemoveCommentCopyWithImpl(
+      _$_ModRemoveComment _value, $Res Function(_$_ModRemoveComment) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4774,7 +4768,7 @@ class __$$ModRemoveCommentImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModRemoveCommentImpl(
+    return _then(_$_ModRemoveComment(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -4810,8 +4804,8 @@ class __$$ModRemoveCommentImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModRemoveCommentImpl extends _ModRemoveComment {
-  const _$ModRemoveCommentImpl(
+class _$_ModRemoveComment extends _ModRemoveComment {
+  const _$_ModRemoveComment(
       {required this.id,
       required this.modPersonId,
       required this.commentId,
@@ -4821,8 +4815,8 @@ class _$ModRemoveCommentImpl extends _ModRemoveComment {
       required this.instanceHost})
       : super._();
 
-  factory _$ModRemoveCommentImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModRemoveCommentImplFromJson(json);
+  factory _$_ModRemoveComment.fromJson(Map<String, dynamic> json) =>
+      _$$_ModRemoveCommentFromJson(json);
 
   @override
   final int id;
@@ -4849,7 +4843,7 @@ class _$ModRemoveCommentImpl extends _ModRemoveComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModRemoveCommentImpl &&
+            other is _$_ModRemoveComment &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -4870,13 +4864,12 @@ class _$ModRemoveCommentImpl extends _ModRemoveComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModRemoveCommentImplCopyWith<_$ModRemoveCommentImpl> get copyWith =>
-      __$$ModRemoveCommentImplCopyWithImpl<_$ModRemoveCommentImpl>(
-          this, _$identity);
+  _$$_ModRemoveCommentCopyWith<_$_ModRemoveComment> get copyWith =>
+      __$$_ModRemoveCommentCopyWithImpl<_$_ModRemoveComment>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModRemoveCommentImplToJson(
+    return _$$_ModRemoveCommentToJson(
       this,
     );
   }
@@ -4890,11 +4883,11 @@ abstract class _ModRemoveComment extends ModRemoveComment {
       final String? reason,
       final bool? removed,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$ModRemoveCommentImpl;
+      required final String instanceHost}) = _$_ModRemoveComment;
   const _ModRemoveComment._() : super._();
 
   factory _ModRemoveComment.fromJson(Map<String, dynamic> json) =
-      _$ModRemoveCommentImpl.fromJson;
+      _$_ModRemoveComment.fromJson;
 
   @override
   int get id;
@@ -4913,7 +4906,7 @@ abstract class _ModRemoveComment extends ModRemoveComment {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModRemoveCommentImplCopyWith<_$ModRemoveCommentImpl> get copyWith =>
+  _$$_ModRemoveCommentCopyWith<_$_ModRemoveComment> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5016,11 +5009,11 @@ class _$ModRemoveCommunityCopyWithImpl<$Res, $Val extends ModRemoveCommunity>
 }
 
 /// @nodoc
-abstract class _$$ModRemoveCommunityImplCopyWith<$Res>
+abstract class _$$_ModRemoveCommunityCopyWith<$Res>
     implements $ModRemoveCommunityCopyWith<$Res> {
-  factory _$$ModRemoveCommunityImplCopyWith(_$ModRemoveCommunityImpl value,
-          $Res Function(_$ModRemoveCommunityImpl) then) =
-      __$$ModRemoveCommunityImplCopyWithImpl<$Res>;
+  factory _$$_ModRemoveCommunityCopyWith(_$_ModRemoveCommunity value,
+          $Res Function(_$_ModRemoveCommunity) then) =
+      __$$_ModRemoveCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5035,11 +5028,11 @@ abstract class _$$ModRemoveCommunityImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModRemoveCommunityImplCopyWithImpl<$Res>
-    extends _$ModRemoveCommunityCopyWithImpl<$Res, _$ModRemoveCommunityImpl>
-    implements _$$ModRemoveCommunityImplCopyWith<$Res> {
-  __$$ModRemoveCommunityImplCopyWithImpl(_$ModRemoveCommunityImpl _value,
-      $Res Function(_$ModRemoveCommunityImpl) _then)
+class __$$_ModRemoveCommunityCopyWithImpl<$Res>
+    extends _$ModRemoveCommunityCopyWithImpl<$Res, _$_ModRemoveCommunity>
+    implements _$$_ModRemoveCommunityCopyWith<$Res> {
+  __$$_ModRemoveCommunityCopyWithImpl(
+      _$_ModRemoveCommunity _value, $Res Function(_$_ModRemoveCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5054,7 +5047,7 @@ class __$$ModRemoveCommunityImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModRemoveCommunityImpl(
+    return _then(_$_ModRemoveCommunity(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -5094,8 +5087,8 @@ class __$$ModRemoveCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModRemoveCommunityImpl extends _ModRemoveCommunity {
-  const _$ModRemoveCommunityImpl(
+class _$_ModRemoveCommunity extends _ModRemoveCommunity {
+  const _$_ModRemoveCommunity(
       {required this.id,
       required this.modPersonId,
       required this.communityId,
@@ -5106,8 +5099,8 @@ class _$ModRemoveCommunityImpl extends _ModRemoveCommunity {
       required this.instanceHost})
       : super._();
 
-  factory _$ModRemoveCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModRemoveCommunityImplFromJson(json);
+  factory _$_ModRemoveCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_ModRemoveCommunityFromJson(json);
 
   @override
   final int id;
@@ -5136,7 +5129,7 @@ class _$ModRemoveCommunityImpl extends _ModRemoveCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModRemoveCommunityImpl &&
+            other is _$_ModRemoveCommunity &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -5158,13 +5151,13 @@ class _$ModRemoveCommunityImpl extends _ModRemoveCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModRemoveCommunityImplCopyWith<_$ModRemoveCommunityImpl> get copyWith =>
-      __$$ModRemoveCommunityImplCopyWithImpl<_$ModRemoveCommunityImpl>(
+  _$$_ModRemoveCommunityCopyWith<_$_ModRemoveCommunity> get copyWith =>
+      __$$_ModRemoveCommunityCopyWithImpl<_$_ModRemoveCommunity>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModRemoveCommunityImplToJson(
+    return _$$_ModRemoveCommunityToJson(
       this,
     );
   }
@@ -5179,11 +5172,11 @@ abstract class _ModRemoveCommunity extends ModRemoveCommunity {
       final bool? removed,
       final DateTime? expires,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$ModRemoveCommunityImpl;
+      required final String instanceHost}) = _$_ModRemoveCommunity;
   const _ModRemoveCommunity._() : super._();
 
   factory _ModRemoveCommunity.fromJson(Map<String, dynamic> json) =
-      _$ModRemoveCommunityImpl.fromJson;
+      _$_ModRemoveCommunity.fromJson;
 
   @override
   int get id;
@@ -5204,7 +5197,7 @@ abstract class _ModRemoveCommunity extends ModRemoveCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModRemoveCommunityImplCopyWith<_$ModRemoveCommunityImpl> get copyWith =>
+  _$$_ModRemoveCommunityCopyWith<_$_ModRemoveCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5300,11 +5293,11 @@ class _$ModHideCommunityCopyWithImpl<$Res, $Val extends ModHideCommunity>
 }
 
 /// @nodoc
-abstract class _$$ModHideCommunityImplCopyWith<$Res>
+abstract class _$$_ModHideCommunityCopyWith<$Res>
     implements $ModHideCommunityCopyWith<$Res> {
-  factory _$$ModHideCommunityImplCopyWith(_$ModHideCommunityImpl value,
-          $Res Function(_$ModHideCommunityImpl) then) =
-      __$$ModHideCommunityImplCopyWithImpl<$Res>;
+  factory _$$_ModHideCommunityCopyWith(
+          _$_ModHideCommunity value, $Res Function(_$_ModHideCommunity) then) =
+      __$$_ModHideCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5318,11 +5311,11 @@ abstract class _$$ModHideCommunityImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModHideCommunityImplCopyWithImpl<$Res>
-    extends _$ModHideCommunityCopyWithImpl<$Res, _$ModHideCommunityImpl>
-    implements _$$ModHideCommunityImplCopyWith<$Res> {
-  __$$ModHideCommunityImplCopyWithImpl(_$ModHideCommunityImpl _value,
-      $Res Function(_$ModHideCommunityImpl) _then)
+class __$$_ModHideCommunityCopyWithImpl<$Res>
+    extends _$ModHideCommunityCopyWithImpl<$Res, _$_ModHideCommunity>
+    implements _$$_ModHideCommunityCopyWith<$Res> {
+  __$$_ModHideCommunityCopyWithImpl(
+      _$_ModHideCommunity _value, $Res Function(_$_ModHideCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5336,7 +5329,7 @@ class __$$ModHideCommunityImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModHideCommunityImpl(
+    return _then(_$_ModHideCommunity(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -5372,8 +5365,8 @@ class __$$ModHideCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModHideCommunityImpl extends _ModHideCommunity {
-  const _$ModHideCommunityImpl(
+class _$_ModHideCommunity extends _ModHideCommunity {
+  const _$_ModHideCommunity(
       {required this.id,
       required this.modPersonId,
       required this.communityId,
@@ -5383,8 +5376,8 @@ class _$ModHideCommunityImpl extends _ModHideCommunity {
       required this.instanceHost})
       : super._();
 
-  factory _$ModHideCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModHideCommunityImplFromJson(json);
+  factory _$_ModHideCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_ModHideCommunityFromJson(json);
 
   @override
   final int id;
@@ -5411,7 +5404,7 @@ class _$ModHideCommunityImpl extends _ModHideCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModHideCommunityImpl &&
+            other is _$_ModHideCommunity &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -5432,13 +5425,12 @@ class _$ModHideCommunityImpl extends _ModHideCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModHideCommunityImplCopyWith<_$ModHideCommunityImpl> get copyWith =>
-      __$$ModHideCommunityImplCopyWithImpl<_$ModHideCommunityImpl>(
-          this, _$identity);
+  _$$_ModHideCommunityCopyWith<_$_ModHideCommunity> get copyWith =>
+      __$$_ModHideCommunityCopyWithImpl<_$_ModHideCommunity>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModHideCommunityImplToJson(
+    return _$$_ModHideCommunityToJson(
       this,
     );
   }
@@ -5452,11 +5444,11 @@ abstract class _ModHideCommunity extends ModHideCommunity {
       final String? reason,
       required final bool hidden,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$ModHideCommunityImpl;
+      required final String instanceHost}) = _$_ModHideCommunity;
   const _ModHideCommunity._() : super._();
 
   factory _ModHideCommunity.fromJson(Map<String, dynamic> json) =
-      _$ModHideCommunityImpl.fromJson;
+      _$_ModHideCommunity.fromJson;
 
   @override
   int get id;
@@ -5475,7 +5467,7 @@ abstract class _ModHideCommunity extends ModHideCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModHideCommunityImplCopyWith<_$ModHideCommunityImpl> get copyWith =>
+  _$$_ModHideCommunityCopyWith<_$_ModHideCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5585,11 +5577,11 @@ class _$ModBanFromCommunityCopyWithImpl<$Res, $Val extends ModBanFromCommunity>
 }
 
 /// @nodoc
-abstract class _$$ModBanFromCommunityImplCopyWith<$Res>
+abstract class _$$_ModBanFromCommunityCopyWith<$Res>
     implements $ModBanFromCommunityCopyWith<$Res> {
-  factory _$$ModBanFromCommunityImplCopyWith(_$ModBanFromCommunityImpl value,
-          $Res Function(_$ModBanFromCommunityImpl) then) =
-      __$$ModBanFromCommunityImplCopyWithImpl<$Res>;
+  factory _$$_ModBanFromCommunityCopyWith(_$_ModBanFromCommunity value,
+          $Res Function(_$_ModBanFromCommunity) then) =
+      __$$_ModBanFromCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5605,11 +5597,11 @@ abstract class _$$ModBanFromCommunityImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModBanFromCommunityImplCopyWithImpl<$Res>
-    extends _$ModBanFromCommunityCopyWithImpl<$Res, _$ModBanFromCommunityImpl>
-    implements _$$ModBanFromCommunityImplCopyWith<$Res> {
-  __$$ModBanFromCommunityImplCopyWithImpl(_$ModBanFromCommunityImpl _value,
-      $Res Function(_$ModBanFromCommunityImpl) _then)
+class __$$_ModBanFromCommunityCopyWithImpl<$Res>
+    extends _$ModBanFromCommunityCopyWithImpl<$Res, _$_ModBanFromCommunity>
+    implements _$$_ModBanFromCommunityCopyWith<$Res> {
+  __$$_ModBanFromCommunityCopyWithImpl(_$_ModBanFromCommunity _value,
+      $Res Function(_$_ModBanFromCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5625,7 +5617,7 @@ class __$$ModBanFromCommunityImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModBanFromCommunityImpl(
+    return _then(_$_ModBanFromCommunity(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -5669,8 +5661,8 @@ class __$$ModBanFromCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModBanFromCommunityImpl extends _ModBanFromCommunity {
-  const _$ModBanFromCommunityImpl(
+class _$_ModBanFromCommunity extends _ModBanFromCommunity {
+  const _$_ModBanFromCommunity(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -5682,8 +5674,8 @@ class _$ModBanFromCommunityImpl extends _ModBanFromCommunity {
       required this.instanceHost})
       : super._();
 
-  factory _$ModBanFromCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModBanFromCommunityImplFromJson(json);
+  factory _$_ModBanFromCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_ModBanFromCommunityFromJson(json);
 
   @override
   final int id;
@@ -5714,7 +5706,7 @@ class _$ModBanFromCommunityImpl extends _ModBanFromCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModBanFromCommunityImpl &&
+            other is _$_ModBanFromCommunity &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -5738,13 +5730,13 @@ class _$ModBanFromCommunityImpl extends _ModBanFromCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModBanFromCommunityImplCopyWith<_$ModBanFromCommunityImpl> get copyWith =>
-      __$$ModBanFromCommunityImplCopyWithImpl<_$ModBanFromCommunityImpl>(
+  _$$_ModBanFromCommunityCopyWith<_$_ModBanFromCommunity> get copyWith =>
+      __$$_ModBanFromCommunityCopyWithImpl<_$_ModBanFromCommunity>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModBanFromCommunityImplToJson(
+    return _$$_ModBanFromCommunityToJson(
       this,
     );
   }
@@ -5760,11 +5752,11 @@ abstract class _ModBanFromCommunity extends ModBanFromCommunity {
       final bool? banned,
       final DateTime? expires,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$ModBanFromCommunityImpl;
+      required final String instanceHost}) = _$_ModBanFromCommunity;
   const _ModBanFromCommunity._() : super._();
 
   factory _ModBanFromCommunity.fromJson(Map<String, dynamic> json) =
-      _$ModBanFromCommunityImpl.fromJson;
+      _$_ModBanFromCommunity.fromJson;
 
   @override
   int get id;
@@ -5787,7 +5779,7 @@ abstract class _ModBanFromCommunity extends ModBanFromCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModBanFromCommunityImplCopyWith<_$ModBanFromCommunityImpl> get copyWith =>
+  _$$_ModBanFromCommunityCopyWith<_$_ModBanFromCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5888,10 +5880,9 @@ class _$ModBanCopyWithImpl<$Res, $Val extends ModBan>
 }
 
 /// @nodoc
-abstract class _$$ModBanImplCopyWith<$Res> implements $ModBanCopyWith<$Res> {
-  factory _$$ModBanImplCopyWith(
-          _$ModBanImpl value, $Res Function(_$ModBanImpl) then) =
-      __$$ModBanImplCopyWithImpl<$Res>;
+abstract class _$$_ModBanCopyWith<$Res> implements $ModBanCopyWith<$Res> {
+  factory _$$_ModBanCopyWith(_$_ModBan value, $Res Function(_$_ModBan) then) =
+      __$$_ModBanCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5906,11 +5897,10 @@ abstract class _$$ModBanImplCopyWith<$Res> implements $ModBanCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$ModBanImplCopyWithImpl<$Res>
-    extends _$ModBanCopyWithImpl<$Res, _$ModBanImpl>
-    implements _$$ModBanImplCopyWith<$Res> {
-  __$$ModBanImplCopyWithImpl(
-      _$ModBanImpl _value, $Res Function(_$ModBanImpl) _then)
+class __$$_ModBanCopyWithImpl<$Res>
+    extends _$ModBanCopyWithImpl<$Res, _$_ModBan>
+    implements _$$_ModBanCopyWith<$Res> {
+  __$$_ModBanCopyWithImpl(_$_ModBan _value, $Res Function(_$_ModBan) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5925,7 +5915,7 @@ class __$$ModBanImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModBanImpl(
+    return _then(_$_ModBan(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -5965,8 +5955,8 @@ class __$$ModBanImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModBanImpl extends _ModBan {
-  const _$ModBanImpl(
+class _$_ModBan extends _ModBan {
+  const _$_ModBan(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -5977,8 +5967,8 @@ class _$ModBanImpl extends _ModBan {
       required this.instanceHost})
       : super._();
 
-  factory _$ModBanImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModBanImplFromJson(json);
+  factory _$_ModBan.fromJson(Map<String, dynamic> json) =>
+      _$$_ModBanFromJson(json);
 
   @override
   final int id;
@@ -6007,7 +5997,7 @@ class _$ModBanImpl extends _ModBan {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModBanImpl &&
+            other is _$_ModBan &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -6029,12 +6019,12 @@ class _$ModBanImpl extends _ModBan {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModBanImplCopyWith<_$ModBanImpl> get copyWith =>
-      __$$ModBanImplCopyWithImpl<_$ModBanImpl>(this, _$identity);
+  _$$_ModBanCopyWith<_$_ModBan> get copyWith =>
+      __$$_ModBanCopyWithImpl<_$_ModBan>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModBanImplToJson(
+    return _$$_ModBanToJson(
       this,
     );
   }
@@ -6049,10 +6039,10 @@ abstract class _ModBan extends ModBan {
       final bool? banned,
       final DateTime? expires,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$ModBanImpl;
+      required final String instanceHost}) = _$_ModBan;
   const _ModBan._() : super._();
 
-  factory _ModBan.fromJson(Map<String, dynamic> json) = _$ModBanImpl.fromJson;
+  factory _ModBan.fromJson(Map<String, dynamic> json) = _$_ModBan.fromJson;
 
   @override
   int get id;
@@ -6073,7 +6063,7 @@ abstract class _ModBan extends ModBan {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModBanImplCopyWith<_$ModBanImpl> get copyWith =>
+  _$$_ModBanCopyWith<_$_ModBan> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -6169,11 +6159,11 @@ class _$ModAddCommunityCopyWithImpl<$Res, $Val extends ModAddCommunity>
 }
 
 /// @nodoc
-abstract class _$$ModAddCommunityImplCopyWith<$Res>
+abstract class _$$_ModAddCommunityCopyWith<$Res>
     implements $ModAddCommunityCopyWith<$Res> {
-  factory _$$ModAddCommunityImplCopyWith(_$ModAddCommunityImpl value,
-          $Res Function(_$ModAddCommunityImpl) then) =
-      __$$ModAddCommunityImplCopyWithImpl<$Res>;
+  factory _$$_ModAddCommunityCopyWith(
+          _$_ModAddCommunity value, $Res Function(_$_ModAddCommunity) then) =
+      __$$_ModAddCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6187,11 +6177,11 @@ abstract class _$$ModAddCommunityImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModAddCommunityImplCopyWithImpl<$Res>
-    extends _$ModAddCommunityCopyWithImpl<$Res, _$ModAddCommunityImpl>
-    implements _$$ModAddCommunityImplCopyWith<$Res> {
-  __$$ModAddCommunityImplCopyWithImpl(
-      _$ModAddCommunityImpl _value, $Res Function(_$ModAddCommunityImpl) _then)
+class __$$_ModAddCommunityCopyWithImpl<$Res>
+    extends _$ModAddCommunityCopyWithImpl<$Res, _$_ModAddCommunity>
+    implements _$$_ModAddCommunityCopyWith<$Res> {
+  __$$_ModAddCommunityCopyWithImpl(
+      _$_ModAddCommunity _value, $Res Function(_$_ModAddCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6205,7 +6195,7 @@ class __$$ModAddCommunityImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModAddCommunityImpl(
+    return _then(_$_ModAddCommunity(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -6241,8 +6231,8 @@ class __$$ModAddCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModAddCommunityImpl extends _ModAddCommunity {
-  const _$ModAddCommunityImpl(
+class _$_ModAddCommunity extends _ModAddCommunity {
+  const _$_ModAddCommunity(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -6252,8 +6242,8 @@ class _$ModAddCommunityImpl extends _ModAddCommunity {
       required this.instanceHost})
       : super._();
 
-  factory _$ModAddCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModAddCommunityImplFromJson(json);
+  factory _$_ModAddCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_ModAddCommunityFromJson(json);
 
   @override
   final int id;
@@ -6280,7 +6270,7 @@ class _$ModAddCommunityImpl extends _ModAddCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModAddCommunityImpl &&
+            other is _$_ModAddCommunity &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -6302,13 +6292,12 @@ class _$ModAddCommunityImpl extends _ModAddCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModAddCommunityImplCopyWith<_$ModAddCommunityImpl> get copyWith =>
-      __$$ModAddCommunityImplCopyWithImpl<_$ModAddCommunityImpl>(
-          this, _$identity);
+  _$$_ModAddCommunityCopyWith<_$_ModAddCommunity> get copyWith =>
+      __$$_ModAddCommunityCopyWithImpl<_$_ModAddCommunity>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModAddCommunityImplToJson(
+    return _$$_ModAddCommunityToJson(
       this,
     );
   }
@@ -6322,11 +6311,11 @@ abstract class _ModAddCommunity extends ModAddCommunity {
       required final int communityId,
       final bool? removed,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$ModAddCommunityImpl;
+      required final String instanceHost}) = _$_ModAddCommunity;
   const _ModAddCommunity._() : super._();
 
   factory _ModAddCommunity.fromJson(Map<String, dynamic> json) =
-      _$ModAddCommunityImpl.fromJson;
+      _$_ModAddCommunity.fromJson;
 
   @override
   int get id;
@@ -6345,7 +6334,7 @@ abstract class _ModAddCommunity extends ModAddCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModAddCommunityImplCopyWith<_$ModAddCommunityImpl> get copyWith =>
+  _$$_ModAddCommunityCopyWith<_$_ModAddCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -6442,11 +6431,11 @@ class _$ModTransferCommunityCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$ModTransferCommunityImplCopyWith<$Res>
+abstract class _$$_ModTransferCommunityCopyWith<$Res>
     implements $ModTransferCommunityCopyWith<$Res> {
-  factory _$$ModTransferCommunityImplCopyWith(_$ModTransferCommunityImpl value,
-          $Res Function(_$ModTransferCommunityImpl) then) =
-      __$$ModTransferCommunityImplCopyWithImpl<$Res>;
+  factory _$$_ModTransferCommunityCopyWith(_$_ModTransferCommunity value,
+          $Res Function(_$_ModTransferCommunity) then) =
+      __$$_ModTransferCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6460,11 +6449,11 @@ abstract class _$$ModTransferCommunityImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModTransferCommunityImplCopyWithImpl<$Res>
-    extends _$ModTransferCommunityCopyWithImpl<$Res, _$ModTransferCommunityImpl>
-    implements _$$ModTransferCommunityImplCopyWith<$Res> {
-  __$$ModTransferCommunityImplCopyWithImpl(_$ModTransferCommunityImpl _value,
-      $Res Function(_$ModTransferCommunityImpl) _then)
+class __$$_ModTransferCommunityCopyWithImpl<$Res>
+    extends _$ModTransferCommunityCopyWithImpl<$Res, _$_ModTransferCommunity>
+    implements _$$_ModTransferCommunityCopyWith<$Res> {
+  __$$_ModTransferCommunityCopyWithImpl(_$_ModTransferCommunity _value,
+      $Res Function(_$_ModTransferCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6478,7 +6467,7 @@ class __$$ModTransferCommunityImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModTransferCommunityImpl(
+    return _then(_$_ModTransferCommunity(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -6514,8 +6503,8 @@ class __$$ModTransferCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModTransferCommunityImpl extends _ModTransferCommunity {
-  const _$ModTransferCommunityImpl(
+class _$_ModTransferCommunity extends _ModTransferCommunity {
+  const _$_ModTransferCommunity(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -6525,8 +6514,8 @@ class _$ModTransferCommunityImpl extends _ModTransferCommunity {
       required this.instanceHost})
       : super._();
 
-  factory _$ModTransferCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModTransferCommunityImplFromJson(json);
+  factory _$_ModTransferCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_ModTransferCommunityFromJson(json);
 
   @override
   final int id;
@@ -6553,7 +6542,7 @@ class _$ModTransferCommunityImpl extends _ModTransferCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModTransferCommunityImpl &&
+            other is _$_ModTransferCommunity &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -6575,14 +6564,13 @@ class _$ModTransferCommunityImpl extends _ModTransferCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModTransferCommunityImplCopyWith<_$ModTransferCommunityImpl>
-      get copyWith =>
-          __$$ModTransferCommunityImplCopyWithImpl<_$ModTransferCommunityImpl>(
-              this, _$identity);
+  _$$_ModTransferCommunityCopyWith<_$_ModTransferCommunity> get copyWith =>
+      __$$_ModTransferCommunityCopyWithImpl<_$_ModTransferCommunity>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModTransferCommunityImplToJson(
+    return _$$_ModTransferCommunityToJson(
       this,
     );
   }
@@ -6596,11 +6584,11 @@ abstract class _ModTransferCommunity extends ModTransferCommunity {
       required final int communityId,
       final bool? removed,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$ModTransferCommunityImpl;
+      required final String instanceHost}) = _$_ModTransferCommunity;
   const _ModTransferCommunity._() : super._();
 
   factory _ModTransferCommunity.fromJson(Map<String, dynamic> json) =
-      _$ModTransferCommunityImpl.fromJson;
+      _$_ModTransferCommunity.fromJson;
 
   @override
   int get id;
@@ -6619,8 +6607,8 @@ abstract class _ModTransferCommunity extends ModTransferCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModTransferCommunityImplCopyWith<_$ModTransferCommunityImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_ModTransferCommunityCopyWith<_$_ModTransferCommunity> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 ModAdd _$ModAddFromJson(Map<String, dynamic> json) {
@@ -6706,10 +6694,9 @@ class _$ModAddCopyWithImpl<$Res, $Val extends ModAdd>
 }
 
 /// @nodoc
-abstract class _$$ModAddImplCopyWith<$Res> implements $ModAddCopyWith<$Res> {
-  factory _$$ModAddImplCopyWith(
-          _$ModAddImpl value, $Res Function(_$ModAddImpl) then) =
-      __$$ModAddImplCopyWithImpl<$Res>;
+abstract class _$$_ModAddCopyWith<$Res> implements $ModAddCopyWith<$Res> {
+  factory _$$_ModAddCopyWith(_$_ModAdd value, $Res Function(_$_ModAdd) then) =
+      __$$_ModAddCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6722,11 +6709,10 @@ abstract class _$$ModAddImplCopyWith<$Res> implements $ModAddCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$ModAddImplCopyWithImpl<$Res>
-    extends _$ModAddCopyWithImpl<$Res, _$ModAddImpl>
-    implements _$$ModAddImplCopyWith<$Res> {
-  __$$ModAddImplCopyWithImpl(
-      _$ModAddImpl _value, $Res Function(_$ModAddImpl) _then)
+class __$$_ModAddCopyWithImpl<$Res>
+    extends _$ModAddCopyWithImpl<$Res, _$_ModAdd>
+    implements _$$_ModAddCopyWith<$Res> {
+  __$$_ModAddCopyWithImpl(_$_ModAdd _value, $Res Function(_$_ModAdd) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6739,7 +6725,7 @@ class __$$ModAddImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModAddImpl(
+    return _then(_$_ModAdd(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -6771,8 +6757,8 @@ class __$$ModAddImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModAddImpl extends _ModAdd {
-  const _$ModAddImpl(
+class _$_ModAdd extends _ModAdd {
+  const _$_ModAdd(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -6781,8 +6767,8 @@ class _$ModAddImpl extends _ModAdd {
       required this.instanceHost})
       : super._();
 
-  factory _$ModAddImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModAddImplFromJson(json);
+  factory _$_ModAdd.fromJson(Map<String, dynamic> json) =>
+      _$$_ModAddFromJson(json);
 
   @override
   final int id;
@@ -6807,7 +6793,7 @@ class _$ModAddImpl extends _ModAdd {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModAddImpl &&
+            other is _$_ModAdd &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -6827,12 +6813,12 @@ class _$ModAddImpl extends _ModAdd {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModAddImplCopyWith<_$ModAddImpl> get copyWith =>
-      __$$ModAddImplCopyWithImpl<_$ModAddImpl>(this, _$identity);
+  _$$_ModAddCopyWith<_$_ModAdd> get copyWith =>
+      __$$_ModAddCopyWithImpl<_$_ModAdd>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModAddImplToJson(
+    return _$$_ModAddToJson(
       this,
     );
   }
@@ -6845,10 +6831,10 @@ abstract class _ModAdd extends ModAdd {
       required final int otherPersonId,
       final bool? removed,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$ModAddImpl;
+      required final String instanceHost}) = _$_ModAdd;
   const _ModAdd._() : super._();
 
-  factory _ModAdd.fromJson(Map<String, dynamic> json) = _$ModAddImpl.fromJson;
+  factory _ModAdd.fromJson(Map<String, dynamic> json) = _$_ModAdd.fromJson;
 
   @override
   int get id;
@@ -6865,7 +6851,7 @@ abstract class _ModAdd extends ModAdd {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModAddImplCopyWith<_$ModAddImpl> get copyWith =>
+  _$$_ModAddCopyWith<_$_ModAdd> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -6954,11 +6940,11 @@ class _$AdminPurgeCommentCopyWithImpl<$Res, $Val extends AdminPurgeComment>
 }
 
 /// @nodoc
-abstract class _$$AdminPurgeCommentImplCopyWith<$Res>
+abstract class _$$_AdminPurgeCommentCopyWith<$Res>
     implements $AdminPurgeCommentCopyWith<$Res> {
-  factory _$$AdminPurgeCommentImplCopyWith(_$AdminPurgeCommentImpl value,
-          $Res Function(_$AdminPurgeCommentImpl) then) =
-      __$$AdminPurgeCommentImplCopyWithImpl<$Res>;
+  factory _$$_AdminPurgeCommentCopyWith(_$_AdminPurgeComment value,
+          $Res Function(_$_AdminPurgeComment) then) =
+      __$$_AdminPurgeCommentCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6971,11 +6957,11 @@ abstract class _$$AdminPurgeCommentImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$AdminPurgeCommentImplCopyWithImpl<$Res>
-    extends _$AdminPurgeCommentCopyWithImpl<$Res, _$AdminPurgeCommentImpl>
-    implements _$$AdminPurgeCommentImplCopyWith<$Res> {
-  __$$AdminPurgeCommentImplCopyWithImpl(_$AdminPurgeCommentImpl _value,
-      $Res Function(_$AdminPurgeCommentImpl) _then)
+class __$$_AdminPurgeCommentCopyWithImpl<$Res>
+    extends _$AdminPurgeCommentCopyWithImpl<$Res, _$_AdminPurgeComment>
+    implements _$$_AdminPurgeCommentCopyWith<$Res> {
+  __$$_AdminPurgeCommentCopyWithImpl(
+      _$_AdminPurgeComment _value, $Res Function(_$_AdminPurgeComment) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6988,7 +6974,7 @@ class __$$AdminPurgeCommentImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$AdminPurgeCommentImpl(
+    return _then(_$_AdminPurgeComment(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -7020,8 +7006,8 @@ class __$$AdminPurgeCommentImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$AdminPurgeCommentImpl extends _AdminPurgeComment {
-  const _$AdminPurgeCommentImpl(
+class _$_AdminPurgeComment extends _AdminPurgeComment {
+  const _$_AdminPurgeComment(
       {required this.id,
       required this.adminPersonId,
       required this.postId,
@@ -7030,8 +7016,8 @@ class _$AdminPurgeCommentImpl extends _AdminPurgeComment {
       required this.instanceHost})
       : super._();
 
-  factory _$AdminPurgeCommentImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AdminPurgeCommentImplFromJson(json);
+  factory _$_AdminPurgeComment.fromJson(Map<String, dynamic> json) =>
+      _$$_AdminPurgeCommentFromJson(json);
 
   @override
   final int id;
@@ -7056,7 +7042,7 @@ class _$AdminPurgeCommentImpl extends _AdminPurgeComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AdminPurgeCommentImpl &&
+            other is _$_AdminPurgeComment &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.adminPersonId, adminPersonId) ||
                 other.adminPersonId == adminPersonId) &&
@@ -7075,13 +7061,13 @@ class _$AdminPurgeCommentImpl extends _AdminPurgeComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$AdminPurgeCommentImplCopyWith<_$AdminPurgeCommentImpl> get copyWith =>
-      __$$AdminPurgeCommentImplCopyWithImpl<_$AdminPurgeCommentImpl>(
+  _$$_AdminPurgeCommentCopyWith<_$_AdminPurgeComment> get copyWith =>
+      __$$_AdminPurgeCommentCopyWithImpl<_$_AdminPurgeComment>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$AdminPurgeCommentImplToJson(
+    return _$$_AdminPurgeCommentToJson(
       this,
     );
   }
@@ -7094,11 +7080,11 @@ abstract class _AdminPurgeComment extends AdminPurgeComment {
       required final int postId,
       final String? reason,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$AdminPurgeCommentImpl;
+      required final String instanceHost}) = _$_AdminPurgeComment;
   const _AdminPurgeComment._() : super._();
 
   factory _AdminPurgeComment.fromJson(Map<String, dynamic> json) =
-      _$AdminPurgeCommentImpl.fromJson;
+      _$_AdminPurgeComment.fromJson;
 
   @override
   int get id;
@@ -7115,7 +7101,7 @@ abstract class _AdminPurgeComment extends AdminPurgeComment {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$AdminPurgeCommentImplCopyWith<_$AdminPurgeCommentImpl> get copyWith =>
+  _$$_AdminPurgeCommentCopyWith<_$_AdminPurgeComment> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7204,11 +7190,11 @@ class _$AdminPurgePostCopyWithImpl<$Res, $Val extends AdminPurgePost>
 }
 
 /// @nodoc
-abstract class _$$AdminPurgePostImplCopyWith<$Res>
+abstract class _$$_AdminPurgePostCopyWith<$Res>
     implements $AdminPurgePostCopyWith<$Res> {
-  factory _$$AdminPurgePostImplCopyWith(_$AdminPurgePostImpl value,
-          $Res Function(_$AdminPurgePostImpl) then) =
-      __$$AdminPurgePostImplCopyWithImpl<$Res>;
+  factory _$$_AdminPurgePostCopyWith(
+          _$_AdminPurgePost value, $Res Function(_$_AdminPurgePost) then) =
+      __$$_AdminPurgePostCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -7221,11 +7207,11 @@ abstract class _$$AdminPurgePostImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$AdminPurgePostImplCopyWithImpl<$Res>
-    extends _$AdminPurgePostCopyWithImpl<$Res, _$AdminPurgePostImpl>
-    implements _$$AdminPurgePostImplCopyWith<$Res> {
-  __$$AdminPurgePostImplCopyWithImpl(
-      _$AdminPurgePostImpl _value, $Res Function(_$AdminPurgePostImpl) _then)
+class __$$_AdminPurgePostCopyWithImpl<$Res>
+    extends _$AdminPurgePostCopyWithImpl<$Res, _$_AdminPurgePost>
+    implements _$$_AdminPurgePostCopyWith<$Res> {
+  __$$_AdminPurgePostCopyWithImpl(
+      _$_AdminPurgePost _value, $Res Function(_$_AdminPurgePost) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7238,7 +7224,7 @@ class __$$AdminPurgePostImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$AdminPurgePostImpl(
+    return _then(_$_AdminPurgePost(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -7270,8 +7256,8 @@ class __$$AdminPurgePostImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$AdminPurgePostImpl extends _AdminPurgePost {
-  const _$AdminPurgePostImpl(
+class _$_AdminPurgePost extends _AdminPurgePost {
+  const _$_AdminPurgePost(
       {required this.id,
       required this.adminPersonId,
       required this.communityId,
@@ -7280,8 +7266,8 @@ class _$AdminPurgePostImpl extends _AdminPurgePost {
       required this.instanceHost})
       : super._();
 
-  factory _$AdminPurgePostImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AdminPurgePostImplFromJson(json);
+  factory _$_AdminPurgePost.fromJson(Map<String, dynamic> json) =>
+      _$$_AdminPurgePostFromJson(json);
 
   @override
   final int id;
@@ -7306,7 +7292,7 @@ class _$AdminPurgePostImpl extends _AdminPurgePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AdminPurgePostImpl &&
+            other is _$_AdminPurgePost &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.adminPersonId, adminPersonId) ||
                 other.adminPersonId == adminPersonId) &&
@@ -7326,13 +7312,12 @@ class _$AdminPurgePostImpl extends _AdminPurgePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$AdminPurgePostImplCopyWith<_$AdminPurgePostImpl> get copyWith =>
-      __$$AdminPurgePostImplCopyWithImpl<_$AdminPurgePostImpl>(
-          this, _$identity);
+  _$$_AdminPurgePostCopyWith<_$_AdminPurgePost> get copyWith =>
+      __$$_AdminPurgePostCopyWithImpl<_$_AdminPurgePost>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$AdminPurgePostImplToJson(
+    return _$$_AdminPurgePostToJson(
       this,
     );
   }
@@ -7345,11 +7330,11 @@ abstract class _AdminPurgePost extends AdminPurgePost {
       required final int communityId,
       final String? reason,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$AdminPurgePostImpl;
+      required final String instanceHost}) = _$_AdminPurgePost;
   const _AdminPurgePost._() : super._();
 
   factory _AdminPurgePost.fromJson(Map<String, dynamic> json) =
-      _$AdminPurgePostImpl.fromJson;
+      _$_AdminPurgePost.fromJson;
 
   @override
   int get id;
@@ -7366,7 +7351,7 @@ abstract class _AdminPurgePost extends AdminPurgePost {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$AdminPurgePostImplCopyWith<_$AdminPurgePostImpl> get copyWith =>
+  _$$_AdminPurgePostCopyWith<_$_AdminPurgePost> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7448,11 +7433,11 @@ class _$AdminPurgePersonCopyWithImpl<$Res, $Val extends AdminPurgePerson>
 }
 
 /// @nodoc
-abstract class _$$AdminPurgePersonImplCopyWith<$Res>
+abstract class _$$_AdminPurgePersonCopyWith<$Res>
     implements $AdminPurgePersonCopyWith<$Res> {
-  factory _$$AdminPurgePersonImplCopyWith(_$AdminPurgePersonImpl value,
-          $Res Function(_$AdminPurgePersonImpl) then) =
-      __$$AdminPurgePersonImplCopyWithImpl<$Res>;
+  factory _$$_AdminPurgePersonCopyWith(
+          _$_AdminPurgePerson value, $Res Function(_$_AdminPurgePerson) then) =
+      __$$_AdminPurgePersonCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -7464,11 +7449,11 @@ abstract class _$$AdminPurgePersonImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$AdminPurgePersonImplCopyWithImpl<$Res>
-    extends _$AdminPurgePersonCopyWithImpl<$Res, _$AdminPurgePersonImpl>
-    implements _$$AdminPurgePersonImplCopyWith<$Res> {
-  __$$AdminPurgePersonImplCopyWithImpl(_$AdminPurgePersonImpl _value,
-      $Res Function(_$AdminPurgePersonImpl) _then)
+class __$$_AdminPurgePersonCopyWithImpl<$Res>
+    extends _$AdminPurgePersonCopyWithImpl<$Res, _$_AdminPurgePerson>
+    implements _$$_AdminPurgePersonCopyWith<$Res> {
+  __$$_AdminPurgePersonCopyWithImpl(
+      _$_AdminPurgePerson _value, $Res Function(_$_AdminPurgePerson) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7480,7 +7465,7 @@ class __$$AdminPurgePersonImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$AdminPurgePersonImpl(
+    return _then(_$_AdminPurgePerson(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -7508,8 +7493,8 @@ class __$$AdminPurgePersonImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$AdminPurgePersonImpl extends _AdminPurgePerson {
-  const _$AdminPurgePersonImpl(
+class _$_AdminPurgePerson extends _AdminPurgePerson {
+  const _$_AdminPurgePerson(
       {required this.id,
       required this.adminPersonId,
       this.reason,
@@ -7517,8 +7502,8 @@ class _$AdminPurgePersonImpl extends _AdminPurgePerson {
       required this.instanceHost})
       : super._();
 
-  factory _$AdminPurgePersonImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AdminPurgePersonImplFromJson(json);
+  factory _$_AdminPurgePerson.fromJson(Map<String, dynamic> json) =>
+      _$$_AdminPurgePersonFromJson(json);
 
   @override
   final int id;
@@ -7541,7 +7526,7 @@ class _$AdminPurgePersonImpl extends _AdminPurgePerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AdminPurgePersonImpl &&
+            other is _$_AdminPurgePerson &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.adminPersonId, adminPersonId) ||
                 other.adminPersonId == adminPersonId) &&
@@ -7559,13 +7544,12 @@ class _$AdminPurgePersonImpl extends _AdminPurgePerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$AdminPurgePersonImplCopyWith<_$AdminPurgePersonImpl> get copyWith =>
-      __$$AdminPurgePersonImplCopyWithImpl<_$AdminPurgePersonImpl>(
-          this, _$identity);
+  _$$_AdminPurgePersonCopyWith<_$_AdminPurgePerson> get copyWith =>
+      __$$_AdminPurgePersonCopyWithImpl<_$_AdminPurgePerson>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$AdminPurgePersonImplToJson(
+    return _$$_AdminPurgePersonToJson(
       this,
     );
   }
@@ -7577,11 +7561,11 @@ abstract class _AdminPurgePerson extends AdminPurgePerson {
       required final int adminPersonId,
       final String? reason,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$AdminPurgePersonImpl;
+      required final String instanceHost}) = _$_AdminPurgePerson;
   const _AdminPurgePerson._() : super._();
 
   factory _AdminPurgePerson.fromJson(Map<String, dynamic> json) =
-      _$AdminPurgePersonImpl.fromJson;
+      _$_AdminPurgePerson.fromJson;
 
   @override
   int get id;
@@ -7596,7 +7580,7 @@ abstract class _AdminPurgePerson extends AdminPurgePerson {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$AdminPurgePersonImplCopyWith<_$AdminPurgePersonImpl> get copyWith =>
+  _$$_AdminPurgePersonCopyWith<_$_AdminPurgePerson> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7678,11 +7662,11 @@ class _$AdminPurgeCommunityCopyWithImpl<$Res, $Val extends AdminPurgeCommunity>
 }
 
 /// @nodoc
-abstract class _$$AdminPurgeCommunityImplCopyWith<$Res>
+abstract class _$$_AdminPurgeCommunityCopyWith<$Res>
     implements $AdminPurgeCommunityCopyWith<$Res> {
-  factory _$$AdminPurgeCommunityImplCopyWith(_$AdminPurgeCommunityImpl value,
-          $Res Function(_$AdminPurgeCommunityImpl) then) =
-      __$$AdminPurgeCommunityImplCopyWithImpl<$Res>;
+  factory _$$_AdminPurgeCommunityCopyWith(_$_AdminPurgeCommunity value,
+          $Res Function(_$_AdminPurgeCommunity) then) =
+      __$$_AdminPurgeCommunityCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -7694,11 +7678,11 @@ abstract class _$$AdminPurgeCommunityImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$AdminPurgeCommunityImplCopyWithImpl<$Res>
-    extends _$AdminPurgeCommunityCopyWithImpl<$Res, _$AdminPurgeCommunityImpl>
-    implements _$$AdminPurgeCommunityImplCopyWith<$Res> {
-  __$$AdminPurgeCommunityImplCopyWithImpl(_$AdminPurgeCommunityImpl _value,
-      $Res Function(_$AdminPurgeCommunityImpl) _then)
+class __$$_AdminPurgeCommunityCopyWithImpl<$Res>
+    extends _$AdminPurgeCommunityCopyWithImpl<$Res, _$_AdminPurgeCommunity>
+    implements _$$_AdminPurgeCommunityCopyWith<$Res> {
+  __$$_AdminPurgeCommunityCopyWithImpl(_$_AdminPurgeCommunity _value,
+      $Res Function(_$_AdminPurgeCommunity) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7710,7 +7694,7 @@ class __$$AdminPurgeCommunityImplCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$AdminPurgeCommunityImpl(
+    return _then(_$_AdminPurgeCommunity(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -7738,8 +7722,8 @@ class __$$AdminPurgeCommunityImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$AdminPurgeCommunityImpl extends _AdminPurgeCommunity {
-  const _$AdminPurgeCommunityImpl(
+class _$_AdminPurgeCommunity extends _AdminPurgeCommunity {
+  const _$_AdminPurgeCommunity(
       {required this.id,
       required this.adminPersonId,
       this.reason,
@@ -7747,8 +7731,8 @@ class _$AdminPurgeCommunityImpl extends _AdminPurgeCommunity {
       required this.instanceHost})
       : super._();
 
-  factory _$AdminPurgeCommunityImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AdminPurgeCommunityImplFromJson(json);
+  factory _$_AdminPurgeCommunity.fromJson(Map<String, dynamic> json) =>
+      _$$_AdminPurgeCommunityFromJson(json);
 
   @override
   final int id;
@@ -7771,7 +7755,7 @@ class _$AdminPurgeCommunityImpl extends _AdminPurgeCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AdminPurgeCommunityImpl &&
+            other is _$_AdminPurgeCommunity &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.adminPersonId, adminPersonId) ||
                 other.adminPersonId == adminPersonId) &&
@@ -7789,13 +7773,13 @@ class _$AdminPurgeCommunityImpl extends _AdminPurgeCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$AdminPurgeCommunityImplCopyWith<_$AdminPurgeCommunityImpl> get copyWith =>
-      __$$AdminPurgeCommunityImplCopyWithImpl<_$AdminPurgeCommunityImpl>(
+  _$$_AdminPurgeCommunityCopyWith<_$_AdminPurgeCommunity> get copyWith =>
+      __$$_AdminPurgeCommunityCopyWithImpl<_$_AdminPurgeCommunity>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$AdminPurgeCommunityImplToJson(
+    return _$$_AdminPurgeCommunityToJson(
       this,
     );
   }
@@ -7807,11 +7791,11 @@ abstract class _AdminPurgeCommunity extends AdminPurgeCommunity {
       required final int adminPersonId,
       final String? reason,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$AdminPurgeCommunityImpl;
+      required final String instanceHost}) = _$_AdminPurgeCommunity;
   const _AdminPurgeCommunity._() : super._();
 
   factory _AdminPurgeCommunity.fromJson(Map<String, dynamic> json) =
-      _$AdminPurgeCommunityImpl.fromJson;
+      _$_AdminPurgeCommunity.fromJson;
 
   @override
   int get id;
@@ -7826,7 +7810,7 @@ abstract class _AdminPurgeCommunity extends AdminPurgeCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$AdminPurgeCommunityImplCopyWith<_$AdminPurgeCommunityImpl> get copyWith =>
+  _$$_AdminPurgeCommunityCopyWith<_$_AdminPurgeCommunity> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7970,11 +7954,11 @@ class _$CommunitySafeCopyWithImpl<$Res, $Val extends CommunitySafe>
 }
 
 /// @nodoc
-abstract class _$$CommunitySafeImplCopyWith<$Res>
+abstract class _$$_CommunitySafeCopyWith<$Res>
     implements $CommunitySafeCopyWith<$Res> {
-  factory _$$CommunitySafeImplCopyWith(
-          _$CommunitySafeImpl value, $Res Function(_$CommunitySafeImpl) then) =
-      __$$CommunitySafeImplCopyWithImpl<$Res>;
+  factory _$$_CommunitySafeCopyWith(
+          _$_CommunitySafe value, $Res Function(_$_CommunitySafe) then) =
+      __$$_CommunitySafeCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -7995,11 +7979,11 @@ abstract class _$$CommunitySafeImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CommunitySafeImplCopyWithImpl<$Res>
-    extends _$CommunitySafeCopyWithImpl<$Res, _$CommunitySafeImpl>
-    implements _$$CommunitySafeImplCopyWith<$Res> {
-  __$$CommunitySafeImplCopyWithImpl(
-      _$CommunitySafeImpl _value, $Res Function(_$CommunitySafeImpl) _then)
+class __$$_CommunitySafeCopyWithImpl<$Res>
+    extends _$CommunitySafeCopyWithImpl<$Res, _$_CommunitySafe>
+    implements _$$_CommunitySafeCopyWith<$Res> {
+  __$$_CommunitySafeCopyWithImpl(
+      _$_CommunitySafe _value, $Res Function(_$_CommunitySafe) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8020,7 +8004,7 @@ class __$$CommunitySafeImplCopyWithImpl<$Res>
     Object? banner = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$CommunitySafeImpl(
+    return _then(_$_CommunitySafe(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -8084,8 +8068,8 @@ class __$$CommunitySafeImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CommunitySafeImpl extends _CommunitySafe {
-  const _$CommunitySafeImpl(
+class _$_CommunitySafe extends _CommunitySafe {
+  const _$_CommunitySafe(
       {required this.id,
       required this.name,
       required this.title,
@@ -8102,8 +8086,8 @@ class _$CommunitySafeImpl extends _CommunitySafe {
       required this.instanceHost})
       : super._();
 
-  factory _$CommunitySafeImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CommunitySafeImplFromJson(json);
+  factory _$_CommunitySafe.fromJson(Map<String, dynamic> json) =>
+      _$$_CommunitySafeFromJson(json);
 
   @override
   final int id;
@@ -8143,7 +8127,7 @@ class _$CommunitySafeImpl extends _CommunitySafe {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CommunitySafeImpl &&
+            other is _$_CommunitySafe &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.title, title) || other.title == title) &&
@@ -8185,12 +8169,12 @@ class _$CommunitySafeImpl extends _CommunitySafe {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CommunitySafeImplCopyWith<_$CommunitySafeImpl> get copyWith =>
-      __$$CommunitySafeImplCopyWithImpl<_$CommunitySafeImpl>(this, _$identity);
+  _$$_CommunitySafeCopyWith<_$_CommunitySafe> get copyWith =>
+      __$$_CommunitySafeCopyWithImpl<_$_CommunitySafe>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CommunitySafeImplToJson(
+    return _$$_CommunitySafeToJson(
       this,
     );
   }
@@ -8211,11 +8195,11 @@ abstract class _CommunitySafe extends CommunitySafe {
       required final bool local,
       final String? icon,
       final String? banner,
-      required final String instanceHost}) = _$CommunitySafeImpl;
+      required final String instanceHost}) = _$_CommunitySafe;
   const _CommunitySafe._() : super._();
 
   factory _CommunitySafe.fromJson(Map<String, dynamic> json) =
-      _$CommunitySafeImpl.fromJson;
+      _$_CommunitySafe.fromJson;
 
   @override
   int get id;
@@ -8247,7 +8231,7 @@ abstract class _CommunitySafe extends CommunitySafe {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$CommunitySafeImplCopyWith<_$CommunitySafeImpl> get copyWith =>
+  _$$_CommunitySafeCopyWith<_$_CommunitySafe> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -8363,11 +8347,11 @@ class _$CommentReportCopyWithImpl<$Res, $Val extends CommentReport>
 }
 
 /// @nodoc
-abstract class _$$CommentReportImplCopyWith<$Res>
+abstract class _$$_CommentReportCopyWith<$Res>
     implements $CommentReportCopyWith<$Res> {
-  factory _$$CommentReportImplCopyWith(
-          _$CommentReportImpl value, $Res Function(_$CommentReportImpl) then) =
-      __$$CommentReportImplCopyWithImpl<$Res>;
+  factory _$$_CommentReportCopyWith(
+          _$_CommentReport value, $Res Function(_$_CommentReport) then) =
+      __$$_CommentReportCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -8384,11 +8368,11 @@ abstract class _$$CommentReportImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CommentReportImplCopyWithImpl<$Res>
-    extends _$CommentReportCopyWithImpl<$Res, _$CommentReportImpl>
-    implements _$$CommentReportImplCopyWith<$Res> {
-  __$$CommentReportImplCopyWithImpl(
-      _$CommentReportImpl _value, $Res Function(_$CommentReportImpl) _then)
+class __$$_CommentReportCopyWithImpl<$Res>
+    extends _$CommentReportCopyWithImpl<$Res, _$_CommentReport>
+    implements _$$_CommentReportCopyWith<$Res> {
+  __$$_CommentReportCopyWithImpl(
+      _$_CommentReport _value, $Res Function(_$_CommentReport) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8405,7 +8389,7 @@ class __$$CommentReportImplCopyWithImpl<$Res>
     Object? updated = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$CommentReportImpl(
+    return _then(_$_CommentReport(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -8453,8 +8437,8 @@ class __$$CommentReportImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CommentReportImpl extends _CommentReport {
-  const _$CommentReportImpl(
+class _$_CommentReport extends _CommentReport {
+  const _$_CommentReport(
       {required this.id,
       required this.creatorId,
       required this.commentId,
@@ -8467,8 +8451,8 @@ class _$CommentReportImpl extends _CommentReport {
       required this.instanceHost})
       : super._();
 
-  factory _$CommentReportImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CommentReportImplFromJson(json);
+  factory _$_CommentReport.fromJson(Map<String, dynamic> json) =>
+      _$$_CommentReportFromJson(json);
 
   @override
   final int id;
@@ -8500,7 +8484,7 @@ class _$CommentReportImpl extends _CommentReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CommentReportImpl &&
+            other is _$_CommentReport &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -8538,12 +8522,12 @@ class _$CommentReportImpl extends _CommentReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CommentReportImplCopyWith<_$CommentReportImpl> get copyWith =>
-      __$$CommentReportImplCopyWithImpl<_$CommentReportImpl>(this, _$identity);
+  _$$_CommentReportCopyWith<_$_CommentReport> get copyWith =>
+      __$$_CommentReportCopyWithImpl<_$_CommentReport>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CommentReportImplToJson(
+    return _$$_CommentReportToJson(
       this,
     );
   }
@@ -8560,11 +8544,11 @@ abstract class _CommentReport extends CommentReport {
       final int? resolverId,
       required final DateTime published,
       final DateTime? updated,
-      required final String instanceHost}) = _$CommentReportImpl;
+      required final String instanceHost}) = _$_CommentReport;
   const _CommentReport._() : super._();
 
   factory _CommentReport.fromJson(Map<String, dynamic> json) =
-      _$CommentReportImpl.fromJson;
+      _$_CommentReport.fromJson;
 
   @override
   int get id;
@@ -8588,7 +8572,7 @@ abstract class _CommentReport extends CommentReport {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$CommentReportImplCopyWith<_$CommentReportImpl> get copyWith =>
+  _$$_CommentReportCopyWith<_$_CommentReport> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -8737,10 +8721,10 @@ class _$CommentCopyWithImpl<$Res, $Val extends Comment>
 }
 
 /// @nodoc
-abstract class _$$CommentImplCopyWith<$Res> implements $CommentCopyWith<$Res> {
-  factory _$$CommentImplCopyWith(
-          _$CommentImpl value, $Res Function(_$CommentImpl) then) =
-      __$$CommentImplCopyWithImpl<$Res>;
+abstract class _$$_CommentCopyWith<$Res> implements $CommentCopyWith<$Res> {
+  factory _$$_CommentCopyWith(
+          _$_Comment value, $Res Function(_$_Comment) then) =
+      __$$_CommentCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -8762,11 +8746,10 @@ abstract class _$$CommentImplCopyWith<$Res> implements $CommentCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$CommentImplCopyWithImpl<$Res>
-    extends _$CommentCopyWithImpl<$Res, _$CommentImpl>
-    implements _$$CommentImplCopyWith<$Res> {
-  __$$CommentImplCopyWithImpl(
-      _$CommentImpl _value, $Res Function(_$CommentImpl) _then)
+class __$$_CommentCopyWithImpl<$Res>
+    extends _$CommentCopyWithImpl<$Res, _$_Comment>
+    implements _$$_CommentCopyWith<$Res> {
+  __$$_CommentCopyWithImpl(_$_Comment _value, $Res Function(_$_Comment) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8788,7 +8771,7 @@ class __$$CommentImplCopyWithImpl<$Res>
     Object? instanceHost = null,
     Object? path = null,
   }) {
-    return _then(_$CommentImpl(
+    return _then(_$_Comment(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -8856,8 +8839,8 @@ class __$$CommentImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CommentImpl extends _Comment {
-  const _$CommentImpl(
+class _$_Comment extends _Comment {
+  const _$_Comment(
       {required this.id,
       required this.creatorId,
       required this.postId,
@@ -8875,8 +8858,8 @@ class _$CommentImpl extends _Comment {
       required this.path})
       : super._();
 
-  factory _$CommentImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CommentImplFromJson(json);
+  factory _$_Comment.fromJson(Map<String, dynamic> json) =>
+      _$$_CommentFromJson(json);
 
   @override
   final int id;
@@ -8918,7 +8901,7 @@ class _$CommentImpl extends _Comment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CommentImpl &&
+            other is _$_Comment &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -8965,12 +8948,12 @@ class _$CommentImpl extends _Comment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CommentImplCopyWith<_$CommentImpl> get copyWith =>
-      __$$CommentImplCopyWithImpl<_$CommentImpl>(this, _$identity);
+  _$$_CommentCopyWith<_$_Comment> get copyWith =>
+      __$$_CommentCopyWithImpl<_$_Comment>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CommentImplToJson(
+    return _$$_CommentToJson(
       this,
     );
   }
@@ -8992,10 +8975,10 @@ abstract class _Comment extends Comment {
       required final bool local,
       required final int languageId,
       required final String instanceHost,
-      required final String path}) = _$CommentImpl;
+      required final String path}) = _$_Comment;
   const _Comment._() : super._();
 
-  factory _Comment.fromJson(Map<String, dynamic> json) = _$CommentImpl.fromJson;
+  factory _Comment.fromJson(Map<String, dynamic> json) = _$_Comment.fromJson;
 
   @override
   int get id;
@@ -9029,7 +9012,7 @@ abstract class _Comment extends Comment {
   String get path;
   @override
   @JsonKey(ignore: true)
-  _$$CommentImplCopyWith<_$CommentImpl> get copyWith =>
+  _$$_CommentCopyWith<_$_Comment> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -9117,11 +9100,11 @@ class _$CommentReplyCopyWithImpl<$Res, $Val extends CommentReply>
 }
 
 /// @nodoc
-abstract class _$$CommentReplyImplCopyWith<$Res>
+abstract class _$$_CommentReplyCopyWith<$Res>
     implements $CommentReplyCopyWith<$Res> {
-  factory _$$CommentReplyImplCopyWith(
-          _$CommentReplyImpl value, $Res Function(_$CommentReplyImpl) then) =
-      __$$CommentReplyImplCopyWithImpl<$Res>;
+  factory _$$_CommentReplyCopyWith(
+          _$_CommentReply value, $Res Function(_$_CommentReply) then) =
+      __$$_CommentReplyCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -9134,11 +9117,11 @@ abstract class _$$CommentReplyImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CommentReplyImplCopyWithImpl<$Res>
-    extends _$CommentReplyCopyWithImpl<$Res, _$CommentReplyImpl>
-    implements _$$CommentReplyImplCopyWith<$Res> {
-  __$$CommentReplyImplCopyWithImpl(
-      _$CommentReplyImpl _value, $Res Function(_$CommentReplyImpl) _then)
+class __$$_CommentReplyCopyWithImpl<$Res>
+    extends _$CommentReplyCopyWithImpl<$Res, _$_CommentReply>
+    implements _$$_CommentReplyCopyWith<$Res> {
+  __$$_CommentReplyCopyWithImpl(
+      _$_CommentReply _value, $Res Function(_$_CommentReply) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -9151,7 +9134,7 @@ class __$$CommentReplyImplCopyWithImpl<$Res>
     Object? published = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$CommentReplyImpl(
+    return _then(_$_CommentReply(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -9183,8 +9166,8 @@ class __$$CommentReplyImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CommentReplyImpl extends _CommentReply {
-  const _$CommentReplyImpl(
+class _$_CommentReply extends _CommentReply {
+  const _$_CommentReply(
       {required this.id,
       required this.recipientId,
       required this.commentId,
@@ -9193,8 +9176,8 @@ class _$CommentReplyImpl extends _CommentReply {
       required this.instanceHost})
       : super._();
 
-  factory _$CommentReplyImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CommentReplyImplFromJson(json);
+  factory _$_CommentReply.fromJson(Map<String, dynamic> json) =>
+      _$$_CommentReplyFromJson(json);
 
   @override
   final int id;
@@ -9218,7 +9201,7 @@ class _$CommentReplyImpl extends _CommentReply {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CommentReplyImpl &&
+            other is _$_CommentReply &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.recipientId, recipientId) ||
                 other.recipientId == recipientId) &&
@@ -9239,12 +9222,12 @@ class _$CommentReplyImpl extends _CommentReply {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CommentReplyImplCopyWith<_$CommentReplyImpl> get copyWith =>
-      __$$CommentReplyImplCopyWithImpl<_$CommentReplyImpl>(this, _$identity);
+  _$$_CommentReplyCopyWith<_$_CommentReply> get copyWith =>
+      __$$_CommentReplyCopyWithImpl<_$_CommentReply>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CommentReplyImplToJson(
+    return _$$_CommentReplyToJson(
       this,
     );
   }
@@ -9257,11 +9240,11 @@ abstract class _CommentReply extends CommentReply {
       required final int commentId,
       required final bool read,
       required final DateTime published,
-      required final String instanceHost}) = _$CommentReplyImpl;
+      required final String instanceHost}) = _$_CommentReply;
   const _CommentReply._() : super._();
 
   factory _CommentReply.fromJson(Map<String, dynamic> json) =
-      _$CommentReplyImpl.fromJson;
+      _$_CommentReply.fromJson;
 
   @override
   int get id;
@@ -9277,7 +9260,7 @@ abstract class _CommentReply extends CommentReply {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$CommentReplyImplCopyWith<_$CommentReplyImpl> get copyWith =>
+  _$$_CommentReplyCopyWith<_$_CommentReply> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -9365,11 +9348,11 @@ class _$PersonMentionCopyWithImpl<$Res, $Val extends PersonMention>
 }
 
 /// @nodoc
-abstract class _$$PersonMentionImplCopyWith<$Res>
+abstract class _$$_PersonMentionCopyWith<$Res>
     implements $PersonMentionCopyWith<$Res> {
-  factory _$$PersonMentionImplCopyWith(
-          _$PersonMentionImpl value, $Res Function(_$PersonMentionImpl) then) =
-      __$$PersonMentionImplCopyWithImpl<$Res>;
+  factory _$$_PersonMentionCopyWith(
+          _$_PersonMention value, $Res Function(_$_PersonMention) then) =
+      __$$_PersonMentionCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -9382,11 +9365,11 @@ abstract class _$$PersonMentionImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$PersonMentionImplCopyWithImpl<$Res>
-    extends _$PersonMentionCopyWithImpl<$Res, _$PersonMentionImpl>
-    implements _$$PersonMentionImplCopyWith<$Res> {
-  __$$PersonMentionImplCopyWithImpl(
-      _$PersonMentionImpl _value, $Res Function(_$PersonMentionImpl) _then)
+class __$$_PersonMentionCopyWithImpl<$Res>
+    extends _$PersonMentionCopyWithImpl<$Res, _$_PersonMention>
+    implements _$$_PersonMentionCopyWith<$Res> {
+  __$$_PersonMentionCopyWithImpl(
+      _$_PersonMention _value, $Res Function(_$_PersonMention) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -9399,7 +9382,7 @@ class __$$PersonMentionImplCopyWithImpl<$Res>
     Object? published = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$PersonMentionImpl(
+    return _then(_$_PersonMention(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -9431,8 +9414,8 @@ class __$$PersonMentionImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$PersonMentionImpl extends _PersonMention {
-  const _$PersonMentionImpl(
+class _$_PersonMention extends _PersonMention {
+  const _$_PersonMention(
       {required this.id,
       required this.recipientId,
       required this.commentId,
@@ -9441,8 +9424,8 @@ class _$PersonMentionImpl extends _PersonMention {
       required this.instanceHost})
       : super._();
 
-  factory _$PersonMentionImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PersonMentionImplFromJson(json);
+  factory _$_PersonMention.fromJson(Map<String, dynamic> json) =>
+      _$$_PersonMentionFromJson(json);
 
   @override
   final int id;
@@ -9466,7 +9449,7 @@ class _$PersonMentionImpl extends _PersonMention {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PersonMentionImpl &&
+            other is _$_PersonMention &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.recipientId, recipientId) ||
                 other.recipientId == recipientId) &&
@@ -9487,12 +9470,12 @@ class _$PersonMentionImpl extends _PersonMention {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PersonMentionImplCopyWith<_$PersonMentionImpl> get copyWith =>
-      __$$PersonMentionImplCopyWithImpl<_$PersonMentionImpl>(this, _$identity);
+  _$$_PersonMentionCopyWith<_$_PersonMention> get copyWith =>
+      __$$_PersonMentionCopyWithImpl<_$_PersonMention>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PersonMentionImplToJson(
+    return _$$_PersonMentionToJson(
       this,
     );
   }
@@ -9505,11 +9488,11 @@ abstract class _PersonMention extends PersonMention {
       required final int commentId,
       required final bool read,
       required final DateTime published,
-      required final String instanceHost}) = _$PersonMentionImpl;
+      required final String instanceHost}) = _$_PersonMention;
   const _PersonMention._() : super._();
 
   factory _PersonMention.fromJson(Map<String, dynamic> json) =
-      _$PersonMentionImpl.fromJson;
+      _$_PersonMention.fromJson;
 
   @override
   int get id;
@@ -9525,7 +9508,7 @@ abstract class _PersonMention extends PersonMention {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$PersonMentionImplCopyWith<_$PersonMentionImpl> get copyWith =>
+  _$$_PersonMentionCopyWith<_$_PersonMention> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -9622,12 +9605,11 @@ class _$RegistrationApplicationCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$RegistrationApplicationImplCopyWith<$Res>
+abstract class _$$_RegistrationApplicationCopyWith<$Res>
     implements $RegistrationApplicationCopyWith<$Res> {
-  factory _$$RegistrationApplicationImplCopyWith(
-          _$RegistrationApplicationImpl value,
-          $Res Function(_$RegistrationApplicationImpl) then) =
-      __$$RegistrationApplicationImplCopyWithImpl<$Res>;
+  factory _$$_RegistrationApplicationCopyWith(_$_RegistrationApplication value,
+          $Res Function(_$_RegistrationApplication) then) =
+      __$$_RegistrationApplicationCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -9641,13 +9623,12 @@ abstract class _$$RegistrationApplicationImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$RegistrationApplicationImplCopyWithImpl<$Res>
+class __$$_RegistrationApplicationCopyWithImpl<$Res>
     extends _$RegistrationApplicationCopyWithImpl<$Res,
-        _$RegistrationApplicationImpl>
-    implements _$$RegistrationApplicationImplCopyWith<$Res> {
-  __$$RegistrationApplicationImplCopyWithImpl(
-      _$RegistrationApplicationImpl _value,
-      $Res Function(_$RegistrationApplicationImpl) _then)
+        _$_RegistrationApplication>
+    implements _$$_RegistrationApplicationCopyWith<$Res> {
+  __$$_RegistrationApplicationCopyWithImpl(_$_RegistrationApplication _value,
+      $Res Function(_$_RegistrationApplication) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -9661,7 +9642,7 @@ class __$$RegistrationApplicationImplCopyWithImpl<$Res>
     Object? published = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$RegistrationApplicationImpl(
+    return _then(_$_RegistrationApplication(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -9697,8 +9678,8 @@ class __$$RegistrationApplicationImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$RegistrationApplicationImpl extends _RegistrationApplication {
-  const _$RegistrationApplicationImpl(
+class _$_RegistrationApplication extends _RegistrationApplication {
+  const _$_RegistrationApplication(
       {required this.id,
       required this.localUserId,
       required this.answer,
@@ -9708,8 +9689,8 @@ class _$RegistrationApplicationImpl extends _RegistrationApplication {
       required this.instanceHost})
       : super._();
 
-  factory _$RegistrationApplicationImpl.fromJson(Map<String, dynamic> json) =>
-      _$$RegistrationApplicationImplFromJson(json);
+  factory _$_RegistrationApplication.fromJson(Map<String, dynamic> json) =>
+      _$$_RegistrationApplicationFromJson(json);
 
   @override
   final int id;
@@ -9735,7 +9716,7 @@ class _$RegistrationApplicationImpl extends _RegistrationApplication {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$RegistrationApplicationImpl &&
+            other is _$_RegistrationApplication &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.localUserId, localUserId) ||
                 other.localUserId == localUserId) &&
@@ -9757,13 +9738,14 @@ class _$RegistrationApplicationImpl extends _RegistrationApplication {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$RegistrationApplicationImplCopyWith<_$RegistrationApplicationImpl>
-      get copyWith => __$$RegistrationApplicationImplCopyWithImpl<
-          _$RegistrationApplicationImpl>(this, _$identity);
+  _$$_RegistrationApplicationCopyWith<_$_RegistrationApplication>
+      get copyWith =>
+          __$$_RegistrationApplicationCopyWithImpl<_$_RegistrationApplication>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$RegistrationApplicationImplToJson(
+    return _$$_RegistrationApplicationToJson(
       this,
     );
   }
@@ -9777,11 +9759,11 @@ abstract class _RegistrationApplication extends RegistrationApplication {
       final int? adminId,
       final String? denyReason,
       required final DateTime published,
-      required final String instanceHost}) = _$RegistrationApplicationImpl;
+      required final String instanceHost}) = _$_RegistrationApplication;
   const _RegistrationApplication._() : super._();
 
   factory _RegistrationApplication.fromJson(Map<String, dynamic> json) =
-      _$RegistrationApplicationImpl.fromJson;
+      _$_RegistrationApplication.fromJson;
 
   @override
   int get id;
@@ -9799,6 +9781,6 @@ abstract class _RegistrationApplication extends RegistrationApplication {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$RegistrationApplicationImplCopyWith<_$RegistrationApplicationImpl>
+  _$$_RegistrationApplicationCopyWith<_$_RegistrationApplication>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/source.g.dart
+++ b/lib/src/v3/models/source.g.dart
@@ -6,8 +6,8 @@ part of 'source.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$PersonSafeImpl _$$PersonSafeImplFromJson(Map<String, dynamic> json) =>
-    _$PersonSafeImpl(
+_$_PersonSafe _$$_PersonSafeFromJson(Map<String, dynamic> json) =>
+    _$_PersonSafe(
       id: json['id'] as int,
       name: json['name'] as String,
       displayName: json['display_name'] as String?,
@@ -29,7 +29,7 @@ _$PersonSafeImpl _$$PersonSafeImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$PersonSafeImplToJson(_$PersonSafeImpl instance) =>
+Map<String, dynamic> _$$_PersonSafeToJson(_$_PersonSafe instance) =>
     <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
@@ -64,9 +64,8 @@ Json? _$JsonConverterToJson<Json, Value>(
 ) =>
     value == null ? null : toJson(value);
 
-_$LocalUserSettingsImpl _$$LocalUserSettingsImplFromJson(
-        Map<String, dynamic> json) =>
-    _$LocalUserSettingsImpl(
+_$_LocalUserSettings _$$_LocalUserSettingsFromJson(Map<String, dynamic> json) =>
+    _$_LocalUserSettings(
       id: json['id'] as int,
       personId: json['person_id'] as int,
       email: json['email'] as String?,
@@ -90,8 +89,8 @@ _$LocalUserSettingsImpl _$$LocalUserSettingsImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$LocalUserSettingsImplToJson(
-        _$LocalUserSettingsImpl instance) =>
+Map<String, dynamic> _$$_LocalUserSettingsToJson(
+        _$_LocalUserSettings instance) =>
     <String, dynamic>{
       'id': instance.id,
       'person_id': instance.personId,
@@ -112,7 +111,7 @@ Map<String, dynamic> _$$LocalUserSettingsImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$SiteImpl _$$SiteImplFromJson(Map<String, dynamic> json) => _$SiteImpl(
+_$_Site _$$_SiteFromJson(Map<String, dynamic> json) => _$_Site(
       id: json['id'] as int,
       name: json['name'] as String,
       sidebar: json['sidebar'] as String?,
@@ -130,8 +129,7 @@ _$SiteImpl _$$SiteImplFromJson(Map<String, dynamic> json) => _$SiteImpl(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$SiteImplToJson(_$SiteImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$$_SiteToJson(_$_Site instance) => <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
       'sidebar': instance.sidebar,
@@ -149,8 +147,7 @@ Map<String, dynamic> _$$SiteImplToJson(_$SiteImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$LocalSiteImpl _$$LocalSiteImplFromJson(Map<String, dynamic> json) =>
-    _$LocalSiteImpl(
+_$_LocalSite _$$_LocalSiteFromJson(Map<String, dynamic> json) => _$_LocalSite(
       id: json['id'] as int,
       siteId: json['site_id'] as int,
       siteSetup: json['site_setup'] as bool,
@@ -179,7 +176,7 @@ _$LocalSiteImpl _$$LocalSiteImplFromJson(Map<String, dynamic> json) =>
       reportsEmailAdmins: json['reports_email_admins'] as bool,
     );
 
-Map<String, dynamic> _$$LocalSiteImplToJson(_$LocalSiteImpl instance) =>
+Map<String, dynamic> _$$_LocalSiteToJson(_$_LocalSite instance) =>
     <String, dynamic>{
       'id': instance.id,
       'site_id': instance.siteId,
@@ -208,8 +205,8 @@ Map<String, dynamic> _$$LocalSiteImplToJson(_$LocalSiteImpl instance) =>
       'reports_email_admins': instance.reportsEmailAdmins,
     };
 
-_$PrivateMessageImpl _$$PrivateMessageImplFromJson(Map<String, dynamic> json) =>
-    _$PrivateMessageImpl(
+_$_PrivateMessage _$$_PrivateMessageFromJson(Map<String, dynamic> json) =>
+    _$_PrivateMessage(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       recipientId: json['recipient_id'] as int,
@@ -224,8 +221,7 @@ _$PrivateMessageImpl _$$PrivateMessageImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$PrivateMessageImplToJson(
-        _$PrivateMessageImpl instance) =>
+Map<String, dynamic> _$$_PrivateMessageToJson(_$_PrivateMessage instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,
@@ -241,8 +237,8 @@ Map<String, dynamic> _$$PrivateMessageImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$PostReportImpl _$$PostReportImplFromJson(Map<String, dynamic> json) =>
-    _$PostReportImpl(
+_$_PostReport _$$_PostReportFromJson(Map<String, dynamic> json) =>
+    _$_PostReport(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       postId: json['post_id'] as int,
@@ -258,7 +254,7 @@ _$PostReportImpl _$$PostReportImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$PostReportImplToJson(_$PostReportImpl instance) =>
+Map<String, dynamic> _$$_PostReportToJson(_$_PostReport instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,
@@ -275,7 +271,7 @@ Map<String, dynamic> _$$PostReportImplToJson(_$PostReportImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$PostImpl _$$PostImplFromJson(Map<String, dynamic> json) => _$PostImpl(
+_$_Post _$$_PostFromJson(Map<String, dynamic> json) => _$_Post(
       id: json['id'] as int,
       name: json['name'] as String,
       url: json['url'] as String?,
@@ -300,8 +296,7 @@ _$PostImpl _$$PostImplFromJson(Map<String, dynamic> json) => _$PostImpl(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$PostImplToJson(_$PostImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$$_PostToJson(_$_Post instance) => <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
       'url': instance.url,
@@ -326,9 +321,9 @@ Map<String, dynamic> _$$PostImplToJson(_$PostImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$PasswordResetRequestImpl _$$PasswordResetRequestImplFromJson(
+_$_PasswordResetRequest _$$_PasswordResetRequestFromJson(
         Map<String, dynamic> json) =>
-    _$PasswordResetRequestImpl(
+    _$_PasswordResetRequest(
       id: json['id'] as int,
       localUserId: json['local_user_id'] as int,
       tokenEncrypted: json['token_encrypted'] as String,
@@ -336,8 +331,8 @@ _$PasswordResetRequestImpl _$$PasswordResetRequestImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$PasswordResetRequestImplToJson(
-        _$PasswordResetRequestImpl instance) =>
+Map<String, dynamic> _$$_PasswordResetRequestToJson(
+        _$_PasswordResetRequest instance) =>
     <String, dynamic>{
       'id': instance.id,
       'local_user_id': instance.localUserId,
@@ -346,8 +341,8 @@ Map<String, dynamic> _$$PasswordResetRequestImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModRemovePostImpl _$$ModRemovePostImplFromJson(Map<String, dynamic> json) =>
-    _$ModRemovePostImpl(
+_$_ModRemovePost _$$_ModRemovePostFromJson(Map<String, dynamic> json) =>
+    _$_ModRemovePost(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       postId: json['post_id'] as int,
@@ -357,7 +352,7 @@ _$ModRemovePostImpl _$$ModRemovePostImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModRemovePostImplToJson(_$ModRemovePostImpl instance) =>
+Map<String, dynamic> _$$_ModRemovePostToJson(_$_ModRemovePost instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -368,8 +363,8 @@ Map<String, dynamic> _$$ModRemovePostImplToJson(_$ModRemovePostImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$ModLockPostImpl _$$ModLockPostImplFromJson(Map<String, dynamic> json) =>
-    _$ModLockPostImpl(
+_$_ModLockPost _$$_ModLockPostFromJson(Map<String, dynamic> json) =>
+    _$_ModLockPost(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       postId: json['post_id'] as int,
@@ -378,7 +373,7 @@ _$ModLockPostImpl _$$ModLockPostImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModLockPostImplToJson(_$ModLockPostImpl instance) =>
+Map<String, dynamic> _$$_ModLockPostToJson(_$_ModLockPost instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -388,8 +383,8 @@ Map<String, dynamic> _$$ModLockPostImplToJson(_$ModLockPostImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$ModStickyPostImpl _$$ModStickyPostImplFromJson(Map<String, dynamic> json) =>
-    _$ModStickyPostImpl(
+_$_ModStickyPost _$$_ModStickyPostFromJson(Map<String, dynamic> json) =>
+    _$_ModStickyPost(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       postId: json['post_id'] as int,
@@ -398,7 +393,7 @@ _$ModStickyPostImpl _$$ModStickyPostImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModStickyPostImplToJson(_$ModStickyPostImpl instance) =>
+Map<String, dynamic> _$$_ModStickyPostToJson(_$_ModStickyPost instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -408,8 +403,8 @@ Map<String, dynamic> _$$ModStickyPostImplToJson(_$ModStickyPostImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$ModFeaturePostImpl _$$ModFeaturePostImplFromJson(Map<String, dynamic> json) =>
-    _$ModFeaturePostImpl(
+_$_ModFeaturePost _$$_ModFeaturePostFromJson(Map<String, dynamic> json) =>
+    _$_ModFeaturePost(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       postId: json['post_id'] as int,
@@ -419,8 +414,7 @@ _$ModFeaturePostImpl _$$ModFeaturePostImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModFeaturePostImplToJson(
-        _$ModFeaturePostImpl instance) =>
+Map<String, dynamic> _$$_ModFeaturePostToJson(_$_ModFeaturePost instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -431,9 +425,8 @@ Map<String, dynamic> _$$ModFeaturePostImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModRemoveCommentImpl _$$ModRemoveCommentImplFromJson(
-        Map<String, dynamic> json) =>
-    _$ModRemoveCommentImpl(
+_$_ModRemoveComment _$$_ModRemoveCommentFromJson(Map<String, dynamic> json) =>
+    _$_ModRemoveComment(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       commentId: json['comment_id'] as int,
@@ -443,8 +436,7 @@ _$ModRemoveCommentImpl _$$ModRemoveCommentImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModRemoveCommentImplToJson(
-        _$ModRemoveCommentImpl instance) =>
+Map<String, dynamic> _$$_ModRemoveCommentToJson(_$_ModRemoveComment instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -455,9 +447,9 @@ Map<String, dynamic> _$$ModRemoveCommentImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModRemoveCommunityImpl _$$ModRemoveCommunityImplFromJson(
+_$_ModRemoveCommunity _$$_ModRemoveCommunityFromJson(
         Map<String, dynamic> json) =>
-    _$ModRemoveCommunityImpl(
+    _$_ModRemoveCommunity(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       communityId: json['community_id'] as int,
@@ -469,8 +461,8 @@ _$ModRemoveCommunityImpl _$$ModRemoveCommunityImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModRemoveCommunityImplToJson(
-        _$ModRemoveCommunityImpl instance) =>
+Map<String, dynamic> _$$_ModRemoveCommunityToJson(
+        _$_ModRemoveCommunity instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -483,9 +475,8 @@ Map<String, dynamic> _$$ModRemoveCommunityImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModHideCommunityImpl _$$ModHideCommunityImplFromJson(
-        Map<String, dynamic> json) =>
-    _$ModHideCommunityImpl(
+_$_ModHideCommunity _$$_ModHideCommunityFromJson(Map<String, dynamic> json) =>
+    _$_ModHideCommunity(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       communityId: json['community_id'] as int,
@@ -495,8 +486,7 @@ _$ModHideCommunityImpl _$$ModHideCommunityImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModHideCommunityImplToJson(
-        _$ModHideCommunityImpl instance) =>
+Map<String, dynamic> _$$_ModHideCommunityToJson(_$_ModHideCommunity instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -507,9 +497,9 @@ Map<String, dynamic> _$$ModHideCommunityImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModBanFromCommunityImpl _$$ModBanFromCommunityImplFromJson(
+_$_ModBanFromCommunity _$$_ModBanFromCommunityFromJson(
         Map<String, dynamic> json) =>
-    _$ModBanFromCommunityImpl(
+    _$_ModBanFromCommunity(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       otherPersonId: json['other_person_id'] as int,
@@ -522,8 +512,8 @@ _$ModBanFromCommunityImpl _$$ModBanFromCommunityImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModBanFromCommunityImplToJson(
-        _$ModBanFromCommunityImpl instance) =>
+Map<String, dynamic> _$$_ModBanFromCommunityToJson(
+        _$_ModBanFromCommunity instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -537,7 +527,7 @@ Map<String, dynamic> _$$ModBanFromCommunityImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModBanImpl _$$ModBanImplFromJson(Map<String, dynamic> json) => _$ModBanImpl(
+_$_ModBan _$$_ModBanFromJson(Map<String, dynamic> json) => _$_ModBan(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       otherPersonId: json['other_person_id'] as int,
@@ -549,8 +539,7 @@ _$ModBanImpl _$$ModBanImplFromJson(Map<String, dynamic> json) => _$ModBanImpl(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModBanImplToJson(_$ModBanImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$$_ModBanToJson(_$_ModBan instance) => <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
       'other_person_id': instance.otherPersonId,
@@ -562,9 +551,8 @@ Map<String, dynamic> _$$ModBanImplToJson(_$ModBanImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$ModAddCommunityImpl _$$ModAddCommunityImplFromJson(
-        Map<String, dynamic> json) =>
-    _$ModAddCommunityImpl(
+_$_ModAddCommunity _$$_ModAddCommunityFromJson(Map<String, dynamic> json) =>
+    _$_ModAddCommunity(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       otherPersonId: json['other_person_id'] as int,
@@ -574,8 +562,7 @@ _$ModAddCommunityImpl _$$ModAddCommunityImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModAddCommunityImplToJson(
-        _$ModAddCommunityImpl instance) =>
+Map<String, dynamic> _$$_ModAddCommunityToJson(_$_ModAddCommunity instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -586,9 +573,9 @@ Map<String, dynamic> _$$ModAddCommunityImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModTransferCommunityImpl _$$ModTransferCommunityImplFromJson(
+_$_ModTransferCommunity _$$_ModTransferCommunityFromJson(
         Map<String, dynamic> json) =>
-    _$ModTransferCommunityImpl(
+    _$_ModTransferCommunity(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       otherPersonId: json['other_person_id'] as int,
@@ -598,8 +585,8 @@ _$ModTransferCommunityImpl _$$ModTransferCommunityImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModTransferCommunityImplToJson(
-        _$ModTransferCommunityImpl instance) =>
+Map<String, dynamic> _$$_ModTransferCommunityToJson(
+        _$_ModTransferCommunity instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -610,7 +597,7 @@ Map<String, dynamic> _$$ModTransferCommunityImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModAddImpl _$$ModAddImplFromJson(Map<String, dynamic> json) => _$ModAddImpl(
+_$_ModAdd _$$_ModAddFromJson(Map<String, dynamic> json) => _$_ModAdd(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       otherPersonId: json['other_person_id'] as int,
@@ -619,8 +606,7 @@ _$ModAddImpl _$$ModAddImplFromJson(Map<String, dynamic> json) => _$ModAddImpl(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModAddImplToJson(_$ModAddImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$$_ModAddToJson(_$_ModAdd instance) => <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
       'other_person_id': instance.otherPersonId,
@@ -629,9 +615,8 @@ Map<String, dynamic> _$$ModAddImplToJson(_$ModAddImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$AdminPurgeCommentImpl _$$AdminPurgeCommentImplFromJson(
-        Map<String, dynamic> json) =>
-    _$AdminPurgeCommentImpl(
+_$_AdminPurgeComment _$$_AdminPurgeCommentFromJson(Map<String, dynamic> json) =>
+    _$_AdminPurgeComment(
       id: json['id'] as int,
       adminPersonId: json['admin_person_id'] as int,
       postId: json['post_id'] as int,
@@ -640,8 +625,8 @@ _$AdminPurgeCommentImpl _$$AdminPurgeCommentImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$AdminPurgeCommentImplToJson(
-        _$AdminPurgeCommentImpl instance) =>
+Map<String, dynamic> _$$_AdminPurgeCommentToJson(
+        _$_AdminPurgeComment instance) =>
     <String, dynamic>{
       'id': instance.id,
       'admin_person_id': instance.adminPersonId,
@@ -651,8 +636,8 @@ Map<String, dynamic> _$$AdminPurgeCommentImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$AdminPurgePostImpl _$$AdminPurgePostImplFromJson(Map<String, dynamic> json) =>
-    _$AdminPurgePostImpl(
+_$_AdminPurgePost _$$_AdminPurgePostFromJson(Map<String, dynamic> json) =>
+    _$_AdminPurgePost(
       id: json['id'] as int,
       adminPersonId: json['admin_person_id'] as int,
       communityId: json['community_id'] as int,
@@ -661,8 +646,7 @@ _$AdminPurgePostImpl _$$AdminPurgePostImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$AdminPurgePostImplToJson(
-        _$AdminPurgePostImpl instance) =>
+Map<String, dynamic> _$$_AdminPurgePostToJson(_$_AdminPurgePost instance) =>
     <String, dynamic>{
       'id': instance.id,
       'admin_person_id': instance.adminPersonId,
@@ -672,9 +656,8 @@ Map<String, dynamic> _$$AdminPurgePostImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$AdminPurgePersonImpl _$$AdminPurgePersonImplFromJson(
-        Map<String, dynamic> json) =>
-    _$AdminPurgePersonImpl(
+_$_AdminPurgePerson _$$_AdminPurgePersonFromJson(Map<String, dynamic> json) =>
+    _$_AdminPurgePerson(
       id: json['id'] as int,
       adminPersonId: json['admin_person_id'] as int,
       reason: json['reason'] as String?,
@@ -682,8 +665,7 @@ _$AdminPurgePersonImpl _$$AdminPurgePersonImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$AdminPurgePersonImplToJson(
-        _$AdminPurgePersonImpl instance) =>
+Map<String, dynamic> _$$_AdminPurgePersonToJson(_$_AdminPurgePerson instance) =>
     <String, dynamic>{
       'id': instance.id,
       'admin_person_id': instance.adminPersonId,
@@ -692,9 +674,9 @@ Map<String, dynamic> _$$AdminPurgePersonImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$AdminPurgeCommunityImpl _$$AdminPurgeCommunityImplFromJson(
+_$_AdminPurgeCommunity _$$_AdminPurgeCommunityFromJson(
         Map<String, dynamic> json) =>
-    _$AdminPurgeCommunityImpl(
+    _$_AdminPurgeCommunity(
       id: json['id'] as int,
       adminPersonId: json['admin_person_id'] as int,
       reason: json['reason'] as String?,
@@ -702,8 +684,8 @@ _$AdminPurgeCommunityImpl _$$AdminPurgeCommunityImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$AdminPurgeCommunityImplToJson(
-        _$AdminPurgeCommunityImpl instance) =>
+Map<String, dynamic> _$$_AdminPurgeCommunityToJson(
+        _$_AdminPurgeCommunity instance) =>
     <String, dynamic>{
       'id': instance.id,
       'admin_person_id': instance.adminPersonId,
@@ -712,8 +694,8 @@ Map<String, dynamic> _$$AdminPurgeCommunityImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$CommunitySafeImpl _$$CommunitySafeImplFromJson(Map<String, dynamic> json) =>
-    _$CommunitySafeImpl(
+_$_CommunitySafe _$$_CommunitySafeFromJson(Map<String, dynamic> json) =>
+    _$_CommunitySafe(
       id: json['id'] as int,
       name: json['name'] as String,
       title: json['title'] as String,
@@ -731,7 +713,7 @@ _$CommunitySafeImpl _$$CommunitySafeImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$CommunitySafeImplToJson(_$CommunitySafeImpl instance) =>
+Map<String, dynamic> _$$_CommunitySafeToJson(_$_CommunitySafe instance) =>
     <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
@@ -750,8 +732,8 @@ Map<String, dynamic> _$$CommunitySafeImplToJson(_$CommunitySafeImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$CommentReportImpl _$$CommentReportImplFromJson(Map<String, dynamic> json) =>
-    _$CommentReportImpl(
+_$_CommentReport _$$_CommentReportFromJson(Map<String, dynamic> json) =>
+    _$_CommentReport(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       commentId: json['comment_id'] as int,
@@ -765,7 +747,7 @@ _$CommentReportImpl _$$CommentReportImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$CommentReportImplToJson(_$CommentReportImpl instance) =>
+Map<String, dynamic> _$$_CommentReportToJson(_$_CommentReport instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,
@@ -780,8 +762,7 @@ Map<String, dynamic> _$$CommentReportImplToJson(_$CommentReportImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$CommentImpl _$$CommentImplFromJson(Map<String, dynamic> json) =>
-    _$CommentImpl(
+_$_Comment _$$_CommentFromJson(Map<String, dynamic> json) => _$_Comment(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       postId: json['post_id'] as int,
@@ -800,7 +781,7 @@ _$CommentImpl _$$CommentImplFromJson(Map<String, dynamic> json) =>
       path: json['path'] as String,
     );
 
-Map<String, dynamic> _$$CommentImplToJson(_$CommentImpl instance) =>
+Map<String, dynamic> _$$_CommentToJson(_$_Comment instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,
@@ -820,8 +801,8 @@ Map<String, dynamic> _$$CommentImplToJson(_$CommentImpl instance) =>
       'path': instance.path,
     };
 
-_$CommentReplyImpl _$$CommentReplyImplFromJson(Map<String, dynamic> json) =>
-    _$CommentReplyImpl(
+_$_CommentReply _$$_CommentReplyFromJson(Map<String, dynamic> json) =>
+    _$_CommentReply(
       id: json['id'] as int,
       recipientId: json['recipient_id'] as int,
       commentId: json['comment_id'] as int,
@@ -830,7 +811,7 @@ _$CommentReplyImpl _$$CommentReplyImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$CommentReplyImplToJson(_$CommentReplyImpl instance) =>
+Map<String, dynamic> _$$_CommentReplyToJson(_$_CommentReply instance) =>
     <String, dynamic>{
       'id': instance.id,
       'recipient_id': instance.recipientId,
@@ -840,8 +821,8 @@ Map<String, dynamic> _$$CommentReplyImplToJson(_$CommentReplyImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$PersonMentionImpl _$$PersonMentionImplFromJson(Map<String, dynamic> json) =>
-    _$PersonMentionImpl(
+_$_PersonMention _$$_PersonMentionFromJson(Map<String, dynamic> json) =>
+    _$_PersonMention(
       id: json['id'] as int,
       recipientId: json['recipient_id'] as int,
       commentId: json['comment_id'] as int,
@@ -850,7 +831,7 @@ _$PersonMentionImpl _$$PersonMentionImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$PersonMentionImplToJson(_$PersonMentionImpl instance) =>
+Map<String, dynamic> _$$_PersonMentionToJson(_$_PersonMention instance) =>
     <String, dynamic>{
       'id': instance.id,
       'recipient_id': instance.recipientId,
@@ -860,9 +841,9 @@ Map<String, dynamic> _$$PersonMentionImplToJson(_$PersonMentionImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$RegistrationApplicationImpl _$$RegistrationApplicationImplFromJson(
+_$_RegistrationApplication _$$_RegistrationApplicationFromJson(
         Map<String, dynamic> json) =>
-    _$RegistrationApplicationImpl(
+    _$_RegistrationApplication(
       id: json['id'] as int,
       localUserId: json['local_user_id'] as int,
       answer: json['answer'] as String,
@@ -872,8 +853,8 @@ _$RegistrationApplicationImpl _$$RegistrationApplicationImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$RegistrationApplicationImplToJson(
-        _$RegistrationApplicationImpl instance) =>
+Map<String, dynamic> _$$_RegistrationApplicationToJson(
+        _$_RegistrationApplication instance) =>
     <String, dynamic>{
       'id': instance.id,
       'local_user_id': instance.localUserId,

--- a/lib/src/v3/models/views.freezed.dart
+++ b/lib/src/v3/models/views.freezed.dart
@@ -93,11 +93,11 @@ class _$PersonViewSafeCopyWithImpl<$Res, $Val extends PersonViewSafe>
 }
 
 /// @nodoc
-abstract class _$$PersonViewSafeImplCopyWith<$Res>
+abstract class _$$_PersonViewSafeCopyWith<$Res>
     implements $PersonViewSafeCopyWith<$Res> {
-  factory _$$PersonViewSafeImplCopyWith(_$PersonViewSafeImpl value,
-          $Res Function(_$PersonViewSafeImpl) then) =
-      __$$PersonViewSafeImplCopyWithImpl<$Res>;
+  factory _$$_PersonViewSafeCopyWith(
+          _$_PersonViewSafe value, $Res Function(_$_PersonViewSafe) then) =
+      __$$_PersonViewSafeCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonSafe person, PersonAggregates counts, String instanceHost});
@@ -109,11 +109,11 @@ abstract class _$$PersonViewSafeImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$PersonViewSafeImplCopyWithImpl<$Res>
-    extends _$PersonViewSafeCopyWithImpl<$Res, _$PersonViewSafeImpl>
-    implements _$$PersonViewSafeImplCopyWith<$Res> {
-  __$$PersonViewSafeImplCopyWithImpl(
-      _$PersonViewSafeImpl _value, $Res Function(_$PersonViewSafeImpl) _then)
+class __$$_PersonViewSafeCopyWithImpl<$Res>
+    extends _$PersonViewSafeCopyWithImpl<$Res, _$_PersonViewSafe>
+    implements _$$_PersonViewSafeCopyWith<$Res> {
+  __$$_PersonViewSafeCopyWithImpl(
+      _$_PersonViewSafe _value, $Res Function(_$_PersonViewSafe) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -123,7 +123,7 @@ class __$$PersonViewSafeImplCopyWithImpl<$Res>
     Object? counts = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$PersonViewSafeImpl(
+    return _then(_$_PersonViewSafe(
       person: null == person
           ? _value.person
           : person // ignore: cast_nullable_to_non_nullable
@@ -143,13 +143,13 @@ class __$$PersonViewSafeImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$PersonViewSafeImpl extends _PersonViewSafe {
-  const _$PersonViewSafeImpl(
+class _$_PersonViewSafe extends _PersonViewSafe {
+  const _$_PersonViewSafe(
       {required this.person, required this.counts, required this.instanceHost})
       : super._();
 
-  factory _$PersonViewSafeImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PersonViewSafeImplFromJson(json);
+  factory _$_PersonViewSafe.fromJson(Map<String, dynamic> json) =>
+      _$$_PersonViewSafeFromJson(json);
 
   @override
   final PersonSafe person;
@@ -167,7 +167,7 @@ class _$PersonViewSafeImpl extends _PersonViewSafe {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PersonViewSafeImpl &&
+            other is _$_PersonViewSafe &&
             (identical(other.person, person) || other.person == person) &&
             (identical(other.counts, counts) || other.counts == counts) &&
             (identical(other.instanceHost, instanceHost) ||
@@ -181,13 +181,12 @@ class _$PersonViewSafeImpl extends _PersonViewSafe {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PersonViewSafeImplCopyWith<_$PersonViewSafeImpl> get copyWith =>
-      __$$PersonViewSafeImplCopyWithImpl<_$PersonViewSafeImpl>(
-          this, _$identity);
+  _$$_PersonViewSafeCopyWith<_$_PersonViewSafe> get copyWith =>
+      __$$_PersonViewSafeCopyWithImpl<_$_PersonViewSafe>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PersonViewSafeImplToJson(
+    return _$$_PersonViewSafeToJson(
       this,
     );
   }
@@ -197,11 +196,11 @@ abstract class _PersonViewSafe extends PersonViewSafe {
   const factory _PersonViewSafe(
       {required final PersonSafe person,
       required final PersonAggregates counts,
-      required final String instanceHost}) = _$PersonViewSafeImpl;
+      required final String instanceHost}) = _$_PersonViewSafe;
   const _PersonViewSafe._() : super._();
 
   factory _PersonViewSafe.fromJson(Map<String, dynamic> json) =
-      _$PersonViewSafeImpl.fromJson;
+      _$_PersonViewSafe.fromJson;
 
   @override
   PersonSafe get person;
@@ -211,7 +210,7 @@ abstract class _PersonViewSafe extends PersonViewSafe {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$PersonViewSafeImplCopyWith<_$PersonViewSafeImpl> get copyWith =>
+  _$$_PersonViewSafeCopyWith<_$_PersonViewSafe> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -412,11 +411,11 @@ class _$PersonMentionViewCopyWithImpl<$Res, $Val extends PersonMentionView>
 }
 
 /// @nodoc
-abstract class _$$PersonMentionViewImplCopyWith<$Res>
+abstract class _$$_PersonMentionViewCopyWith<$Res>
     implements $PersonMentionViewCopyWith<$Res> {
-  factory _$$PersonMentionViewImplCopyWith(_$PersonMentionViewImpl value,
-          $Res Function(_$PersonMentionViewImpl) then) =
-      __$$PersonMentionViewImplCopyWithImpl<$Res>;
+  factory _$$_PersonMentionViewCopyWith(_$_PersonMentionView value,
+          $Res Function(_$_PersonMentionView) then) =
+      __$$_PersonMentionViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -451,11 +450,11 @@ abstract class _$$PersonMentionViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$PersonMentionViewImplCopyWithImpl<$Res>
-    extends _$PersonMentionViewCopyWithImpl<$Res, _$PersonMentionViewImpl>
-    implements _$$PersonMentionViewImplCopyWith<$Res> {
-  __$$PersonMentionViewImplCopyWithImpl(_$PersonMentionViewImpl _value,
-      $Res Function(_$PersonMentionViewImpl) _then)
+class __$$_PersonMentionViewCopyWithImpl<$Res>
+    extends _$PersonMentionViewCopyWithImpl<$Res, _$_PersonMentionView>
+    implements _$$_PersonMentionViewCopyWith<$Res> {
+  __$$_PersonMentionViewCopyWithImpl(
+      _$_PersonMentionView _value, $Res Function(_$_PersonMentionView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -475,7 +474,7 @@ class __$$PersonMentionViewImplCopyWithImpl<$Res>
     Object? myVote = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$PersonMentionViewImpl(
+    return _then(_$_PersonMentionView(
       personMention: null == personMention
           ? _value.personMention
           : personMention // ignore: cast_nullable_to_non_nullable
@@ -535,8 +534,8 @@ class __$$PersonMentionViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$PersonMentionViewImpl extends _PersonMentionView {
-  const _$PersonMentionViewImpl(
+class _$_PersonMentionView extends _PersonMentionView {
+  const _$_PersonMentionView(
       {required this.personMention,
       required this.comment,
       required this.creator,
@@ -552,8 +551,8 @@ class _$PersonMentionViewImpl extends _PersonMentionView {
       required this.instanceHost})
       : super._();
 
-  factory _$PersonMentionViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PersonMentionViewImplFromJson(json);
+  factory _$_PersonMentionView.fromJson(Map<String, dynamic> json) =>
+      _$$_PersonMentionViewFromJson(json);
 
   @override
   final PersonMention personMention;
@@ -592,7 +591,7 @@ class _$PersonMentionViewImpl extends _PersonMentionView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PersonMentionViewImpl &&
+            other is _$_PersonMentionView &&
             (identical(other.personMention, personMention) ||
                 other.personMention == personMention) &&
             (identical(other.comment, comment) || other.comment == comment) &&
@@ -638,13 +637,13 @@ class _$PersonMentionViewImpl extends _PersonMentionView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PersonMentionViewImplCopyWith<_$PersonMentionViewImpl> get copyWith =>
-      __$$PersonMentionViewImplCopyWithImpl<_$PersonMentionViewImpl>(
+  _$$_PersonMentionViewCopyWith<_$_PersonMentionView> get copyWith =>
+      __$$_PersonMentionViewCopyWithImpl<_$_PersonMentionView>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PersonMentionViewImplToJson(
+    return _$$_PersonMentionViewToJson(
       this,
     );
   }
@@ -664,11 +663,11 @@ abstract class _PersonMentionView extends PersonMentionView {
       required final bool saved,
       required final bool creatorBlocked,
       final VoteType? myVote,
-      required final String instanceHost}) = _$PersonMentionViewImpl;
+      required final String instanceHost}) = _$_PersonMentionView;
   const _PersonMentionView._() : super._();
 
   factory _PersonMentionView.fromJson(Map<String, dynamic> json) =
-      _$PersonMentionViewImpl.fromJson;
+      _$_PersonMentionView.fromJson;
 
   @override
   PersonMention get personMention;
@@ -698,7 +697,7 @@ abstract class _PersonMentionView extends PersonMentionView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$PersonMentionViewImplCopyWith<_$PersonMentionViewImpl> get copyWith =>
+  _$$_PersonMentionViewCopyWith<_$_PersonMentionView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -802,12 +801,11 @@ class _$LocalUserSettingsViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$LocalUserSettingsViewImplCopyWith<$Res>
+abstract class _$$_LocalUserSettingsViewCopyWith<$Res>
     implements $LocalUserSettingsViewCopyWith<$Res> {
-  factory _$$LocalUserSettingsViewImplCopyWith(
-          _$LocalUserSettingsViewImpl value,
-          $Res Function(_$LocalUserSettingsViewImpl) then) =
-      __$$LocalUserSettingsViewImplCopyWithImpl<$Res>;
+  factory _$$_LocalUserSettingsViewCopyWith(_$_LocalUserSettingsView value,
+          $Res Function(_$_LocalUserSettingsView) then) =
+      __$$_LocalUserSettingsViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -825,12 +823,11 @@ abstract class _$$LocalUserSettingsViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$LocalUserSettingsViewImplCopyWithImpl<$Res>
-    extends _$LocalUserSettingsViewCopyWithImpl<$Res,
-        _$LocalUserSettingsViewImpl>
-    implements _$$LocalUserSettingsViewImplCopyWith<$Res> {
-  __$$LocalUserSettingsViewImplCopyWithImpl(_$LocalUserSettingsViewImpl _value,
-      $Res Function(_$LocalUserSettingsViewImpl) _then)
+class __$$_LocalUserSettingsViewCopyWithImpl<$Res>
+    extends _$LocalUserSettingsViewCopyWithImpl<$Res, _$_LocalUserSettingsView>
+    implements _$$_LocalUserSettingsViewCopyWith<$Res> {
+  __$$_LocalUserSettingsViewCopyWithImpl(_$_LocalUserSettingsView _value,
+      $Res Function(_$_LocalUserSettingsView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -841,7 +838,7 @@ class __$$LocalUserSettingsViewImplCopyWithImpl<$Res>
     Object? counts = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$LocalUserSettingsViewImpl(
+    return _then(_$_LocalUserSettingsView(
       localUser: null == localUser
           ? _value.localUser
           : localUser // ignore: cast_nullable_to_non_nullable
@@ -865,16 +862,16 @@ class __$$LocalUserSettingsViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$LocalUserSettingsViewImpl extends _LocalUserSettingsView {
-  const _$LocalUserSettingsViewImpl(
+class _$_LocalUserSettingsView extends _LocalUserSettingsView {
+  const _$_LocalUserSettingsView(
       {required this.localUser,
       required this.person,
       required this.counts,
       required this.instanceHost})
       : super._();
 
-  factory _$LocalUserSettingsViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$LocalUserSettingsViewImplFromJson(json);
+  factory _$_LocalUserSettingsView.fromJson(Map<String, dynamic> json) =>
+      _$$_LocalUserSettingsViewFromJson(json);
 
   @override
   final LocalUserSettings localUser;
@@ -894,7 +891,7 @@ class _$LocalUserSettingsViewImpl extends _LocalUserSettingsView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$LocalUserSettingsViewImpl &&
+            other is _$_LocalUserSettingsView &&
             (identical(other.localUser, localUser) ||
                 other.localUser == localUser) &&
             (identical(other.person, person) || other.person == person) &&
@@ -911,13 +908,13 @@ class _$LocalUserSettingsViewImpl extends _LocalUserSettingsView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$LocalUserSettingsViewImplCopyWith<_$LocalUserSettingsViewImpl>
-      get copyWith => __$$LocalUserSettingsViewImplCopyWithImpl<
-          _$LocalUserSettingsViewImpl>(this, _$identity);
+  _$$_LocalUserSettingsViewCopyWith<_$_LocalUserSettingsView> get copyWith =>
+      __$$_LocalUserSettingsViewCopyWithImpl<_$_LocalUserSettingsView>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$LocalUserSettingsViewImplToJson(
+    return _$$_LocalUserSettingsViewToJson(
       this,
     );
   }
@@ -928,11 +925,11 @@ abstract class _LocalUserSettingsView extends LocalUserSettingsView {
       {required final LocalUserSettings localUser,
       required final PersonSafe person,
       required final PersonAggregates counts,
-      required final String instanceHost}) = _$LocalUserSettingsViewImpl;
+      required final String instanceHost}) = _$_LocalUserSettingsView;
   const _LocalUserSettingsView._() : super._();
 
   factory _LocalUserSettingsView.fromJson(Map<String, dynamic> json) =
-      _$LocalUserSettingsViewImpl.fromJson;
+      _$_LocalUserSettingsView.fromJson;
 
   @override
   LocalUserSettings get localUser;
@@ -944,8 +941,8 @@ abstract class _LocalUserSettingsView extends LocalUserSettingsView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$LocalUserSettingsViewImplCopyWith<_$LocalUserSettingsViewImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_LocalUserSettingsViewCopyWith<_$_LocalUserSettingsView> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 SiteView _$SiteViewFromJson(Map<String, dynamic> json) {
@@ -1045,11 +1042,10 @@ class _$SiteViewCopyWithImpl<$Res, $Val extends SiteView>
 }
 
 /// @nodoc
-abstract class _$$SiteViewImplCopyWith<$Res>
-    implements $SiteViewCopyWith<$Res> {
-  factory _$$SiteViewImplCopyWith(
-          _$SiteViewImpl value, $Res Function(_$SiteViewImpl) then) =
-      __$$SiteViewImplCopyWithImpl<$Res>;
+abstract class _$$_SiteViewCopyWith<$Res> implements $SiteViewCopyWith<$Res> {
+  factory _$$_SiteViewCopyWith(
+          _$_SiteView value, $Res Function(_$_SiteView) then) =
+      __$$_SiteViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1067,11 +1063,11 @@ abstract class _$$SiteViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$SiteViewImplCopyWithImpl<$Res>
-    extends _$SiteViewCopyWithImpl<$Res, _$SiteViewImpl>
-    implements _$$SiteViewImplCopyWith<$Res> {
-  __$$SiteViewImplCopyWithImpl(
-      _$SiteViewImpl _value, $Res Function(_$SiteViewImpl) _then)
+class __$$_SiteViewCopyWithImpl<$Res>
+    extends _$SiteViewCopyWithImpl<$Res, _$_SiteView>
+    implements _$$_SiteViewCopyWith<$Res> {
+  __$$_SiteViewCopyWithImpl(
+      _$_SiteView _value, $Res Function(_$_SiteView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1082,7 +1078,7 @@ class __$$SiteViewImplCopyWithImpl<$Res>
     Object? counts = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$SiteViewImpl(
+    return _then(_$_SiteView(
       site: null == site
           ? _value.site
           : site // ignore: cast_nullable_to_non_nullable
@@ -1106,16 +1102,16 @@ class __$$SiteViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$SiteViewImpl extends _SiteView {
-  const _$SiteViewImpl(
+class _$_SiteView extends _SiteView {
+  const _$_SiteView(
       {required this.site,
       required this.localSite,
       required this.counts,
       required this.instanceHost})
       : super._();
 
-  factory _$SiteViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SiteViewImplFromJson(json);
+  factory _$_SiteView.fromJson(Map<String, dynamic> json) =>
+      _$$_SiteViewFromJson(json);
 
   @override
   final Site site;
@@ -1135,7 +1131,7 @@ class _$SiteViewImpl extends _SiteView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SiteViewImpl &&
+            other is _$_SiteView &&
             (identical(other.site, site) || other.site == site) &&
             (identical(other.localSite, localSite) ||
                 other.localSite == localSite) &&
@@ -1152,12 +1148,12 @@ class _$SiteViewImpl extends _SiteView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$SiteViewImplCopyWith<_$SiteViewImpl> get copyWith =>
-      __$$SiteViewImplCopyWithImpl<_$SiteViewImpl>(this, _$identity);
+  _$$_SiteViewCopyWith<_$_SiteView> get copyWith =>
+      __$$_SiteViewCopyWithImpl<_$_SiteView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$SiteViewImplToJson(
+    return _$$_SiteViewToJson(
       this,
     );
   }
@@ -1168,11 +1164,10 @@ abstract class _SiteView extends SiteView {
       {required final Site site,
       required final LocalSite localSite,
       required final SiteAggregates counts,
-      required final String instanceHost}) = _$SiteViewImpl;
+      required final String instanceHost}) = _$_SiteView;
   const _SiteView._() : super._();
 
-  factory _SiteView.fromJson(Map<String, dynamic> json) =
-      _$SiteViewImpl.fromJson;
+  factory _SiteView.fromJson(Map<String, dynamic> json) = _$_SiteView.fromJson;
 
   @override
   Site get site;
@@ -1184,7 +1179,7 @@ abstract class _SiteView extends SiteView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$SiteViewImplCopyWith<_$SiteViewImpl> get copyWith =>
+  _$$_SiteViewCopyWith<_$_SiteView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1286,11 +1281,11 @@ class _$PrivateMessageViewCopyWithImpl<$Res, $Val extends PrivateMessageView>
 }
 
 /// @nodoc
-abstract class _$$PrivateMessageViewImplCopyWith<$Res>
+abstract class _$$_PrivateMessageViewCopyWith<$Res>
     implements $PrivateMessageViewCopyWith<$Res> {
-  factory _$$PrivateMessageViewImplCopyWith(_$PrivateMessageViewImpl value,
-          $Res Function(_$PrivateMessageViewImpl) then) =
-      __$$PrivateMessageViewImplCopyWithImpl<$Res>;
+  factory _$$_PrivateMessageViewCopyWith(_$_PrivateMessageView value,
+          $Res Function(_$_PrivateMessageView) then) =
+      __$$_PrivateMessageViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1308,11 +1303,11 @@ abstract class _$$PrivateMessageViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$PrivateMessageViewImplCopyWithImpl<$Res>
-    extends _$PrivateMessageViewCopyWithImpl<$Res, _$PrivateMessageViewImpl>
-    implements _$$PrivateMessageViewImplCopyWith<$Res> {
-  __$$PrivateMessageViewImplCopyWithImpl(_$PrivateMessageViewImpl _value,
-      $Res Function(_$PrivateMessageViewImpl) _then)
+class __$$_PrivateMessageViewCopyWithImpl<$Res>
+    extends _$PrivateMessageViewCopyWithImpl<$Res, _$_PrivateMessageView>
+    implements _$$_PrivateMessageViewCopyWith<$Res> {
+  __$$_PrivateMessageViewCopyWithImpl(
+      _$_PrivateMessageView _value, $Res Function(_$_PrivateMessageView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1323,7 +1318,7 @@ class __$$PrivateMessageViewImplCopyWithImpl<$Res>
     Object? recipient = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$PrivateMessageViewImpl(
+    return _then(_$_PrivateMessageView(
       privateMessage: null == privateMessage
           ? _value.privateMessage
           : privateMessage // ignore: cast_nullable_to_non_nullable
@@ -1347,16 +1342,16 @@ class __$$PrivateMessageViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$PrivateMessageViewImpl extends _PrivateMessageView {
-  const _$PrivateMessageViewImpl(
+class _$_PrivateMessageView extends _PrivateMessageView {
+  const _$_PrivateMessageView(
       {required this.privateMessage,
       required this.creator,
       required this.recipient,
       required this.instanceHost})
       : super._();
 
-  factory _$PrivateMessageViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PrivateMessageViewImplFromJson(json);
+  factory _$_PrivateMessageView.fromJson(Map<String, dynamic> json) =>
+      _$$_PrivateMessageViewFromJson(json);
 
   @override
   final PrivateMessage privateMessage;
@@ -1376,7 +1371,7 @@ class _$PrivateMessageViewImpl extends _PrivateMessageView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PrivateMessageViewImpl &&
+            other is _$_PrivateMessageView &&
             (identical(other.privateMessage, privateMessage) ||
                 other.privateMessage == privateMessage) &&
             (identical(other.creator, creator) || other.creator == creator) &&
@@ -1394,13 +1389,13 @@ class _$PrivateMessageViewImpl extends _PrivateMessageView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PrivateMessageViewImplCopyWith<_$PrivateMessageViewImpl> get copyWith =>
-      __$$PrivateMessageViewImplCopyWithImpl<_$PrivateMessageViewImpl>(
+  _$$_PrivateMessageViewCopyWith<_$_PrivateMessageView> get copyWith =>
+      __$$_PrivateMessageViewCopyWithImpl<_$_PrivateMessageView>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PrivateMessageViewImplToJson(
+    return _$$_PrivateMessageViewToJson(
       this,
     );
   }
@@ -1411,11 +1406,11 @@ abstract class _PrivateMessageView extends PrivateMessageView {
       {required final PrivateMessage privateMessage,
       required final PersonSafe creator,
       required final PersonSafe recipient,
-      required final String instanceHost}) = _$PrivateMessageViewImpl;
+      required final String instanceHost}) = _$_PrivateMessageView;
   const _PrivateMessageView._() : super._();
 
   factory _PrivateMessageView.fromJson(Map<String, dynamic> json) =
-      _$PrivateMessageViewImpl.fromJson;
+      _$_PrivateMessageView.fromJson;
 
   @override
   PrivateMessage get privateMessage;
@@ -1427,7 +1422,7 @@ abstract class _PrivateMessageView extends PrivateMessageView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$PrivateMessageViewImplCopyWith<_$PrivateMessageViewImpl> get copyWith =>
+  _$$_PrivateMessageViewCopyWith<_$_PrivateMessageView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1593,11 +1588,10 @@ class _$PostViewCopyWithImpl<$Res, $Val extends PostView>
 }
 
 /// @nodoc
-abstract class _$$PostViewImplCopyWith<$Res>
-    implements $PostViewCopyWith<$Res> {
-  factory _$$PostViewImplCopyWith(
-          _$PostViewImpl value, $Res Function(_$PostViewImpl) then) =
-      __$$PostViewImplCopyWithImpl<$Res>;
+abstract class _$$_PostViewCopyWith<$Res> implements $PostViewCopyWith<$Res> {
+  factory _$$_PostViewCopyWith(
+          _$_PostView value, $Res Function(_$_PostView) then) =
+      __$$_PostViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1625,11 +1619,11 @@ abstract class _$$PostViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$PostViewImplCopyWithImpl<$Res>
-    extends _$PostViewCopyWithImpl<$Res, _$PostViewImpl>
-    implements _$$PostViewImplCopyWith<$Res> {
-  __$$PostViewImplCopyWithImpl(
-      _$PostViewImpl _value, $Res Function(_$PostViewImpl) _then)
+class __$$_PostViewCopyWithImpl<$Res>
+    extends _$PostViewCopyWithImpl<$Res, _$_PostView>
+    implements _$$_PostViewCopyWith<$Res> {
+  __$$_PostViewCopyWithImpl(
+      _$_PostView _value, $Res Function(_$_PostView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1648,7 +1642,7 @@ class __$$PostViewImplCopyWithImpl<$Res>
     Object? myVote = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$PostViewImpl(
+    return _then(_$_PostView(
       post: null == post
           ? _value.post
           : post // ignore: cast_nullable_to_non_nullable
@@ -1704,8 +1698,8 @@ class __$$PostViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$PostViewImpl extends _PostView {
-  const _$PostViewImpl(
+class _$_PostView extends _PostView {
+  const _$_PostView(
       {required this.post,
       required this.creator,
       required this.community,
@@ -1720,8 +1714,8 @@ class _$PostViewImpl extends _PostView {
       required this.instanceHost})
       : super._();
 
-  factory _$PostViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PostViewImplFromJson(json);
+  factory _$_PostView.fromJson(Map<String, dynamic> json) =>
+      _$$_PostViewFromJson(json);
 
   @override
   final Post post;
@@ -1758,7 +1752,7 @@ class _$PostViewImpl extends _PostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PostViewImpl &&
+            other is _$_PostView &&
             (identical(other.post, post) || other.post == post) &&
             (identical(other.creator, creator) || other.creator == creator) &&
             (identical(other.community, community) ||
@@ -1801,12 +1795,12 @@ class _$PostViewImpl extends _PostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PostViewImplCopyWith<_$PostViewImpl> get copyWith =>
-      __$$PostViewImplCopyWithImpl<_$PostViewImpl>(this, _$identity);
+  _$$_PostViewCopyWith<_$_PostView> get copyWith =>
+      __$$_PostViewCopyWithImpl<_$_PostView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PostViewImplToJson(
+    return _$$_PostViewToJson(
       this,
     );
   }
@@ -1825,11 +1819,10 @@ abstract class _PostView extends PostView {
       required final bool creatorBlocked,
       required final int unreadComments,
       final VoteType? myVote,
-      required final String instanceHost}) = _$PostViewImpl;
+      required final String instanceHost}) = _$_PostView;
   const _PostView._() : super._();
 
-  factory _PostView.fromJson(Map<String, dynamic> json) =
-      _$PostViewImpl.fromJson;
+  factory _PostView.fromJson(Map<String, dynamic> json) = _$_PostView.fromJson;
 
   @override
   Post get post;
@@ -1857,7 +1850,7 @@ abstract class _PostView extends PostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$PostViewImplCopyWith<_$PostViewImpl> get copyWith =>
+  _$$_PostViewCopyWith<_$_PostView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2041,11 +2034,11 @@ class _$PostReportViewCopyWithImpl<$Res, $Val extends PostReportView>
 }
 
 /// @nodoc
-abstract class _$$PostReportViewImplCopyWith<$Res>
+abstract class _$$_PostReportViewCopyWith<$Res>
     implements $PostReportViewCopyWith<$Res> {
-  factory _$$PostReportViewImplCopyWith(_$PostReportViewImpl value,
-          $Res Function(_$PostReportViewImpl) then) =
-      __$$PostReportViewImplCopyWithImpl<$Res>;
+  factory _$$_PostReportViewCopyWith(
+          _$_PostReportView value, $Res Function(_$_PostReportView) then) =
+      __$$_PostReportViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2077,11 +2070,11 @@ abstract class _$$PostReportViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$PostReportViewImplCopyWithImpl<$Res>
-    extends _$PostReportViewCopyWithImpl<$Res, _$PostReportViewImpl>
-    implements _$$PostReportViewImplCopyWith<$Res> {
-  __$$PostReportViewImplCopyWithImpl(
-      _$PostReportViewImpl _value, $Res Function(_$PostReportViewImpl) _then)
+class __$$_PostReportViewCopyWithImpl<$Res>
+    extends _$PostReportViewCopyWithImpl<$Res, _$_PostReportView>
+    implements _$$_PostReportViewCopyWith<$Res> {
+  __$$_PostReportViewCopyWithImpl(
+      _$_PostReportView _value, $Res Function(_$_PostReportView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2098,7 +2091,7 @@ class __$$PostReportViewImplCopyWithImpl<$Res>
     Object? resolver = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$PostReportViewImpl(
+    return _then(_$_PostReportView(
       postReport: null == postReport
           ? _value.postReport
           : postReport // ignore: cast_nullable_to_non_nullable
@@ -2146,8 +2139,8 @@ class __$$PostReportViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$PostReportViewImpl extends _PostReportView {
-  const _$PostReportViewImpl(
+class _$_PostReportView extends _PostReportView {
+  const _$_PostReportView(
       {required this.postReport,
       required this.post,
       required this.community,
@@ -2160,8 +2153,8 @@ class _$PostReportViewImpl extends _PostReportView {
       required this.instanceHost})
       : super._();
 
-  factory _$PostReportViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PostReportViewImplFromJson(json);
+  factory _$_PostReportView.fromJson(Map<String, dynamic> json) =>
+      _$$_PostReportViewFromJson(json);
 
   @override
   final PostReport postReport;
@@ -2193,7 +2186,7 @@ class _$PostReportViewImpl extends _PostReportView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PostReportViewImpl &&
+            other is _$_PostReportView &&
             (identical(other.postReport, postReport) ||
                 other.postReport == postReport) &&
             (identical(other.post, post) || other.post == post) &&
@@ -2232,13 +2225,12 @@ class _$PostReportViewImpl extends _PostReportView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PostReportViewImplCopyWith<_$PostReportViewImpl> get copyWith =>
-      __$$PostReportViewImplCopyWithImpl<_$PostReportViewImpl>(
-          this, _$identity);
+  _$$_PostReportViewCopyWith<_$_PostReportView> get copyWith =>
+      __$$_PostReportViewCopyWithImpl<_$_PostReportView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PostReportViewImplToJson(
+    return _$$_PostReportViewToJson(
       this,
     );
   }
@@ -2255,11 +2247,11 @@ abstract class _PostReportView extends PostReportView {
       final VoteType? myVote,
       required final PostAggregates counts,
       final PersonSafe? resolver,
-      required final String instanceHost}) = _$PostReportViewImpl;
+      required final String instanceHost}) = _$_PostReportView;
   const _PostReportView._() : super._();
 
   factory _PostReportView.fromJson(Map<String, dynamic> json) =
-      _$PostReportViewImpl.fromJson;
+      _$_PostReportView.fromJson;
 
   @override
   PostReport get postReport;
@@ -2283,7 +2275,7 @@ abstract class _PostReportView extends PostReportView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$PostReportViewImplCopyWith<_$PostReportViewImpl> get copyWith =>
+  _$$_PostReportViewCopyWith<_$_PostReportView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2492,11 +2484,11 @@ class _$CommentViewCopyWithImpl<$Res, $Val extends CommentView>
 }
 
 /// @nodoc
-abstract class _$$CommentViewImplCopyWith<$Res>
+abstract class _$$_CommentViewCopyWith<$Res>
     implements $CommentViewCopyWith<$Res> {
-  factory _$$CommentViewImplCopyWith(
-          _$CommentViewImpl value, $Res Function(_$CommentViewImpl) then) =
-      __$$CommentViewImplCopyWithImpl<$Res>;
+  factory _$$_CommentViewCopyWith(
+          _$_CommentView value, $Res Function(_$_CommentView) then) =
+      __$$_CommentViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2531,11 +2523,11 @@ abstract class _$$CommentViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CommentViewImplCopyWithImpl<$Res>
-    extends _$CommentViewCopyWithImpl<$Res, _$CommentViewImpl>
-    implements _$$CommentViewImplCopyWith<$Res> {
-  __$$CommentViewImplCopyWithImpl(
-      _$CommentViewImpl _value, $Res Function(_$CommentViewImpl) _then)
+class __$$_CommentViewCopyWithImpl<$Res>
+    extends _$CommentViewCopyWithImpl<$Res, _$_CommentView>
+    implements _$$_CommentViewCopyWith<$Res> {
+  __$$_CommentViewCopyWithImpl(
+      _$_CommentView _value, $Res Function(_$_CommentView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2555,7 +2547,7 @@ class __$$CommentViewImplCopyWithImpl<$Res>
     Object? myVote = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$CommentViewImpl(
+    return _then(_$_CommentView(
       comment: null == comment
           ? _value.comment
           : comment // ignore: cast_nullable_to_non_nullable
@@ -2615,8 +2607,8 @@ class __$$CommentViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CommentViewImpl extends _CommentView {
-  const _$CommentViewImpl(
+class _$_CommentView extends _CommentView {
+  const _$_CommentView(
       {required this.comment,
       required this.creator,
       this.commentReply,
@@ -2632,8 +2624,8 @@ class _$CommentViewImpl extends _CommentView {
       required this.instanceHost})
       : super._();
 
-  factory _$CommentViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CommentViewImplFromJson(json);
+  factory _$_CommentView.fromJson(Map<String, dynamic> json) =>
+      _$$_CommentViewFromJson(json);
 
   @override
   final Comment comment;
@@ -2672,7 +2664,7 @@ class _$CommentViewImpl extends _CommentView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CommentViewImpl &&
+            other is _$_CommentView &&
             (identical(other.comment, comment) || other.comment == comment) &&
             (identical(other.creator, creator) || other.creator == creator) &&
             (identical(other.commentReply, commentReply) ||
@@ -2718,12 +2710,12 @@ class _$CommentViewImpl extends _CommentView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CommentViewImplCopyWith<_$CommentViewImpl> get copyWith =>
-      __$$CommentViewImplCopyWithImpl<_$CommentViewImpl>(this, _$identity);
+  _$$_CommentViewCopyWith<_$_CommentView> get copyWith =>
+      __$$_CommentViewCopyWithImpl<_$_CommentView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CommentViewImplToJson(
+    return _$$_CommentViewToJson(
       this,
     );
   }
@@ -2743,11 +2735,11 @@ abstract class _CommentView extends CommentView {
       required final bool saved,
       required final bool creatorBlocked,
       final VoteType? myVote,
-      required final String instanceHost}) = _$CommentViewImpl;
+      required final String instanceHost}) = _$_CommentView;
   const _CommentView._() : super._();
 
   factory _CommentView.fromJson(Map<String, dynamic> json) =
-      _$CommentViewImpl.fromJson;
+      _$_CommentView.fromJson;
 
   @override
   Comment get comment;
@@ -2777,7 +2769,7 @@ abstract class _CommentView extends CommentView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$CommentViewImplCopyWith<_$CommentViewImpl> get copyWith =>
+  _$$_CommentViewCopyWith<_$_CommentView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2982,11 +2974,11 @@ class _$CommentReplyViewCopyWithImpl<$Res, $Val extends CommentReplyView>
 }
 
 /// @nodoc
-abstract class _$$CommentReplyViewImplCopyWith<$Res>
+abstract class _$$_CommentReplyViewCopyWith<$Res>
     implements $CommentReplyViewCopyWith<$Res> {
-  factory _$$CommentReplyViewImplCopyWith(_$CommentReplyViewImpl value,
-          $Res Function(_$CommentReplyViewImpl) then) =
-      __$$CommentReplyViewImplCopyWithImpl<$Res>;
+  factory _$$_CommentReplyViewCopyWith(
+          _$_CommentReplyView value, $Res Function(_$_CommentReplyView) then) =
+      __$$_CommentReplyViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3021,11 +3013,11 @@ abstract class _$$CommentReplyViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CommentReplyViewImplCopyWithImpl<$Res>
-    extends _$CommentReplyViewCopyWithImpl<$Res, _$CommentReplyViewImpl>
-    implements _$$CommentReplyViewImplCopyWith<$Res> {
-  __$$CommentReplyViewImplCopyWithImpl(_$CommentReplyViewImpl _value,
-      $Res Function(_$CommentReplyViewImpl) _then)
+class __$$_CommentReplyViewCopyWithImpl<$Res>
+    extends _$CommentReplyViewCopyWithImpl<$Res, _$_CommentReplyView>
+    implements _$$_CommentReplyViewCopyWith<$Res> {
+  __$$_CommentReplyViewCopyWithImpl(
+      _$_CommentReplyView _value, $Res Function(_$_CommentReplyView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3045,7 +3037,7 @@ class __$$CommentReplyViewImplCopyWithImpl<$Res>
     Object? myVote = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$CommentReplyViewImpl(
+    return _then(_$_CommentReplyView(
       commentReply: null == commentReply
           ? _value.commentReply
           : commentReply // ignore: cast_nullable_to_non_nullable
@@ -3105,8 +3097,8 @@ class __$$CommentReplyViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CommentReplyViewImpl extends _CommentReplyView {
-  const _$CommentReplyViewImpl(
+class _$_CommentReplyView extends _CommentReplyView {
+  const _$_CommentReplyView(
       {required this.commentReply,
       required this.comment,
       required this.creator,
@@ -3122,8 +3114,8 @@ class _$CommentReplyViewImpl extends _CommentReplyView {
       required this.instanceHost})
       : super._();
 
-  factory _$CommentReplyViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CommentReplyViewImplFromJson(json);
+  factory _$_CommentReplyView.fromJson(Map<String, dynamic> json) =>
+      _$$_CommentReplyViewFromJson(json);
 
   @override
   final CommentReply commentReply;
@@ -3162,7 +3154,7 @@ class _$CommentReplyViewImpl extends _CommentReplyView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CommentReplyViewImpl &&
+            other is _$_CommentReplyView &&
             (identical(other.commentReply, commentReply) ||
                 other.commentReply == commentReply) &&
             (identical(other.comment, comment) || other.comment == comment) &&
@@ -3208,13 +3200,12 @@ class _$CommentReplyViewImpl extends _CommentReplyView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CommentReplyViewImplCopyWith<_$CommentReplyViewImpl> get copyWith =>
-      __$$CommentReplyViewImplCopyWithImpl<_$CommentReplyViewImpl>(
-          this, _$identity);
+  _$$_CommentReplyViewCopyWith<_$_CommentReplyView> get copyWith =>
+      __$$_CommentReplyViewCopyWithImpl<_$_CommentReplyView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CommentReplyViewImplToJson(
+    return _$$_CommentReplyViewToJson(
       this,
     );
   }
@@ -3234,11 +3225,11 @@ abstract class _CommentReplyView extends CommentReplyView {
       required final bool saved,
       required final bool creatorBlocked,
       final VoteType? myVote,
-      required final String instanceHost}) = _$CommentReplyViewImpl;
+      required final String instanceHost}) = _$_CommentReplyView;
   const _CommentReplyView._() : super._();
 
   factory _CommentReplyView.fromJson(Map<String, dynamic> json) =
-      _$CommentReplyViewImpl.fromJson;
+      _$_CommentReplyView.fromJson;
 
   @override
   CommentReply get commentReply;
@@ -3268,7 +3259,7 @@ abstract class _CommentReplyView extends CommentReplyView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$CommentReplyViewImplCopyWith<_$CommentReplyViewImpl> get copyWith =>
+  _$$_CommentReplyViewCopyWith<_$_CommentReplyView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3468,11 +3459,11 @@ class _$CommentReportViewCopyWithImpl<$Res, $Val extends CommentReportView>
 }
 
 /// @nodoc
-abstract class _$$CommentReportViewImplCopyWith<$Res>
+abstract class _$$_CommentReportViewCopyWith<$Res>
     implements $CommentReportViewCopyWith<$Res> {
-  factory _$$CommentReportViewImplCopyWith(_$CommentReportViewImpl value,
-          $Res Function(_$CommentReportViewImpl) then) =
-      __$$CommentReportViewImplCopyWithImpl<$Res>;
+  factory _$$_CommentReportViewCopyWith(_$_CommentReportView value,
+          $Res Function(_$_CommentReportView) then) =
+      __$$_CommentReportViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3507,11 +3498,11 @@ abstract class _$$CommentReportViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CommentReportViewImplCopyWithImpl<$Res>
-    extends _$CommentReportViewCopyWithImpl<$Res, _$CommentReportViewImpl>
-    implements _$$CommentReportViewImplCopyWith<$Res> {
-  __$$CommentReportViewImplCopyWithImpl(_$CommentReportViewImpl _value,
-      $Res Function(_$CommentReportViewImpl) _then)
+class __$$_CommentReportViewCopyWithImpl<$Res>
+    extends _$CommentReportViewCopyWithImpl<$Res, _$_CommentReportView>
+    implements _$$_CommentReportViewCopyWith<$Res> {
+  __$$_CommentReportViewCopyWithImpl(
+      _$_CommentReportView _value, $Res Function(_$_CommentReportView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3529,7 +3520,7 @@ class __$$CommentReportViewImplCopyWithImpl<$Res>
     Object? resolver = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$CommentReportViewImpl(
+    return _then(_$_CommentReportView(
       commentReport: null == commentReport
           ? _value.commentReport
           : commentReport // ignore: cast_nullable_to_non_nullable
@@ -3581,8 +3572,8 @@ class __$$CommentReportViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CommentReportViewImpl extends _CommentReportView {
-  const _$CommentReportViewImpl(
+class _$_CommentReportView extends _CommentReportView {
+  const _$_CommentReportView(
       {required this.commentReport,
       required this.comment,
       required this.post,
@@ -3596,8 +3587,8 @@ class _$CommentReportViewImpl extends _CommentReportView {
       required this.instanceHost})
       : super._();
 
-  factory _$CommentReportViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CommentReportViewImplFromJson(json);
+  factory _$_CommentReportView.fromJson(Map<String, dynamic> json) =>
+      _$$_CommentReportViewFromJson(json);
 
   @override
   final CommentReport commentReport;
@@ -3631,7 +3622,7 @@ class _$CommentReportViewImpl extends _CommentReportView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CommentReportViewImpl &&
+            other is _$_CommentReportView &&
             (identical(other.commentReport, commentReport) ||
                 other.commentReport == commentReport) &&
             (identical(other.comment, comment) || other.comment == comment) &&
@@ -3672,13 +3663,13 @@ class _$CommentReportViewImpl extends _CommentReportView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CommentReportViewImplCopyWith<_$CommentReportViewImpl> get copyWith =>
-      __$$CommentReportViewImplCopyWithImpl<_$CommentReportViewImpl>(
+  _$$_CommentReportViewCopyWith<_$_CommentReportView> get copyWith =>
+      __$$_CommentReportViewCopyWithImpl<_$_CommentReportView>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CommentReportViewImplToJson(
+    return _$$_CommentReportViewToJson(
       this,
     );
   }
@@ -3696,11 +3687,11 @@ abstract class _CommentReportView extends CommentReportView {
       final VoteType? myVote,
       required final CommentAggregates counts,
       final PersonSafe? resolver,
-      required final String instanceHost}) = _$CommentReportViewImpl;
+      required final String instanceHost}) = _$_CommentReportView;
   const _CommentReportView._() : super._();
 
   factory _CommentReportView.fromJson(Map<String, dynamic> json) =
-      _$CommentReportViewImpl.fromJson;
+      _$_CommentReportView.fromJson;
 
   @override
   CommentReport get commentReport;
@@ -3726,7 +3717,7 @@ abstract class _CommentReportView extends CommentReportView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$CommentReportViewImplCopyWith<_$CommentReportViewImpl> get copyWith =>
+  _$$_CommentReportViewCopyWith<_$_CommentReportView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3848,11 +3839,11 @@ class _$ModAddCommunityViewCopyWithImpl<$Res, $Val extends ModAddCommunityView>
 }
 
 /// @nodoc
-abstract class _$$ModAddCommunityViewImplCopyWith<$Res>
+abstract class _$$_ModAddCommunityViewCopyWith<$Res>
     implements $ModAddCommunityViewCopyWith<$Res> {
-  factory _$$ModAddCommunityViewImplCopyWith(_$ModAddCommunityViewImpl value,
-          $Res Function(_$ModAddCommunityViewImpl) then) =
-      __$$ModAddCommunityViewImplCopyWithImpl<$Res>;
+  factory _$$_ModAddCommunityViewCopyWith(_$_ModAddCommunityView value,
+          $Res Function(_$_ModAddCommunityView) then) =
+      __$$_ModAddCommunityViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3873,11 +3864,11 @@ abstract class _$$ModAddCommunityViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModAddCommunityViewImplCopyWithImpl<$Res>
-    extends _$ModAddCommunityViewCopyWithImpl<$Res, _$ModAddCommunityViewImpl>
-    implements _$$ModAddCommunityViewImplCopyWith<$Res> {
-  __$$ModAddCommunityViewImplCopyWithImpl(_$ModAddCommunityViewImpl _value,
-      $Res Function(_$ModAddCommunityViewImpl) _then)
+class __$$_ModAddCommunityViewCopyWithImpl<$Res>
+    extends _$ModAddCommunityViewCopyWithImpl<$Res, _$_ModAddCommunityView>
+    implements _$$_ModAddCommunityViewCopyWith<$Res> {
+  __$$_ModAddCommunityViewCopyWithImpl(_$_ModAddCommunityView _value,
+      $Res Function(_$_ModAddCommunityView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3889,7 +3880,7 @@ class __$$ModAddCommunityViewImplCopyWithImpl<$Res>
     Object? moddedPerson = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModAddCommunityViewImpl(
+    return _then(_$_ModAddCommunityView(
       modAddCommunity: null == modAddCommunity
           ? _value.modAddCommunity
           : modAddCommunity // ignore: cast_nullable_to_non_nullable
@@ -3917,8 +3908,8 @@ class __$$ModAddCommunityViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModAddCommunityViewImpl extends _ModAddCommunityView {
-  const _$ModAddCommunityViewImpl(
+class _$_ModAddCommunityView extends _ModAddCommunityView {
+  const _$_ModAddCommunityView(
       {required this.modAddCommunity,
       this.moderator,
       required this.community,
@@ -3926,8 +3917,8 @@ class _$ModAddCommunityViewImpl extends _ModAddCommunityView {
       required this.instanceHost})
       : super._();
 
-  factory _$ModAddCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModAddCommunityViewImplFromJson(json);
+  factory _$_ModAddCommunityView.fromJson(Map<String, dynamic> json) =>
+      _$$_ModAddCommunityViewFromJson(json);
 
   @override
   final ModAddCommunity modAddCommunity;
@@ -3949,7 +3940,7 @@ class _$ModAddCommunityViewImpl extends _ModAddCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModAddCommunityViewImpl &&
+            other is _$_ModAddCommunityView &&
             (identical(other.modAddCommunity, modAddCommunity) ||
                 other.modAddCommunity == modAddCommunity) &&
             (identical(other.moderator, moderator) ||
@@ -3970,13 +3961,13 @@ class _$ModAddCommunityViewImpl extends _ModAddCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModAddCommunityViewImplCopyWith<_$ModAddCommunityViewImpl> get copyWith =>
-      __$$ModAddCommunityViewImplCopyWithImpl<_$ModAddCommunityViewImpl>(
+  _$$_ModAddCommunityViewCopyWith<_$_ModAddCommunityView> get copyWith =>
+      __$$_ModAddCommunityViewCopyWithImpl<_$_ModAddCommunityView>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModAddCommunityViewImplToJson(
+    return _$$_ModAddCommunityViewToJson(
       this,
     );
   }
@@ -3988,11 +3979,11 @@ abstract class _ModAddCommunityView extends ModAddCommunityView {
       final PersonSafe? moderator,
       required final CommunitySafe community,
       required final PersonSafe moddedPerson,
-      required final String instanceHost}) = _$ModAddCommunityViewImpl;
+      required final String instanceHost}) = _$_ModAddCommunityView;
   const _ModAddCommunityView._() : super._();
 
   factory _ModAddCommunityView.fromJson(Map<String, dynamic> json) =
-      _$ModAddCommunityViewImpl.fromJson;
+      _$_ModAddCommunityView.fromJson;
 
   @override
   ModAddCommunity get modAddCommunity;
@@ -4006,7 +3997,7 @@ abstract class _ModAddCommunityView extends ModAddCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModAddCommunityViewImplCopyWith<_$ModAddCommunityViewImpl> get copyWith =>
+  _$$_ModAddCommunityViewCopyWith<_$_ModAddCommunityView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4132,12 +4123,12 @@ class _$ModTransferCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$ModTransferCommunityViewImplCopyWith<$Res>
+abstract class _$$_ModTransferCommunityViewCopyWith<$Res>
     implements $ModTransferCommunityViewCopyWith<$Res> {
-  factory _$$ModTransferCommunityViewImplCopyWith(
-          _$ModTransferCommunityViewImpl value,
-          $Res Function(_$ModTransferCommunityViewImpl) then) =
-      __$$ModTransferCommunityViewImplCopyWithImpl<$Res>;
+  factory _$$_ModTransferCommunityViewCopyWith(
+          _$_ModTransferCommunityView value,
+          $Res Function(_$_ModTransferCommunityView) then) =
+      __$$_ModTransferCommunityViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4158,13 +4149,12 @@ abstract class _$$ModTransferCommunityViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModTransferCommunityViewImplCopyWithImpl<$Res>
+class __$$_ModTransferCommunityViewCopyWithImpl<$Res>
     extends _$ModTransferCommunityViewCopyWithImpl<$Res,
-        _$ModTransferCommunityViewImpl>
-    implements _$$ModTransferCommunityViewImplCopyWith<$Res> {
-  __$$ModTransferCommunityViewImplCopyWithImpl(
-      _$ModTransferCommunityViewImpl _value,
-      $Res Function(_$ModTransferCommunityViewImpl) _then)
+        _$_ModTransferCommunityView>
+    implements _$$_ModTransferCommunityViewCopyWith<$Res> {
+  __$$_ModTransferCommunityViewCopyWithImpl(_$_ModTransferCommunityView _value,
+      $Res Function(_$_ModTransferCommunityView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4176,7 +4166,7 @@ class __$$ModTransferCommunityViewImplCopyWithImpl<$Res>
     Object? moddedPerson = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModTransferCommunityViewImpl(
+    return _then(_$_ModTransferCommunityView(
       modTransferCommunity: null == modTransferCommunity
           ? _value.modTransferCommunity
           : modTransferCommunity // ignore: cast_nullable_to_non_nullable
@@ -4204,8 +4194,8 @@ class __$$ModTransferCommunityViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModTransferCommunityViewImpl extends _ModTransferCommunityView {
-  const _$ModTransferCommunityViewImpl(
+class _$_ModTransferCommunityView extends _ModTransferCommunityView {
+  const _$_ModTransferCommunityView(
       {required this.modTransferCommunity,
       required this.moderator,
       required this.community,
@@ -4213,8 +4203,8 @@ class _$ModTransferCommunityViewImpl extends _ModTransferCommunityView {
       required this.instanceHost})
       : super._();
 
-  factory _$ModTransferCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModTransferCommunityViewImplFromJson(json);
+  factory _$_ModTransferCommunityView.fromJson(Map<String, dynamic> json) =>
+      _$$_ModTransferCommunityViewFromJson(json);
 
   @override
   final ModTransferCommunity modTransferCommunity;
@@ -4236,7 +4226,7 @@ class _$ModTransferCommunityViewImpl extends _ModTransferCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModTransferCommunityViewImpl &&
+            other is _$_ModTransferCommunityView &&
             (identical(other.modTransferCommunity, modTransferCommunity) ||
                 other.modTransferCommunity == modTransferCommunity) &&
             (identical(other.moderator, moderator) ||
@@ -4257,13 +4247,13 @@ class _$ModTransferCommunityViewImpl extends _ModTransferCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModTransferCommunityViewImplCopyWith<_$ModTransferCommunityViewImpl>
-      get copyWith => __$$ModTransferCommunityViewImplCopyWithImpl<
-          _$ModTransferCommunityViewImpl>(this, _$identity);
+  _$$_ModTransferCommunityViewCopyWith<_$_ModTransferCommunityView>
+      get copyWith => __$$_ModTransferCommunityViewCopyWithImpl<
+          _$_ModTransferCommunityView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModTransferCommunityViewImplToJson(
+    return _$$_ModTransferCommunityViewToJson(
       this,
     );
   }
@@ -4275,11 +4265,11 @@ abstract class _ModTransferCommunityView extends ModTransferCommunityView {
       required final PersonSafe? moderator,
       required final CommunitySafe community,
       required final PersonSafe moddedPerson,
-      required final String instanceHost}) = _$ModTransferCommunityViewImpl;
+      required final String instanceHost}) = _$_ModTransferCommunityView;
   const _ModTransferCommunityView._() : super._();
 
   factory _ModTransferCommunityView.fromJson(Map<String, dynamic> json) =
-      _$ModTransferCommunityViewImpl.fromJson;
+      _$_ModTransferCommunityView.fromJson;
 
   @override
   ModTransferCommunity get modTransferCommunity;
@@ -4293,7 +4283,7 @@ abstract class _ModTransferCommunityView extends ModTransferCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModTransferCommunityViewImplCopyWith<_$ModTransferCommunityViewImpl>
+  _$$_ModTransferCommunityViewCopyWith<_$_ModTransferCommunityView>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -4399,11 +4389,11 @@ class _$ModAddViewCopyWithImpl<$Res, $Val extends ModAddView>
 }
 
 /// @nodoc
-abstract class _$$ModAddViewImplCopyWith<$Res>
+abstract class _$$_ModAddViewCopyWith<$Res>
     implements $ModAddViewCopyWith<$Res> {
-  factory _$$ModAddViewImplCopyWith(
-          _$ModAddViewImpl value, $Res Function(_$ModAddViewImpl) then) =
-      __$$ModAddViewImplCopyWithImpl<$Res>;
+  factory _$$_ModAddViewCopyWith(
+          _$_ModAddView value, $Res Function(_$_ModAddView) then) =
+      __$$_ModAddViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4421,11 +4411,11 @@ abstract class _$$ModAddViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModAddViewImplCopyWithImpl<$Res>
-    extends _$ModAddViewCopyWithImpl<$Res, _$ModAddViewImpl>
-    implements _$$ModAddViewImplCopyWith<$Res> {
-  __$$ModAddViewImplCopyWithImpl(
-      _$ModAddViewImpl _value, $Res Function(_$ModAddViewImpl) _then)
+class __$$_ModAddViewCopyWithImpl<$Res>
+    extends _$ModAddViewCopyWithImpl<$Res, _$_ModAddView>
+    implements _$$_ModAddViewCopyWith<$Res> {
+  __$$_ModAddViewCopyWithImpl(
+      _$_ModAddView _value, $Res Function(_$_ModAddView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4436,7 +4426,7 @@ class __$$ModAddViewImplCopyWithImpl<$Res>
     Object? moddedPerson = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModAddViewImpl(
+    return _then(_$_ModAddView(
       modAdd: null == modAdd
           ? _value.modAdd
           : modAdd // ignore: cast_nullable_to_non_nullable
@@ -4460,16 +4450,16 @@ class __$$ModAddViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModAddViewImpl extends _ModAddView {
-  const _$ModAddViewImpl(
+class _$_ModAddView extends _ModAddView {
+  const _$_ModAddView(
       {required this.modAdd,
       required this.moderator,
       required this.moddedPerson,
       required this.instanceHost})
       : super._();
 
-  factory _$ModAddViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModAddViewImplFromJson(json);
+  factory _$_ModAddView.fromJson(Map<String, dynamic> json) =>
+      _$$_ModAddViewFromJson(json);
 
   @override
   final ModAdd modAdd;
@@ -4489,7 +4479,7 @@ class _$ModAddViewImpl extends _ModAddView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModAddViewImpl &&
+            other is _$_ModAddView &&
             (identical(other.modAdd, modAdd) || other.modAdd == modAdd) &&
             (identical(other.moderator, moderator) ||
                 other.moderator == moderator) &&
@@ -4507,12 +4497,12 @@ class _$ModAddViewImpl extends _ModAddView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModAddViewImplCopyWith<_$ModAddViewImpl> get copyWith =>
-      __$$ModAddViewImplCopyWithImpl<_$ModAddViewImpl>(this, _$identity);
+  _$$_ModAddViewCopyWith<_$_ModAddView> get copyWith =>
+      __$$_ModAddViewCopyWithImpl<_$_ModAddView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModAddViewImplToJson(
+    return _$$_ModAddViewToJson(
       this,
     );
   }
@@ -4523,11 +4513,11 @@ abstract class _ModAddView extends ModAddView {
       {required final ModAdd modAdd,
       required final PersonSafe? moderator,
       required final PersonSafe moddedPerson,
-      required final String instanceHost}) = _$ModAddViewImpl;
+      required final String instanceHost}) = _$_ModAddView;
   const _ModAddView._() : super._();
 
   factory _ModAddView.fromJson(Map<String, dynamic> json) =
-      _$ModAddViewImpl.fromJson;
+      _$_ModAddView.fromJson;
 
   @override
   ModAdd get modAdd;
@@ -4539,7 +4529,7 @@ abstract class _ModAddView extends ModAddView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModAddViewImplCopyWith<_$ModAddViewImpl> get copyWith =>
+  _$$_ModAddViewCopyWith<_$_ModAddView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4665,12 +4655,11 @@ class _$ModBanFromCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$ModBanFromCommunityViewImplCopyWith<$Res>
+abstract class _$$_ModBanFromCommunityViewCopyWith<$Res>
     implements $ModBanFromCommunityViewCopyWith<$Res> {
-  factory _$$ModBanFromCommunityViewImplCopyWith(
-          _$ModBanFromCommunityViewImpl value,
-          $Res Function(_$ModBanFromCommunityViewImpl) then) =
-      __$$ModBanFromCommunityViewImplCopyWithImpl<$Res>;
+  factory _$$_ModBanFromCommunityViewCopyWith(_$_ModBanFromCommunityView value,
+          $Res Function(_$_ModBanFromCommunityView) then) =
+      __$$_ModBanFromCommunityViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4691,13 +4680,12 @@ abstract class _$$ModBanFromCommunityViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModBanFromCommunityViewImplCopyWithImpl<$Res>
+class __$$_ModBanFromCommunityViewCopyWithImpl<$Res>
     extends _$ModBanFromCommunityViewCopyWithImpl<$Res,
-        _$ModBanFromCommunityViewImpl>
-    implements _$$ModBanFromCommunityViewImplCopyWith<$Res> {
-  __$$ModBanFromCommunityViewImplCopyWithImpl(
-      _$ModBanFromCommunityViewImpl _value,
-      $Res Function(_$ModBanFromCommunityViewImpl) _then)
+        _$_ModBanFromCommunityView>
+    implements _$$_ModBanFromCommunityViewCopyWith<$Res> {
+  __$$_ModBanFromCommunityViewCopyWithImpl(_$_ModBanFromCommunityView _value,
+      $Res Function(_$_ModBanFromCommunityView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4709,7 +4697,7 @@ class __$$ModBanFromCommunityViewImplCopyWithImpl<$Res>
     Object? bannedPerson = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModBanFromCommunityViewImpl(
+    return _then(_$_ModBanFromCommunityView(
       modBanFromCommunity: null == modBanFromCommunity
           ? _value.modBanFromCommunity
           : modBanFromCommunity // ignore: cast_nullable_to_non_nullable
@@ -4737,8 +4725,8 @@ class __$$ModBanFromCommunityViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModBanFromCommunityViewImpl extends _ModBanFromCommunityView {
-  const _$ModBanFromCommunityViewImpl(
+class _$_ModBanFromCommunityView extends _ModBanFromCommunityView {
+  const _$_ModBanFromCommunityView(
       {required this.modBanFromCommunity,
       required this.moderator,
       required this.community,
@@ -4746,8 +4734,8 @@ class _$ModBanFromCommunityViewImpl extends _ModBanFromCommunityView {
       required this.instanceHost})
       : super._();
 
-  factory _$ModBanFromCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModBanFromCommunityViewImplFromJson(json);
+  factory _$_ModBanFromCommunityView.fromJson(Map<String, dynamic> json) =>
+      _$$_ModBanFromCommunityViewFromJson(json);
 
   @override
   final ModBanFromCommunity modBanFromCommunity;
@@ -4769,7 +4757,7 @@ class _$ModBanFromCommunityViewImpl extends _ModBanFromCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModBanFromCommunityViewImpl &&
+            other is _$_ModBanFromCommunityView &&
             (identical(other.modBanFromCommunity, modBanFromCommunity) ||
                 other.modBanFromCommunity == modBanFromCommunity) &&
             (identical(other.moderator, moderator) ||
@@ -4790,13 +4778,14 @@ class _$ModBanFromCommunityViewImpl extends _ModBanFromCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModBanFromCommunityViewImplCopyWith<_$ModBanFromCommunityViewImpl>
-      get copyWith => __$$ModBanFromCommunityViewImplCopyWithImpl<
-          _$ModBanFromCommunityViewImpl>(this, _$identity);
+  _$$_ModBanFromCommunityViewCopyWith<_$_ModBanFromCommunityView>
+      get copyWith =>
+          __$$_ModBanFromCommunityViewCopyWithImpl<_$_ModBanFromCommunityView>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModBanFromCommunityViewImplToJson(
+    return _$$_ModBanFromCommunityViewToJson(
       this,
     );
   }
@@ -4808,11 +4797,11 @@ abstract class _ModBanFromCommunityView extends ModBanFromCommunityView {
       required final PersonSafe? moderator,
       required final CommunitySafe community,
       required final PersonSafe bannedPerson,
-      required final String instanceHost}) = _$ModBanFromCommunityViewImpl;
+      required final String instanceHost}) = _$_ModBanFromCommunityView;
   const _ModBanFromCommunityView._() : super._();
 
   factory _ModBanFromCommunityView.fromJson(Map<String, dynamic> json) =
-      _$ModBanFromCommunityViewImpl.fromJson;
+      _$_ModBanFromCommunityView.fromJson;
 
   @override
   ModBanFromCommunity get modBanFromCommunity;
@@ -4826,7 +4815,7 @@ abstract class _ModBanFromCommunityView extends ModBanFromCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModBanFromCommunityViewImplCopyWith<_$ModBanFromCommunityViewImpl>
+  _$$_ModBanFromCommunityViewCopyWith<_$_ModBanFromCommunityView>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -4932,11 +4921,11 @@ class _$ModBanViewCopyWithImpl<$Res, $Val extends ModBanView>
 }
 
 /// @nodoc
-abstract class _$$ModBanViewImplCopyWith<$Res>
+abstract class _$$_ModBanViewCopyWith<$Res>
     implements $ModBanViewCopyWith<$Res> {
-  factory _$$ModBanViewImplCopyWith(
-          _$ModBanViewImpl value, $Res Function(_$ModBanViewImpl) then) =
-      __$$ModBanViewImplCopyWithImpl<$Res>;
+  factory _$$_ModBanViewCopyWith(
+          _$_ModBanView value, $Res Function(_$_ModBanView) then) =
+      __$$_ModBanViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4954,11 +4943,11 @@ abstract class _$$ModBanViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModBanViewImplCopyWithImpl<$Res>
-    extends _$ModBanViewCopyWithImpl<$Res, _$ModBanViewImpl>
-    implements _$$ModBanViewImplCopyWith<$Res> {
-  __$$ModBanViewImplCopyWithImpl(
-      _$ModBanViewImpl _value, $Res Function(_$ModBanViewImpl) _then)
+class __$$_ModBanViewCopyWithImpl<$Res>
+    extends _$ModBanViewCopyWithImpl<$Res, _$_ModBanView>
+    implements _$$_ModBanViewCopyWith<$Res> {
+  __$$_ModBanViewCopyWithImpl(
+      _$_ModBanView _value, $Res Function(_$_ModBanView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4969,7 +4958,7 @@ class __$$ModBanViewImplCopyWithImpl<$Res>
     Object? bannedPerson = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModBanViewImpl(
+    return _then(_$_ModBanView(
       modBan: null == modBan
           ? _value.modBan
           : modBan // ignore: cast_nullable_to_non_nullable
@@ -4993,16 +4982,16 @@ class __$$ModBanViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModBanViewImpl extends _ModBanView {
-  const _$ModBanViewImpl(
+class _$_ModBanView extends _ModBanView {
+  const _$_ModBanView(
       {required this.modBan,
       required this.moderator,
       required this.bannedPerson,
       required this.instanceHost})
       : super._();
 
-  factory _$ModBanViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModBanViewImplFromJson(json);
+  factory _$_ModBanView.fromJson(Map<String, dynamic> json) =>
+      _$$_ModBanViewFromJson(json);
 
   @override
   final ModBan modBan;
@@ -5022,7 +5011,7 @@ class _$ModBanViewImpl extends _ModBanView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModBanViewImpl &&
+            other is _$_ModBanView &&
             (identical(other.modBan, modBan) || other.modBan == modBan) &&
             (identical(other.moderator, moderator) ||
                 other.moderator == moderator) &&
@@ -5040,12 +5029,12 @@ class _$ModBanViewImpl extends _ModBanView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModBanViewImplCopyWith<_$ModBanViewImpl> get copyWith =>
-      __$$ModBanViewImplCopyWithImpl<_$ModBanViewImpl>(this, _$identity);
+  _$$_ModBanViewCopyWith<_$_ModBanView> get copyWith =>
+      __$$_ModBanViewCopyWithImpl<_$_ModBanView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModBanViewImplToJson(
+    return _$$_ModBanViewToJson(
       this,
     );
   }
@@ -5056,11 +5045,11 @@ abstract class _ModBanView extends ModBanView {
       {required final ModBan modBan,
       required final PersonSafe? moderator,
       required final PersonSafe bannedPerson,
-      required final String instanceHost}) = _$ModBanViewImpl;
+      required final String instanceHost}) = _$_ModBanView;
   const _ModBanView._() : super._();
 
   factory _ModBanView.fromJson(Map<String, dynamic> json) =
-      _$ModBanViewImpl.fromJson;
+      _$_ModBanView.fromJson;
 
   @override
   ModBan get modBan;
@@ -5072,7 +5061,7 @@ abstract class _ModBanView extends ModBanView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModBanViewImplCopyWith<_$ModBanViewImpl> get copyWith =>
+  _$$_ModBanViewCopyWith<_$_ModBanView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5194,11 +5183,11 @@ class _$ModLockPostViewCopyWithImpl<$Res, $Val extends ModLockPostView>
 }
 
 /// @nodoc
-abstract class _$$ModLockPostViewImplCopyWith<$Res>
+abstract class _$$_ModLockPostViewCopyWith<$Res>
     implements $ModLockPostViewCopyWith<$Res> {
-  factory _$$ModLockPostViewImplCopyWith(_$ModLockPostViewImpl value,
-          $Res Function(_$ModLockPostViewImpl) then) =
-      __$$ModLockPostViewImplCopyWithImpl<$Res>;
+  factory _$$_ModLockPostViewCopyWith(
+          _$_ModLockPostView value, $Res Function(_$_ModLockPostView) then) =
+      __$$_ModLockPostViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5219,11 +5208,11 @@ abstract class _$$ModLockPostViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModLockPostViewImplCopyWithImpl<$Res>
-    extends _$ModLockPostViewCopyWithImpl<$Res, _$ModLockPostViewImpl>
-    implements _$$ModLockPostViewImplCopyWith<$Res> {
-  __$$ModLockPostViewImplCopyWithImpl(
-      _$ModLockPostViewImpl _value, $Res Function(_$ModLockPostViewImpl) _then)
+class __$$_ModLockPostViewCopyWithImpl<$Res>
+    extends _$ModLockPostViewCopyWithImpl<$Res, _$_ModLockPostView>
+    implements _$$_ModLockPostViewCopyWith<$Res> {
+  __$$_ModLockPostViewCopyWithImpl(
+      _$_ModLockPostView _value, $Res Function(_$_ModLockPostView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5235,7 +5224,7 @@ class __$$ModLockPostViewImplCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModLockPostViewImpl(
+    return _then(_$_ModLockPostView(
       modLockPost: null == modLockPost
           ? _value.modLockPost
           : modLockPost // ignore: cast_nullable_to_non_nullable
@@ -5263,8 +5252,8 @@ class __$$ModLockPostViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModLockPostViewImpl extends _ModLockPostView {
-  const _$ModLockPostViewImpl(
+class _$_ModLockPostView extends _ModLockPostView {
+  const _$_ModLockPostView(
       {required this.modLockPost,
       required this.moderator,
       required this.post,
@@ -5272,8 +5261,8 @@ class _$ModLockPostViewImpl extends _ModLockPostView {
       required this.instanceHost})
       : super._();
 
-  factory _$ModLockPostViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModLockPostViewImplFromJson(json);
+  factory _$_ModLockPostView.fromJson(Map<String, dynamic> json) =>
+      _$$_ModLockPostViewFromJson(json);
 
   @override
   final ModLockPost modLockPost;
@@ -5295,7 +5284,7 @@ class _$ModLockPostViewImpl extends _ModLockPostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModLockPostViewImpl &&
+            other is _$_ModLockPostView &&
             (identical(other.modLockPost, modLockPost) ||
                 other.modLockPost == modLockPost) &&
             (identical(other.moderator, moderator) ||
@@ -5315,13 +5304,12 @@ class _$ModLockPostViewImpl extends _ModLockPostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModLockPostViewImplCopyWith<_$ModLockPostViewImpl> get copyWith =>
-      __$$ModLockPostViewImplCopyWithImpl<_$ModLockPostViewImpl>(
-          this, _$identity);
+  _$$_ModLockPostViewCopyWith<_$_ModLockPostView> get copyWith =>
+      __$$_ModLockPostViewCopyWithImpl<_$_ModLockPostView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModLockPostViewImplToJson(
+    return _$$_ModLockPostViewToJson(
       this,
     );
   }
@@ -5333,11 +5321,11 @@ abstract class _ModLockPostView extends ModLockPostView {
       required final PersonSafe? moderator,
       required final Post post,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$ModLockPostViewImpl;
+      required final String instanceHost}) = _$_ModLockPostView;
   const _ModLockPostView._() : super._();
 
   factory _ModLockPostView.fromJson(Map<String, dynamic> json) =
-      _$ModLockPostViewImpl.fromJson;
+      _$_ModLockPostView.fromJson;
 
   @override
   ModLockPost get modLockPost;
@@ -5351,7 +5339,7 @@ abstract class _ModLockPostView extends ModLockPostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModLockPostViewImplCopyWith<_$ModLockPostViewImpl> get copyWith =>
+  _$$_ModLockPostViewCopyWith<_$_ModLockPostView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5506,11 +5494,11 @@ class _$ModRemoveCommentViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$ModRemoveCommentViewImplCopyWith<$Res>
+abstract class _$$_ModRemoveCommentViewCopyWith<$Res>
     implements $ModRemoveCommentViewCopyWith<$Res> {
-  factory _$$ModRemoveCommentViewImplCopyWith(_$ModRemoveCommentViewImpl value,
-          $Res Function(_$ModRemoveCommentViewImpl) then) =
-      __$$ModRemoveCommentViewImplCopyWithImpl<$Res>;
+  factory _$$_ModRemoveCommentViewCopyWith(_$_ModRemoveCommentView value,
+          $Res Function(_$_ModRemoveCommentView) then) =
+      __$$_ModRemoveCommentViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5537,11 +5525,11 @@ abstract class _$$ModRemoveCommentViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModRemoveCommentViewImplCopyWithImpl<$Res>
-    extends _$ModRemoveCommentViewCopyWithImpl<$Res, _$ModRemoveCommentViewImpl>
-    implements _$$ModRemoveCommentViewImplCopyWith<$Res> {
-  __$$ModRemoveCommentViewImplCopyWithImpl(_$ModRemoveCommentViewImpl _value,
-      $Res Function(_$ModRemoveCommentViewImpl) _then)
+class __$$_ModRemoveCommentViewCopyWithImpl<$Res>
+    extends _$ModRemoveCommentViewCopyWithImpl<$Res, _$_ModRemoveCommentView>
+    implements _$$_ModRemoveCommentViewCopyWith<$Res> {
+  __$$_ModRemoveCommentViewCopyWithImpl(_$_ModRemoveCommentView _value,
+      $Res Function(_$_ModRemoveCommentView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5555,7 +5543,7 @@ class __$$ModRemoveCommentViewImplCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModRemoveCommentViewImpl(
+    return _then(_$_ModRemoveCommentView(
       modRemoveComment: null == modRemoveComment
           ? _value.modRemoveComment
           : modRemoveComment // ignore: cast_nullable_to_non_nullable
@@ -5591,8 +5579,8 @@ class __$$ModRemoveCommentViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModRemoveCommentViewImpl extends _ModRemoveCommentView {
-  const _$ModRemoveCommentViewImpl(
+class _$_ModRemoveCommentView extends _ModRemoveCommentView {
+  const _$_ModRemoveCommentView(
       {required this.modRemoveComment,
       required this.moderator,
       required this.comment,
@@ -5602,8 +5590,8 @@ class _$ModRemoveCommentViewImpl extends _ModRemoveCommentView {
       required this.instanceHost})
       : super._();
 
-  factory _$ModRemoveCommentViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModRemoveCommentViewImplFromJson(json);
+  factory _$_ModRemoveCommentView.fromJson(Map<String, dynamic> json) =>
+      _$$_ModRemoveCommentViewFromJson(json);
 
   @override
   final ModRemoveComment modRemoveComment;
@@ -5629,7 +5617,7 @@ class _$ModRemoveCommentViewImpl extends _ModRemoveCommentView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModRemoveCommentViewImpl &&
+            other is _$_ModRemoveCommentView &&
             (identical(other.modRemoveComment, modRemoveComment) ||
                 other.modRemoveComment == modRemoveComment) &&
             (identical(other.moderator, moderator) ||
@@ -5652,14 +5640,13 @@ class _$ModRemoveCommentViewImpl extends _ModRemoveCommentView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModRemoveCommentViewImplCopyWith<_$ModRemoveCommentViewImpl>
-      get copyWith =>
-          __$$ModRemoveCommentViewImplCopyWithImpl<_$ModRemoveCommentViewImpl>(
-              this, _$identity);
+  _$$_ModRemoveCommentViewCopyWith<_$_ModRemoveCommentView> get copyWith =>
+      __$$_ModRemoveCommentViewCopyWithImpl<_$_ModRemoveCommentView>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModRemoveCommentViewImplToJson(
+    return _$$_ModRemoveCommentViewToJson(
       this,
     );
   }
@@ -5673,11 +5660,11 @@ abstract class _ModRemoveCommentView extends ModRemoveCommentView {
       required final PersonSafe commenter,
       required final Post post,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$ModRemoveCommentViewImpl;
+      required final String instanceHost}) = _$_ModRemoveCommentView;
   const _ModRemoveCommentView._() : super._();
 
   factory _ModRemoveCommentView.fromJson(Map<String, dynamic> json) =
-      _$ModRemoveCommentViewImpl.fromJson;
+      _$_ModRemoveCommentView.fromJson;
 
   @override
   ModRemoveComment get modRemoveComment;
@@ -5695,8 +5682,8 @@ abstract class _ModRemoveCommentView extends ModRemoveCommentView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModRemoveCommentViewImplCopyWith<_$ModRemoveCommentViewImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_ModRemoveCommentViewCopyWith<_$_ModRemoveCommentView> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 ModRemoveCommunityView _$ModRemoveCommunityViewFromJson(
@@ -5805,12 +5792,11 @@ class _$ModRemoveCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$ModRemoveCommunityViewImplCopyWith<$Res>
+abstract class _$$_ModRemoveCommunityViewCopyWith<$Res>
     implements $ModRemoveCommunityViewCopyWith<$Res> {
-  factory _$$ModRemoveCommunityViewImplCopyWith(
-          _$ModRemoveCommunityViewImpl value,
-          $Res Function(_$ModRemoveCommunityViewImpl) then) =
-      __$$ModRemoveCommunityViewImplCopyWithImpl<$Res>;
+  factory _$$_ModRemoveCommunityViewCopyWith(_$_ModRemoveCommunityView value,
+          $Res Function(_$_ModRemoveCommunityView) then) =
+      __$$_ModRemoveCommunityViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5828,13 +5814,12 @@ abstract class _$$ModRemoveCommunityViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModRemoveCommunityViewImplCopyWithImpl<$Res>
+class __$$_ModRemoveCommunityViewCopyWithImpl<$Res>
     extends _$ModRemoveCommunityViewCopyWithImpl<$Res,
-        _$ModRemoveCommunityViewImpl>
-    implements _$$ModRemoveCommunityViewImplCopyWith<$Res> {
-  __$$ModRemoveCommunityViewImplCopyWithImpl(
-      _$ModRemoveCommunityViewImpl _value,
-      $Res Function(_$ModRemoveCommunityViewImpl) _then)
+        _$_ModRemoveCommunityView>
+    implements _$$_ModRemoveCommunityViewCopyWith<$Res> {
+  __$$_ModRemoveCommunityViewCopyWithImpl(_$_ModRemoveCommunityView _value,
+      $Res Function(_$_ModRemoveCommunityView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5845,7 +5830,7 @@ class __$$ModRemoveCommunityViewImplCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModRemoveCommunityViewImpl(
+    return _then(_$_ModRemoveCommunityView(
       modRemoveCommunity: null == modRemoveCommunity
           ? _value.modRemoveCommunity
           : modRemoveCommunity // ignore: cast_nullable_to_non_nullable
@@ -5869,16 +5854,16 @@ class __$$ModRemoveCommunityViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModRemoveCommunityViewImpl extends _ModRemoveCommunityView {
-  const _$ModRemoveCommunityViewImpl(
+class _$_ModRemoveCommunityView extends _ModRemoveCommunityView {
+  const _$_ModRemoveCommunityView(
       {required this.modRemoveCommunity,
       required this.moderator,
       required this.community,
       required this.instanceHost})
       : super._();
 
-  factory _$ModRemoveCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModRemoveCommunityViewImplFromJson(json);
+  factory _$_ModRemoveCommunityView.fromJson(Map<String, dynamic> json) =>
+      _$$_ModRemoveCommunityViewFromJson(json);
 
   @override
   final ModRemoveCommunity modRemoveCommunity;
@@ -5898,7 +5883,7 @@ class _$ModRemoveCommunityViewImpl extends _ModRemoveCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModRemoveCommunityViewImpl &&
+            other is _$_ModRemoveCommunityView &&
             (identical(other.modRemoveCommunity, modRemoveCommunity) ||
                 other.modRemoveCommunity == modRemoveCommunity) &&
             (identical(other.moderator, moderator) ||
@@ -5917,13 +5902,13 @@ class _$ModRemoveCommunityViewImpl extends _ModRemoveCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModRemoveCommunityViewImplCopyWith<_$ModRemoveCommunityViewImpl>
-      get copyWith => __$$ModRemoveCommunityViewImplCopyWithImpl<
-          _$ModRemoveCommunityViewImpl>(this, _$identity);
+  _$$_ModRemoveCommunityViewCopyWith<_$_ModRemoveCommunityView> get copyWith =>
+      __$$_ModRemoveCommunityViewCopyWithImpl<_$_ModRemoveCommunityView>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModRemoveCommunityViewImplToJson(
+    return _$$_ModRemoveCommunityViewToJson(
       this,
     );
   }
@@ -5934,11 +5919,11 @@ abstract class _ModRemoveCommunityView extends ModRemoveCommunityView {
       {required final ModRemoveCommunity modRemoveCommunity,
       required final PersonSafe? moderator,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$ModRemoveCommunityViewImpl;
+      required final String instanceHost}) = _$_ModRemoveCommunityView;
   const _ModRemoveCommunityView._() : super._();
 
   factory _ModRemoveCommunityView.fromJson(Map<String, dynamic> json) =
-      _$ModRemoveCommunityViewImpl.fromJson;
+      _$_ModRemoveCommunityView.fromJson;
 
   @override
   ModRemoveCommunity get modRemoveCommunity;
@@ -5950,8 +5935,8 @@ abstract class _ModRemoveCommunityView extends ModRemoveCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModRemoveCommunityViewImplCopyWith<_$ModRemoveCommunityViewImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_ModRemoveCommunityViewCopyWith<_$_ModRemoveCommunityView> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 ModHideCommunityView _$ModHideCommunityViewFromJson(Map<String, dynamic> json) {
@@ -6057,11 +6042,11 @@ class _$ModHideCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$ModHideCommunityViewImplCopyWith<$Res>
+abstract class _$$_ModHideCommunityViewCopyWith<$Res>
     implements $ModHideCommunityViewCopyWith<$Res> {
-  factory _$$ModHideCommunityViewImplCopyWith(_$ModHideCommunityViewImpl value,
-          $Res Function(_$ModHideCommunityViewImpl) then) =
-      __$$ModHideCommunityViewImplCopyWithImpl<$Res>;
+  factory _$$_ModHideCommunityViewCopyWith(_$_ModHideCommunityView value,
+          $Res Function(_$_ModHideCommunityView) then) =
+      __$$_ModHideCommunityViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6079,11 +6064,11 @@ abstract class _$$ModHideCommunityViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModHideCommunityViewImplCopyWithImpl<$Res>
-    extends _$ModHideCommunityViewCopyWithImpl<$Res, _$ModHideCommunityViewImpl>
-    implements _$$ModHideCommunityViewImplCopyWith<$Res> {
-  __$$ModHideCommunityViewImplCopyWithImpl(_$ModHideCommunityViewImpl _value,
-      $Res Function(_$ModHideCommunityViewImpl) _then)
+class __$$_ModHideCommunityViewCopyWithImpl<$Res>
+    extends _$ModHideCommunityViewCopyWithImpl<$Res, _$_ModHideCommunityView>
+    implements _$$_ModHideCommunityViewCopyWith<$Res> {
+  __$$_ModHideCommunityViewCopyWithImpl(_$_ModHideCommunityView _value,
+      $Res Function(_$_ModHideCommunityView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6094,7 +6079,7 @@ class __$$ModHideCommunityViewImplCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModHideCommunityViewImpl(
+    return _then(_$_ModHideCommunityView(
       modHideCommunity: null == modHideCommunity
           ? _value.modHideCommunity
           : modHideCommunity // ignore: cast_nullable_to_non_nullable
@@ -6118,16 +6103,16 @@ class __$$ModHideCommunityViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModHideCommunityViewImpl extends _ModHideCommunityView {
-  const _$ModHideCommunityViewImpl(
+class _$_ModHideCommunityView extends _ModHideCommunityView {
+  const _$_ModHideCommunityView(
       {required this.modHideCommunity,
       this.admin,
       required this.community,
       required this.instanceHost})
       : super._();
 
-  factory _$ModHideCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModHideCommunityViewImplFromJson(json);
+  factory _$_ModHideCommunityView.fromJson(Map<String, dynamic> json) =>
+      _$$_ModHideCommunityViewFromJson(json);
 
   @override
   final ModHideCommunity modHideCommunity;
@@ -6147,7 +6132,7 @@ class _$ModHideCommunityViewImpl extends _ModHideCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModHideCommunityViewImpl &&
+            other is _$_ModHideCommunityView &&
             (identical(other.modHideCommunity, modHideCommunity) ||
                 other.modHideCommunity == modHideCommunity) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -6165,14 +6150,13 @@ class _$ModHideCommunityViewImpl extends _ModHideCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModHideCommunityViewImplCopyWith<_$ModHideCommunityViewImpl>
-      get copyWith =>
-          __$$ModHideCommunityViewImplCopyWithImpl<_$ModHideCommunityViewImpl>(
-              this, _$identity);
+  _$$_ModHideCommunityViewCopyWith<_$_ModHideCommunityView> get copyWith =>
+      __$$_ModHideCommunityViewCopyWithImpl<_$_ModHideCommunityView>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModHideCommunityViewImplToJson(
+    return _$$_ModHideCommunityViewToJson(
       this,
     );
   }
@@ -6183,11 +6167,11 @@ abstract class _ModHideCommunityView extends ModHideCommunityView {
       {required final ModHideCommunity modHideCommunity,
       final PersonSafe? admin,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$ModHideCommunityViewImpl;
+      required final String instanceHost}) = _$_ModHideCommunityView;
   const _ModHideCommunityView._() : super._();
 
   factory _ModHideCommunityView.fromJson(Map<String, dynamic> json) =
-      _$ModHideCommunityViewImpl.fromJson;
+      _$_ModHideCommunityView.fromJson;
 
   @override
   ModHideCommunity get modHideCommunity;
@@ -6199,8 +6183,8 @@ abstract class _ModHideCommunityView extends ModHideCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModHideCommunityViewImplCopyWith<_$ModHideCommunityViewImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_ModHideCommunityViewCopyWith<_$_ModHideCommunityView> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 ModRemovePostView _$ModRemovePostViewFromJson(Map<String, dynamic> json) {
@@ -6321,11 +6305,11 @@ class _$ModRemovePostViewCopyWithImpl<$Res, $Val extends ModRemovePostView>
 }
 
 /// @nodoc
-abstract class _$$ModRemovePostViewImplCopyWith<$Res>
+abstract class _$$_ModRemovePostViewCopyWith<$Res>
     implements $ModRemovePostViewCopyWith<$Res> {
-  factory _$$ModRemovePostViewImplCopyWith(_$ModRemovePostViewImpl value,
-          $Res Function(_$ModRemovePostViewImpl) then) =
-      __$$ModRemovePostViewImplCopyWithImpl<$Res>;
+  factory _$$_ModRemovePostViewCopyWith(_$_ModRemovePostView value,
+          $Res Function(_$_ModRemovePostView) then) =
+      __$$_ModRemovePostViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6346,11 +6330,11 @@ abstract class _$$ModRemovePostViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModRemovePostViewImplCopyWithImpl<$Res>
-    extends _$ModRemovePostViewCopyWithImpl<$Res, _$ModRemovePostViewImpl>
-    implements _$$ModRemovePostViewImplCopyWith<$Res> {
-  __$$ModRemovePostViewImplCopyWithImpl(_$ModRemovePostViewImpl _value,
-      $Res Function(_$ModRemovePostViewImpl) _then)
+class __$$_ModRemovePostViewCopyWithImpl<$Res>
+    extends _$ModRemovePostViewCopyWithImpl<$Res, _$_ModRemovePostView>
+    implements _$$_ModRemovePostViewCopyWith<$Res> {
+  __$$_ModRemovePostViewCopyWithImpl(
+      _$_ModRemovePostView _value, $Res Function(_$_ModRemovePostView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6362,7 +6346,7 @@ class __$$ModRemovePostViewImplCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModRemovePostViewImpl(
+    return _then(_$_ModRemovePostView(
       modRemovePost: null == modRemovePost
           ? _value.modRemovePost
           : modRemovePost // ignore: cast_nullable_to_non_nullable
@@ -6390,8 +6374,8 @@ class __$$ModRemovePostViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModRemovePostViewImpl extends _ModRemovePostView {
-  const _$ModRemovePostViewImpl(
+class _$_ModRemovePostView extends _ModRemovePostView {
+  const _$_ModRemovePostView(
       {required this.modRemovePost,
       required this.moderator,
       required this.post,
@@ -6399,8 +6383,8 @@ class _$ModRemovePostViewImpl extends _ModRemovePostView {
       required this.instanceHost})
       : super._();
 
-  factory _$ModRemovePostViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModRemovePostViewImplFromJson(json);
+  factory _$_ModRemovePostView.fromJson(Map<String, dynamic> json) =>
+      _$$_ModRemovePostViewFromJson(json);
 
   @override
   final ModRemovePost modRemovePost;
@@ -6422,7 +6406,7 @@ class _$ModRemovePostViewImpl extends _ModRemovePostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModRemovePostViewImpl &&
+            other is _$_ModRemovePostView &&
             (identical(other.modRemovePost, modRemovePost) ||
                 other.modRemovePost == modRemovePost) &&
             (identical(other.moderator, moderator) ||
@@ -6442,13 +6426,13 @@ class _$ModRemovePostViewImpl extends _ModRemovePostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModRemovePostViewImplCopyWith<_$ModRemovePostViewImpl> get copyWith =>
-      __$$ModRemovePostViewImplCopyWithImpl<_$ModRemovePostViewImpl>(
+  _$$_ModRemovePostViewCopyWith<_$_ModRemovePostView> get copyWith =>
+      __$$_ModRemovePostViewCopyWithImpl<_$_ModRemovePostView>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModRemovePostViewImplToJson(
+    return _$$_ModRemovePostViewToJson(
       this,
     );
   }
@@ -6460,11 +6444,11 @@ abstract class _ModRemovePostView extends ModRemovePostView {
       required final PersonSafe? moderator,
       required final Post post,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$ModRemovePostViewImpl;
+      required final String instanceHost}) = _$_ModRemovePostView;
   const _ModRemovePostView._() : super._();
 
   factory _ModRemovePostView.fromJson(Map<String, dynamic> json) =
-      _$ModRemovePostViewImpl.fromJson;
+      _$_ModRemovePostView.fromJson;
 
   @override
   ModRemovePost get modRemovePost;
@@ -6478,7 +6462,7 @@ abstract class _ModRemovePostView extends ModRemovePostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModRemovePostViewImplCopyWith<_$ModRemovePostViewImpl> get copyWith =>
+  _$$_ModRemovePostViewCopyWith<_$_ModRemovePostView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -6600,11 +6584,11 @@ class _$ModStickyPostViewCopyWithImpl<$Res, $Val extends ModStickyPostView>
 }
 
 /// @nodoc
-abstract class _$$ModStickyPostViewImplCopyWith<$Res>
+abstract class _$$_ModStickyPostViewCopyWith<$Res>
     implements $ModStickyPostViewCopyWith<$Res> {
-  factory _$$ModStickyPostViewImplCopyWith(_$ModStickyPostViewImpl value,
-          $Res Function(_$ModStickyPostViewImpl) then) =
-      __$$ModStickyPostViewImplCopyWithImpl<$Res>;
+  factory _$$_ModStickyPostViewCopyWith(_$_ModStickyPostView value,
+          $Res Function(_$_ModStickyPostView) then) =
+      __$$_ModStickyPostViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6625,11 +6609,11 @@ abstract class _$$ModStickyPostViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModStickyPostViewImplCopyWithImpl<$Res>
-    extends _$ModStickyPostViewCopyWithImpl<$Res, _$ModStickyPostViewImpl>
-    implements _$$ModStickyPostViewImplCopyWith<$Res> {
-  __$$ModStickyPostViewImplCopyWithImpl(_$ModStickyPostViewImpl _value,
-      $Res Function(_$ModStickyPostViewImpl) _then)
+class __$$_ModStickyPostViewCopyWithImpl<$Res>
+    extends _$ModStickyPostViewCopyWithImpl<$Res, _$_ModStickyPostView>
+    implements _$$_ModStickyPostViewCopyWith<$Res> {
+  __$$_ModStickyPostViewCopyWithImpl(
+      _$_ModStickyPostView _value, $Res Function(_$_ModStickyPostView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6641,7 +6625,7 @@ class __$$ModStickyPostViewImplCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModStickyPostViewImpl(
+    return _then(_$_ModStickyPostView(
       modStickyPost: null == modStickyPost
           ? _value.modStickyPost
           : modStickyPost // ignore: cast_nullable_to_non_nullable
@@ -6669,8 +6653,8 @@ class __$$ModStickyPostViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModStickyPostViewImpl extends _ModStickyPostView {
-  const _$ModStickyPostViewImpl(
+class _$_ModStickyPostView extends _ModStickyPostView {
+  const _$_ModStickyPostView(
       {required this.modStickyPost,
       required this.moderator,
       required this.post,
@@ -6678,8 +6662,8 @@ class _$ModStickyPostViewImpl extends _ModStickyPostView {
       required this.instanceHost})
       : super._();
 
-  factory _$ModStickyPostViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModStickyPostViewImplFromJson(json);
+  factory _$_ModStickyPostView.fromJson(Map<String, dynamic> json) =>
+      _$$_ModStickyPostViewFromJson(json);
 
   @override
   final ModStickyPost modStickyPost;
@@ -6701,7 +6685,7 @@ class _$ModStickyPostViewImpl extends _ModStickyPostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModStickyPostViewImpl &&
+            other is _$_ModStickyPostView &&
             (identical(other.modStickyPost, modStickyPost) ||
                 other.modStickyPost == modStickyPost) &&
             (identical(other.moderator, moderator) ||
@@ -6721,13 +6705,13 @@ class _$ModStickyPostViewImpl extends _ModStickyPostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModStickyPostViewImplCopyWith<_$ModStickyPostViewImpl> get copyWith =>
-      __$$ModStickyPostViewImplCopyWithImpl<_$ModStickyPostViewImpl>(
+  _$$_ModStickyPostViewCopyWith<_$_ModStickyPostView> get copyWith =>
+      __$$_ModStickyPostViewCopyWithImpl<_$_ModStickyPostView>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModStickyPostViewImplToJson(
+    return _$$_ModStickyPostViewToJson(
       this,
     );
   }
@@ -6739,11 +6723,11 @@ abstract class _ModStickyPostView extends ModStickyPostView {
       required final PersonSafe? moderator,
       required final Post post,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$ModStickyPostViewImpl;
+      required final String instanceHost}) = _$_ModStickyPostView;
   const _ModStickyPostView._() : super._();
 
   factory _ModStickyPostView.fromJson(Map<String, dynamic> json) =
-      _$ModStickyPostViewImpl.fromJson;
+      _$_ModStickyPostView.fromJson;
 
   @override
   ModStickyPost get modStickyPost;
@@ -6757,7 +6741,7 @@ abstract class _ModStickyPostView extends ModStickyPostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModStickyPostViewImplCopyWith<_$ModStickyPostViewImpl> get copyWith =>
+  _$$_ModStickyPostViewCopyWith<_$_ModStickyPostView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -6879,11 +6863,11 @@ class _$ModFeaturePostViewCopyWithImpl<$Res, $Val extends ModFeaturePostView>
 }
 
 /// @nodoc
-abstract class _$$ModFeaturePostViewImplCopyWith<$Res>
+abstract class _$$_ModFeaturePostViewCopyWith<$Res>
     implements $ModFeaturePostViewCopyWith<$Res> {
-  factory _$$ModFeaturePostViewImplCopyWith(_$ModFeaturePostViewImpl value,
-          $Res Function(_$ModFeaturePostViewImpl) then) =
-      __$$ModFeaturePostViewImplCopyWithImpl<$Res>;
+  factory _$$_ModFeaturePostViewCopyWith(_$_ModFeaturePostView value,
+          $Res Function(_$_ModFeaturePostView) then) =
+      __$$_ModFeaturePostViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6904,11 +6888,11 @@ abstract class _$$ModFeaturePostViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ModFeaturePostViewImplCopyWithImpl<$Res>
-    extends _$ModFeaturePostViewCopyWithImpl<$Res, _$ModFeaturePostViewImpl>
-    implements _$$ModFeaturePostViewImplCopyWith<$Res> {
-  __$$ModFeaturePostViewImplCopyWithImpl(_$ModFeaturePostViewImpl _value,
-      $Res Function(_$ModFeaturePostViewImpl) _then)
+class __$$_ModFeaturePostViewCopyWithImpl<$Res>
+    extends _$ModFeaturePostViewCopyWithImpl<$Res, _$_ModFeaturePostView>
+    implements _$$_ModFeaturePostViewCopyWith<$Res> {
+  __$$_ModFeaturePostViewCopyWithImpl(
+      _$_ModFeaturePostView _value, $Res Function(_$_ModFeaturePostView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6920,7 +6904,7 @@ class __$$ModFeaturePostViewImplCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$ModFeaturePostViewImpl(
+    return _then(_$_ModFeaturePostView(
       modFeaturePost: null == modFeaturePost
           ? _value.modFeaturePost
           : modFeaturePost // ignore: cast_nullable_to_non_nullable
@@ -6948,8 +6932,8 @@ class __$$ModFeaturePostViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$ModFeaturePostViewImpl extends _ModFeaturePostView {
-  const _$ModFeaturePostViewImpl(
+class _$_ModFeaturePostView extends _ModFeaturePostView {
+  const _$_ModFeaturePostView(
       {required this.modFeaturePost,
       this.moderator,
       required this.post,
@@ -6957,8 +6941,8 @@ class _$ModFeaturePostViewImpl extends _ModFeaturePostView {
       required this.instanceHost})
       : super._();
 
-  factory _$ModFeaturePostViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ModFeaturePostViewImplFromJson(json);
+  factory _$_ModFeaturePostView.fromJson(Map<String, dynamic> json) =>
+      _$$_ModFeaturePostViewFromJson(json);
 
   @override
   final ModFeaturePost modFeaturePost;
@@ -6980,7 +6964,7 @@ class _$ModFeaturePostViewImpl extends _ModFeaturePostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ModFeaturePostViewImpl &&
+            other is _$_ModFeaturePostView &&
             (identical(other.modFeaturePost, modFeaturePost) ||
                 other.modFeaturePost == modFeaturePost) &&
             (identical(other.moderator, moderator) ||
@@ -7000,13 +6984,13 @@ class _$ModFeaturePostViewImpl extends _ModFeaturePostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$ModFeaturePostViewImplCopyWith<_$ModFeaturePostViewImpl> get copyWith =>
-      __$$ModFeaturePostViewImplCopyWithImpl<_$ModFeaturePostViewImpl>(
+  _$$_ModFeaturePostViewCopyWith<_$_ModFeaturePostView> get copyWith =>
+      __$$_ModFeaturePostViewCopyWithImpl<_$_ModFeaturePostView>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ModFeaturePostViewImplToJson(
+    return _$$_ModFeaturePostViewToJson(
       this,
     );
   }
@@ -7018,11 +7002,11 @@ abstract class _ModFeaturePostView extends ModFeaturePostView {
       final PersonSafe? moderator,
       required final Post post,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$ModFeaturePostViewImpl;
+      required final String instanceHost}) = _$_ModFeaturePostView;
   const _ModFeaturePostView._() : super._();
 
   factory _ModFeaturePostView.fromJson(Map<String, dynamic> json) =
-      _$ModFeaturePostViewImpl.fromJson;
+      _$_ModFeaturePostView.fromJson;
 
   @override
   ModFeaturePost get modFeaturePost;
@@ -7036,7 +7020,7 @@ abstract class _ModFeaturePostView extends ModFeaturePostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$ModFeaturePostViewImplCopyWith<_$ModFeaturePostViewImpl> get copyWith =>
+  _$$_ModFeaturePostViewCopyWith<_$_ModFeaturePostView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7122,12 +7106,11 @@ class _$CommunityFollowerViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$CommunityFollowerViewImplCopyWith<$Res>
+abstract class _$$_CommunityFollowerViewCopyWith<$Res>
     implements $CommunityFollowerViewCopyWith<$Res> {
-  factory _$$CommunityFollowerViewImplCopyWith(
-          _$CommunityFollowerViewImpl value,
-          $Res Function(_$CommunityFollowerViewImpl) then) =
-      __$$CommunityFollowerViewImplCopyWithImpl<$Res>;
+  factory _$$_CommunityFollowerViewCopyWith(_$_CommunityFollowerView value,
+          $Res Function(_$_CommunityFollowerView) then) =
+      __$$_CommunityFollowerViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -7140,12 +7123,11 @@ abstract class _$$CommunityFollowerViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CommunityFollowerViewImplCopyWithImpl<$Res>
-    extends _$CommunityFollowerViewCopyWithImpl<$Res,
-        _$CommunityFollowerViewImpl>
-    implements _$$CommunityFollowerViewImplCopyWith<$Res> {
-  __$$CommunityFollowerViewImplCopyWithImpl(_$CommunityFollowerViewImpl _value,
-      $Res Function(_$CommunityFollowerViewImpl) _then)
+class __$$_CommunityFollowerViewCopyWithImpl<$Res>
+    extends _$CommunityFollowerViewCopyWithImpl<$Res, _$_CommunityFollowerView>
+    implements _$$_CommunityFollowerViewCopyWith<$Res> {
+  __$$_CommunityFollowerViewCopyWithImpl(_$_CommunityFollowerView _value,
+      $Res Function(_$_CommunityFollowerView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7155,7 +7137,7 @@ class __$$CommunityFollowerViewImplCopyWithImpl<$Res>
     Object? follower = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$CommunityFollowerViewImpl(
+    return _then(_$_CommunityFollowerView(
       community: null == community
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
@@ -7175,15 +7157,15 @@ class __$$CommunityFollowerViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CommunityFollowerViewImpl extends _CommunityFollowerView {
-  const _$CommunityFollowerViewImpl(
+class _$_CommunityFollowerView extends _CommunityFollowerView {
+  const _$_CommunityFollowerView(
       {required this.community,
       required this.follower,
       required this.instanceHost})
       : super._();
 
-  factory _$CommunityFollowerViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CommunityFollowerViewImplFromJson(json);
+  factory _$_CommunityFollowerView.fromJson(Map<String, dynamic> json) =>
+      _$$_CommunityFollowerViewFromJson(json);
 
   @override
   final CommunitySafe community;
@@ -7201,7 +7183,7 @@ class _$CommunityFollowerViewImpl extends _CommunityFollowerView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CommunityFollowerViewImpl &&
+            other is _$_CommunityFollowerView &&
             (identical(other.community, community) ||
                 other.community == community) &&
             (identical(other.follower, follower) ||
@@ -7218,13 +7200,13 @@ class _$CommunityFollowerViewImpl extends _CommunityFollowerView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CommunityFollowerViewImplCopyWith<_$CommunityFollowerViewImpl>
-      get copyWith => __$$CommunityFollowerViewImplCopyWithImpl<
-          _$CommunityFollowerViewImpl>(this, _$identity);
+  _$$_CommunityFollowerViewCopyWith<_$_CommunityFollowerView> get copyWith =>
+      __$$_CommunityFollowerViewCopyWithImpl<_$_CommunityFollowerView>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CommunityFollowerViewImplToJson(
+    return _$$_CommunityFollowerViewToJson(
       this,
     );
   }
@@ -7234,11 +7216,11 @@ abstract class _CommunityFollowerView extends CommunityFollowerView {
   const factory _CommunityFollowerView(
       {required final CommunitySafe community,
       required final PersonSafe follower,
-      required final String instanceHost}) = _$CommunityFollowerViewImpl;
+      required final String instanceHost}) = _$_CommunityFollowerView;
   const _CommunityFollowerView._() : super._();
 
   factory _CommunityFollowerView.fromJson(Map<String, dynamic> json) =
-      _$CommunityFollowerViewImpl.fromJson;
+      _$_CommunityFollowerView.fromJson;
 
   @override
   CommunitySafe get community;
@@ -7248,8 +7230,8 @@ abstract class _CommunityFollowerView extends CommunityFollowerView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$CommunityFollowerViewImplCopyWith<_$CommunityFollowerViewImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_CommunityFollowerViewCopyWith<_$_CommunityFollowerView> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 CommunityModeratorView _$CommunityModeratorViewFromJson(
@@ -7338,12 +7320,11 @@ class _$CommunityModeratorViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$CommunityModeratorViewImplCopyWith<$Res>
+abstract class _$$_CommunityModeratorViewCopyWith<$Res>
     implements $CommunityModeratorViewCopyWith<$Res> {
-  factory _$$CommunityModeratorViewImplCopyWith(
-          _$CommunityModeratorViewImpl value,
-          $Res Function(_$CommunityModeratorViewImpl) then) =
-      __$$CommunityModeratorViewImplCopyWithImpl<$Res>;
+  factory _$$_CommunityModeratorViewCopyWith(_$_CommunityModeratorView value,
+          $Res Function(_$_CommunityModeratorView) then) =
+      __$$_CommunityModeratorViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -7356,13 +7337,12 @@ abstract class _$$CommunityModeratorViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CommunityModeratorViewImplCopyWithImpl<$Res>
+class __$$_CommunityModeratorViewCopyWithImpl<$Res>
     extends _$CommunityModeratorViewCopyWithImpl<$Res,
-        _$CommunityModeratorViewImpl>
-    implements _$$CommunityModeratorViewImplCopyWith<$Res> {
-  __$$CommunityModeratorViewImplCopyWithImpl(
-      _$CommunityModeratorViewImpl _value,
-      $Res Function(_$CommunityModeratorViewImpl) _then)
+        _$_CommunityModeratorView>
+    implements _$$_CommunityModeratorViewCopyWith<$Res> {
+  __$$_CommunityModeratorViewCopyWithImpl(_$_CommunityModeratorView _value,
+      $Res Function(_$_CommunityModeratorView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7372,7 +7352,7 @@ class __$$CommunityModeratorViewImplCopyWithImpl<$Res>
     Object? moderator = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$CommunityModeratorViewImpl(
+    return _then(_$_CommunityModeratorView(
       community: null == community
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
@@ -7392,15 +7372,15 @@ class __$$CommunityModeratorViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CommunityModeratorViewImpl extends _CommunityModeratorView {
-  const _$CommunityModeratorViewImpl(
+class _$_CommunityModeratorView extends _CommunityModeratorView {
+  const _$_CommunityModeratorView(
       {required this.community,
       required this.moderator,
       required this.instanceHost})
       : super._();
 
-  factory _$CommunityModeratorViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CommunityModeratorViewImplFromJson(json);
+  factory _$_CommunityModeratorView.fromJson(Map<String, dynamic> json) =>
+      _$$_CommunityModeratorViewFromJson(json);
 
   @override
   final CommunitySafe community;
@@ -7418,7 +7398,7 @@ class _$CommunityModeratorViewImpl extends _CommunityModeratorView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CommunityModeratorViewImpl &&
+            other is _$_CommunityModeratorView &&
             (identical(other.community, community) ||
                 other.community == community) &&
             (identical(other.moderator, moderator) ||
@@ -7435,13 +7415,13 @@ class _$CommunityModeratorViewImpl extends _CommunityModeratorView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CommunityModeratorViewImplCopyWith<_$CommunityModeratorViewImpl>
-      get copyWith => __$$CommunityModeratorViewImplCopyWithImpl<
-          _$CommunityModeratorViewImpl>(this, _$identity);
+  _$$_CommunityModeratorViewCopyWith<_$_CommunityModeratorView> get copyWith =>
+      __$$_CommunityModeratorViewCopyWithImpl<_$_CommunityModeratorView>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CommunityModeratorViewImplToJson(
+    return _$$_CommunityModeratorViewToJson(
       this,
     );
   }
@@ -7451,11 +7431,11 @@ abstract class _CommunityModeratorView extends CommunityModeratorView {
   const factory _CommunityModeratorView(
       {required final CommunitySafe community,
       required final PersonSafe? moderator,
-      required final String instanceHost}) = _$CommunityModeratorViewImpl;
+      required final String instanceHost}) = _$_CommunityModeratorView;
   const _CommunityModeratorView._() : super._();
 
   factory _CommunityModeratorView.fromJson(Map<String, dynamic> json) =
-      _$CommunityModeratorViewImpl.fromJson;
+      _$_CommunityModeratorView.fromJson;
 
   @override
   CommunitySafe get community;
@@ -7465,8 +7445,8 @@ abstract class _CommunityModeratorView extends CommunityModeratorView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$CommunityModeratorViewImplCopyWith<_$CommunityModeratorViewImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_CommunityModeratorViewCopyWith<_$_CommunityModeratorView> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 PersonBlockView _$PersonBlockViewFromJson(Map<String, dynamic> json) {
@@ -7548,11 +7528,11 @@ class _$PersonBlockViewCopyWithImpl<$Res, $Val extends PersonBlockView>
 }
 
 /// @nodoc
-abstract class _$$PersonBlockViewImplCopyWith<$Res>
+abstract class _$$_PersonBlockViewCopyWith<$Res>
     implements $PersonBlockViewCopyWith<$Res> {
-  factory _$$PersonBlockViewImplCopyWith(_$PersonBlockViewImpl value,
-          $Res Function(_$PersonBlockViewImpl) then) =
-      __$$PersonBlockViewImplCopyWithImpl<$Res>;
+  factory _$$_PersonBlockViewCopyWith(
+          _$_PersonBlockView value, $Res Function(_$_PersonBlockView) then) =
+      __$$_PersonBlockViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonSafe person, PersonSafe target, String instanceHost});
@@ -7564,11 +7544,11 @@ abstract class _$$PersonBlockViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$PersonBlockViewImplCopyWithImpl<$Res>
-    extends _$PersonBlockViewCopyWithImpl<$Res, _$PersonBlockViewImpl>
-    implements _$$PersonBlockViewImplCopyWith<$Res> {
-  __$$PersonBlockViewImplCopyWithImpl(
-      _$PersonBlockViewImpl _value, $Res Function(_$PersonBlockViewImpl) _then)
+class __$$_PersonBlockViewCopyWithImpl<$Res>
+    extends _$PersonBlockViewCopyWithImpl<$Res, _$_PersonBlockView>
+    implements _$$_PersonBlockViewCopyWith<$Res> {
+  __$$_PersonBlockViewCopyWithImpl(
+      _$_PersonBlockView _value, $Res Function(_$_PersonBlockView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7578,7 +7558,7 @@ class __$$PersonBlockViewImplCopyWithImpl<$Res>
     Object? target = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$PersonBlockViewImpl(
+    return _then(_$_PersonBlockView(
       person: null == person
           ? _value.person
           : person // ignore: cast_nullable_to_non_nullable
@@ -7598,13 +7578,13 @@ class __$$PersonBlockViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$PersonBlockViewImpl extends _PersonBlockView {
-  const _$PersonBlockViewImpl(
+class _$_PersonBlockView extends _PersonBlockView {
+  const _$_PersonBlockView(
       {required this.person, required this.target, required this.instanceHost})
       : super._();
 
-  factory _$PersonBlockViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PersonBlockViewImplFromJson(json);
+  factory _$_PersonBlockView.fromJson(Map<String, dynamic> json) =>
+      _$$_PersonBlockViewFromJson(json);
 
   @override
   final PersonSafe person;
@@ -7622,7 +7602,7 @@ class _$PersonBlockViewImpl extends _PersonBlockView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PersonBlockViewImpl &&
+            other is _$_PersonBlockView &&
             (identical(other.person, person) || other.person == person) &&
             (identical(other.target, target) || other.target == target) &&
             (identical(other.instanceHost, instanceHost) ||
@@ -7636,13 +7616,12 @@ class _$PersonBlockViewImpl extends _PersonBlockView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$PersonBlockViewImplCopyWith<_$PersonBlockViewImpl> get copyWith =>
-      __$$PersonBlockViewImplCopyWithImpl<_$PersonBlockViewImpl>(
-          this, _$identity);
+  _$$_PersonBlockViewCopyWith<_$_PersonBlockView> get copyWith =>
+      __$$_PersonBlockViewCopyWithImpl<_$_PersonBlockView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$PersonBlockViewImplToJson(
+    return _$$_PersonBlockViewToJson(
       this,
     );
   }
@@ -7652,11 +7631,11 @@ abstract class _PersonBlockView extends PersonBlockView {
   const factory _PersonBlockView(
       {required final PersonSafe person,
       required final PersonSafe target,
-      required final String instanceHost}) = _$PersonBlockViewImpl;
+      required final String instanceHost}) = _$_PersonBlockView;
   const _PersonBlockView._() : super._();
 
   factory _PersonBlockView.fromJson(Map<String, dynamic> json) =
-      _$PersonBlockViewImpl.fromJson;
+      _$_PersonBlockView.fromJson;
 
   @override
   PersonSafe get person;
@@ -7666,7 +7645,7 @@ abstract class _PersonBlockView extends PersonBlockView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$PersonBlockViewImplCopyWith<_$PersonBlockViewImpl> get copyWith =>
+  _$$_PersonBlockViewCopyWith<_$_PersonBlockView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7749,11 +7728,11 @@ class _$CommunityBlockViewCopyWithImpl<$Res, $Val extends CommunityBlockView>
 }
 
 /// @nodoc
-abstract class _$$CommunityBlockViewImplCopyWith<$Res>
+abstract class _$$_CommunityBlockViewCopyWith<$Res>
     implements $CommunityBlockViewCopyWith<$Res> {
-  factory _$$CommunityBlockViewImplCopyWith(_$CommunityBlockViewImpl value,
-          $Res Function(_$CommunityBlockViewImpl) then) =
-      __$$CommunityBlockViewImplCopyWithImpl<$Res>;
+  factory _$$_CommunityBlockViewCopyWith(_$_CommunityBlockView value,
+          $Res Function(_$_CommunityBlockView) then) =
+      __$$_CommunityBlockViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonSafe person, CommunitySafe community, String instanceHost});
@@ -7765,11 +7744,11 @@ abstract class _$$CommunityBlockViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CommunityBlockViewImplCopyWithImpl<$Res>
-    extends _$CommunityBlockViewCopyWithImpl<$Res, _$CommunityBlockViewImpl>
-    implements _$$CommunityBlockViewImplCopyWith<$Res> {
-  __$$CommunityBlockViewImplCopyWithImpl(_$CommunityBlockViewImpl _value,
-      $Res Function(_$CommunityBlockViewImpl) _then)
+class __$$_CommunityBlockViewCopyWithImpl<$Res>
+    extends _$CommunityBlockViewCopyWithImpl<$Res, _$_CommunityBlockView>
+    implements _$$_CommunityBlockViewCopyWith<$Res> {
+  __$$_CommunityBlockViewCopyWithImpl(
+      _$_CommunityBlockView _value, $Res Function(_$_CommunityBlockView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7779,7 +7758,7 @@ class __$$CommunityBlockViewImplCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$CommunityBlockViewImpl(
+    return _then(_$_CommunityBlockView(
       person: null == person
           ? _value.person
           : person // ignore: cast_nullable_to_non_nullable
@@ -7799,15 +7778,15 @@ class __$$CommunityBlockViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CommunityBlockViewImpl extends _CommunityBlockView {
-  const _$CommunityBlockViewImpl(
+class _$_CommunityBlockView extends _CommunityBlockView {
+  const _$_CommunityBlockView(
       {required this.person,
       required this.community,
       required this.instanceHost})
       : super._();
 
-  factory _$CommunityBlockViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CommunityBlockViewImplFromJson(json);
+  factory _$_CommunityBlockView.fromJson(Map<String, dynamic> json) =>
+      _$$_CommunityBlockViewFromJson(json);
 
   @override
   final PersonSafe person;
@@ -7825,7 +7804,7 @@ class _$CommunityBlockViewImpl extends _CommunityBlockView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CommunityBlockViewImpl &&
+            other is _$_CommunityBlockView &&
             (identical(other.person, person) || other.person == person) &&
             (identical(other.community, community) ||
                 other.community == community) &&
@@ -7840,13 +7819,13 @@ class _$CommunityBlockViewImpl extends _CommunityBlockView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CommunityBlockViewImplCopyWith<_$CommunityBlockViewImpl> get copyWith =>
-      __$$CommunityBlockViewImplCopyWithImpl<_$CommunityBlockViewImpl>(
+  _$$_CommunityBlockViewCopyWith<_$_CommunityBlockView> get copyWith =>
+      __$$_CommunityBlockViewCopyWithImpl<_$_CommunityBlockView>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CommunityBlockViewImplToJson(
+    return _$$_CommunityBlockViewToJson(
       this,
     );
   }
@@ -7856,11 +7835,11 @@ abstract class _CommunityBlockView extends CommunityBlockView {
   const factory _CommunityBlockView(
       {required final PersonSafe person,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$CommunityBlockViewImpl;
+      required final String instanceHost}) = _$_CommunityBlockView;
   const _CommunityBlockView._() : super._();
 
   factory _CommunityBlockView.fromJson(Map<String, dynamic> json) =
-      _$CommunityBlockViewImpl.fromJson;
+      _$_CommunityBlockView.fromJson;
 
   @override
   PersonSafe get person;
@@ -7870,7 +7849,7 @@ abstract class _CommunityBlockView extends CommunityBlockView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$CommunityBlockViewImplCopyWith<_$CommunityBlockViewImpl> get copyWith =>
+  _$$_CommunityBlockViewCopyWith<_$_CommunityBlockView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7955,12 +7934,11 @@ class _$CommunityPersonBanViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$CommunityPersonBanViewImplCopyWith<$Res>
+abstract class _$$_CommunityPersonBanViewCopyWith<$Res>
     implements $CommunityPersonBanViewCopyWith<$Res> {
-  factory _$$CommunityPersonBanViewImplCopyWith(
-          _$CommunityPersonBanViewImpl value,
-          $Res Function(_$CommunityPersonBanViewImpl) then) =
-      __$$CommunityPersonBanViewImplCopyWithImpl<$Res>;
+  factory _$$_CommunityPersonBanViewCopyWith(_$_CommunityPersonBanView value,
+          $Res Function(_$_CommunityPersonBanView) then) =
+      __$$_CommunityPersonBanViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CommunitySafe community, PersonSafe person, String instanceHost});
@@ -7972,13 +7950,12 @@ abstract class _$$CommunityPersonBanViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CommunityPersonBanViewImplCopyWithImpl<$Res>
+class __$$_CommunityPersonBanViewCopyWithImpl<$Res>
     extends _$CommunityPersonBanViewCopyWithImpl<$Res,
-        _$CommunityPersonBanViewImpl>
-    implements _$$CommunityPersonBanViewImplCopyWith<$Res> {
-  __$$CommunityPersonBanViewImplCopyWithImpl(
-      _$CommunityPersonBanViewImpl _value,
-      $Res Function(_$CommunityPersonBanViewImpl) _then)
+        _$_CommunityPersonBanView>
+    implements _$$_CommunityPersonBanViewCopyWith<$Res> {
+  __$$_CommunityPersonBanViewCopyWithImpl(_$_CommunityPersonBanView _value,
+      $Res Function(_$_CommunityPersonBanView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7988,7 +7965,7 @@ class __$$CommunityPersonBanViewImplCopyWithImpl<$Res>
     Object? person = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$CommunityPersonBanViewImpl(
+    return _then(_$_CommunityPersonBanView(
       community: null == community
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
@@ -8008,15 +7985,15 @@ class __$$CommunityPersonBanViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CommunityPersonBanViewImpl extends _CommunityPersonBanView {
-  const _$CommunityPersonBanViewImpl(
+class _$_CommunityPersonBanView extends _CommunityPersonBanView {
+  const _$_CommunityPersonBanView(
       {required this.community,
       required this.person,
       required this.instanceHost})
       : super._();
 
-  factory _$CommunityPersonBanViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CommunityPersonBanViewImplFromJson(json);
+  factory _$_CommunityPersonBanView.fromJson(Map<String, dynamic> json) =>
+      _$$_CommunityPersonBanViewFromJson(json);
 
   @override
   final CommunitySafe community;
@@ -8034,7 +8011,7 @@ class _$CommunityPersonBanViewImpl extends _CommunityPersonBanView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CommunityPersonBanViewImpl &&
+            other is _$_CommunityPersonBanView &&
             (identical(other.community, community) ||
                 other.community == community) &&
             (identical(other.person, person) || other.person == person) &&
@@ -8049,13 +8026,13 @@ class _$CommunityPersonBanViewImpl extends _CommunityPersonBanView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CommunityPersonBanViewImplCopyWith<_$CommunityPersonBanViewImpl>
-      get copyWith => __$$CommunityPersonBanViewImplCopyWithImpl<
-          _$CommunityPersonBanViewImpl>(this, _$identity);
+  _$$_CommunityPersonBanViewCopyWith<_$_CommunityPersonBanView> get copyWith =>
+      __$$_CommunityPersonBanViewCopyWithImpl<_$_CommunityPersonBanView>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CommunityPersonBanViewImplToJson(
+    return _$$_CommunityPersonBanViewToJson(
       this,
     );
   }
@@ -8065,11 +8042,11 @@ abstract class _CommunityPersonBanView extends CommunityPersonBanView {
   const factory _CommunityPersonBanView(
       {required final CommunitySafe community,
       required final PersonSafe person,
-      required final String instanceHost}) = _$CommunityPersonBanViewImpl;
+      required final String instanceHost}) = _$_CommunityPersonBanView;
   const _CommunityPersonBanView._() : super._();
 
   factory _CommunityPersonBanView.fromJson(Map<String, dynamic> json) =
-      _$CommunityPersonBanViewImpl.fromJson;
+      _$_CommunityPersonBanView.fromJson;
 
   @override
   CommunitySafe get community;
@@ -8079,8 +8056,8 @@ abstract class _CommunityPersonBanView extends CommunityPersonBanView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$CommunityPersonBanViewImplCopyWith<_$CommunityPersonBanViewImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_CommunityPersonBanViewCopyWith<_$_CommunityPersonBanView> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 CommunityView _$CommunityViewFromJson(Map<String, dynamic> json) {
@@ -8179,11 +8156,11 @@ class _$CommunityViewCopyWithImpl<$Res, $Val extends CommunityView>
 }
 
 /// @nodoc
-abstract class _$$CommunityViewImplCopyWith<$Res>
+abstract class _$$_CommunityViewCopyWith<$Res>
     implements $CommunityViewCopyWith<$Res> {
-  factory _$$CommunityViewImplCopyWith(
-          _$CommunityViewImpl value, $Res Function(_$CommunityViewImpl) then) =
-      __$$CommunityViewImplCopyWithImpl<$Res>;
+  factory _$$_CommunityViewCopyWith(
+          _$_CommunityView value, $Res Function(_$_CommunityView) then) =
+      __$$_CommunityViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -8200,11 +8177,11 @@ abstract class _$$CommunityViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$CommunityViewImplCopyWithImpl<$Res>
-    extends _$CommunityViewCopyWithImpl<$Res, _$CommunityViewImpl>
-    implements _$$CommunityViewImplCopyWith<$Res> {
-  __$$CommunityViewImplCopyWithImpl(
-      _$CommunityViewImpl _value, $Res Function(_$CommunityViewImpl) _then)
+class __$$_CommunityViewCopyWithImpl<$Res>
+    extends _$CommunityViewCopyWithImpl<$Res, _$_CommunityView>
+    implements _$$_CommunityViewCopyWith<$Res> {
+  __$$_CommunityViewCopyWithImpl(
+      _$_CommunityView _value, $Res Function(_$_CommunityView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8216,7 +8193,7 @@ class __$$CommunityViewImplCopyWithImpl<$Res>
     Object? counts = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$CommunityViewImpl(
+    return _then(_$_CommunityView(
       community: null == community
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
@@ -8244,8 +8221,8 @@ class __$$CommunityViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$CommunityViewImpl extends _CommunityView {
-  const _$CommunityViewImpl(
+class _$_CommunityView extends _CommunityView {
+  const _$_CommunityView(
       {required this.community,
       this.subscribed = SubscribedType.notSubscribed,
       required this.blocked,
@@ -8253,8 +8230,8 @@ class _$CommunityViewImpl extends _CommunityView {
       required this.instanceHost})
       : super._();
 
-  factory _$CommunityViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$CommunityViewImplFromJson(json);
+  factory _$_CommunityView.fromJson(Map<String, dynamic> json) =>
+      _$$_CommunityViewFromJson(json);
 
   @override
   final CommunitySafe community;
@@ -8277,7 +8254,7 @@ class _$CommunityViewImpl extends _CommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$CommunityViewImpl &&
+            other is _$_CommunityView &&
             (identical(other.community, community) ||
                 other.community == community) &&
             (identical(other.subscribed, subscribed) ||
@@ -8296,12 +8273,12 @@ class _$CommunityViewImpl extends _CommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$CommunityViewImplCopyWith<_$CommunityViewImpl> get copyWith =>
-      __$$CommunityViewImplCopyWithImpl<_$CommunityViewImpl>(this, _$identity);
+  _$$_CommunityViewCopyWith<_$_CommunityView> get copyWith =>
+      __$$_CommunityViewCopyWithImpl<_$_CommunityView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$CommunityViewImplToJson(
+    return _$$_CommunityViewToJson(
       this,
     );
   }
@@ -8313,11 +8290,11 @@ abstract class _CommunityView extends CommunityView {
       final SubscribedType subscribed,
       required final bool blocked,
       required final CommunityAggregates counts,
-      required final String instanceHost}) = _$CommunityViewImpl;
+      required final String instanceHost}) = _$_CommunityView;
   const _CommunityView._() : super._();
 
   factory _CommunityView.fromJson(Map<String, dynamic> json) =
-      _$CommunityViewImpl.fromJson;
+      _$_CommunityView.fromJson;
 
   @override
   CommunitySafe get community;
@@ -8331,7 +8308,7 @@ abstract class _CommunityView extends CommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$CommunityViewImplCopyWith<_$CommunityViewImpl> get copyWith =>
+  _$$_CommunityViewCopyWith<_$_CommunityView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -8459,12 +8436,12 @@ class _$RegistrationApplicationViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$RegistrationApplicationViewImplCopyWith<$Res>
+abstract class _$$_RegistrationApplicationViewCopyWith<$Res>
     implements $RegistrationApplicationViewCopyWith<$Res> {
-  factory _$$RegistrationApplicationViewImplCopyWith(
-          _$RegistrationApplicationViewImpl value,
-          $Res Function(_$RegistrationApplicationViewImpl) then) =
-      __$$RegistrationApplicationViewImplCopyWithImpl<$Res>;
+  factory _$$_RegistrationApplicationViewCopyWith(
+          _$_RegistrationApplicationView value,
+          $Res Function(_$_RegistrationApplicationView) then) =
+      __$$_RegistrationApplicationViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -8485,13 +8462,13 @@ abstract class _$$RegistrationApplicationViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$RegistrationApplicationViewImplCopyWithImpl<$Res>
+class __$$_RegistrationApplicationViewCopyWithImpl<$Res>
     extends _$RegistrationApplicationViewCopyWithImpl<$Res,
-        _$RegistrationApplicationViewImpl>
-    implements _$$RegistrationApplicationViewImplCopyWith<$Res> {
-  __$$RegistrationApplicationViewImplCopyWithImpl(
-      _$RegistrationApplicationViewImpl _value,
-      $Res Function(_$RegistrationApplicationViewImpl) _then)
+        _$_RegistrationApplicationView>
+    implements _$$_RegistrationApplicationViewCopyWith<$Res> {
+  __$$_RegistrationApplicationViewCopyWithImpl(
+      _$_RegistrationApplicationView _value,
+      $Res Function(_$_RegistrationApplicationView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8503,7 +8480,7 @@ class __$$RegistrationApplicationViewImplCopyWithImpl<$Res>
     Object? admin = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$RegistrationApplicationViewImpl(
+    return _then(_$_RegistrationApplicationView(
       registrationApplication: null == registrationApplication
           ? _value.registrationApplication
           : registrationApplication // ignore: cast_nullable_to_non_nullable
@@ -8531,8 +8508,8 @@ class __$$RegistrationApplicationViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$RegistrationApplicationViewImpl extends _RegistrationApplicationView {
-  const _$RegistrationApplicationViewImpl(
+class _$_RegistrationApplicationView extends _RegistrationApplicationView {
+  const _$_RegistrationApplicationView(
       {required this.registrationApplication,
       required this.creatorLocalUser,
       required this.creator,
@@ -8540,9 +8517,8 @@ class _$RegistrationApplicationViewImpl extends _RegistrationApplicationView {
       required this.instanceHost})
       : super._();
 
-  factory _$RegistrationApplicationViewImpl.fromJson(
-          Map<String, dynamic> json) =>
-      _$$RegistrationApplicationViewImplFromJson(json);
+  factory _$_RegistrationApplicationView.fromJson(Map<String, dynamic> json) =>
+      _$$_RegistrationApplicationViewFromJson(json);
 
   @override
   final RegistrationApplication registrationApplication;
@@ -8564,7 +8540,7 @@ class _$RegistrationApplicationViewImpl extends _RegistrationApplicationView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$RegistrationApplicationViewImpl &&
+            other is _$_RegistrationApplicationView &&
             (identical(
                     other.registrationApplication, registrationApplication) ||
                 other.registrationApplication == registrationApplication) &&
@@ -8584,13 +8560,13 @@ class _$RegistrationApplicationViewImpl extends _RegistrationApplicationView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$RegistrationApplicationViewImplCopyWith<_$RegistrationApplicationViewImpl>
-      get copyWith => __$$RegistrationApplicationViewImplCopyWithImpl<
-          _$RegistrationApplicationViewImpl>(this, _$identity);
+  _$$_RegistrationApplicationViewCopyWith<_$_RegistrationApplicationView>
+      get copyWith => __$$_RegistrationApplicationViewCopyWithImpl<
+          _$_RegistrationApplicationView>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$RegistrationApplicationViewImplToJson(
+    return _$$_RegistrationApplicationViewToJson(
       this,
     );
   }
@@ -8603,11 +8579,11 @@ abstract class _RegistrationApplicationView
       required final LocalUserSettings creatorLocalUser,
       required final PersonSafe creator,
       final PersonSafe? admin,
-      required final String instanceHost}) = _$RegistrationApplicationViewImpl;
+      required final String instanceHost}) = _$_RegistrationApplicationView;
   const _RegistrationApplicationView._() : super._();
 
   factory _RegistrationApplicationView.fromJson(Map<String, dynamic> json) =
-      _$RegistrationApplicationViewImpl.fromJson;
+      _$_RegistrationApplicationView.fromJson;
 
   @override
   RegistrationApplication get registrationApplication;
@@ -8621,7 +8597,7 @@ abstract class _RegistrationApplicationView
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$RegistrationApplicationViewImplCopyWith<_$RegistrationApplicationViewImpl>
+  _$$_RegistrationApplicationViewCopyWith<_$_RegistrationApplicationView>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -8729,12 +8705,11 @@ class _$AdminPurgeCommentViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$AdminPurgeCommentViewImplCopyWith<$Res>
+abstract class _$$_AdminPurgeCommentViewCopyWith<$Res>
     implements $AdminPurgeCommentViewCopyWith<$Res> {
-  factory _$$AdminPurgeCommentViewImplCopyWith(
-          _$AdminPurgeCommentViewImpl value,
-          $Res Function(_$AdminPurgeCommentViewImpl) then) =
-      __$$AdminPurgeCommentViewImplCopyWithImpl<$Res>;
+  factory _$$_AdminPurgeCommentViewCopyWith(_$_AdminPurgeCommentView value,
+          $Res Function(_$_AdminPurgeCommentView) then) =
+      __$$_AdminPurgeCommentViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -8752,12 +8727,11 @@ abstract class _$$AdminPurgeCommentViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$AdminPurgeCommentViewImplCopyWithImpl<$Res>
-    extends _$AdminPurgeCommentViewCopyWithImpl<$Res,
-        _$AdminPurgeCommentViewImpl>
-    implements _$$AdminPurgeCommentViewImplCopyWith<$Res> {
-  __$$AdminPurgeCommentViewImplCopyWithImpl(_$AdminPurgeCommentViewImpl _value,
-      $Res Function(_$AdminPurgeCommentViewImpl) _then)
+class __$$_AdminPurgeCommentViewCopyWithImpl<$Res>
+    extends _$AdminPurgeCommentViewCopyWithImpl<$Res, _$_AdminPurgeCommentView>
+    implements _$$_AdminPurgeCommentViewCopyWith<$Res> {
+  __$$_AdminPurgeCommentViewCopyWithImpl(_$_AdminPurgeCommentView _value,
+      $Res Function(_$_AdminPurgeCommentView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8768,7 +8742,7 @@ class __$$AdminPurgeCommentViewImplCopyWithImpl<$Res>
     Object? post = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$AdminPurgeCommentViewImpl(
+    return _then(_$_AdminPurgeCommentView(
       adminPurgeComment: null == adminPurgeComment
           ? _value.adminPurgeComment
           : adminPurgeComment // ignore: cast_nullable_to_non_nullable
@@ -8792,16 +8766,16 @@ class __$$AdminPurgeCommentViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$AdminPurgeCommentViewImpl extends _AdminPurgeCommentView {
-  const _$AdminPurgeCommentViewImpl(
+class _$_AdminPurgeCommentView extends _AdminPurgeCommentView {
+  const _$_AdminPurgeCommentView(
       {required this.adminPurgeComment,
       this.admin,
       required this.post,
       required this.instanceHost})
       : super._();
 
-  factory _$AdminPurgeCommentViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AdminPurgeCommentViewImplFromJson(json);
+  factory _$_AdminPurgeCommentView.fromJson(Map<String, dynamic> json) =>
+      _$$_AdminPurgeCommentViewFromJson(json);
 
   @override
   final AdminPurgeComment adminPurgeComment;
@@ -8821,7 +8795,7 @@ class _$AdminPurgeCommentViewImpl extends _AdminPurgeCommentView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AdminPurgeCommentViewImpl &&
+            other is _$_AdminPurgeCommentView &&
             (identical(other.adminPurgeComment, adminPurgeComment) ||
                 other.adminPurgeComment == adminPurgeComment) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -8838,13 +8812,13 @@ class _$AdminPurgeCommentViewImpl extends _AdminPurgeCommentView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$AdminPurgeCommentViewImplCopyWith<_$AdminPurgeCommentViewImpl>
-      get copyWith => __$$AdminPurgeCommentViewImplCopyWithImpl<
-          _$AdminPurgeCommentViewImpl>(this, _$identity);
+  _$$_AdminPurgeCommentViewCopyWith<_$_AdminPurgeCommentView> get copyWith =>
+      __$$_AdminPurgeCommentViewCopyWithImpl<_$_AdminPurgeCommentView>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$AdminPurgeCommentViewImplToJson(
+    return _$$_AdminPurgeCommentViewToJson(
       this,
     );
   }
@@ -8855,11 +8829,11 @@ abstract class _AdminPurgeCommentView extends AdminPurgeCommentView {
       {required final AdminPurgeComment adminPurgeComment,
       final PersonSafe? admin,
       required final Post post,
-      required final String instanceHost}) = _$AdminPurgeCommentViewImpl;
+      required final String instanceHost}) = _$_AdminPurgeCommentView;
   const _AdminPurgeCommentView._() : super._();
 
   factory _AdminPurgeCommentView.fromJson(Map<String, dynamic> json) =
-      _$AdminPurgeCommentViewImpl.fromJson;
+      _$_AdminPurgeCommentView.fromJson;
 
   @override
   AdminPurgeComment get adminPurgeComment;
@@ -8871,8 +8845,8 @@ abstract class _AdminPurgeCommentView extends AdminPurgeCommentView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$AdminPurgeCommentViewImplCopyWith<_$AdminPurgeCommentViewImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_AdminPurgeCommentViewCopyWith<_$_AdminPurgeCommentView> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 AdminPurgePostView _$AdminPurgePostViewFromJson(Map<String, dynamic> json) {
@@ -8977,11 +8951,11 @@ class _$AdminPurgePostViewCopyWithImpl<$Res, $Val extends AdminPurgePostView>
 }
 
 /// @nodoc
-abstract class _$$AdminPurgePostViewImplCopyWith<$Res>
+abstract class _$$_AdminPurgePostViewCopyWith<$Res>
     implements $AdminPurgePostViewCopyWith<$Res> {
-  factory _$$AdminPurgePostViewImplCopyWith(_$AdminPurgePostViewImpl value,
-          $Res Function(_$AdminPurgePostViewImpl) then) =
-      __$$AdminPurgePostViewImplCopyWithImpl<$Res>;
+  factory _$$_AdminPurgePostViewCopyWith(_$_AdminPurgePostView value,
+          $Res Function(_$_AdminPurgePostView) then) =
+      __$$_AdminPurgePostViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -8999,11 +8973,11 @@ abstract class _$$AdminPurgePostViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$AdminPurgePostViewImplCopyWithImpl<$Res>
-    extends _$AdminPurgePostViewCopyWithImpl<$Res, _$AdminPurgePostViewImpl>
-    implements _$$AdminPurgePostViewImplCopyWith<$Res> {
-  __$$AdminPurgePostViewImplCopyWithImpl(_$AdminPurgePostViewImpl _value,
-      $Res Function(_$AdminPurgePostViewImpl) _then)
+class __$$_AdminPurgePostViewCopyWithImpl<$Res>
+    extends _$AdminPurgePostViewCopyWithImpl<$Res, _$_AdminPurgePostView>
+    implements _$$_AdminPurgePostViewCopyWith<$Res> {
+  __$$_AdminPurgePostViewCopyWithImpl(
+      _$_AdminPurgePostView _value, $Res Function(_$_AdminPurgePostView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -9014,7 +8988,7 @@ class __$$AdminPurgePostViewImplCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$AdminPurgePostViewImpl(
+    return _then(_$_AdminPurgePostView(
       adminPurgePost: null == adminPurgePost
           ? _value.adminPurgePost
           : adminPurgePost // ignore: cast_nullable_to_non_nullable
@@ -9038,16 +9012,16 @@ class __$$AdminPurgePostViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$AdminPurgePostViewImpl extends _AdminPurgePostView {
-  const _$AdminPurgePostViewImpl(
+class _$_AdminPurgePostView extends _AdminPurgePostView {
+  const _$_AdminPurgePostView(
       {required this.adminPurgePost,
       this.admin,
       required this.community,
       required this.instanceHost})
       : super._();
 
-  factory _$AdminPurgePostViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AdminPurgePostViewImplFromJson(json);
+  factory _$_AdminPurgePostView.fromJson(Map<String, dynamic> json) =>
+      _$$_AdminPurgePostViewFromJson(json);
 
   @override
   final AdminPurgePost adminPurgePost;
@@ -9067,7 +9041,7 @@ class _$AdminPurgePostViewImpl extends _AdminPurgePostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AdminPurgePostViewImpl &&
+            other is _$_AdminPurgePostView &&
             (identical(other.adminPurgePost, adminPurgePost) ||
                 other.adminPurgePost == adminPurgePost) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -9085,13 +9059,13 @@ class _$AdminPurgePostViewImpl extends _AdminPurgePostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$AdminPurgePostViewImplCopyWith<_$AdminPurgePostViewImpl> get copyWith =>
-      __$$AdminPurgePostViewImplCopyWithImpl<_$AdminPurgePostViewImpl>(
+  _$$_AdminPurgePostViewCopyWith<_$_AdminPurgePostView> get copyWith =>
+      __$$_AdminPurgePostViewCopyWithImpl<_$_AdminPurgePostView>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$AdminPurgePostViewImplToJson(
+    return _$$_AdminPurgePostViewToJson(
       this,
     );
   }
@@ -9102,11 +9076,11 @@ abstract class _AdminPurgePostView extends AdminPurgePostView {
       {required final AdminPurgePost adminPurgePost,
       final PersonSafe? admin,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$AdminPurgePostViewImpl;
+      required final String instanceHost}) = _$_AdminPurgePostView;
   const _AdminPurgePostView._() : super._();
 
   factory _AdminPurgePostView.fromJson(Map<String, dynamic> json) =
-      _$AdminPurgePostViewImpl.fromJson;
+      _$_AdminPurgePostView.fromJson;
 
   @override
   AdminPurgePost get adminPurgePost;
@@ -9118,7 +9092,7 @@ abstract class _AdminPurgePostView extends AdminPurgePostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$AdminPurgePostViewImplCopyWith<_$AdminPurgePostViewImpl> get copyWith =>
+  _$$_AdminPurgePostViewCopyWith<_$_AdminPurgePostView> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -9209,11 +9183,11 @@ class _$AdminPurgePersonViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$AdminPurgePersonViewImplCopyWith<$Res>
+abstract class _$$_AdminPurgePersonViewCopyWith<$Res>
     implements $AdminPurgePersonViewCopyWith<$Res> {
-  factory _$$AdminPurgePersonViewImplCopyWith(_$AdminPurgePersonViewImpl value,
-          $Res Function(_$AdminPurgePersonViewImpl) then) =
-      __$$AdminPurgePersonViewImplCopyWithImpl<$Res>;
+  factory _$$_AdminPurgePersonViewCopyWith(_$_AdminPurgePersonView value,
+          $Res Function(_$_AdminPurgePersonView) then) =
+      __$$_AdminPurgePersonViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -9228,11 +9202,11 @@ abstract class _$$AdminPurgePersonViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$AdminPurgePersonViewImplCopyWithImpl<$Res>
-    extends _$AdminPurgePersonViewCopyWithImpl<$Res, _$AdminPurgePersonViewImpl>
-    implements _$$AdminPurgePersonViewImplCopyWith<$Res> {
-  __$$AdminPurgePersonViewImplCopyWithImpl(_$AdminPurgePersonViewImpl _value,
-      $Res Function(_$AdminPurgePersonViewImpl) _then)
+class __$$_AdminPurgePersonViewCopyWithImpl<$Res>
+    extends _$AdminPurgePersonViewCopyWithImpl<$Res, _$_AdminPurgePersonView>
+    implements _$$_AdminPurgePersonViewCopyWith<$Res> {
+  __$$_AdminPurgePersonViewCopyWithImpl(_$_AdminPurgePersonView _value,
+      $Res Function(_$_AdminPurgePersonView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -9242,7 +9216,7 @@ class __$$AdminPurgePersonViewImplCopyWithImpl<$Res>
     Object? admin = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$AdminPurgePersonViewImpl(
+    return _then(_$_AdminPurgePersonView(
       adminPurgePerson: null == adminPurgePerson
           ? _value.adminPurgePerson
           : adminPurgePerson // ignore: cast_nullable_to_non_nullable
@@ -9262,13 +9236,13 @@ class __$$AdminPurgePersonViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$AdminPurgePersonViewImpl extends _AdminPurgePersonView {
-  const _$AdminPurgePersonViewImpl(
+class _$_AdminPurgePersonView extends _AdminPurgePersonView {
+  const _$_AdminPurgePersonView(
       {required this.adminPurgePerson, this.admin, required this.instanceHost})
       : super._();
 
-  factory _$AdminPurgePersonViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AdminPurgePersonViewImplFromJson(json);
+  factory _$_AdminPurgePersonView.fromJson(Map<String, dynamic> json) =>
+      _$$_AdminPurgePersonViewFromJson(json);
 
   @override
   final AdminPurgePerson adminPurgePerson;
@@ -9286,7 +9260,7 @@ class _$AdminPurgePersonViewImpl extends _AdminPurgePersonView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AdminPurgePersonViewImpl &&
+            other is _$_AdminPurgePersonView &&
             (identical(other.adminPurgePerson, adminPurgePerson) ||
                 other.adminPurgePerson == adminPurgePerson) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -9302,14 +9276,13 @@ class _$AdminPurgePersonViewImpl extends _AdminPurgePersonView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$AdminPurgePersonViewImplCopyWith<_$AdminPurgePersonViewImpl>
-      get copyWith =>
-          __$$AdminPurgePersonViewImplCopyWithImpl<_$AdminPurgePersonViewImpl>(
-              this, _$identity);
+  _$$_AdminPurgePersonViewCopyWith<_$_AdminPurgePersonView> get copyWith =>
+      __$$_AdminPurgePersonViewCopyWithImpl<_$_AdminPurgePersonView>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$AdminPurgePersonViewImplToJson(
+    return _$$_AdminPurgePersonViewToJson(
       this,
     );
   }
@@ -9319,11 +9292,11 @@ abstract class _AdminPurgePersonView extends AdminPurgePersonView {
   const factory _AdminPurgePersonView(
       {required final AdminPurgePerson adminPurgePerson,
       final PersonSafe? admin,
-      required final String instanceHost}) = _$AdminPurgePersonViewImpl;
+      required final String instanceHost}) = _$_AdminPurgePersonView;
   const _AdminPurgePersonView._() : super._();
 
   factory _AdminPurgePersonView.fromJson(Map<String, dynamic> json) =
-      _$AdminPurgePersonViewImpl.fromJson;
+      _$_AdminPurgePersonView.fromJson;
 
   @override
   AdminPurgePerson get adminPurgePerson;
@@ -9333,8 +9306,8 @@ abstract class _AdminPurgePersonView extends AdminPurgePersonView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$AdminPurgePersonViewImplCopyWith<_$AdminPurgePersonViewImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  _$$_AdminPurgePersonViewCopyWith<_$_AdminPurgePersonView> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 AdminPurgeCommunityView _$AdminPurgeCommunityViewFromJson(
@@ -9427,12 +9400,11 @@ class _$AdminPurgeCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$AdminPurgeCommunityViewImplCopyWith<$Res>
+abstract class _$$_AdminPurgeCommunityViewCopyWith<$Res>
     implements $AdminPurgeCommunityViewCopyWith<$Res> {
-  factory _$$AdminPurgeCommunityViewImplCopyWith(
-          _$AdminPurgeCommunityViewImpl value,
-          $Res Function(_$AdminPurgeCommunityViewImpl) then) =
-      __$$AdminPurgeCommunityViewImplCopyWithImpl<$Res>;
+  factory _$$_AdminPurgeCommunityViewCopyWith(_$_AdminPurgeCommunityView value,
+          $Res Function(_$_AdminPurgeCommunityView) then) =
+      __$$_AdminPurgeCommunityViewCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -9447,13 +9419,12 @@ abstract class _$$AdminPurgeCommunityViewImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$AdminPurgeCommunityViewImplCopyWithImpl<$Res>
+class __$$_AdminPurgeCommunityViewCopyWithImpl<$Res>
     extends _$AdminPurgeCommunityViewCopyWithImpl<$Res,
-        _$AdminPurgeCommunityViewImpl>
-    implements _$$AdminPurgeCommunityViewImplCopyWith<$Res> {
-  __$$AdminPurgeCommunityViewImplCopyWithImpl(
-      _$AdminPurgeCommunityViewImpl _value,
-      $Res Function(_$AdminPurgeCommunityViewImpl) _then)
+        _$_AdminPurgeCommunityView>
+    implements _$$_AdminPurgeCommunityViewCopyWith<$Res> {
+  __$$_AdminPurgeCommunityViewCopyWithImpl(_$_AdminPurgeCommunityView _value,
+      $Res Function(_$_AdminPurgeCommunityView) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -9463,7 +9434,7 @@ class __$$AdminPurgeCommunityViewImplCopyWithImpl<$Res>
     Object? admin = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$AdminPurgeCommunityViewImpl(
+    return _then(_$_AdminPurgeCommunityView(
       adminPurgeCommunity: null == adminPurgeCommunity
           ? _value.adminPurgeCommunity
           : adminPurgeCommunity // ignore: cast_nullable_to_non_nullable
@@ -9483,15 +9454,15 @@ class __$$AdminPurgeCommunityViewImplCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$AdminPurgeCommunityViewImpl extends _AdminPurgeCommunityView {
-  const _$AdminPurgeCommunityViewImpl(
+class _$_AdminPurgeCommunityView extends _AdminPurgeCommunityView {
+  const _$_AdminPurgeCommunityView(
       {required this.adminPurgeCommunity,
       this.admin,
       required this.instanceHost})
       : super._();
 
-  factory _$AdminPurgeCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AdminPurgeCommunityViewImplFromJson(json);
+  factory _$_AdminPurgeCommunityView.fromJson(Map<String, dynamic> json) =>
+      _$$_AdminPurgeCommunityViewFromJson(json);
 
   @override
   final AdminPurgeCommunity adminPurgeCommunity;
@@ -9509,7 +9480,7 @@ class _$AdminPurgeCommunityViewImpl extends _AdminPurgeCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AdminPurgeCommunityViewImpl &&
+            other is _$_AdminPurgeCommunityView &&
             (identical(other.adminPurgeCommunity, adminPurgeCommunity) ||
                 other.adminPurgeCommunity == adminPurgeCommunity) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -9525,13 +9496,14 @@ class _$AdminPurgeCommunityViewImpl extends _AdminPurgeCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$AdminPurgeCommunityViewImplCopyWith<_$AdminPurgeCommunityViewImpl>
-      get copyWith => __$$AdminPurgeCommunityViewImplCopyWithImpl<
-          _$AdminPurgeCommunityViewImpl>(this, _$identity);
+  _$$_AdminPurgeCommunityViewCopyWith<_$_AdminPurgeCommunityView>
+      get copyWith =>
+          __$$_AdminPurgeCommunityViewCopyWithImpl<_$_AdminPurgeCommunityView>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$AdminPurgeCommunityViewImplToJson(
+    return _$$_AdminPurgeCommunityViewToJson(
       this,
     );
   }
@@ -9541,11 +9513,11 @@ abstract class _AdminPurgeCommunityView extends AdminPurgeCommunityView {
   const factory _AdminPurgeCommunityView(
       {required final AdminPurgeCommunity adminPurgeCommunity,
       final PersonSafe? admin,
-      required final String instanceHost}) = _$AdminPurgeCommunityViewImpl;
+      required final String instanceHost}) = _$_AdminPurgeCommunityView;
   const _AdminPurgeCommunityView._() : super._();
 
   factory _AdminPurgeCommunityView.fromJson(Map<String, dynamic> json) =
-      _$AdminPurgeCommunityViewImpl.fromJson;
+      _$_AdminPurgeCommunityView.fromJson;
 
   @override
   AdminPurgeCommunity get adminPurgeCommunity;
@@ -9555,6 +9527,6 @@ abstract class _AdminPurgeCommunityView extends AdminPurgeCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$AdminPurgeCommunityViewImplCopyWith<_$AdminPurgeCommunityViewImpl>
+  _$$_AdminPurgeCommunityViewCopyWith<_$_AdminPurgeCommunityView>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/views.g.dart
+++ b/lib/src/v3/models/views.g.dart
@@ -6,24 +6,22 @@ part of 'views.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$PersonViewSafeImpl _$$PersonViewSafeImplFromJson(Map<String, dynamic> json) =>
-    _$PersonViewSafeImpl(
+_$_PersonViewSafe _$$_PersonViewSafeFromJson(Map<String, dynamic> json) =>
+    _$_PersonViewSafe(
       person: PersonSafe.fromJson(json['person'] as Map<String, dynamic>),
       counts: PersonAggregates.fromJson(json['counts'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$PersonViewSafeImplToJson(
-        _$PersonViewSafeImpl instance) =>
+Map<String, dynamic> _$$_PersonViewSafeToJson(_$_PersonViewSafe instance) =>
     <String, dynamic>{
       'person': instance.person.toJson(),
       'counts': instance.counts.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$PersonMentionViewImpl _$$PersonMentionViewImplFromJson(
-        Map<String, dynamic> json) =>
-    _$PersonMentionViewImpl(
+_$_PersonMentionView _$$_PersonMentionViewFromJson(Map<String, dynamic> json) =>
+    _$_PersonMentionView(
       personMention: PersonMention.fromJson(
           json['person_mention'] as Map<String, dynamic>),
       comment: Comment.fromJson(json['comment'] as Map<String, dynamic>),
@@ -46,8 +44,8 @@ _$PersonMentionViewImpl _$$PersonMentionViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$PersonMentionViewImplToJson(
-        _$PersonMentionViewImpl instance) =>
+Map<String, dynamic> _$$_PersonMentionViewToJson(
+        _$_PersonMentionView instance) =>
     <String, dynamic>{
       'person_mention': instance.personMention.toJson(),
       'comment': instance.comment.toJson(),
@@ -64,9 +62,9 @@ Map<String, dynamic> _$$PersonMentionViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$LocalUserSettingsViewImpl _$$LocalUserSettingsViewImplFromJson(
+_$_LocalUserSettingsView _$$_LocalUserSettingsViewFromJson(
         Map<String, dynamic> json) =>
-    _$LocalUserSettingsViewImpl(
+    _$_LocalUserSettingsView(
       localUser: LocalUserSettings.fromJson(
           json['local_user'] as Map<String, dynamic>),
       person: PersonSafe.fromJson(json['person'] as Map<String, dynamic>),
@@ -74,8 +72,8 @@ _$LocalUserSettingsViewImpl _$$LocalUserSettingsViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$LocalUserSettingsViewImplToJson(
-        _$LocalUserSettingsViewImpl instance) =>
+Map<String, dynamic> _$$_LocalUserSettingsViewToJson(
+        _$_LocalUserSettingsView instance) =>
     <String, dynamic>{
       'local_user': instance.localUser.toJson(),
       'person': instance.person.toJson(),
@@ -83,15 +81,14 @@ Map<String, dynamic> _$$LocalUserSettingsViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$SiteViewImpl _$$SiteViewImplFromJson(Map<String, dynamic> json) =>
-    _$SiteViewImpl(
+_$_SiteView _$$_SiteViewFromJson(Map<String, dynamic> json) => _$_SiteView(
       site: Site.fromJson(json['site'] as Map<String, dynamic>),
       localSite: LocalSite.fromJson(json['local_site'] as Map<String, dynamic>),
       counts: SiteAggregates.fromJson(json['counts'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$SiteViewImplToJson(_$SiteViewImpl instance) =>
+Map<String, dynamic> _$$_SiteViewToJson(_$_SiteView instance) =>
     <String, dynamic>{
       'site': instance.site.toJson(),
       'local_site': instance.localSite.toJson(),
@@ -99,9 +96,9 @@ Map<String, dynamic> _$$SiteViewImplToJson(_$SiteViewImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$PrivateMessageViewImpl _$$PrivateMessageViewImplFromJson(
+_$_PrivateMessageView _$$_PrivateMessageViewFromJson(
         Map<String, dynamic> json) =>
-    _$PrivateMessageViewImpl(
+    _$_PrivateMessageView(
       privateMessage: PrivateMessage.fromJson(
           json['private_message'] as Map<String, dynamic>),
       creator: PersonSafe.fromJson(json['creator'] as Map<String, dynamic>),
@@ -109,8 +106,8 @@ _$PrivateMessageViewImpl _$$PrivateMessageViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$PrivateMessageViewImplToJson(
-        _$PrivateMessageViewImpl instance) =>
+Map<String, dynamic> _$$_PrivateMessageViewToJson(
+        _$_PrivateMessageView instance) =>
     <String, dynamic>{
       'private_message': instance.privateMessage.toJson(),
       'creator': instance.creator.toJson(),
@@ -118,8 +115,7 @@ Map<String, dynamic> _$$PrivateMessageViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$PostViewImpl _$$PostViewImplFromJson(Map<String, dynamic> json) =>
-    _$PostViewImpl(
+_$_PostView _$$_PostViewFromJson(Map<String, dynamic> json) => _$_PostView(
       post: Post.fromJson(json['post'] as Map<String, dynamic>),
       creator: PersonSafe.fromJson(json['creator'] as Map<String, dynamic>),
       community:
@@ -139,7 +135,7 @@ _$PostViewImpl _$$PostViewImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$PostViewImplToJson(_$PostViewImpl instance) =>
+Map<String, dynamic> _$$_PostViewToJson(_$_PostView instance) =>
     <String, dynamic>{
       'post': instance.post.toJson(),
       'creator': instance.creator.toJson(),
@@ -155,8 +151,8 @@ Map<String, dynamic> _$$PostViewImplToJson(_$PostViewImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$PostReportViewImpl _$$PostReportViewImplFromJson(Map<String, dynamic> json) =>
-    _$PostReportViewImpl(
+_$_PostReportView _$$_PostReportViewFromJson(Map<String, dynamic> json) =>
+    _$_PostReportView(
       postReport:
           PostReport.fromJson(json['post_report'] as Map<String, dynamic>),
       post: Post.fromJson(json['post'] as Map<String, dynamic>),
@@ -176,8 +172,7 @@ _$PostReportViewImpl _$$PostReportViewImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$PostReportViewImplToJson(
-        _$PostReportViewImpl instance) =>
+Map<String, dynamic> _$$_PostReportViewToJson(_$_PostReportView instance) =>
     <String, dynamic>{
       'post_report': instance.postReport.toJson(),
       'post': instance.post.toJson(),
@@ -191,8 +186,8 @@ Map<String, dynamic> _$$PostReportViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$CommentViewImpl _$$CommentViewImplFromJson(Map<String, dynamic> json) =>
-    _$CommentViewImpl(
+_$_CommentView _$$_CommentViewFromJson(Map<String, dynamic> json) =>
+    _$_CommentView(
       comment: Comment.fromJson(json['comment'] as Map<String, dynamic>),
       creator: PersonSafe.fromJson(json['creator'] as Map<String, dynamic>),
       commentReply: json['comment_reply'] == null
@@ -219,7 +214,7 @@ _$CommentViewImpl _$$CommentViewImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$CommentViewImplToJson(_$CommentViewImpl instance) =>
+Map<String, dynamic> _$$_CommentViewToJson(_$_CommentView instance) =>
     <String, dynamic>{
       'comment': instance.comment.toJson(),
       'creator': instance.creator.toJson(),
@@ -236,9 +231,8 @@ Map<String, dynamic> _$$CommentViewImplToJson(_$CommentViewImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$CommentReplyViewImpl _$$CommentReplyViewImplFromJson(
-        Map<String, dynamic> json) =>
-    _$CommentReplyViewImpl(
+_$_CommentReplyView _$$_CommentReplyViewFromJson(Map<String, dynamic> json) =>
+    _$_CommentReplyView(
       commentReply:
           CommentReply.fromJson(json['comment_reply'] as Map<String, dynamic>),
       comment: Comment.fromJson(json['comment'] as Map<String, dynamic>),
@@ -263,8 +257,7 @@ _$CommentReplyViewImpl _$$CommentReplyViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$CommentReplyViewImplToJson(
-        _$CommentReplyViewImpl instance) =>
+Map<String, dynamic> _$$_CommentReplyViewToJson(_$_CommentReplyView instance) =>
     <String, dynamic>{
       'comment_reply': instance.commentReply.toJson(),
       'comment': instance.comment.toJson(),
@@ -281,9 +274,8 @@ Map<String, dynamic> _$$CommentReplyViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$CommentReportViewImpl _$$CommentReportViewImplFromJson(
-        Map<String, dynamic> json) =>
-    _$CommentReportViewImpl(
+_$_CommentReportView _$$_CommentReportViewFromJson(Map<String, dynamic> json) =>
+    _$_CommentReportView(
       commentReport: CommentReport.fromJson(
           json['comment_report'] as Map<String, dynamic>),
       comment: Comment.fromJson(json['comment'] as Map<String, dynamic>),
@@ -305,8 +297,8 @@ _$CommentReportViewImpl _$$CommentReportViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$CommentReportViewImplToJson(
-        _$CommentReportViewImpl instance) =>
+Map<String, dynamic> _$$_CommentReportViewToJson(
+        _$_CommentReportView instance) =>
     <String, dynamic>{
       'comment_report': instance.commentReport.toJson(),
       'comment': instance.comment.toJson(),
@@ -321,9 +313,9 @@ Map<String, dynamic> _$$CommentReportViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModAddCommunityViewImpl _$$ModAddCommunityViewImplFromJson(
+_$_ModAddCommunityView _$$_ModAddCommunityViewFromJson(
         Map<String, dynamic> json) =>
-    _$ModAddCommunityViewImpl(
+    _$_ModAddCommunityView(
       modAddCommunity: ModAddCommunity.fromJson(
           json['mod_add_community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -336,8 +328,8 @@ _$ModAddCommunityViewImpl _$$ModAddCommunityViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModAddCommunityViewImplToJson(
-        _$ModAddCommunityViewImpl instance) =>
+Map<String, dynamic> _$$_ModAddCommunityViewToJson(
+        _$_ModAddCommunityView instance) =>
     <String, dynamic>{
       'mod_add_community': instance.modAddCommunity.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -346,9 +338,9 @@ Map<String, dynamic> _$$ModAddCommunityViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModTransferCommunityViewImpl _$$ModTransferCommunityViewImplFromJson(
+_$_ModTransferCommunityView _$$_ModTransferCommunityViewFromJson(
         Map<String, dynamic> json) =>
-    _$ModTransferCommunityViewImpl(
+    _$_ModTransferCommunityView(
       modTransferCommunity: ModTransferCommunity.fromJson(
           json['mod_transfer_community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -361,8 +353,8 @@ _$ModTransferCommunityViewImpl _$$ModTransferCommunityViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModTransferCommunityViewImplToJson(
-        _$ModTransferCommunityViewImpl instance) =>
+Map<String, dynamic> _$$_ModTransferCommunityViewToJson(
+        _$_ModTransferCommunityView instance) =>
     <String, dynamic>{
       'mod_transfer_community': instance.modTransferCommunity.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -371,8 +363,8 @@ Map<String, dynamic> _$$ModTransferCommunityViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModAddViewImpl _$$ModAddViewImplFromJson(Map<String, dynamic> json) =>
-    _$ModAddViewImpl(
+_$_ModAddView _$$_ModAddViewFromJson(Map<String, dynamic> json) =>
+    _$_ModAddView(
       modAdd: ModAdd.fromJson(json['mod_add'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
           ? null
@@ -382,7 +374,7 @@ _$ModAddViewImpl _$$ModAddViewImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModAddViewImplToJson(_$ModAddViewImpl instance) =>
+Map<String, dynamic> _$$_ModAddViewToJson(_$_ModAddView instance) =>
     <String, dynamic>{
       'mod_add': instance.modAdd.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -390,9 +382,9 @@ Map<String, dynamic> _$$ModAddViewImplToJson(_$ModAddViewImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$ModBanFromCommunityViewImpl _$$ModBanFromCommunityViewImplFromJson(
+_$_ModBanFromCommunityView _$$_ModBanFromCommunityViewFromJson(
         Map<String, dynamic> json) =>
-    _$ModBanFromCommunityViewImpl(
+    _$_ModBanFromCommunityView(
       modBanFromCommunity: ModBanFromCommunity.fromJson(
           json['mod_ban_from_community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -405,8 +397,8 @@ _$ModBanFromCommunityViewImpl _$$ModBanFromCommunityViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModBanFromCommunityViewImplToJson(
-        _$ModBanFromCommunityViewImpl instance) =>
+Map<String, dynamic> _$$_ModBanFromCommunityViewToJson(
+        _$_ModBanFromCommunityView instance) =>
     <String, dynamic>{
       'mod_ban_from_community': instance.modBanFromCommunity.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -415,8 +407,8 @@ Map<String, dynamic> _$$ModBanFromCommunityViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModBanViewImpl _$$ModBanViewImplFromJson(Map<String, dynamic> json) =>
-    _$ModBanViewImpl(
+_$_ModBanView _$$_ModBanViewFromJson(Map<String, dynamic> json) =>
+    _$_ModBanView(
       modBan: ModBan.fromJson(json['mod_ban'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
           ? null
@@ -426,7 +418,7 @@ _$ModBanViewImpl _$$ModBanViewImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModBanViewImplToJson(_$ModBanViewImpl instance) =>
+Map<String, dynamic> _$$_ModBanViewToJson(_$_ModBanView instance) =>
     <String, dynamic>{
       'mod_ban': instance.modBan.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -434,9 +426,8 @@ Map<String, dynamic> _$$ModBanViewImplToJson(_$ModBanViewImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$ModLockPostViewImpl _$$ModLockPostViewImplFromJson(
-        Map<String, dynamic> json) =>
-    _$ModLockPostViewImpl(
+_$_ModLockPostView _$$_ModLockPostViewFromJson(Map<String, dynamic> json) =>
+    _$_ModLockPostView(
       modLockPost:
           ModLockPost.fromJson(json['mod_lock_post'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -448,8 +439,7 @@ _$ModLockPostViewImpl _$$ModLockPostViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModLockPostViewImplToJson(
-        _$ModLockPostViewImpl instance) =>
+Map<String, dynamic> _$$_ModLockPostViewToJson(_$_ModLockPostView instance) =>
     <String, dynamic>{
       'mod_lock_post': instance.modLockPost.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -458,9 +448,9 @@ Map<String, dynamic> _$$ModLockPostViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModRemoveCommentViewImpl _$$ModRemoveCommentViewImplFromJson(
+_$_ModRemoveCommentView _$$_ModRemoveCommentViewFromJson(
         Map<String, dynamic> json) =>
-    _$ModRemoveCommentViewImpl(
+    _$_ModRemoveCommentView(
       modRemoveComment: ModRemoveComment.fromJson(
           json['mod_remove_comment'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -474,8 +464,8 @@ _$ModRemoveCommentViewImpl _$$ModRemoveCommentViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModRemoveCommentViewImplToJson(
-        _$ModRemoveCommentViewImpl instance) =>
+Map<String, dynamic> _$$_ModRemoveCommentViewToJson(
+        _$_ModRemoveCommentView instance) =>
     <String, dynamic>{
       'mod_remove_comment': instance.modRemoveComment.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -486,9 +476,9 @@ Map<String, dynamic> _$$ModRemoveCommentViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModRemoveCommunityViewImpl _$$ModRemoveCommunityViewImplFromJson(
+_$_ModRemoveCommunityView _$$_ModRemoveCommunityViewFromJson(
         Map<String, dynamic> json) =>
-    _$ModRemoveCommunityViewImpl(
+    _$_ModRemoveCommunityView(
       modRemoveCommunity: ModRemoveCommunity.fromJson(
           json['mod_remove_community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -499,8 +489,8 @@ _$ModRemoveCommunityViewImpl _$$ModRemoveCommunityViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModRemoveCommunityViewImplToJson(
-        _$ModRemoveCommunityViewImpl instance) =>
+Map<String, dynamic> _$$_ModRemoveCommunityViewToJson(
+        _$_ModRemoveCommunityView instance) =>
     <String, dynamic>{
       'mod_remove_community': instance.modRemoveCommunity.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -508,9 +498,9 @@ Map<String, dynamic> _$$ModRemoveCommunityViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModHideCommunityViewImpl _$$ModHideCommunityViewImplFromJson(
+_$_ModHideCommunityView _$$_ModHideCommunityViewFromJson(
         Map<String, dynamic> json) =>
-    _$ModHideCommunityViewImpl(
+    _$_ModHideCommunityView(
       modHideCommunity: ModHideCommunity.fromJson(
           json['mod_hide_community'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -521,8 +511,8 @@ _$ModHideCommunityViewImpl _$$ModHideCommunityViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModHideCommunityViewImplToJson(
-        _$ModHideCommunityViewImpl instance) =>
+Map<String, dynamic> _$$_ModHideCommunityViewToJson(
+        _$_ModHideCommunityView instance) =>
     <String, dynamic>{
       'mod_hide_community': instance.modHideCommunity.toJson(),
       'admin': instance.admin?.toJson(),
@@ -530,9 +520,8 @@ Map<String, dynamic> _$$ModHideCommunityViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModRemovePostViewImpl _$$ModRemovePostViewImplFromJson(
-        Map<String, dynamic> json) =>
-    _$ModRemovePostViewImpl(
+_$_ModRemovePostView _$$_ModRemovePostViewFromJson(Map<String, dynamic> json) =>
+    _$_ModRemovePostView(
       modRemovePost: ModRemovePost.fromJson(
           json['mod_remove_post'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -544,8 +533,8 @@ _$ModRemovePostViewImpl _$$ModRemovePostViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModRemovePostViewImplToJson(
-        _$ModRemovePostViewImpl instance) =>
+Map<String, dynamic> _$$_ModRemovePostViewToJson(
+        _$_ModRemovePostView instance) =>
     <String, dynamic>{
       'mod_remove_post': instance.modRemovePost.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -554,9 +543,8 @@ Map<String, dynamic> _$$ModRemovePostViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModStickyPostViewImpl _$$ModStickyPostViewImplFromJson(
-        Map<String, dynamic> json) =>
-    _$ModStickyPostViewImpl(
+_$_ModStickyPostView _$$_ModStickyPostViewFromJson(Map<String, dynamic> json) =>
+    _$_ModStickyPostView(
       modStickyPost: ModStickyPost.fromJson(
           json['mod_sticky_post'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -568,8 +556,8 @@ _$ModStickyPostViewImpl _$$ModStickyPostViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModStickyPostViewImplToJson(
-        _$ModStickyPostViewImpl instance) =>
+Map<String, dynamic> _$$_ModStickyPostViewToJson(
+        _$_ModStickyPostView instance) =>
     <String, dynamic>{
       'mod_sticky_post': instance.modStickyPost.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -578,9 +566,9 @@ Map<String, dynamic> _$$ModStickyPostViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$ModFeaturePostViewImpl _$$ModFeaturePostViewImplFromJson(
+_$_ModFeaturePostView _$$_ModFeaturePostViewFromJson(
         Map<String, dynamic> json) =>
-    _$ModFeaturePostViewImpl(
+    _$_ModFeaturePostView(
       modFeaturePost: ModFeaturePost.fromJson(
           json['mod_feature_post'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -592,8 +580,8 @@ _$ModFeaturePostViewImpl _$$ModFeaturePostViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$ModFeaturePostViewImplToJson(
-        _$ModFeaturePostViewImpl instance) =>
+Map<String, dynamic> _$$_ModFeaturePostViewToJson(
+        _$_ModFeaturePostView instance) =>
     <String, dynamic>{
       'mod_feature_post': instance.modFeaturePost.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -602,26 +590,26 @@ Map<String, dynamic> _$$ModFeaturePostViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$CommunityFollowerViewImpl _$$CommunityFollowerViewImplFromJson(
+_$_CommunityFollowerView _$$_CommunityFollowerViewFromJson(
         Map<String, dynamic> json) =>
-    _$CommunityFollowerViewImpl(
+    _$_CommunityFollowerView(
       community:
           CommunitySafe.fromJson(json['community'] as Map<String, dynamic>),
       follower: PersonSafe.fromJson(json['follower'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$CommunityFollowerViewImplToJson(
-        _$CommunityFollowerViewImpl instance) =>
+Map<String, dynamic> _$$_CommunityFollowerViewToJson(
+        _$_CommunityFollowerView instance) =>
     <String, dynamic>{
       'community': instance.community.toJson(),
       'follower': instance.follower.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$CommunityModeratorViewImpl _$$CommunityModeratorViewImplFromJson(
+_$_CommunityModeratorView _$$_CommunityModeratorViewFromJson(
         Map<String, dynamic> json) =>
-    _$CommunityModeratorViewImpl(
+    _$_CommunityModeratorView(
       community:
           CommunitySafe.fromJson(json['community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -630,66 +618,64 @@ _$CommunityModeratorViewImpl _$$CommunityModeratorViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$CommunityModeratorViewImplToJson(
-        _$CommunityModeratorViewImpl instance) =>
+Map<String, dynamic> _$$_CommunityModeratorViewToJson(
+        _$_CommunityModeratorView instance) =>
     <String, dynamic>{
       'community': instance.community.toJson(),
       'moderator': instance.moderator?.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$PersonBlockViewImpl _$$PersonBlockViewImplFromJson(
-        Map<String, dynamic> json) =>
-    _$PersonBlockViewImpl(
+_$_PersonBlockView _$$_PersonBlockViewFromJson(Map<String, dynamic> json) =>
+    _$_PersonBlockView(
       person: PersonSafe.fromJson(json['person'] as Map<String, dynamic>),
       target: PersonSafe.fromJson(json['target'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$PersonBlockViewImplToJson(
-        _$PersonBlockViewImpl instance) =>
+Map<String, dynamic> _$$_PersonBlockViewToJson(_$_PersonBlockView instance) =>
     <String, dynamic>{
       'person': instance.person.toJson(),
       'target': instance.target.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$CommunityBlockViewImpl _$$CommunityBlockViewImplFromJson(
+_$_CommunityBlockView _$$_CommunityBlockViewFromJson(
         Map<String, dynamic> json) =>
-    _$CommunityBlockViewImpl(
+    _$_CommunityBlockView(
       person: PersonSafe.fromJson(json['person'] as Map<String, dynamic>),
       community:
           CommunitySafe.fromJson(json['community'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$CommunityBlockViewImplToJson(
-        _$CommunityBlockViewImpl instance) =>
+Map<String, dynamic> _$$_CommunityBlockViewToJson(
+        _$_CommunityBlockView instance) =>
     <String, dynamic>{
       'person': instance.person.toJson(),
       'community': instance.community.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$CommunityPersonBanViewImpl _$$CommunityPersonBanViewImplFromJson(
+_$_CommunityPersonBanView _$$_CommunityPersonBanViewFromJson(
         Map<String, dynamic> json) =>
-    _$CommunityPersonBanViewImpl(
+    _$_CommunityPersonBanView(
       community:
           CommunitySafe.fromJson(json['community'] as Map<String, dynamic>),
       person: PersonSafe.fromJson(json['person'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$CommunityPersonBanViewImplToJson(
-        _$CommunityPersonBanViewImpl instance) =>
+Map<String, dynamic> _$$_CommunityPersonBanViewToJson(
+        _$_CommunityPersonBanView instance) =>
     <String, dynamic>{
       'community': instance.community.toJson(),
       'person': instance.person.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$CommunityViewImpl _$$CommunityViewImplFromJson(Map<String, dynamic> json) =>
-    _$CommunityViewImpl(
+_$_CommunityView _$$_CommunityViewFromJson(Map<String, dynamic> json) =>
+    _$_CommunityView(
       community:
           CommunitySafe.fromJson(json['community'] as Map<String, dynamic>),
       subscribed: json['subscribed'] == null
@@ -701,7 +687,7 @@ _$CommunityViewImpl _$$CommunityViewImplFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$CommunityViewImplToJson(_$CommunityViewImpl instance) =>
+Map<String, dynamic> _$$_CommunityViewToJson(_$_CommunityView instance) =>
     <String, dynamic>{
       'community': instance.community.toJson(),
       'subscribed': instance.subscribed.toJson(),
@@ -710,9 +696,9 @@ Map<String, dynamic> _$$CommunityViewImplToJson(_$CommunityViewImpl instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$RegistrationApplicationViewImpl _$$RegistrationApplicationViewImplFromJson(
+_$_RegistrationApplicationView _$$_RegistrationApplicationViewFromJson(
         Map<String, dynamic> json) =>
-    _$RegistrationApplicationViewImpl(
+    _$_RegistrationApplicationView(
       registrationApplication: RegistrationApplication.fromJson(
           json['registration_application'] as Map<String, dynamic>),
       creatorLocalUser: LocalUserSettings.fromJson(
@@ -724,8 +710,8 @@ _$RegistrationApplicationViewImpl _$$RegistrationApplicationViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$RegistrationApplicationViewImplToJson(
-        _$RegistrationApplicationViewImpl instance) =>
+Map<String, dynamic> _$$_RegistrationApplicationViewToJson(
+        _$_RegistrationApplicationView instance) =>
     <String, dynamic>{
       'registration_application': instance.registrationApplication.toJson(),
       'creator_local_user': instance.creatorLocalUser.toJson(),
@@ -734,9 +720,9 @@ Map<String, dynamic> _$$RegistrationApplicationViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$AdminPurgeCommentViewImpl _$$AdminPurgeCommentViewImplFromJson(
+_$_AdminPurgeCommentView _$$_AdminPurgeCommentViewFromJson(
         Map<String, dynamic> json) =>
-    _$AdminPurgeCommentViewImpl(
+    _$_AdminPurgeCommentView(
       adminPurgeComment: AdminPurgeComment.fromJson(
           json['admin_purge_comment'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -746,8 +732,8 @@ _$AdminPurgeCommentViewImpl _$$AdminPurgeCommentViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$AdminPurgeCommentViewImplToJson(
-        _$AdminPurgeCommentViewImpl instance) =>
+Map<String, dynamic> _$$_AdminPurgeCommentViewToJson(
+        _$_AdminPurgeCommentView instance) =>
     <String, dynamic>{
       'admin_purge_comment': instance.adminPurgeComment.toJson(),
       'admin': instance.admin?.toJson(),
@@ -755,9 +741,9 @@ Map<String, dynamic> _$$AdminPurgeCommentViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$AdminPurgePostViewImpl _$$AdminPurgePostViewImplFromJson(
+_$_AdminPurgePostView _$$_AdminPurgePostViewFromJson(
         Map<String, dynamic> json) =>
-    _$AdminPurgePostViewImpl(
+    _$_AdminPurgePostView(
       adminPurgePost: AdminPurgePost.fromJson(
           json['admin_purge_post'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -768,8 +754,8 @@ _$AdminPurgePostViewImpl _$$AdminPurgePostViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$AdminPurgePostViewImplToJson(
-        _$AdminPurgePostViewImpl instance) =>
+Map<String, dynamic> _$$_AdminPurgePostViewToJson(
+        _$_AdminPurgePostView instance) =>
     <String, dynamic>{
       'admin_purge_post': instance.adminPurgePost.toJson(),
       'admin': instance.admin?.toJson(),
@@ -777,9 +763,9 @@ Map<String, dynamic> _$$AdminPurgePostViewImplToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$AdminPurgePersonViewImpl _$$AdminPurgePersonViewImplFromJson(
+_$_AdminPurgePersonView _$$_AdminPurgePersonViewFromJson(
         Map<String, dynamic> json) =>
-    _$AdminPurgePersonViewImpl(
+    _$_AdminPurgePersonView(
       adminPurgePerson: AdminPurgePerson.fromJson(
           json['admin_purge_person'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -788,17 +774,17 @@ _$AdminPurgePersonViewImpl _$$AdminPurgePersonViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$AdminPurgePersonViewImplToJson(
-        _$AdminPurgePersonViewImpl instance) =>
+Map<String, dynamic> _$$_AdminPurgePersonViewToJson(
+        _$_AdminPurgePersonView instance) =>
     <String, dynamic>{
       'admin_purge_person': instance.adminPurgePerson.toJson(),
       'admin': instance.admin?.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$AdminPurgeCommunityViewImpl _$$AdminPurgeCommunityViewImplFromJson(
+_$_AdminPurgeCommunityView _$$_AdminPurgeCommunityViewFromJson(
         Map<String, dynamic> json) =>
-    _$AdminPurgeCommunityViewImpl(
+    _$_AdminPurgeCommunityView(
       adminPurgeCommunity: AdminPurgeCommunity.fromJson(
           json['admin_purge_community'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -807,8 +793,8 @@ _$AdminPurgeCommunityViewImpl _$$AdminPurgeCommunityViewImplFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$AdminPurgeCommunityViewImplToJson(
-        _$AdminPurgeCommunityViewImpl instance) =>
+Map<String, dynamic> _$$_AdminPurgeCommunityViewToJson(
+        _$_AdminPurgeCommunityView instance) =>
     <String, dynamic>{
       'admin_purge_community': instance.adminPurgeCommunity.toJson(),
       'admin': instance.admin?.toJson(),

--- a/test/v3/comment_test.dart
+++ b/test/v3/comment_test.dart
@@ -129,7 +129,7 @@ void main() {
 
         test(
           'correctly fetches with auth',
-              () => run(
+          () => run(
             GetComment(
               id: goodMyCommentId,
               auth: goodAuth,

--- a/test/v3/site_test.dart
+++ b/test/v3/site_test.dart
@@ -6,6 +6,71 @@ import 'util.dart';
 void main() {
   group('lemmy API v3', () {
     group('site', () {
+      group('Block Instance', () {
+        test('correctly blocks', () async {
+          final blockInstanceResponse = await run(
+            BlockInstance(
+              instanceId: goodInstanceId,
+              block: true,
+              auth: goodAuth,
+            ),
+          );
+
+          expect(blockInstanceResponse.blocked, true);
+        });
+
+        test('correctly unblocks', () async {
+          final blockInstanceResponse = await run(
+            BlockInstance(
+              instanceId: goodInstanceId,
+              block: false,
+              auth: goodAuth,
+            ),
+          );
+
+          expect(blockInstanceResponse.blocked, false);
+        });
+
+        test(
+          'bad auth',
+          () => {
+            lemmyThrows(
+              const BlockInstance(
+                instanceId: badInstanceId,
+                block: true,
+                auth: badAuth,
+              ),
+            ),
+          },
+        );
+
+        test(
+          'no auth',
+          () => {
+            lemmyThrows(
+              const BlockInstance(
+                instanceId: badInstanceId,
+                block: true,
+              ),
+            ),
+          },
+        );
+
+        /// Note: it seems like lemmy does not throw an error when we try to block an instance that does not exist
+        // test(
+        //   'incorrect instance',
+        //   () => {
+        //     lemmyThrows(
+        //       BlockInstance(
+        //         instanceId: badInstanceId,
+        //         block: false,
+        //         auth: goodAuth,
+        //       ),
+        //     ),
+        //   },
+        // );
+      });
+
       group('Search', () {
         test(
           'correctly fetches',

--- a/test/v3/util.dart
+++ b/test/v3/util.dart
@@ -19,6 +19,9 @@ Future<void> lemmyThrows(LemmyApiQuery query) async {
   );
 }
 
+const goodInstanceId = 7;
+const badInstanceId = -1;
+
 const goodCommunityName = 'lemmy';
 const badCommunityName = '--';
 


### PR DESCRIPTION
This PR introduces support for instance blocking for lemmy 0.19.x instances. A few notes:
- The parameters are derived from `lemmy-js-client`. More specifically, I obtained the params from:
  - https://github.com/LemmyNet/lemmy-js-client/blob/33eccecf948512e5e6817278810304457c6329bf/src/types/BlockInstance.ts
  - https://github.com/LemmyNet/lemmy-js-client/blob/33eccecf948512e5e6817278810304457c6329bf/src/types/BlockInstanceResponse.ts
- An additional param `auth` was added into the request as a way to work with the latest changes made from #4
- Added test cases for the new endpoint and was tested with `voyager.lemmy.ml`

Note: I'm not too sure why the `.freezed.dart` and `.g.dart` files were modified.

References: https://github.com/thunder-app/thunder/issues/762