### PR TITLE
Support new sort types

### DIFF
--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -51,6 +51,8 @@ enum SortType {
   hot('Hot'),
   new_('New'),
   old('Old'),
+  scaled('Scaled'),
+  controversial('Controversial'),
   topHour('TopHour'),
   topSixHour('TopSixHour'),
   topTwelveHour('TopTwelveHour'),
@@ -81,6 +83,7 @@ enum CommentSortType {
   top('Top'),
   new_('New'),
   old('Old'),
+  controversial('Controversial'),
   chat('Chat');
 
   final String value;


### PR DESCRIPTION
This PR adds the new sort types in Lemmy 0.19.x to the enum definition.

Note that this change alone does not add support in Thunder, since we redefine each supported sort type in our own wrapper class. See thunder-app/thunder#829 for the full implementation.

https://github.com/thunder-app/lemmy_api_client/assets/7417301/073fce2d-7bb3-4f62-a3b3-b6d9fda7f55a