### PR TITLE
Make newestCommentTime optional

### DIFF
--- a/lib/src/v3/api/comment.freezed.dart
+++ b/lib/src/v3/api/comment.freezed.dart
@@ -87,11 +87,11 @@ class _$CreateCommentCopyWithImpl<$Res, $Val extends CreateComment>
 }
 
 /// @nodoc
-abstract class _$$_CreateCommentCopyWith<$Res>
+abstract class _$$CreateCommentImplCopyWith<$Res>
     implements $CreateCommentCopyWith<$Res> {
-  factory _$$_CreateCommentCopyWith(
-          _$_CreateComment value, $Res Function(_$_CreateComment) then) =
-      __$$_CreateCommentCopyWithImpl<$Res>;
+  factory _$$CreateCommentImplCopyWith(
+          _$CreateCommentImpl value, $Res Function(_$CreateCommentImpl) then) =
+      __$$CreateCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -99,11 +99,11 @@ abstract class _$$_CreateCommentCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CreateCommentCopyWithImpl<$Res>
-    extends _$CreateCommentCopyWithImpl<$Res, _$_CreateComment>
-    implements _$$_CreateCommentCopyWith<$Res> {
-  __$$_CreateCommentCopyWithImpl(
-      _$_CreateComment _value, $Res Function(_$_CreateComment) _then)
+class __$$CreateCommentImplCopyWithImpl<$Res>
+    extends _$CreateCommentCopyWithImpl<$Res, _$CreateCommentImpl>
+    implements _$$CreateCommentImplCopyWith<$Res> {
+  __$$CreateCommentImplCopyWithImpl(
+      _$CreateCommentImpl _value, $Res Function(_$CreateCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -115,7 +115,7 @@ class __$$_CreateCommentCopyWithImpl<$Res>
     Object? formId = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_CreateComment(
+    return _then(_$CreateCommentImpl(
       content: null == content
           ? _value.content
           : content // ignore: cast_nullable_to_non_nullable
@@ -143,8 +143,8 @@ class __$$_CreateCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreateComment extends _CreateComment {
-  const _$_CreateComment(
+class _$CreateCommentImpl extends _CreateComment {
+  const _$CreateCommentImpl(
       {required this.content,
       this.parentId,
       required this.postId,
@@ -152,8 +152,8 @@ class _$_CreateComment extends _CreateComment {
       required this.auth})
       : super._();
 
-  factory _$_CreateComment.fromJson(Map<String, dynamic> json) =>
-      _$$_CreateCommentFromJson(json);
+  factory _$CreateCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreateCommentImplFromJson(json);
 
   @override
   final String content;
@@ -175,7 +175,7 @@ class _$_CreateComment extends _CreateComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreateComment &&
+            other is _$CreateCommentImpl &&
             (identical(other.content, content) || other.content == content) &&
             (identical(other.parentId, parentId) ||
                 other.parentId == parentId) &&
@@ -192,12 +192,12 @@ class _$_CreateComment extends _CreateComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreateCommentCopyWith<_$_CreateComment> get copyWith =>
-      __$$_CreateCommentCopyWithImpl<_$_CreateComment>(this, _$identity);
+  _$$CreateCommentImplCopyWith<_$CreateCommentImpl> get copyWith =>
+      __$$CreateCommentImplCopyWithImpl<_$CreateCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreateCommentToJson(
+    return _$$CreateCommentImplToJson(
       this,
     );
   }
@@ -209,11 +209,11 @@ abstract class _CreateComment extends CreateComment {
       final int? parentId,
       required final int postId,
       final String? formId,
-      required final String auth}) = _$_CreateComment;
+      required final String auth}) = _$CreateCommentImpl;
   const _CreateComment._() : super._();
 
   factory _CreateComment.fromJson(Map<String, dynamic> json) =
-      _$_CreateComment.fromJson;
+      _$CreateCommentImpl.fromJson;
 
   @override
   String get content;
@@ -227,7 +227,7 @@ abstract class _CreateComment extends CreateComment {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreateCommentCopyWith<_$_CreateComment> get copyWith =>
+  _$$CreateCommentImplCopyWith<_$CreateCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -297,22 +297,22 @@ class _$EditCommentCopyWithImpl<$Res, $Val extends EditComment>
 }
 
 /// @nodoc
-abstract class _$$_EditCommentCopyWith<$Res>
+abstract class _$$EditCommentImplCopyWith<$Res>
     implements $EditCommentCopyWith<$Res> {
-  factory _$$_EditCommentCopyWith(
-          _$_EditComment value, $Res Function(_$_EditComment) then) =
-      __$$_EditCommentCopyWithImpl<$Res>;
+  factory _$$EditCommentImplCopyWith(
+          _$EditCommentImpl value, $Res Function(_$EditCommentImpl) then) =
+      __$$EditCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String content, int commentId, String? formId, String auth});
 }
 
 /// @nodoc
-class __$$_EditCommentCopyWithImpl<$Res>
-    extends _$EditCommentCopyWithImpl<$Res, _$_EditComment>
-    implements _$$_EditCommentCopyWith<$Res> {
-  __$$_EditCommentCopyWithImpl(
-      _$_EditComment _value, $Res Function(_$_EditComment) _then)
+class __$$EditCommentImplCopyWithImpl<$Res>
+    extends _$EditCommentCopyWithImpl<$Res, _$EditCommentImpl>
+    implements _$$EditCommentImplCopyWith<$Res> {
+  __$$EditCommentImplCopyWithImpl(
+      _$EditCommentImpl _value, $Res Function(_$EditCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -323,7 +323,7 @@ class __$$_EditCommentCopyWithImpl<$Res>
     Object? formId = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_EditComment(
+    return _then(_$EditCommentImpl(
       content: null == content
           ? _value.content
           : content // ignore: cast_nullable_to_non_nullable
@@ -347,16 +347,16 @@ class __$$_EditCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_EditComment extends _EditComment {
-  const _$_EditComment(
+class _$EditCommentImpl extends _EditComment {
+  const _$EditCommentImpl(
       {required this.content,
       required this.commentId,
       this.formId,
       required this.auth})
       : super._();
 
-  factory _$_EditComment.fromJson(Map<String, dynamic> json) =>
-      _$$_EditCommentFromJson(json);
+  factory _$EditCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EditCommentImplFromJson(json);
 
   @override
   final String content;
@@ -376,7 +376,7 @@ class _$_EditComment extends _EditComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_EditComment &&
+            other is _$EditCommentImpl &&
             (identical(other.content, content) || other.content == content) &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
@@ -392,12 +392,12 @@ class _$_EditComment extends _EditComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_EditCommentCopyWith<_$_EditComment> get copyWith =>
-      __$$_EditCommentCopyWithImpl<_$_EditComment>(this, _$identity);
+  _$$EditCommentImplCopyWith<_$EditCommentImpl> get copyWith =>
+      __$$EditCommentImplCopyWithImpl<_$EditCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_EditCommentToJson(
+    return _$$EditCommentImplToJson(
       this,
     );
   }
@@ -408,11 +408,11 @@ abstract class _EditComment extends EditComment {
       {required final String content,
       required final int commentId,
       final String? formId,
-      required final String auth}) = _$_EditComment;
+      required final String auth}) = _$EditCommentImpl;
   const _EditComment._() : super._();
 
   factory _EditComment.fromJson(Map<String, dynamic> json) =
-      _$_EditComment.fromJson;
+      _$EditCommentImpl.fromJson;
 
   @override
   String get content;
@@ -424,7 +424,7 @@ abstract class _EditComment extends EditComment {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_EditCommentCopyWith<_$_EditComment> get copyWith =>
+  _$$EditCommentImplCopyWith<_$EditCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -488,22 +488,22 @@ class _$DeleteCommentCopyWithImpl<$Res, $Val extends DeleteComment>
 }
 
 /// @nodoc
-abstract class _$$_DeleteCommentCopyWith<$Res>
+abstract class _$$DeleteCommentImplCopyWith<$Res>
     implements $DeleteCommentCopyWith<$Res> {
-  factory _$$_DeleteCommentCopyWith(
-          _$_DeleteComment value, $Res Function(_$_DeleteComment) then) =
-      __$$_DeleteCommentCopyWithImpl<$Res>;
+  factory _$$DeleteCommentImplCopyWith(
+          _$DeleteCommentImpl value, $Res Function(_$DeleteCommentImpl) then) =
+      __$$DeleteCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, bool deleted, String auth});
 }
 
 /// @nodoc
-class __$$_DeleteCommentCopyWithImpl<$Res>
-    extends _$DeleteCommentCopyWithImpl<$Res, _$_DeleteComment>
-    implements _$$_DeleteCommentCopyWith<$Res> {
-  __$$_DeleteCommentCopyWithImpl(
-      _$_DeleteComment _value, $Res Function(_$_DeleteComment) _then)
+class __$$DeleteCommentImplCopyWithImpl<$Res>
+    extends _$DeleteCommentCopyWithImpl<$Res, _$DeleteCommentImpl>
+    implements _$$DeleteCommentImplCopyWith<$Res> {
+  __$$DeleteCommentImplCopyWithImpl(
+      _$DeleteCommentImpl _value, $Res Function(_$DeleteCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -513,7 +513,7 @@ class __$$_DeleteCommentCopyWithImpl<$Res>
     Object? deleted = null,
     Object? auth = null,
   }) {
-    return _then(_$_DeleteComment(
+    return _then(_$DeleteCommentImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -533,13 +533,13 @@ class __$$_DeleteCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_DeleteComment extends _DeleteComment {
-  const _$_DeleteComment(
+class _$DeleteCommentImpl extends _DeleteComment {
+  const _$DeleteCommentImpl(
       {required this.commentId, required this.deleted, required this.auth})
       : super._();
 
-  factory _$_DeleteComment.fromJson(Map<String, dynamic> json) =>
-      _$$_DeleteCommentFromJson(json);
+  factory _$DeleteCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeleteCommentImplFromJson(json);
 
   @override
   final int commentId;
@@ -557,7 +557,7 @@ class _$_DeleteComment extends _DeleteComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeleteComment &&
+            other is _$DeleteCommentImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.deleted, deleted) || other.deleted == deleted) &&
@@ -571,12 +571,12 @@ class _$_DeleteComment extends _DeleteComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeleteCommentCopyWith<_$_DeleteComment> get copyWith =>
-      __$$_DeleteCommentCopyWithImpl<_$_DeleteComment>(this, _$identity);
+  _$$DeleteCommentImplCopyWith<_$DeleteCommentImpl> get copyWith =>
+      __$$DeleteCommentImplCopyWithImpl<_$DeleteCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeleteCommentToJson(
+    return _$$DeleteCommentImplToJson(
       this,
     );
   }
@@ -586,11 +586,11 @@ abstract class _DeleteComment extends DeleteComment {
   const factory _DeleteComment(
       {required final int commentId,
       required final bool deleted,
-      required final String auth}) = _$_DeleteComment;
+      required final String auth}) = _$DeleteCommentImpl;
   const _DeleteComment._() : super._();
 
   factory _DeleteComment.fromJson(Map<String, dynamic> json) =
-      _$_DeleteComment.fromJson;
+      _$DeleteCommentImpl.fromJson;
 
   @override
   int get commentId;
@@ -600,7 +600,7 @@ abstract class _DeleteComment extends DeleteComment {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_DeleteCommentCopyWith<_$_DeleteComment> get copyWith =>
+  _$$DeleteCommentImplCopyWith<_$DeleteCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -670,22 +670,22 @@ class _$RemoveCommentCopyWithImpl<$Res, $Val extends RemoveComment>
 }
 
 /// @nodoc
-abstract class _$$_RemoveCommentCopyWith<$Res>
+abstract class _$$RemoveCommentImplCopyWith<$Res>
     implements $RemoveCommentCopyWith<$Res> {
-  factory _$$_RemoveCommentCopyWith(
-          _$_RemoveComment value, $Res Function(_$_RemoveComment) then) =
-      __$$_RemoveCommentCopyWithImpl<$Res>;
+  factory _$$RemoveCommentImplCopyWith(
+          _$RemoveCommentImpl value, $Res Function(_$RemoveCommentImpl) then) =
+      __$$RemoveCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, bool removed, String? reason, String auth});
 }
 
 /// @nodoc
-class __$$_RemoveCommentCopyWithImpl<$Res>
-    extends _$RemoveCommentCopyWithImpl<$Res, _$_RemoveComment>
-    implements _$$_RemoveCommentCopyWith<$Res> {
-  __$$_RemoveCommentCopyWithImpl(
-      _$_RemoveComment _value, $Res Function(_$_RemoveComment) _then)
+class __$$RemoveCommentImplCopyWithImpl<$Res>
+    extends _$RemoveCommentCopyWithImpl<$Res, _$RemoveCommentImpl>
+    implements _$$RemoveCommentImplCopyWith<$Res> {
+  __$$RemoveCommentImplCopyWithImpl(
+      _$RemoveCommentImpl _value, $Res Function(_$RemoveCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -696,7 +696,7 @@ class __$$_RemoveCommentCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_RemoveComment(
+    return _then(_$RemoveCommentImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -720,16 +720,16 @@ class __$$_RemoveCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_RemoveComment extends _RemoveComment {
-  const _$_RemoveComment(
+class _$RemoveCommentImpl extends _RemoveComment {
+  const _$RemoveCommentImpl(
       {required this.commentId,
       required this.removed,
       this.reason,
       required this.auth})
       : super._();
 
-  factory _$_RemoveComment.fromJson(Map<String, dynamic> json) =>
-      _$$_RemoveCommentFromJson(json);
+  factory _$RemoveCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RemoveCommentImplFromJson(json);
 
   @override
   final int commentId;
@@ -749,7 +749,7 @@ class _$_RemoveComment extends _RemoveComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_RemoveComment &&
+            other is _$RemoveCommentImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.removed, removed) || other.removed == removed) &&
@@ -765,12 +765,12 @@ class _$_RemoveComment extends _RemoveComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RemoveCommentCopyWith<_$_RemoveComment> get copyWith =>
-      __$$_RemoveCommentCopyWithImpl<_$_RemoveComment>(this, _$identity);
+  _$$RemoveCommentImplCopyWith<_$RemoveCommentImpl> get copyWith =>
+      __$$RemoveCommentImplCopyWithImpl<_$RemoveCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RemoveCommentToJson(
+    return _$$RemoveCommentImplToJson(
       this,
     );
   }
@@ -781,11 +781,11 @@ abstract class _RemoveComment extends RemoveComment {
       {required final int commentId,
       required final bool removed,
       final String? reason,
-      required final String auth}) = _$_RemoveComment;
+      required final String auth}) = _$RemoveCommentImpl;
   const _RemoveComment._() : super._();
 
   factory _RemoveComment.fromJson(Map<String, dynamic> json) =
-      _$_RemoveComment.fromJson;
+      _$RemoveCommentImpl.fromJson;
 
   @override
   int get commentId;
@@ -797,7 +797,7 @@ abstract class _RemoveComment extends RemoveComment {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_RemoveCommentCopyWith<_$_RemoveComment> get copyWith =>
+  _$$RemoveCommentImplCopyWith<_$RemoveCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -861,22 +861,22 @@ class _$MarkCommentAsReadCopyWithImpl<$Res, $Val extends MarkCommentAsRead>
 }
 
 /// @nodoc
-abstract class _$$_MarkCommentAsReadCopyWith<$Res>
+abstract class _$$MarkCommentAsReadImplCopyWith<$Res>
     implements $MarkCommentAsReadCopyWith<$Res> {
-  factory _$$_MarkCommentAsReadCopyWith(_$_MarkCommentAsRead value,
-          $Res Function(_$_MarkCommentAsRead) then) =
-      __$$_MarkCommentAsReadCopyWithImpl<$Res>;
+  factory _$$MarkCommentAsReadImplCopyWith(_$MarkCommentAsReadImpl value,
+          $Res Function(_$MarkCommentAsReadImpl) then) =
+      __$$MarkCommentAsReadImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentReplyId, bool read, String auth});
 }
 
 /// @nodoc
-class __$$_MarkCommentAsReadCopyWithImpl<$Res>
-    extends _$MarkCommentAsReadCopyWithImpl<$Res, _$_MarkCommentAsRead>
-    implements _$$_MarkCommentAsReadCopyWith<$Res> {
-  __$$_MarkCommentAsReadCopyWithImpl(
-      _$_MarkCommentAsRead _value, $Res Function(_$_MarkCommentAsRead) _then)
+class __$$MarkCommentAsReadImplCopyWithImpl<$Res>
+    extends _$MarkCommentAsReadCopyWithImpl<$Res, _$MarkCommentAsReadImpl>
+    implements _$$MarkCommentAsReadImplCopyWith<$Res> {
+  __$$MarkCommentAsReadImplCopyWithImpl(_$MarkCommentAsReadImpl _value,
+      $Res Function(_$MarkCommentAsReadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -886,7 +886,7 @@ class __$$_MarkCommentAsReadCopyWithImpl<$Res>
     Object? read = null,
     Object? auth = null,
   }) {
-    return _then(_$_MarkCommentAsRead(
+    return _then(_$MarkCommentAsReadImpl(
       commentReplyId: null == commentReplyId
           ? _value.commentReplyId
           : commentReplyId // ignore: cast_nullable_to_non_nullable
@@ -906,13 +906,13 @@ class __$$_MarkCommentAsReadCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_MarkCommentAsRead extends _MarkCommentAsRead {
-  const _$_MarkCommentAsRead(
+class _$MarkCommentAsReadImpl extends _MarkCommentAsRead {
+  const _$MarkCommentAsReadImpl(
       {required this.commentReplyId, required this.read, required this.auth})
       : super._();
 
-  factory _$_MarkCommentAsRead.fromJson(Map<String, dynamic> json) =>
-      _$$_MarkCommentAsReadFromJson(json);
+  factory _$MarkCommentAsReadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MarkCommentAsReadImplFromJson(json);
 
   @override
   final int commentReplyId;
@@ -930,7 +930,7 @@ class _$_MarkCommentAsRead extends _MarkCommentAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MarkCommentAsRead &&
+            other is _$MarkCommentAsReadImpl &&
             (identical(other.commentReplyId, commentReplyId) ||
                 other.commentReplyId == commentReplyId) &&
             (identical(other.read, read) || other.read == read) &&
@@ -944,13 +944,13 @@ class _$_MarkCommentAsRead extends _MarkCommentAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MarkCommentAsReadCopyWith<_$_MarkCommentAsRead> get copyWith =>
-      __$$_MarkCommentAsReadCopyWithImpl<_$_MarkCommentAsRead>(
+  _$$MarkCommentAsReadImplCopyWith<_$MarkCommentAsReadImpl> get copyWith =>
+      __$$MarkCommentAsReadImplCopyWithImpl<_$MarkCommentAsReadImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MarkCommentAsReadToJson(
+    return _$$MarkCommentAsReadImplToJson(
       this,
     );
   }
@@ -960,11 +960,11 @@ abstract class _MarkCommentAsRead extends MarkCommentAsRead {
   const factory _MarkCommentAsRead(
       {required final int commentReplyId,
       required final bool read,
-      required final String auth}) = _$_MarkCommentAsRead;
+      required final String auth}) = _$MarkCommentAsReadImpl;
   const _MarkCommentAsRead._() : super._();
 
   factory _MarkCommentAsRead.fromJson(Map<String, dynamic> json) =
-      _$_MarkCommentAsRead.fromJson;
+      _$MarkCommentAsReadImpl.fromJson;
 
   @override
   int get commentReplyId;
@@ -974,7 +974,7 @@ abstract class _MarkCommentAsRead extends MarkCommentAsRead {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_MarkCommentAsReadCopyWith<_$_MarkCommentAsRead> get copyWith =>
+  _$$MarkCommentAsReadImplCopyWith<_$MarkCommentAsReadImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1038,22 +1038,22 @@ class _$SaveCommentCopyWithImpl<$Res, $Val extends SaveComment>
 }
 
 /// @nodoc
-abstract class _$$_SaveCommentCopyWith<$Res>
+abstract class _$$SaveCommentImplCopyWith<$Res>
     implements $SaveCommentCopyWith<$Res> {
-  factory _$$_SaveCommentCopyWith(
-          _$_SaveComment value, $Res Function(_$_SaveComment) then) =
-      __$$_SaveCommentCopyWithImpl<$Res>;
+  factory _$$SaveCommentImplCopyWith(
+          _$SaveCommentImpl value, $Res Function(_$SaveCommentImpl) then) =
+      __$$SaveCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, bool save, String auth});
 }
 
 /// @nodoc
-class __$$_SaveCommentCopyWithImpl<$Res>
-    extends _$SaveCommentCopyWithImpl<$Res, _$_SaveComment>
-    implements _$$_SaveCommentCopyWith<$Res> {
-  __$$_SaveCommentCopyWithImpl(
-      _$_SaveComment _value, $Res Function(_$_SaveComment) _then)
+class __$$SaveCommentImplCopyWithImpl<$Res>
+    extends _$SaveCommentCopyWithImpl<$Res, _$SaveCommentImpl>
+    implements _$$SaveCommentImplCopyWith<$Res> {
+  __$$SaveCommentImplCopyWithImpl(
+      _$SaveCommentImpl _value, $Res Function(_$SaveCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1063,7 +1063,7 @@ class __$$_SaveCommentCopyWithImpl<$Res>
     Object? save = null,
     Object? auth = null,
   }) {
-    return _then(_$_SaveComment(
+    return _then(_$SaveCommentImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -1083,13 +1083,13 @@ class __$$_SaveCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_SaveComment extends _SaveComment {
-  const _$_SaveComment(
+class _$SaveCommentImpl extends _SaveComment {
+  const _$SaveCommentImpl(
       {required this.commentId, required this.save, required this.auth})
       : super._();
 
-  factory _$_SaveComment.fromJson(Map<String, dynamic> json) =>
-      _$$_SaveCommentFromJson(json);
+  factory _$SaveCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SaveCommentImplFromJson(json);
 
   @override
   final int commentId;
@@ -1107,7 +1107,7 @@ class _$_SaveComment extends _SaveComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SaveComment &&
+            other is _$SaveCommentImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.save, save) || other.save == save) &&
@@ -1121,12 +1121,12 @@ class _$_SaveComment extends _SaveComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SaveCommentCopyWith<_$_SaveComment> get copyWith =>
-      __$$_SaveCommentCopyWithImpl<_$_SaveComment>(this, _$identity);
+  _$$SaveCommentImplCopyWith<_$SaveCommentImpl> get copyWith =>
+      __$$SaveCommentImplCopyWithImpl<_$SaveCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SaveCommentToJson(
+    return _$$SaveCommentImplToJson(
       this,
     );
   }
@@ -1136,11 +1136,11 @@ abstract class _SaveComment extends SaveComment {
   const factory _SaveComment(
       {required final int commentId,
       required final bool save,
-      required final String auth}) = _$_SaveComment;
+      required final String auth}) = _$SaveCommentImpl;
   const _SaveComment._() : super._();
 
   factory _SaveComment.fromJson(Map<String, dynamic> json) =
-      _$_SaveComment.fromJson;
+      _$SaveCommentImpl.fromJson;
 
   @override
   int get commentId;
@@ -1150,7 +1150,7 @@ abstract class _SaveComment extends SaveComment {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_SaveCommentCopyWith<_$_SaveComment> get copyWith =>
+  _$$SaveCommentImplCopyWith<_$SaveCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1214,22 +1214,22 @@ class _$CreateCommentLikeCopyWithImpl<$Res, $Val extends CreateCommentLike>
 }
 
 /// @nodoc
-abstract class _$$_CreateCommentLikeCopyWith<$Res>
+abstract class _$$CreateCommentLikeImplCopyWith<$Res>
     implements $CreateCommentLikeCopyWith<$Res> {
-  factory _$$_CreateCommentLikeCopyWith(_$_CreateCommentLike value,
-          $Res Function(_$_CreateCommentLike) then) =
-      __$$_CreateCommentLikeCopyWithImpl<$Res>;
+  factory _$$CreateCommentLikeImplCopyWith(_$CreateCommentLikeImpl value,
+          $Res Function(_$CreateCommentLikeImpl) then) =
+      __$$CreateCommentLikeImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, VoteType score, String auth});
 }
 
 /// @nodoc
-class __$$_CreateCommentLikeCopyWithImpl<$Res>
-    extends _$CreateCommentLikeCopyWithImpl<$Res, _$_CreateCommentLike>
-    implements _$$_CreateCommentLikeCopyWith<$Res> {
-  __$$_CreateCommentLikeCopyWithImpl(
-      _$_CreateCommentLike _value, $Res Function(_$_CreateCommentLike) _then)
+class __$$CreateCommentLikeImplCopyWithImpl<$Res>
+    extends _$CreateCommentLikeCopyWithImpl<$Res, _$CreateCommentLikeImpl>
+    implements _$$CreateCommentLikeImplCopyWith<$Res> {
+  __$$CreateCommentLikeImplCopyWithImpl(_$CreateCommentLikeImpl _value,
+      $Res Function(_$CreateCommentLikeImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1239,7 +1239,7 @@ class __$$_CreateCommentLikeCopyWithImpl<$Res>
     Object? score = null,
     Object? auth = null,
   }) {
-    return _then(_$_CreateCommentLike(
+    return _then(_$CreateCommentLikeImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -1259,13 +1259,13 @@ class __$$_CreateCommentLikeCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreateCommentLike extends _CreateCommentLike {
-  const _$_CreateCommentLike(
+class _$CreateCommentLikeImpl extends _CreateCommentLike {
+  const _$CreateCommentLikeImpl(
       {required this.commentId, required this.score, required this.auth})
       : super._();
 
-  factory _$_CreateCommentLike.fromJson(Map<String, dynamic> json) =>
-      _$$_CreateCommentLikeFromJson(json);
+  factory _$CreateCommentLikeImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreateCommentLikeImplFromJson(json);
 
   @override
   final int commentId;
@@ -1283,7 +1283,7 @@ class _$_CreateCommentLike extends _CreateCommentLike {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreateCommentLike &&
+            other is _$CreateCommentLikeImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.score, score) || other.score == score) &&
@@ -1297,13 +1297,13 @@ class _$_CreateCommentLike extends _CreateCommentLike {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreateCommentLikeCopyWith<_$_CreateCommentLike> get copyWith =>
-      __$$_CreateCommentLikeCopyWithImpl<_$_CreateCommentLike>(
+  _$$CreateCommentLikeImplCopyWith<_$CreateCommentLikeImpl> get copyWith =>
+      __$$CreateCommentLikeImplCopyWithImpl<_$CreateCommentLikeImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreateCommentLikeToJson(
+    return _$$CreateCommentLikeImplToJson(
       this,
     );
   }
@@ -1313,11 +1313,11 @@ abstract class _CreateCommentLike extends CreateCommentLike {
   const factory _CreateCommentLike(
       {required final int commentId,
       required final VoteType score,
-      required final String auth}) = _$_CreateCommentLike;
+      required final String auth}) = _$CreateCommentLikeImpl;
   const _CreateCommentLike._() : super._();
 
   factory _CreateCommentLike.fromJson(Map<String, dynamic> json) =
-      _$_CreateCommentLike.fromJson;
+      _$CreateCommentLikeImpl.fromJson;
 
   @override
   int get commentId;
@@ -1327,7 +1327,7 @@ abstract class _CreateCommentLike extends CreateCommentLike {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreateCommentLikeCopyWith<_$_CreateCommentLike> get copyWith =>
+  _$$CreateCommentLikeImplCopyWith<_$CreateCommentLikeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1385,22 +1385,22 @@ class _$GetCommentCopyWithImpl<$Res, $Val extends GetComment>
 }
 
 /// @nodoc
-abstract class _$$_GetCommentCopyWith<$Res>
+abstract class _$$GetCommentImplCopyWith<$Res>
     implements $GetCommentCopyWith<$Res> {
-  factory _$$_GetCommentCopyWith(
-          _$_GetComment value, $Res Function(_$_GetComment) then) =
-      __$$_GetCommentCopyWithImpl<$Res>;
+  factory _$$GetCommentImplCopyWith(
+          _$GetCommentImpl value, $Res Function(_$GetCommentImpl) then) =
+      __$$GetCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int id, String? auth});
 }
 
 /// @nodoc
-class __$$_GetCommentCopyWithImpl<$Res>
-    extends _$GetCommentCopyWithImpl<$Res, _$_GetComment>
-    implements _$$_GetCommentCopyWith<$Res> {
-  __$$_GetCommentCopyWithImpl(
-      _$_GetComment _value, $Res Function(_$_GetComment) _then)
+class __$$GetCommentImplCopyWithImpl<$Res>
+    extends _$GetCommentCopyWithImpl<$Res, _$GetCommentImpl>
+    implements _$$GetCommentImplCopyWith<$Res> {
+  __$$GetCommentImplCopyWithImpl(
+      _$GetCommentImpl _value, $Res Function(_$GetCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1409,7 +1409,7 @@ class __$$_GetCommentCopyWithImpl<$Res>
     Object? id = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetComment(
+    return _then(_$GetCommentImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -1425,11 +1425,11 @@ class __$$_GetCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetComment extends _GetComment {
-  const _$_GetComment({required this.id, this.auth}) : super._();
+class _$GetCommentImpl extends _GetComment {
+  const _$GetCommentImpl({required this.id, this.auth}) : super._();
 
-  factory _$_GetComment.fromJson(Map<String, dynamic> json) =>
-      _$$_GetCommentFromJson(json);
+  factory _$GetCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetCommentImplFromJson(json);
 
   @override
   final int id;
@@ -1445,7 +1445,7 @@ class _$_GetComment extends _GetComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetComment &&
+            other is _$GetCommentImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.auth, auth) || other.auth == auth));
   }
@@ -1457,12 +1457,12 @@ class _$_GetComment extends _GetComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetCommentCopyWith<_$_GetComment> get copyWith =>
-      __$$_GetCommentCopyWithImpl<_$_GetComment>(this, _$identity);
+  _$$GetCommentImplCopyWith<_$GetCommentImpl> get copyWith =>
+      __$$GetCommentImplCopyWithImpl<_$GetCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetCommentToJson(
+    return _$$GetCommentImplToJson(
       this,
     );
   }
@@ -1470,11 +1470,11 @@ class _$_GetComment extends _GetComment {
 
 abstract class _GetComment extends GetComment {
   const factory _GetComment({required final int id, final String? auth}) =
-      _$_GetComment;
+      _$GetCommentImpl;
   const _GetComment._() : super._();
 
   factory _GetComment.fromJson(Map<String, dynamic> json) =
-      _$_GetComment.fromJson;
+      _$GetCommentImpl.fromJson;
 
   @override
   int get id;
@@ -1482,7 +1482,7 @@ abstract class _GetComment extends GetComment {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetCommentCopyWith<_$_GetComment> get copyWith =>
+  _$$GetCommentImplCopyWith<_$GetCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1606,11 +1606,11 @@ class _$GetCommentsCopyWithImpl<$Res, $Val extends GetComments>
 }
 
 /// @nodoc
-abstract class _$$_GetCommentsCopyWith<$Res>
+abstract class _$$GetCommentsImplCopyWith<$Res>
     implements $GetCommentsCopyWith<$Res> {
-  factory _$$_GetCommentsCopyWith(
-          _$_GetComments value, $Res Function(_$_GetComments) then) =
-      __$$_GetCommentsCopyWithImpl<$Res>;
+  factory _$$GetCommentsImplCopyWith(
+          _$GetCommentsImpl value, $Res Function(_$GetCommentsImpl) then) =
+      __$$GetCommentsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1628,11 +1628,11 @@ abstract class _$$_GetCommentsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetCommentsCopyWithImpl<$Res>
-    extends _$GetCommentsCopyWithImpl<$Res, _$_GetComments>
-    implements _$$_GetCommentsCopyWith<$Res> {
-  __$$_GetCommentsCopyWithImpl(
-      _$_GetComments _value, $Res Function(_$_GetComments) _then)
+class __$$GetCommentsImplCopyWithImpl<$Res>
+    extends _$GetCommentsCopyWithImpl<$Res, _$GetCommentsImpl>
+    implements _$$GetCommentsImplCopyWith<$Res> {
+  __$$GetCommentsImplCopyWithImpl(
+      _$GetCommentsImpl _value, $Res Function(_$GetCommentsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1650,7 +1650,7 @@ class __$$_GetCommentsCopyWithImpl<$Res>
     Object? auth = freezed,
     Object? maxDepth = freezed,
   }) {
-    return _then(_$_GetComments(
+    return _then(_$GetCommentsImpl(
       type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -1702,8 +1702,8 @@ class __$$_GetCommentsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetComments extends _GetComments {
-  const _$_GetComments(
+class _$GetCommentsImpl extends _GetComments {
+  const _$GetCommentsImpl(
       {@JsonKey(name: 'type_') this.type,
       this.sort,
       this.page,
@@ -1717,8 +1717,8 @@ class _$_GetComments extends _GetComments {
       this.maxDepth})
       : super._();
 
-  factory _$_GetComments.fromJson(Map<String, dynamic> json) =>
-      _$$_GetCommentsFromJson(json);
+  factory _$GetCommentsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetCommentsImplFromJson(json);
 
   @override
   @JsonKey(name: 'type_')
@@ -1753,7 +1753,7 @@ class _$_GetComments extends _GetComments {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetComments &&
+            other is _$GetCommentsImpl &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
@@ -1780,12 +1780,12 @@ class _$_GetComments extends _GetComments {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetCommentsCopyWith<_$_GetComments> get copyWith =>
-      __$$_GetCommentsCopyWithImpl<_$_GetComments>(this, _$identity);
+  _$$GetCommentsImplCopyWith<_$GetCommentsImpl> get copyWith =>
+      __$$GetCommentsImplCopyWithImpl<_$GetCommentsImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetCommentsToJson(
+    return _$$GetCommentsImplToJson(
       this,
     );
   }
@@ -1803,11 +1803,11 @@ abstract class _GetComments extends GetComments {
       final int? parentId,
       final bool? savedOnly,
       final String? auth,
-      final int? maxDepth}) = _$_GetComments;
+      final int? maxDepth}) = _$GetCommentsImpl;
   const _GetComments._() : super._();
 
   factory _GetComments.fromJson(Map<String, dynamic> json) =
-      _$_GetComments.fromJson;
+      _$GetCommentsImpl.fromJson;
 
   @override
   @JsonKey(name: 'type_')
@@ -1834,7 +1834,7 @@ abstract class _GetComments extends GetComments {
   int? get maxDepth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetCommentsCopyWith<_$_GetComments> get copyWith =>
+  _$$GetCommentsImplCopyWith<_$GetCommentsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1898,22 +1898,22 @@ class _$CreateCommentReportCopyWithImpl<$Res, $Val extends CreateCommentReport>
 }
 
 /// @nodoc
-abstract class _$$_CreateCommentReportCopyWith<$Res>
+abstract class _$$CreateCommentReportImplCopyWith<$Res>
     implements $CreateCommentReportCopyWith<$Res> {
-  factory _$$_CreateCommentReportCopyWith(_$_CreateCommentReport value,
-          $Res Function(_$_CreateCommentReport) then) =
-      __$$_CreateCommentReportCopyWithImpl<$Res>;
+  factory _$$CreateCommentReportImplCopyWith(_$CreateCommentReportImpl value,
+          $Res Function(_$CreateCommentReportImpl) then) =
+      __$$CreateCommentReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, String reason, String auth});
 }
 
 /// @nodoc
-class __$$_CreateCommentReportCopyWithImpl<$Res>
-    extends _$CreateCommentReportCopyWithImpl<$Res, _$_CreateCommentReport>
-    implements _$$_CreateCommentReportCopyWith<$Res> {
-  __$$_CreateCommentReportCopyWithImpl(_$_CreateCommentReport _value,
-      $Res Function(_$_CreateCommentReport) _then)
+class __$$CreateCommentReportImplCopyWithImpl<$Res>
+    extends _$CreateCommentReportCopyWithImpl<$Res, _$CreateCommentReportImpl>
+    implements _$$CreateCommentReportImplCopyWith<$Res> {
+  __$$CreateCommentReportImplCopyWithImpl(_$CreateCommentReportImpl _value,
+      $Res Function(_$CreateCommentReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1923,7 +1923,7 @@ class __$$_CreateCommentReportCopyWithImpl<$Res>
     Object? reason = null,
     Object? auth = null,
   }) {
-    return _then(_$_CreateCommentReport(
+    return _then(_$CreateCommentReportImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -1943,13 +1943,13 @@ class __$$_CreateCommentReportCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreateCommentReport extends _CreateCommentReport {
-  const _$_CreateCommentReport(
+class _$CreateCommentReportImpl extends _CreateCommentReport {
+  const _$CreateCommentReportImpl(
       {required this.commentId, required this.reason, required this.auth})
       : super._();
 
-  factory _$_CreateCommentReport.fromJson(Map<String, dynamic> json) =>
-      _$$_CreateCommentReportFromJson(json);
+  factory _$CreateCommentReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreateCommentReportImplFromJson(json);
 
   @override
   final int commentId;
@@ -1967,7 +1967,7 @@ class _$_CreateCommentReport extends _CreateCommentReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreateCommentReport &&
+            other is _$CreateCommentReportImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.reason, reason) || other.reason == reason) &&
@@ -1981,13 +1981,13 @@ class _$_CreateCommentReport extends _CreateCommentReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreateCommentReportCopyWith<_$_CreateCommentReport> get copyWith =>
-      __$$_CreateCommentReportCopyWithImpl<_$_CreateCommentReport>(
+  _$$CreateCommentReportImplCopyWith<_$CreateCommentReportImpl> get copyWith =>
+      __$$CreateCommentReportImplCopyWithImpl<_$CreateCommentReportImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreateCommentReportToJson(
+    return _$$CreateCommentReportImplToJson(
       this,
     );
   }
@@ -1997,11 +1997,11 @@ abstract class _CreateCommentReport extends CreateCommentReport {
   const factory _CreateCommentReport(
       {required final int commentId,
       required final String reason,
-      required final String auth}) = _$_CreateCommentReport;
+      required final String auth}) = _$CreateCommentReportImpl;
   const _CreateCommentReport._() : super._();
 
   factory _CreateCommentReport.fromJson(Map<String, dynamic> json) =
-      _$_CreateCommentReport.fromJson;
+      _$CreateCommentReportImpl.fromJson;
 
   @override
   int get commentId;
@@ -2011,7 +2011,7 @@ abstract class _CreateCommentReport extends CreateCommentReport {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreateCommentReportCopyWith<_$_CreateCommentReport> get copyWith =>
+  _$$CreateCommentReportImplCopyWith<_$CreateCommentReportImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2076,22 +2076,22 @@ class _$ResolveCommentReportCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ResolveCommentReportCopyWith<$Res>
+abstract class _$$ResolveCommentReportImplCopyWith<$Res>
     implements $ResolveCommentReportCopyWith<$Res> {
-  factory _$$_ResolveCommentReportCopyWith(_$_ResolveCommentReport value,
-          $Res Function(_$_ResolveCommentReport) then) =
-      __$$_ResolveCommentReportCopyWithImpl<$Res>;
+  factory _$$ResolveCommentReportImplCopyWith(_$ResolveCommentReportImpl value,
+          $Res Function(_$ResolveCommentReportImpl) then) =
+      __$$ResolveCommentReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int reportId, bool resolved, String auth});
 }
 
 /// @nodoc
-class __$$_ResolveCommentReportCopyWithImpl<$Res>
-    extends _$ResolveCommentReportCopyWithImpl<$Res, _$_ResolveCommentReport>
-    implements _$$_ResolveCommentReportCopyWith<$Res> {
-  __$$_ResolveCommentReportCopyWithImpl(_$_ResolveCommentReport _value,
-      $Res Function(_$_ResolveCommentReport) _then)
+class __$$ResolveCommentReportImplCopyWithImpl<$Res>
+    extends _$ResolveCommentReportCopyWithImpl<$Res, _$ResolveCommentReportImpl>
+    implements _$$ResolveCommentReportImplCopyWith<$Res> {
+  __$$ResolveCommentReportImplCopyWithImpl(_$ResolveCommentReportImpl _value,
+      $Res Function(_$ResolveCommentReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2101,7 +2101,7 @@ class __$$_ResolveCommentReportCopyWithImpl<$Res>
     Object? resolved = null,
     Object? auth = null,
   }) {
-    return _then(_$_ResolveCommentReport(
+    return _then(_$ResolveCommentReportImpl(
       reportId: null == reportId
           ? _value.reportId
           : reportId // ignore: cast_nullable_to_non_nullable
@@ -2121,13 +2121,13 @@ class __$$_ResolveCommentReportCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ResolveCommentReport extends _ResolveCommentReport {
-  const _$_ResolveCommentReport(
+class _$ResolveCommentReportImpl extends _ResolveCommentReport {
+  const _$ResolveCommentReportImpl(
       {required this.reportId, required this.resolved, required this.auth})
       : super._();
 
-  factory _$_ResolveCommentReport.fromJson(Map<String, dynamic> json) =>
-      _$$_ResolveCommentReportFromJson(json);
+  factory _$ResolveCommentReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ResolveCommentReportImplFromJson(json);
 
   @override
   final int reportId;
@@ -2145,7 +2145,7 @@ class _$_ResolveCommentReport extends _ResolveCommentReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ResolveCommentReport &&
+            other is _$ResolveCommentReportImpl &&
             (identical(other.reportId, reportId) ||
                 other.reportId == reportId) &&
             (identical(other.resolved, resolved) ||
@@ -2160,13 +2160,14 @@ class _$_ResolveCommentReport extends _ResolveCommentReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ResolveCommentReportCopyWith<_$_ResolveCommentReport> get copyWith =>
-      __$$_ResolveCommentReportCopyWithImpl<_$_ResolveCommentReport>(
-          this, _$identity);
+  _$$ResolveCommentReportImplCopyWith<_$ResolveCommentReportImpl>
+      get copyWith =>
+          __$$ResolveCommentReportImplCopyWithImpl<_$ResolveCommentReportImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ResolveCommentReportToJson(
+    return _$$ResolveCommentReportImplToJson(
       this,
     );
   }
@@ -2176,11 +2177,11 @@ abstract class _ResolveCommentReport extends ResolveCommentReport {
   const factory _ResolveCommentReport(
       {required final int reportId,
       required final bool resolved,
-      required final String auth}) = _$_ResolveCommentReport;
+      required final String auth}) = _$ResolveCommentReportImpl;
   const _ResolveCommentReport._() : super._();
 
   factory _ResolveCommentReport.fromJson(Map<String, dynamic> json) =
-      _$_ResolveCommentReport.fromJson;
+      _$ResolveCommentReportImpl.fromJson;
 
   @override
   int get reportId;
@@ -2190,8 +2191,8 @@ abstract class _ResolveCommentReport extends ResolveCommentReport {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ResolveCommentReportCopyWith<_$_ResolveCommentReport> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ResolveCommentReportImplCopyWith<_$ResolveCommentReportImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 ListCommentReports _$ListCommentReportsFromJson(Map<String, dynamic> json) {
@@ -2271,11 +2272,11 @@ class _$ListCommentReportsCopyWithImpl<$Res, $Val extends ListCommentReports>
 }
 
 /// @nodoc
-abstract class _$$_ListCommentReportsCopyWith<$Res>
+abstract class _$$ListCommentReportsImplCopyWith<$Res>
     implements $ListCommentReportsCopyWith<$Res> {
-  factory _$$_ListCommentReportsCopyWith(_$_ListCommentReports value,
-          $Res Function(_$_ListCommentReports) then) =
-      __$$_ListCommentReportsCopyWithImpl<$Res>;
+  factory _$$ListCommentReportsImplCopyWith(_$ListCommentReportsImpl value,
+          $Res Function(_$ListCommentReportsImpl) then) =
+      __$$ListCommentReportsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2287,11 +2288,11 @@ abstract class _$$_ListCommentReportsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ListCommentReportsCopyWithImpl<$Res>
-    extends _$ListCommentReportsCopyWithImpl<$Res, _$_ListCommentReports>
-    implements _$$_ListCommentReportsCopyWith<$Res> {
-  __$$_ListCommentReportsCopyWithImpl(
-      _$_ListCommentReports _value, $Res Function(_$_ListCommentReports) _then)
+class __$$ListCommentReportsImplCopyWithImpl<$Res>
+    extends _$ListCommentReportsCopyWithImpl<$Res, _$ListCommentReportsImpl>
+    implements _$$ListCommentReportsImplCopyWith<$Res> {
+  __$$ListCommentReportsImplCopyWithImpl(_$ListCommentReportsImpl _value,
+      $Res Function(_$ListCommentReportsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2303,7 +2304,7 @@ class __$$_ListCommentReportsCopyWithImpl<$Res>
     Object? unresolvedOnly = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_ListCommentReports(
+    return _then(_$ListCommentReportsImpl(
       page: freezed == page
           ? _value.page
           : page // ignore: cast_nullable_to_non_nullable
@@ -2331,8 +2332,8 @@ class __$$_ListCommentReportsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ListCommentReports extends _ListCommentReports {
-  const _$_ListCommentReports(
+class _$ListCommentReportsImpl extends _ListCommentReports {
+  const _$ListCommentReportsImpl(
       {this.page,
       this.limit,
       this.communityId,
@@ -2340,8 +2341,8 @@ class _$_ListCommentReports extends _ListCommentReports {
       required this.auth})
       : super._();
 
-  factory _$_ListCommentReports.fromJson(Map<String, dynamic> json) =>
-      _$$_ListCommentReportsFromJson(json);
+  factory _$ListCommentReportsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ListCommentReportsImplFromJson(json);
 
   @override
   final int? page;
@@ -2363,7 +2364,7 @@ class _$_ListCommentReports extends _ListCommentReports {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListCommentReports &&
+            other is _$ListCommentReportsImpl &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
             (identical(other.communityId, communityId) ||
@@ -2381,13 +2382,13 @@ class _$_ListCommentReports extends _ListCommentReports {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListCommentReportsCopyWith<_$_ListCommentReports> get copyWith =>
-      __$$_ListCommentReportsCopyWithImpl<_$_ListCommentReports>(
+  _$$ListCommentReportsImplCopyWith<_$ListCommentReportsImpl> get copyWith =>
+      __$$ListCommentReportsImplCopyWithImpl<_$ListCommentReportsImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListCommentReportsToJson(
+    return _$$ListCommentReportsImplToJson(
       this,
     );
   }
@@ -2399,11 +2400,11 @@ abstract class _ListCommentReports extends ListCommentReports {
       final int? limit,
       final int? communityId,
       final bool? unresolvedOnly,
-      required final String auth}) = _$_ListCommentReports;
+      required final String auth}) = _$ListCommentReportsImpl;
   const _ListCommentReports._() : super._();
 
   factory _ListCommentReports.fromJson(Map<String, dynamic> json) =
-      _$_ListCommentReports.fromJson;
+      _$ListCommentReportsImpl.fromJson;
 
   @override
   int? get page;
@@ -2417,6 +2418,6 @@ abstract class _ListCommentReports extends ListCommentReports {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ListCommentReportsCopyWith<_$_ListCommentReports> get copyWith =>
+  _$$ListCommentReportsImplCopyWith<_$ListCommentReportsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/comment.g.dart
+++ b/lib/src/v3/api/comment.g.dart
@@ -6,8 +6,8 @@ part of 'comment.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CreateComment _$$_CreateCommentFromJson(Map<String, dynamic> json) =>
-    _$_CreateComment(
+_$CreateCommentImpl _$$CreateCommentImplFromJson(Map<String, dynamic> json) =>
+    _$CreateCommentImpl(
       content: json['content'] as String,
       parentId: json['parent_id'] as int?,
       postId: json['post_id'] as int,
@@ -15,7 +15,7 @@ _$_CreateComment _$$_CreateCommentFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_CreateCommentToJson(_$_CreateComment instance) {
+Map<String, dynamic> _$$CreateCommentImplToJson(_$CreateCommentImpl instance) {
   final val = <String, dynamic>{
     'content': instance.content,
   };
@@ -33,15 +33,15 @@ Map<String, dynamic> _$$_CreateCommentToJson(_$_CreateComment instance) {
   return val;
 }
 
-_$_EditComment _$$_EditCommentFromJson(Map<String, dynamic> json) =>
-    _$_EditComment(
+_$EditCommentImpl _$$EditCommentImplFromJson(Map<String, dynamic> json) =>
+    _$EditCommentImpl(
       content: json['content'] as String,
       commentId: json['comment_id'] as int,
       formId: json['form_id'] as String?,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_EditCommentToJson(_$_EditComment instance) {
+Map<String, dynamic> _$$EditCommentImplToJson(_$EditCommentImpl instance) {
   final val = <String, dynamic>{
     'content': instance.content,
     'comment_id': instance.commentId,
@@ -58,29 +58,29 @@ Map<String, dynamic> _$$_EditCommentToJson(_$_EditComment instance) {
   return val;
 }
 
-_$_DeleteComment _$$_DeleteCommentFromJson(Map<String, dynamic> json) =>
-    _$_DeleteComment(
+_$DeleteCommentImpl _$$DeleteCommentImplFromJson(Map<String, dynamic> json) =>
+    _$DeleteCommentImpl(
       commentId: json['comment_id'] as int,
       deleted: json['deleted'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_DeleteCommentToJson(_$_DeleteComment instance) =>
+Map<String, dynamic> _$$DeleteCommentImplToJson(_$DeleteCommentImpl instance) =>
     <String, dynamic>{
       'comment_id': instance.commentId,
       'deleted': instance.deleted,
       'auth': instance.auth,
     };
 
-_$_RemoveComment _$$_RemoveCommentFromJson(Map<String, dynamic> json) =>
-    _$_RemoveComment(
+_$RemoveCommentImpl _$$RemoveCommentImplFromJson(Map<String, dynamic> json) =>
+    _$RemoveCommentImpl(
       commentId: json['comment_id'] as int,
       removed: json['removed'] as bool,
       reason: json['reason'] as String?,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_RemoveCommentToJson(_$_RemoveComment instance) {
+Map<String, dynamic> _$$RemoveCommentImplToJson(_$RemoveCommentImpl instance) {
   final val = <String, dynamic>{
     'comment_id': instance.commentId,
     'removed': instance.removed,
@@ -97,57 +97,59 @@ Map<String, dynamic> _$$_RemoveCommentToJson(_$_RemoveComment instance) {
   return val;
 }
 
-_$_MarkCommentAsRead _$$_MarkCommentAsReadFromJson(Map<String, dynamic> json) =>
-    _$_MarkCommentAsRead(
+_$MarkCommentAsReadImpl _$$MarkCommentAsReadImplFromJson(
+        Map<String, dynamic> json) =>
+    _$MarkCommentAsReadImpl(
       commentReplyId: json['comment_reply_id'] as int,
       read: json['read'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_MarkCommentAsReadToJson(
-        _$_MarkCommentAsRead instance) =>
+Map<String, dynamic> _$$MarkCommentAsReadImplToJson(
+        _$MarkCommentAsReadImpl instance) =>
     <String, dynamic>{
       'comment_reply_id': instance.commentReplyId,
       'read': instance.read,
       'auth': instance.auth,
     };
 
-_$_SaveComment _$$_SaveCommentFromJson(Map<String, dynamic> json) =>
-    _$_SaveComment(
+_$SaveCommentImpl _$$SaveCommentImplFromJson(Map<String, dynamic> json) =>
+    _$SaveCommentImpl(
       commentId: json['comment_id'] as int,
       save: json['save'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_SaveCommentToJson(_$_SaveComment instance) =>
+Map<String, dynamic> _$$SaveCommentImplToJson(_$SaveCommentImpl instance) =>
     <String, dynamic>{
       'comment_id': instance.commentId,
       'save': instance.save,
       'auth': instance.auth,
     };
 
-_$_CreateCommentLike _$$_CreateCommentLikeFromJson(Map<String, dynamic> json) =>
-    _$_CreateCommentLike(
+_$CreateCommentLikeImpl _$$CreateCommentLikeImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CreateCommentLikeImpl(
       commentId: json['comment_id'] as int,
       score: VoteType.fromJson(json['score'] as int),
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_CreateCommentLikeToJson(
-        _$_CreateCommentLike instance) =>
+Map<String, dynamic> _$$CreateCommentLikeImplToJson(
+        _$CreateCommentLikeImpl instance) =>
     <String, dynamic>{
       'comment_id': instance.commentId,
       'score': instance.score.toJson(),
       'auth': instance.auth,
     };
 
-_$_GetComment _$$_GetCommentFromJson(Map<String, dynamic> json) =>
-    _$_GetComment(
+_$GetCommentImpl _$$GetCommentImplFromJson(Map<String, dynamic> json) =>
+    _$GetCommentImpl(
       id: json['id'] as int,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetCommentToJson(_$_GetComment instance) {
+Map<String, dynamic> _$$GetCommentImplToJson(_$GetCommentImpl instance) {
   final val = <String, dynamic>{
     'id': instance.id,
   };
@@ -162,8 +164,8 @@ Map<String, dynamic> _$$_GetCommentToJson(_$_GetComment instance) {
   return val;
 }
 
-_$_GetComments _$$_GetCommentsFromJson(Map<String, dynamic> json) =>
-    _$_GetComments(
+_$GetCommentsImpl _$$GetCommentsImplFromJson(Map<String, dynamic> json) =>
+    _$GetCommentsImpl(
       type: json['type_'] == null
           ? null
           : CommentListingType.fromJson(json['type_'] as String),
@@ -180,7 +182,7 @@ _$_GetComments _$$_GetCommentsFromJson(Map<String, dynamic> json) =>
       maxDepth: json['max_depth'] as int?,
     );
 
-Map<String, dynamic> _$$_GetCommentsToJson(_$_GetComments instance) {
+Map<String, dynamic> _$$GetCommentsImplToJson(_$GetCommentsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -203,41 +205,41 @@ Map<String, dynamic> _$$_GetCommentsToJson(_$_GetComments instance) {
   return val;
 }
 
-_$_CreateCommentReport _$$_CreateCommentReportFromJson(
+_$CreateCommentReportImpl _$$CreateCommentReportImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CreateCommentReport(
+    _$CreateCommentReportImpl(
       commentId: json['comment_id'] as int,
       reason: json['reason'] as String,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_CreateCommentReportToJson(
-        _$_CreateCommentReport instance) =>
+Map<String, dynamic> _$$CreateCommentReportImplToJson(
+        _$CreateCommentReportImpl instance) =>
     <String, dynamic>{
       'comment_id': instance.commentId,
       'reason': instance.reason,
       'auth': instance.auth,
     };
 
-_$_ResolveCommentReport _$$_ResolveCommentReportFromJson(
+_$ResolveCommentReportImpl _$$ResolveCommentReportImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ResolveCommentReport(
+    _$ResolveCommentReportImpl(
       reportId: json['report_id'] as int,
       resolved: json['resolved'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_ResolveCommentReportToJson(
-        _$_ResolveCommentReport instance) =>
+Map<String, dynamic> _$$ResolveCommentReportImplToJson(
+        _$ResolveCommentReportImpl instance) =>
     <String, dynamic>{
       'report_id': instance.reportId,
       'resolved': instance.resolved,
       'auth': instance.auth,
     };
 
-_$_ListCommentReports _$$_ListCommentReportsFromJson(
+_$ListCommentReportsImpl _$$ListCommentReportsImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ListCommentReports(
+    _$ListCommentReportsImpl(
       page: json['page'] as int?,
       limit: json['limit'] as int?,
       communityId: json['community_id'] as int?,
@@ -245,8 +247,8 @@ _$_ListCommentReports _$$_ListCommentReportsFromJson(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_ListCommentReportsToJson(
-    _$_ListCommentReports instance) {
+Map<String, dynamic> _$$ListCommentReportsImplToJson(
+    _$ListCommentReportsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {

--- a/lib/src/v3/api/community.freezed.dart
+++ b/lib/src/v3/api/community.freezed.dart
@@ -74,22 +74,22 @@ class _$GetCommunityCopyWithImpl<$Res, $Val extends GetCommunity>
 }
 
 /// @nodoc
-abstract class _$$_GetCommunityCopyWith<$Res>
+abstract class _$$GetCommunityImplCopyWith<$Res>
     implements $GetCommunityCopyWith<$Res> {
-  factory _$$_GetCommunityCopyWith(
-          _$_GetCommunity value, $Res Function(_$_GetCommunity) then) =
-      __$$_GetCommunityCopyWithImpl<$Res>;
+  factory _$$GetCommunityImplCopyWith(
+          _$GetCommunityImpl value, $Res Function(_$GetCommunityImpl) then) =
+      __$$GetCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int? id, String? name, String? auth});
 }
 
 /// @nodoc
-class __$$_GetCommunityCopyWithImpl<$Res>
-    extends _$GetCommunityCopyWithImpl<$Res, _$_GetCommunity>
-    implements _$$_GetCommunityCopyWith<$Res> {
-  __$$_GetCommunityCopyWithImpl(
-      _$_GetCommunity _value, $Res Function(_$_GetCommunity) _then)
+class __$$GetCommunityImplCopyWithImpl<$Res>
+    extends _$GetCommunityCopyWithImpl<$Res, _$GetCommunityImpl>
+    implements _$$GetCommunityImplCopyWith<$Res> {
+  __$$GetCommunityImplCopyWithImpl(
+      _$GetCommunityImpl _value, $Res Function(_$GetCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -99,7 +99,7 @@ class __$$_GetCommunityCopyWithImpl<$Res>
     Object? name = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetCommunity(
+    return _then(_$GetCommunityImpl(
       id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -119,11 +119,11 @@ class __$$_GetCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetCommunity extends _GetCommunity {
-  const _$_GetCommunity({this.id, this.name, this.auth}) : super._();
+class _$GetCommunityImpl extends _GetCommunity {
+  const _$GetCommunityImpl({this.id, this.name, this.auth}) : super._();
 
-  factory _$_GetCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_GetCommunityFromJson(json);
+  factory _$GetCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetCommunityImplFromJson(json);
 
   @override
   final int? id;
@@ -141,7 +141,7 @@ class _$_GetCommunity extends _GetCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetCommunity &&
+            other is _$GetCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -154,12 +154,12 @@ class _$_GetCommunity extends _GetCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetCommunityCopyWith<_$_GetCommunity> get copyWith =>
-      __$$_GetCommunityCopyWithImpl<_$_GetCommunity>(this, _$identity);
+  _$$GetCommunityImplCopyWith<_$GetCommunityImpl> get copyWith =>
+      __$$GetCommunityImplCopyWithImpl<_$GetCommunityImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetCommunityToJson(
+    return _$$GetCommunityImplToJson(
       this,
     );
   }
@@ -169,11 +169,11 @@ abstract class _GetCommunity extends GetCommunity {
   const factory _GetCommunity(
       {final int? id,
       final String? name,
-      final String? auth}) = _$_GetCommunity;
+      final String? auth}) = _$GetCommunityImpl;
   const _GetCommunity._() : super._();
 
   factory _GetCommunity.fromJson(Map<String, dynamic> json) =
-      _$_GetCommunity.fromJson;
+      _$GetCommunityImpl.fromJson;
 
   @override
   int? get id;
@@ -183,7 +183,7 @@ abstract class _GetCommunity extends GetCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetCommunityCopyWith<_$_GetCommunity> get copyWith =>
+  _$$GetCommunityImplCopyWith<_$GetCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -278,11 +278,11 @@ class _$CreateCommunityCopyWithImpl<$Res, $Val extends CreateCommunity>
 }
 
 /// @nodoc
-abstract class _$$_CreateCommunityCopyWith<$Res>
+abstract class _$$CreateCommunityImplCopyWith<$Res>
     implements $CreateCommunityCopyWith<$Res> {
-  factory _$$_CreateCommunityCopyWith(
-          _$_CreateCommunity value, $Res Function(_$_CreateCommunity) then) =
-      __$$_CreateCommunityCopyWithImpl<$Res>;
+  factory _$$CreateCommunityImplCopyWith(_$CreateCommunityImpl value,
+          $Res Function(_$CreateCommunityImpl) then) =
+      __$$CreateCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -296,11 +296,11 @@ abstract class _$$_CreateCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CreateCommunityCopyWithImpl<$Res>
-    extends _$CreateCommunityCopyWithImpl<$Res, _$_CreateCommunity>
-    implements _$$_CreateCommunityCopyWith<$Res> {
-  __$$_CreateCommunityCopyWithImpl(
-      _$_CreateCommunity _value, $Res Function(_$_CreateCommunity) _then)
+class __$$CreateCommunityImplCopyWithImpl<$Res>
+    extends _$CreateCommunityCopyWithImpl<$Res, _$CreateCommunityImpl>
+    implements _$$CreateCommunityImplCopyWith<$Res> {
+  __$$CreateCommunityImplCopyWithImpl(
+      _$CreateCommunityImpl _value, $Res Function(_$CreateCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -314,7 +314,7 @@ class __$$_CreateCommunityCopyWithImpl<$Res>
     Object? nsfw = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_CreateCommunity(
+    return _then(_$CreateCommunityImpl(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -350,8 +350,8 @@ class __$$_CreateCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreateCommunity extends _CreateCommunity {
-  const _$_CreateCommunity(
+class _$CreateCommunityImpl extends _CreateCommunity {
+  const _$CreateCommunityImpl(
       {required this.name,
       required this.title,
       this.description,
@@ -361,8 +361,8 @@ class _$_CreateCommunity extends _CreateCommunity {
       required this.auth})
       : super._();
 
-  factory _$_CreateCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_CreateCommunityFromJson(json);
+  factory _$CreateCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreateCommunityImplFromJson(json);
 
   @override
   final String name;
@@ -388,7 +388,7 @@ class _$_CreateCommunity extends _CreateCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreateCommunity &&
+            other is _$CreateCommunityImpl &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.description, description) ||
@@ -407,12 +407,13 @@ class _$_CreateCommunity extends _CreateCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreateCommunityCopyWith<_$_CreateCommunity> get copyWith =>
-      __$$_CreateCommunityCopyWithImpl<_$_CreateCommunity>(this, _$identity);
+  _$$CreateCommunityImplCopyWith<_$CreateCommunityImpl> get copyWith =>
+      __$$CreateCommunityImplCopyWithImpl<_$CreateCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreateCommunityToJson(
+    return _$$CreateCommunityImplToJson(
       this,
     );
   }
@@ -426,11 +427,11 @@ abstract class _CreateCommunity extends CreateCommunity {
       final String? icon,
       final String? banner,
       final bool? nsfw,
-      required final String auth}) = _$_CreateCommunity;
+      required final String auth}) = _$CreateCommunityImpl;
   const _CreateCommunity._() : super._();
 
   factory _CreateCommunity.fromJson(Map<String, dynamic> json) =
-      _$_CreateCommunity.fromJson;
+      _$CreateCommunityImpl.fromJson;
 
   @override
   String get name;
@@ -448,7 +449,7 @@ abstract class _CreateCommunity extends CreateCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreateCommunityCopyWith<_$_CreateCommunity> get copyWith =>
+  _$$CreateCommunityImplCopyWith<_$CreateCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -530,11 +531,11 @@ class _$ListCommunitiesCopyWithImpl<$Res, $Val extends ListCommunities>
 }
 
 /// @nodoc
-abstract class _$$_ListCommunitiesCopyWith<$Res>
+abstract class _$$ListCommunitiesImplCopyWith<$Res>
     implements $ListCommunitiesCopyWith<$Res> {
-  factory _$$_ListCommunitiesCopyWith(
-          _$_ListCommunities value, $Res Function(_$_ListCommunities) then) =
-      __$$_ListCommunitiesCopyWithImpl<$Res>;
+  factory _$$ListCommunitiesImplCopyWith(_$ListCommunitiesImpl value,
+          $Res Function(_$ListCommunitiesImpl) then) =
+      __$$ListCommunitiesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -546,11 +547,11 @@ abstract class _$$_ListCommunitiesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ListCommunitiesCopyWithImpl<$Res>
-    extends _$ListCommunitiesCopyWithImpl<$Res, _$_ListCommunities>
-    implements _$$_ListCommunitiesCopyWith<$Res> {
-  __$$_ListCommunitiesCopyWithImpl(
-      _$_ListCommunities _value, $Res Function(_$_ListCommunities) _then)
+class __$$ListCommunitiesImplCopyWithImpl<$Res>
+    extends _$ListCommunitiesCopyWithImpl<$Res, _$ListCommunitiesImpl>
+    implements _$$ListCommunitiesImplCopyWith<$Res> {
+  __$$ListCommunitiesImplCopyWithImpl(
+      _$ListCommunitiesImpl _value, $Res Function(_$ListCommunitiesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -562,7 +563,7 @@ class __$$_ListCommunitiesCopyWithImpl<$Res>
     Object? limit = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_ListCommunities(
+    return _then(_$ListCommunitiesImpl(
       type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -590,8 +591,8 @@ class __$$_ListCommunitiesCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ListCommunities extends _ListCommunities {
-  const _$_ListCommunities(
+class _$ListCommunitiesImpl extends _ListCommunities {
+  const _$ListCommunitiesImpl(
       {@JsonKey(name: 'type_') this.type,
       this.sort,
       this.page,
@@ -599,8 +600,8 @@ class _$_ListCommunities extends _ListCommunities {
       this.auth})
       : super._();
 
-  factory _$_ListCommunities.fromJson(Map<String, dynamic> json) =>
-      _$$_ListCommunitiesFromJson(json);
+  factory _$ListCommunitiesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ListCommunitiesImplFromJson(json);
 
   @override
   @JsonKey(name: 'type_')
@@ -623,7 +624,7 @@ class _$_ListCommunities extends _ListCommunities {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListCommunities &&
+            other is _$ListCommunitiesImpl &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
@@ -638,12 +639,13 @@ class _$_ListCommunities extends _ListCommunities {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListCommunitiesCopyWith<_$_ListCommunities> get copyWith =>
-      __$$_ListCommunitiesCopyWithImpl<_$_ListCommunities>(this, _$identity);
+  _$$ListCommunitiesImplCopyWith<_$ListCommunitiesImpl> get copyWith =>
+      __$$ListCommunitiesImplCopyWithImpl<_$ListCommunitiesImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListCommunitiesToJson(
+    return _$$ListCommunitiesImplToJson(
       this,
     );
   }
@@ -655,11 +657,11 @@ abstract class _ListCommunities extends ListCommunities {
       final SortType? sort,
       final int? page,
       final int? limit,
-      final String? auth}) = _$_ListCommunities;
+      final String? auth}) = _$ListCommunitiesImpl;
   const _ListCommunities._() : super._();
 
   factory _ListCommunities.fromJson(Map<String, dynamic> json) =
-      _$_ListCommunities.fromJson;
+      _$ListCommunitiesImpl.fromJson;
 
   @override
   @JsonKey(name: 'type_')
@@ -674,7 +676,7 @@ abstract class _ListCommunities extends ListCommunities {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ListCommunitiesCopyWith<_$_ListCommunities> get copyWith =>
+  _$$ListCommunitiesImplCopyWith<_$ListCommunitiesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -769,11 +771,11 @@ class _$BanFromCommunityCopyWithImpl<$Res, $Val extends BanFromCommunity>
 }
 
 /// @nodoc
-abstract class _$$_BanFromCommunityCopyWith<$Res>
+abstract class _$$BanFromCommunityImplCopyWith<$Res>
     implements $BanFromCommunityCopyWith<$Res> {
-  factory _$$_BanFromCommunityCopyWith(
-          _$_BanFromCommunity value, $Res Function(_$_BanFromCommunity) then) =
-      __$$_BanFromCommunityCopyWithImpl<$Res>;
+  factory _$$BanFromCommunityImplCopyWith(_$BanFromCommunityImpl value,
+          $Res Function(_$BanFromCommunityImpl) then) =
+      __$$BanFromCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -787,11 +789,11 @@ abstract class _$$_BanFromCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_BanFromCommunityCopyWithImpl<$Res>
-    extends _$BanFromCommunityCopyWithImpl<$Res, _$_BanFromCommunity>
-    implements _$$_BanFromCommunityCopyWith<$Res> {
-  __$$_BanFromCommunityCopyWithImpl(
-      _$_BanFromCommunity _value, $Res Function(_$_BanFromCommunity) _then)
+class __$$BanFromCommunityImplCopyWithImpl<$Res>
+    extends _$BanFromCommunityCopyWithImpl<$Res, _$BanFromCommunityImpl>
+    implements _$$BanFromCommunityImplCopyWith<$Res> {
+  __$$BanFromCommunityImplCopyWithImpl(_$BanFromCommunityImpl _value,
+      $Res Function(_$BanFromCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -805,7 +807,7 @@ class __$$_BanFromCommunityCopyWithImpl<$Res>
     Object? expires = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_BanFromCommunity(
+    return _then(_$BanFromCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -841,8 +843,8 @@ class __$$_BanFromCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_BanFromCommunity extends _BanFromCommunity {
-  const _$_BanFromCommunity(
+class _$BanFromCommunityImpl extends _BanFromCommunity {
+  const _$BanFromCommunityImpl(
       {required this.communityId,
       required this.personId,
       required this.ban,
@@ -852,8 +854,8 @@ class _$_BanFromCommunity extends _BanFromCommunity {
       required this.auth})
       : super._();
 
-  factory _$_BanFromCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_BanFromCommunityFromJson(json);
+  factory _$BanFromCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BanFromCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -879,7 +881,7 @@ class _$_BanFromCommunity extends _BanFromCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BanFromCommunity &&
+            other is _$BanFromCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.personId, personId) ||
@@ -900,12 +902,13 @@ class _$_BanFromCommunity extends _BanFromCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BanFromCommunityCopyWith<_$_BanFromCommunity> get copyWith =>
-      __$$_BanFromCommunityCopyWithImpl<_$_BanFromCommunity>(this, _$identity);
+  _$$BanFromCommunityImplCopyWith<_$BanFromCommunityImpl> get copyWith =>
+      __$$BanFromCommunityImplCopyWithImpl<_$BanFromCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BanFromCommunityToJson(
+    return _$$BanFromCommunityImplToJson(
       this,
     );
   }
@@ -919,11 +922,11 @@ abstract class _BanFromCommunity extends BanFromCommunity {
       final bool? removeData,
       final String? reason,
       final int? expires,
-      required final String auth}) = _$_BanFromCommunity;
+      required final String auth}) = _$BanFromCommunityImpl;
   const _BanFromCommunity._() : super._();
 
   factory _BanFromCommunity.fromJson(Map<String, dynamic> json) =
-      _$_BanFromCommunity.fromJson;
+      _$BanFromCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -941,7 +944,7 @@ abstract class _BanFromCommunity extends BanFromCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_BanFromCommunityCopyWith<_$_BanFromCommunity> get copyWith =>
+  _$$BanFromCommunityImplCopyWith<_$BanFromCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1011,22 +1014,22 @@ class _$AddModToCommunityCopyWithImpl<$Res, $Val extends AddModToCommunity>
 }
 
 /// @nodoc
-abstract class _$$_AddModToCommunityCopyWith<$Res>
+abstract class _$$AddModToCommunityImplCopyWith<$Res>
     implements $AddModToCommunityCopyWith<$Res> {
-  factory _$$_AddModToCommunityCopyWith(_$_AddModToCommunity value,
-          $Res Function(_$_AddModToCommunity) then) =
-      __$$_AddModToCommunityCopyWithImpl<$Res>;
+  factory _$$AddModToCommunityImplCopyWith(_$AddModToCommunityImpl value,
+          $Res Function(_$AddModToCommunityImpl) then) =
+      __$$AddModToCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, int personId, bool added, String auth});
 }
 
 /// @nodoc
-class __$$_AddModToCommunityCopyWithImpl<$Res>
-    extends _$AddModToCommunityCopyWithImpl<$Res, _$_AddModToCommunity>
-    implements _$$_AddModToCommunityCopyWith<$Res> {
-  __$$_AddModToCommunityCopyWithImpl(
-      _$_AddModToCommunity _value, $Res Function(_$_AddModToCommunity) _then)
+class __$$AddModToCommunityImplCopyWithImpl<$Res>
+    extends _$AddModToCommunityCopyWithImpl<$Res, _$AddModToCommunityImpl>
+    implements _$$AddModToCommunityImplCopyWith<$Res> {
+  __$$AddModToCommunityImplCopyWithImpl(_$AddModToCommunityImpl _value,
+      $Res Function(_$AddModToCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1037,7 +1040,7 @@ class __$$_AddModToCommunityCopyWithImpl<$Res>
     Object? added = null,
     Object? auth = null,
   }) {
-    return _then(_$_AddModToCommunity(
+    return _then(_$AddModToCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1061,16 +1064,16 @@ class __$$_AddModToCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_AddModToCommunity extends _AddModToCommunity {
-  const _$_AddModToCommunity(
+class _$AddModToCommunityImpl extends _AddModToCommunity {
+  const _$AddModToCommunityImpl(
       {required this.communityId,
       required this.personId,
       required this.added,
       required this.auth})
       : super._();
 
-  factory _$_AddModToCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_AddModToCommunityFromJson(json);
+  factory _$AddModToCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AddModToCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -1090,7 +1093,7 @@ class _$_AddModToCommunity extends _AddModToCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AddModToCommunity &&
+            other is _$AddModToCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.personId, personId) ||
@@ -1107,13 +1110,13 @@ class _$_AddModToCommunity extends _AddModToCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AddModToCommunityCopyWith<_$_AddModToCommunity> get copyWith =>
-      __$$_AddModToCommunityCopyWithImpl<_$_AddModToCommunity>(
+  _$$AddModToCommunityImplCopyWith<_$AddModToCommunityImpl> get copyWith =>
+      __$$AddModToCommunityImplCopyWithImpl<_$AddModToCommunityImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AddModToCommunityToJson(
+    return _$$AddModToCommunityImplToJson(
       this,
     );
   }
@@ -1124,11 +1127,11 @@ abstract class _AddModToCommunity extends AddModToCommunity {
       {required final int communityId,
       required final int personId,
       required final bool added,
-      required final String auth}) = _$_AddModToCommunity;
+      required final String auth}) = _$AddModToCommunityImpl;
   const _AddModToCommunity._() : super._();
 
   factory _AddModToCommunity.fromJson(Map<String, dynamic> json) =
-      _$_AddModToCommunity.fromJson;
+      _$AddModToCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -1140,7 +1143,7 @@ abstract class _AddModToCommunity extends AddModToCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_AddModToCommunityCopyWith<_$_AddModToCommunity> get copyWith =>
+  _$$AddModToCommunityImplCopyWith<_$AddModToCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1235,11 +1238,11 @@ class _$EditCommunityCopyWithImpl<$Res, $Val extends EditCommunity>
 }
 
 /// @nodoc
-abstract class _$$_EditCommunityCopyWith<$Res>
+abstract class _$$EditCommunityImplCopyWith<$Res>
     implements $EditCommunityCopyWith<$Res> {
-  factory _$$_EditCommunityCopyWith(
-          _$_EditCommunity value, $Res Function(_$_EditCommunity) then) =
-      __$$_EditCommunityCopyWithImpl<$Res>;
+  factory _$$EditCommunityImplCopyWith(
+          _$EditCommunityImpl value, $Res Function(_$EditCommunityImpl) then) =
+      __$$EditCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1253,11 +1256,11 @@ abstract class _$$_EditCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_EditCommunityCopyWithImpl<$Res>
-    extends _$EditCommunityCopyWithImpl<$Res, _$_EditCommunity>
-    implements _$$_EditCommunityCopyWith<$Res> {
-  __$$_EditCommunityCopyWithImpl(
-      _$_EditCommunity _value, $Res Function(_$_EditCommunity) _then)
+class __$$EditCommunityImplCopyWithImpl<$Res>
+    extends _$EditCommunityCopyWithImpl<$Res, _$EditCommunityImpl>
+    implements _$$EditCommunityImplCopyWith<$Res> {
+  __$$EditCommunityImplCopyWithImpl(
+      _$EditCommunityImpl _value, $Res Function(_$EditCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1271,7 +1274,7 @@ class __$$_EditCommunityCopyWithImpl<$Res>
     Object? nsfw = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_EditCommunity(
+    return _then(_$EditCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1307,8 +1310,8 @@ class __$$_EditCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_EditCommunity extends _EditCommunity {
-  const _$_EditCommunity(
+class _$EditCommunityImpl extends _EditCommunity {
+  const _$EditCommunityImpl(
       {required this.communityId,
       this.title,
       this.description,
@@ -1318,8 +1321,8 @@ class _$_EditCommunity extends _EditCommunity {
       required this.auth})
       : super._();
 
-  factory _$_EditCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_EditCommunityFromJson(json);
+  factory _$EditCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EditCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -1345,7 +1348,7 @@ class _$_EditCommunity extends _EditCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_EditCommunity &&
+            other is _$EditCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.title, title) || other.title == title) &&
@@ -1365,12 +1368,12 @@ class _$_EditCommunity extends _EditCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_EditCommunityCopyWith<_$_EditCommunity> get copyWith =>
-      __$$_EditCommunityCopyWithImpl<_$_EditCommunity>(this, _$identity);
+  _$$EditCommunityImplCopyWith<_$EditCommunityImpl> get copyWith =>
+      __$$EditCommunityImplCopyWithImpl<_$EditCommunityImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_EditCommunityToJson(
+    return _$$EditCommunityImplToJson(
       this,
     );
   }
@@ -1384,11 +1387,11 @@ abstract class _EditCommunity extends EditCommunity {
       final String? icon,
       final String? banner,
       final bool? nsfw,
-      required final String auth}) = _$_EditCommunity;
+      required final String auth}) = _$EditCommunityImpl;
   const _EditCommunity._() : super._();
 
   factory _EditCommunity.fromJson(Map<String, dynamic> json) =
-      _$_EditCommunity.fromJson;
+      _$EditCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -1406,7 +1409,7 @@ abstract class _EditCommunity extends EditCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_EditCommunityCopyWith<_$_EditCommunity> get copyWith =>
+  _$$EditCommunityImplCopyWith<_$EditCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1470,22 +1473,22 @@ class _$DeleteCommunityCopyWithImpl<$Res, $Val extends DeleteCommunity>
 }
 
 /// @nodoc
-abstract class _$$_DeleteCommunityCopyWith<$Res>
+abstract class _$$DeleteCommunityImplCopyWith<$Res>
     implements $DeleteCommunityCopyWith<$Res> {
-  factory _$$_DeleteCommunityCopyWith(
-          _$_DeleteCommunity value, $Res Function(_$_DeleteCommunity) then) =
-      __$$_DeleteCommunityCopyWithImpl<$Res>;
+  factory _$$DeleteCommunityImplCopyWith(_$DeleteCommunityImpl value,
+          $Res Function(_$DeleteCommunityImpl) then) =
+      __$$DeleteCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, bool deleted, String auth});
 }
 
 /// @nodoc
-class __$$_DeleteCommunityCopyWithImpl<$Res>
-    extends _$DeleteCommunityCopyWithImpl<$Res, _$_DeleteCommunity>
-    implements _$$_DeleteCommunityCopyWith<$Res> {
-  __$$_DeleteCommunityCopyWithImpl(
-      _$_DeleteCommunity _value, $Res Function(_$_DeleteCommunity) _then)
+class __$$DeleteCommunityImplCopyWithImpl<$Res>
+    extends _$DeleteCommunityCopyWithImpl<$Res, _$DeleteCommunityImpl>
+    implements _$$DeleteCommunityImplCopyWith<$Res> {
+  __$$DeleteCommunityImplCopyWithImpl(
+      _$DeleteCommunityImpl _value, $Res Function(_$DeleteCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1495,7 +1498,7 @@ class __$$_DeleteCommunityCopyWithImpl<$Res>
     Object? deleted = null,
     Object? auth = null,
   }) {
-    return _then(_$_DeleteCommunity(
+    return _then(_$DeleteCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1515,13 +1518,13 @@ class __$$_DeleteCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_DeleteCommunity extends _DeleteCommunity {
-  const _$_DeleteCommunity(
+class _$DeleteCommunityImpl extends _DeleteCommunity {
+  const _$DeleteCommunityImpl(
       {required this.communityId, required this.deleted, required this.auth})
       : super._();
 
-  factory _$_DeleteCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_DeleteCommunityFromJson(json);
+  factory _$DeleteCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeleteCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -1539,7 +1542,7 @@ class _$_DeleteCommunity extends _DeleteCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeleteCommunity &&
+            other is _$DeleteCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.deleted, deleted) || other.deleted == deleted) &&
@@ -1553,12 +1556,13 @@ class _$_DeleteCommunity extends _DeleteCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeleteCommunityCopyWith<_$_DeleteCommunity> get copyWith =>
-      __$$_DeleteCommunityCopyWithImpl<_$_DeleteCommunity>(this, _$identity);
+  _$$DeleteCommunityImplCopyWith<_$DeleteCommunityImpl> get copyWith =>
+      __$$DeleteCommunityImplCopyWithImpl<_$DeleteCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeleteCommunityToJson(
+    return _$$DeleteCommunityImplToJson(
       this,
     );
   }
@@ -1568,11 +1572,11 @@ abstract class _DeleteCommunity extends DeleteCommunity {
   const factory _DeleteCommunity(
       {required final int communityId,
       required final bool deleted,
-      required final String auth}) = _$_DeleteCommunity;
+      required final String auth}) = _$DeleteCommunityImpl;
   const _DeleteCommunity._() : super._();
 
   factory _DeleteCommunity.fromJson(Map<String, dynamic> json) =
-      _$_DeleteCommunity.fromJson;
+      _$DeleteCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -1582,7 +1586,7 @@ abstract class _DeleteCommunity extends DeleteCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_DeleteCommunityCopyWith<_$_DeleteCommunity> get copyWith =>
+  _$$DeleteCommunityImplCopyWith<_$DeleteCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1663,11 +1667,11 @@ class _$RemoveCommunityCopyWithImpl<$Res, $Val extends RemoveCommunity>
 }
 
 /// @nodoc
-abstract class _$$_RemoveCommunityCopyWith<$Res>
+abstract class _$$RemoveCommunityImplCopyWith<$Res>
     implements $RemoveCommunityCopyWith<$Res> {
-  factory _$$_RemoveCommunityCopyWith(
-          _$_RemoveCommunity value, $Res Function(_$_RemoveCommunity) then) =
-      __$$_RemoveCommunityCopyWithImpl<$Res>;
+  factory _$$RemoveCommunityImplCopyWith(_$RemoveCommunityImpl value,
+          $Res Function(_$RemoveCommunityImpl) then) =
+      __$$RemoveCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1679,11 +1683,11 @@ abstract class _$$_RemoveCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_RemoveCommunityCopyWithImpl<$Res>
-    extends _$RemoveCommunityCopyWithImpl<$Res, _$_RemoveCommunity>
-    implements _$$_RemoveCommunityCopyWith<$Res> {
-  __$$_RemoveCommunityCopyWithImpl(
-      _$_RemoveCommunity _value, $Res Function(_$_RemoveCommunity) _then)
+class __$$RemoveCommunityImplCopyWithImpl<$Res>
+    extends _$RemoveCommunityCopyWithImpl<$Res, _$RemoveCommunityImpl>
+    implements _$$RemoveCommunityImplCopyWith<$Res> {
+  __$$RemoveCommunityImplCopyWithImpl(
+      _$RemoveCommunityImpl _value, $Res Function(_$RemoveCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1695,7 +1699,7 @@ class __$$_RemoveCommunityCopyWithImpl<$Res>
     Object? expires = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_RemoveCommunity(
+    return _then(_$RemoveCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1723,8 +1727,8 @@ class __$$_RemoveCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_RemoveCommunity extends _RemoveCommunity {
-  const _$_RemoveCommunity(
+class _$RemoveCommunityImpl extends _RemoveCommunity {
+  const _$RemoveCommunityImpl(
       {required this.communityId,
       required this.removed,
       this.reason,
@@ -1732,8 +1736,8 @@ class _$_RemoveCommunity extends _RemoveCommunity {
       required this.auth})
       : super._();
 
-  factory _$_RemoveCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_RemoveCommunityFromJson(json);
+  factory _$RemoveCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RemoveCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -1755,7 +1759,7 @@ class _$_RemoveCommunity extends _RemoveCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_RemoveCommunity &&
+            other is _$RemoveCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.removed, removed) || other.removed == removed) &&
@@ -1772,12 +1776,13 @@ class _$_RemoveCommunity extends _RemoveCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RemoveCommunityCopyWith<_$_RemoveCommunity> get copyWith =>
-      __$$_RemoveCommunityCopyWithImpl<_$_RemoveCommunity>(this, _$identity);
+  _$$RemoveCommunityImplCopyWith<_$RemoveCommunityImpl> get copyWith =>
+      __$$RemoveCommunityImplCopyWithImpl<_$RemoveCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RemoveCommunityToJson(
+    return _$$RemoveCommunityImplToJson(
       this,
     );
   }
@@ -1789,11 +1794,11 @@ abstract class _RemoveCommunity extends RemoveCommunity {
       required final bool removed,
       final String? reason,
       final int? expires,
-      required final String auth}) = _$_RemoveCommunity;
+      required final String auth}) = _$RemoveCommunityImpl;
   const _RemoveCommunity._() : super._();
 
   factory _RemoveCommunity.fromJson(Map<String, dynamic> json) =
-      _$_RemoveCommunity.fromJson;
+      _$RemoveCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -1807,7 +1812,7 @@ abstract class _RemoveCommunity extends RemoveCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_RemoveCommunityCopyWith<_$_RemoveCommunity> get copyWith =>
+  _$$RemoveCommunityImplCopyWith<_$RemoveCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1871,22 +1876,22 @@ class _$FollowCommunityCopyWithImpl<$Res, $Val extends FollowCommunity>
 }
 
 /// @nodoc
-abstract class _$$_FollowCommunityCopyWith<$Res>
+abstract class _$$FollowCommunityImplCopyWith<$Res>
     implements $FollowCommunityCopyWith<$Res> {
-  factory _$$_FollowCommunityCopyWith(
-          _$_FollowCommunity value, $Res Function(_$_FollowCommunity) then) =
-      __$$_FollowCommunityCopyWithImpl<$Res>;
+  factory _$$FollowCommunityImplCopyWith(_$FollowCommunityImpl value,
+          $Res Function(_$FollowCommunityImpl) then) =
+      __$$FollowCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, bool follow, String auth});
 }
 
 /// @nodoc
-class __$$_FollowCommunityCopyWithImpl<$Res>
-    extends _$FollowCommunityCopyWithImpl<$Res, _$_FollowCommunity>
-    implements _$$_FollowCommunityCopyWith<$Res> {
-  __$$_FollowCommunityCopyWithImpl(
-      _$_FollowCommunity _value, $Res Function(_$_FollowCommunity) _then)
+class __$$FollowCommunityImplCopyWithImpl<$Res>
+    extends _$FollowCommunityCopyWithImpl<$Res, _$FollowCommunityImpl>
+    implements _$$FollowCommunityImplCopyWith<$Res> {
+  __$$FollowCommunityImplCopyWithImpl(
+      _$FollowCommunityImpl _value, $Res Function(_$FollowCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1896,7 +1901,7 @@ class __$$_FollowCommunityCopyWithImpl<$Res>
     Object? follow = null,
     Object? auth = null,
   }) {
-    return _then(_$_FollowCommunity(
+    return _then(_$FollowCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1916,13 +1921,13 @@ class __$$_FollowCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_FollowCommunity extends _FollowCommunity {
-  const _$_FollowCommunity(
+class _$FollowCommunityImpl extends _FollowCommunity {
+  const _$FollowCommunityImpl(
       {required this.communityId, required this.follow, required this.auth})
       : super._();
 
-  factory _$_FollowCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_FollowCommunityFromJson(json);
+  factory _$FollowCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FollowCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -1940,7 +1945,7 @@ class _$_FollowCommunity extends _FollowCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FollowCommunity &&
+            other is _$FollowCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.follow, follow) || other.follow == follow) &&
@@ -1954,12 +1959,13 @@ class _$_FollowCommunity extends _FollowCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FollowCommunityCopyWith<_$_FollowCommunity> get copyWith =>
-      __$$_FollowCommunityCopyWithImpl<_$_FollowCommunity>(this, _$identity);
+  _$$FollowCommunityImplCopyWith<_$FollowCommunityImpl> get copyWith =>
+      __$$FollowCommunityImplCopyWithImpl<_$FollowCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FollowCommunityToJson(
+    return _$$FollowCommunityImplToJson(
       this,
     );
   }
@@ -1969,11 +1975,11 @@ abstract class _FollowCommunity extends FollowCommunity {
   const factory _FollowCommunity(
       {required final int communityId,
       required final bool follow,
-      required final String auth}) = _$_FollowCommunity;
+      required final String auth}) = _$FollowCommunityImpl;
   const _FollowCommunity._() : super._();
 
   factory _FollowCommunity.fromJson(Map<String, dynamic> json) =
-      _$_FollowCommunity.fromJson;
+      _$FollowCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -1983,7 +1989,7 @@ abstract class _FollowCommunity extends FollowCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_FollowCommunityCopyWith<_$_FollowCommunity> get copyWith =>
+  _$$FollowCommunityImplCopyWith<_$FollowCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2047,22 +2053,22 @@ class _$TransferCommunityCopyWithImpl<$Res, $Val extends TransferCommunity>
 }
 
 /// @nodoc
-abstract class _$$_TransferCommunityCopyWith<$Res>
+abstract class _$$TransferCommunityImplCopyWith<$Res>
     implements $TransferCommunityCopyWith<$Res> {
-  factory _$$_TransferCommunityCopyWith(_$_TransferCommunity value,
-          $Res Function(_$_TransferCommunity) then) =
-      __$$_TransferCommunityCopyWithImpl<$Res>;
+  factory _$$TransferCommunityImplCopyWith(_$TransferCommunityImpl value,
+          $Res Function(_$TransferCommunityImpl) then) =
+      __$$TransferCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, int personId, String auth});
 }
 
 /// @nodoc
-class __$$_TransferCommunityCopyWithImpl<$Res>
-    extends _$TransferCommunityCopyWithImpl<$Res, _$_TransferCommunity>
-    implements _$$_TransferCommunityCopyWith<$Res> {
-  __$$_TransferCommunityCopyWithImpl(
-      _$_TransferCommunity _value, $Res Function(_$_TransferCommunity) _then)
+class __$$TransferCommunityImplCopyWithImpl<$Res>
+    extends _$TransferCommunityCopyWithImpl<$Res, _$TransferCommunityImpl>
+    implements _$$TransferCommunityImplCopyWith<$Res> {
+  __$$TransferCommunityImplCopyWithImpl(_$TransferCommunityImpl _value,
+      $Res Function(_$TransferCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2072,7 +2078,7 @@ class __$$_TransferCommunityCopyWithImpl<$Res>
     Object? personId = null,
     Object? auth = null,
   }) {
-    return _then(_$_TransferCommunity(
+    return _then(_$TransferCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -2092,13 +2098,13 @@ class __$$_TransferCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_TransferCommunity extends _TransferCommunity {
-  const _$_TransferCommunity(
+class _$TransferCommunityImpl extends _TransferCommunity {
+  const _$TransferCommunityImpl(
       {required this.communityId, required this.personId, required this.auth})
       : super._();
 
-  factory _$_TransferCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_TransferCommunityFromJson(json);
+  factory _$TransferCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TransferCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -2116,7 +2122,7 @@ class _$_TransferCommunity extends _TransferCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_TransferCommunity &&
+            other is _$TransferCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.personId, personId) ||
@@ -2131,13 +2137,13 @@ class _$_TransferCommunity extends _TransferCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_TransferCommunityCopyWith<_$_TransferCommunity> get copyWith =>
-      __$$_TransferCommunityCopyWithImpl<_$_TransferCommunity>(
+  _$$TransferCommunityImplCopyWith<_$TransferCommunityImpl> get copyWith =>
+      __$$TransferCommunityImplCopyWithImpl<_$TransferCommunityImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_TransferCommunityToJson(
+    return _$$TransferCommunityImplToJson(
       this,
     );
   }
@@ -2147,11 +2153,11 @@ abstract class _TransferCommunity extends TransferCommunity {
   const factory _TransferCommunity(
       {required final int communityId,
       required final int personId,
-      required final String auth}) = _$_TransferCommunity;
+      required final String auth}) = _$TransferCommunityImpl;
   const _TransferCommunity._() : super._();
 
   factory _TransferCommunity.fromJson(Map<String, dynamic> json) =
-      _$_TransferCommunity.fromJson;
+      _$TransferCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -2161,7 +2167,7 @@ abstract class _TransferCommunity extends TransferCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_TransferCommunityCopyWith<_$_TransferCommunity> get copyWith =>
+  _$$TransferCommunityImplCopyWith<_$TransferCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2225,22 +2231,22 @@ class _$BlockCommunityCopyWithImpl<$Res, $Val extends BlockCommunity>
 }
 
 /// @nodoc
-abstract class _$$_BlockCommunityCopyWith<$Res>
+abstract class _$$BlockCommunityImplCopyWith<$Res>
     implements $BlockCommunityCopyWith<$Res> {
-  factory _$$_BlockCommunityCopyWith(
-          _$_BlockCommunity value, $Res Function(_$_BlockCommunity) then) =
-      __$$_BlockCommunityCopyWithImpl<$Res>;
+  factory _$$BlockCommunityImplCopyWith(_$BlockCommunityImpl value,
+          $Res Function(_$BlockCommunityImpl) then) =
+      __$$BlockCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, bool block, String auth});
 }
 
 /// @nodoc
-class __$$_BlockCommunityCopyWithImpl<$Res>
-    extends _$BlockCommunityCopyWithImpl<$Res, _$_BlockCommunity>
-    implements _$$_BlockCommunityCopyWith<$Res> {
-  __$$_BlockCommunityCopyWithImpl(
-      _$_BlockCommunity _value, $Res Function(_$_BlockCommunity) _then)
+class __$$BlockCommunityImplCopyWithImpl<$Res>
+    extends _$BlockCommunityCopyWithImpl<$Res, _$BlockCommunityImpl>
+    implements _$$BlockCommunityImplCopyWith<$Res> {
+  __$$BlockCommunityImplCopyWithImpl(
+      _$BlockCommunityImpl _value, $Res Function(_$BlockCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2250,7 +2256,7 @@ class __$$_BlockCommunityCopyWithImpl<$Res>
     Object? block = null,
     Object? auth = null,
   }) {
-    return _then(_$_BlockCommunity(
+    return _then(_$BlockCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -2270,13 +2276,13 @@ class __$$_BlockCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_BlockCommunity extends _BlockCommunity {
-  const _$_BlockCommunity(
+class _$BlockCommunityImpl extends _BlockCommunity {
+  const _$BlockCommunityImpl(
       {required this.communityId, required this.block, required this.auth})
       : super._();
 
-  factory _$_BlockCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_BlockCommunityFromJson(json);
+  factory _$BlockCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BlockCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -2294,7 +2300,7 @@ class _$_BlockCommunity extends _BlockCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BlockCommunity &&
+            other is _$BlockCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.block, block) || other.block == block) &&
@@ -2308,12 +2314,13 @@ class _$_BlockCommunity extends _BlockCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BlockCommunityCopyWith<_$_BlockCommunity> get copyWith =>
-      __$$_BlockCommunityCopyWithImpl<_$_BlockCommunity>(this, _$identity);
+  _$$BlockCommunityImplCopyWith<_$BlockCommunityImpl> get copyWith =>
+      __$$BlockCommunityImplCopyWithImpl<_$BlockCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BlockCommunityToJson(
+    return _$$BlockCommunityImplToJson(
       this,
     );
   }
@@ -2323,11 +2330,11 @@ abstract class _BlockCommunity extends BlockCommunity {
   const factory _BlockCommunity(
       {required final int communityId,
       required final bool block,
-      required final String auth}) = _$_BlockCommunity;
+      required final String auth}) = _$BlockCommunityImpl;
   const _BlockCommunity._() : super._();
 
   factory _BlockCommunity.fromJson(Map<String, dynamic> json) =
-      _$_BlockCommunity.fromJson;
+      _$BlockCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -2337,6 +2344,6 @@ abstract class _BlockCommunity extends BlockCommunity {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_BlockCommunityCopyWith<_$_BlockCommunity> get copyWith =>
+  _$$BlockCommunityImplCopyWith<_$BlockCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/community.g.dart
+++ b/lib/src/v3/api/community.g.dart
@@ -6,14 +6,14 @@ part of 'community.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetCommunity _$$_GetCommunityFromJson(Map<String, dynamic> json) =>
-    _$_GetCommunity(
+_$GetCommunityImpl _$$GetCommunityImplFromJson(Map<String, dynamic> json) =>
+    _$GetCommunityImpl(
       id: json['id'] as int?,
       name: json['name'] as String?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetCommunityToJson(_$_GetCommunity instance) {
+Map<String, dynamic> _$$GetCommunityImplToJson(_$GetCommunityImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -28,8 +28,9 @@ Map<String, dynamic> _$$_GetCommunityToJson(_$_GetCommunity instance) {
   return val;
 }
 
-_$_CreateCommunity _$$_CreateCommunityFromJson(Map<String, dynamic> json) =>
-    _$_CreateCommunity(
+_$CreateCommunityImpl _$$CreateCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CreateCommunityImpl(
       name: json['name'] as String,
       title: json['title'] as String,
       description: json['description'] as String?,
@@ -39,7 +40,8 @@ _$_CreateCommunity _$$_CreateCommunityFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_CreateCommunityToJson(_$_CreateCommunity instance) {
+Map<String, dynamic> _$$CreateCommunityImplToJson(
+    _$CreateCommunityImpl instance) {
   final val = <String, dynamic>{
     'name': instance.name,
     'title': instance.title,
@@ -59,8 +61,9 @@ Map<String, dynamic> _$$_CreateCommunityToJson(_$_CreateCommunity instance) {
   return val;
 }
 
-_$_ListCommunities _$$_ListCommunitiesFromJson(Map<String, dynamic> json) =>
-    _$_ListCommunities(
+_$ListCommunitiesImpl _$$ListCommunitiesImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ListCommunitiesImpl(
       type: json['type_'] == null
           ? null
           : PostListingType.fromJson(json['type_']),
@@ -70,7 +73,8 @@ _$_ListCommunities _$$_ListCommunitiesFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ListCommunitiesToJson(_$_ListCommunities instance) {
+Map<String, dynamic> _$$ListCommunitiesImplToJson(
+    _$ListCommunitiesImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -87,8 +91,9 @@ Map<String, dynamic> _$$_ListCommunitiesToJson(_$_ListCommunities instance) {
   return val;
 }
 
-_$_BanFromCommunity _$$_BanFromCommunityFromJson(Map<String, dynamic> json) =>
-    _$_BanFromCommunity(
+_$BanFromCommunityImpl _$$BanFromCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$BanFromCommunityImpl(
       communityId: json['community_id'] as int,
       personId: json['person_id'] as int,
       ban: json['ban'] as bool,
@@ -98,7 +103,8 @@ _$_BanFromCommunity _$$_BanFromCommunityFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_BanFromCommunityToJson(_$_BanFromCommunity instance) {
+Map<String, dynamic> _$$BanFromCommunityImplToJson(
+    _$BanFromCommunityImpl instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
     'person_id': instance.personId,
@@ -118,16 +124,17 @@ Map<String, dynamic> _$$_BanFromCommunityToJson(_$_BanFromCommunity instance) {
   return val;
 }
 
-_$_AddModToCommunity _$$_AddModToCommunityFromJson(Map<String, dynamic> json) =>
-    _$_AddModToCommunity(
+_$AddModToCommunityImpl _$$AddModToCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$AddModToCommunityImpl(
       communityId: json['community_id'] as int,
       personId: json['person_id'] as int,
       added: json['added'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_AddModToCommunityToJson(
-        _$_AddModToCommunity instance) =>
+Map<String, dynamic> _$$AddModToCommunityImplToJson(
+        _$AddModToCommunityImpl instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'person_id': instance.personId,
@@ -135,8 +142,8 @@ Map<String, dynamic> _$$_AddModToCommunityToJson(
       'auth': instance.auth,
     };
 
-_$_EditCommunity _$$_EditCommunityFromJson(Map<String, dynamic> json) =>
-    _$_EditCommunity(
+_$EditCommunityImpl _$$EditCommunityImplFromJson(Map<String, dynamic> json) =>
+    _$EditCommunityImpl(
       communityId: json['community_id'] as int,
       title: json['title'] as String?,
       description: json['description'] as String?,
@@ -146,7 +153,7 @@ _$_EditCommunity _$$_EditCommunityFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_EditCommunityToJson(_$_EditCommunity instance) {
+Map<String, dynamic> _$$EditCommunityImplToJson(_$EditCommunityImpl instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
   };
@@ -166,22 +173,25 @@ Map<String, dynamic> _$$_EditCommunityToJson(_$_EditCommunity instance) {
   return val;
 }
 
-_$_DeleteCommunity _$$_DeleteCommunityFromJson(Map<String, dynamic> json) =>
-    _$_DeleteCommunity(
+_$DeleteCommunityImpl _$$DeleteCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$DeleteCommunityImpl(
       communityId: json['community_id'] as int,
       deleted: json['deleted'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_DeleteCommunityToJson(_$_DeleteCommunity instance) =>
+Map<String, dynamic> _$$DeleteCommunityImplToJson(
+        _$DeleteCommunityImpl instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'deleted': instance.deleted,
       'auth': instance.auth,
     };
 
-_$_RemoveCommunity _$$_RemoveCommunityFromJson(Map<String, dynamic> json) =>
-    _$_RemoveCommunity(
+_$RemoveCommunityImpl _$$RemoveCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$RemoveCommunityImpl(
       communityId: json['community_id'] as int,
       removed: json['removed'] as bool,
       reason: json['reason'] as String?,
@@ -189,7 +199,8 @@ _$_RemoveCommunity _$$_RemoveCommunityFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_RemoveCommunityToJson(_$_RemoveCommunity instance) {
+Map<String, dynamic> _$$RemoveCommunityImplToJson(
+    _$RemoveCommunityImpl instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
     'removed': instance.removed,
@@ -207,43 +218,47 @@ Map<String, dynamic> _$$_RemoveCommunityToJson(_$_RemoveCommunity instance) {
   return val;
 }
 
-_$_FollowCommunity _$$_FollowCommunityFromJson(Map<String, dynamic> json) =>
-    _$_FollowCommunity(
+_$FollowCommunityImpl _$$FollowCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$FollowCommunityImpl(
       communityId: json['community_id'] as int,
       follow: json['follow'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_FollowCommunityToJson(_$_FollowCommunity instance) =>
+Map<String, dynamic> _$$FollowCommunityImplToJson(
+        _$FollowCommunityImpl instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'follow': instance.follow,
       'auth': instance.auth,
     };
 
-_$_TransferCommunity _$$_TransferCommunityFromJson(Map<String, dynamic> json) =>
-    _$_TransferCommunity(
+_$TransferCommunityImpl _$$TransferCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$TransferCommunityImpl(
       communityId: json['community_id'] as int,
       personId: json['person_id'] as int,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_TransferCommunityToJson(
-        _$_TransferCommunity instance) =>
+Map<String, dynamic> _$$TransferCommunityImplToJson(
+        _$TransferCommunityImpl instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'person_id': instance.personId,
       'auth': instance.auth,
     };
 
-_$_BlockCommunity _$$_BlockCommunityFromJson(Map<String, dynamic> json) =>
-    _$_BlockCommunity(
+_$BlockCommunityImpl _$$BlockCommunityImplFromJson(Map<String, dynamic> json) =>
+    _$BlockCommunityImpl(
       communityId: json['community_id'] as int,
       block: json['block'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_BlockCommunityToJson(_$_BlockCommunity instance) =>
+Map<String, dynamic> _$$BlockCommunityImplToJson(
+        _$BlockCommunityImpl instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'block': instance.block,

--- a/lib/src/v3/api/person.freezed.dart
+++ b/lib/src/v3/api/person.freezed.dart
@@ -76,9 +76,10 @@ class _$LoginCopyWithImpl<$Res, $Val extends Login>
 }
 
 /// @nodoc
-abstract class _$$_LoginCopyWith<$Res> implements $LoginCopyWith<$Res> {
-  factory _$$_LoginCopyWith(_$_Login value, $Res Function(_$_Login) then) =
-      __$$_LoginCopyWithImpl<$Res>;
+abstract class _$$LoginImplCopyWith<$Res> implements $LoginCopyWith<$Res> {
+  factory _$$LoginImplCopyWith(
+          _$LoginImpl value, $Res Function(_$LoginImpl) then) =
+      __$$LoginImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -88,9 +89,11 @@ abstract class _$$_LoginCopyWith<$Res> implements $LoginCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_LoginCopyWithImpl<$Res> extends _$LoginCopyWithImpl<$Res, _$_Login>
-    implements _$$_LoginCopyWith<$Res> {
-  __$$_LoginCopyWithImpl(_$_Login _value, $Res Function(_$_Login) _then)
+class __$$LoginImplCopyWithImpl<$Res>
+    extends _$LoginCopyWithImpl<$Res, _$LoginImpl>
+    implements _$$LoginImplCopyWith<$Res> {
+  __$$LoginImplCopyWithImpl(
+      _$LoginImpl _value, $Res Function(_$LoginImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -100,7 +103,7 @@ class __$$_LoginCopyWithImpl<$Res> extends _$LoginCopyWithImpl<$Res, _$_Login>
     Object? password = null,
     Object? totp2faToken = freezed,
   }) {
-    return _then(_$_Login(
+    return _then(_$LoginImpl(
       usernameOrEmail: null == usernameOrEmail
           ? _value.usernameOrEmail
           : usernameOrEmail // ignore: cast_nullable_to_non_nullable
@@ -120,15 +123,15 @@ class __$$_LoginCopyWithImpl<$Res> extends _$LoginCopyWithImpl<$Res, _$_Login>
 /// @nodoc
 
 @apiSerde
-class _$_Login extends _Login {
-  const _$_Login(
+class _$LoginImpl extends _Login {
+  const _$LoginImpl(
       {required this.usernameOrEmail,
       required this.password,
       @JsonKey(name: 'totp_2fa_token') this.totp2faToken})
       : super._();
 
-  factory _$_Login.fromJson(Map<String, dynamic> json) =>
-      _$$_LoginFromJson(json);
+  factory _$LoginImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LoginImplFromJson(json);
 
   @override
   final String usernameOrEmail;
@@ -147,7 +150,7 @@ class _$_Login extends _Login {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Login &&
+            other is _$LoginImpl &&
             (identical(other.usernameOrEmail, usernameOrEmail) ||
                 other.usernameOrEmail == usernameOrEmail) &&
             (identical(other.password, password) ||
@@ -164,12 +167,12 @@ class _$_Login extends _Login {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LoginCopyWith<_$_Login> get copyWith =>
-      __$$_LoginCopyWithImpl<_$_Login>(this, _$identity);
+  _$$LoginImplCopyWith<_$LoginImpl> get copyWith =>
+      __$$LoginImplCopyWithImpl<_$LoginImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LoginToJson(
+    return _$$LoginImplToJson(
       this,
     );
   }
@@ -177,12 +180,13 @@ class _$_Login extends _Login {
 
 abstract class _Login extends Login {
   const factory _Login(
-      {required final String usernameOrEmail,
-      required final String password,
-      @JsonKey(name: 'totp_2fa_token') final String? totp2faToken}) = _$_Login;
+          {required final String usernameOrEmail,
+          required final String password,
+          @JsonKey(name: 'totp_2fa_token') final String? totp2faToken}) =
+      _$LoginImpl;
   const _Login._() : super._();
 
-  factory _Login.fromJson(Map<String, dynamic> json) = _$_Login.fromJson;
+  factory _Login.fromJson(Map<String, dynamic> json) = _$LoginImpl.fromJson;
 
   @override
   String get usernameOrEmail;
@@ -193,7 +197,7 @@ abstract class _Login extends Login {
   String? get totp2faToken;
   @override
   @JsonKey(ignore: true)
-  _$$_LoginCopyWith<_$_Login> get copyWith =>
+  _$$LoginImplCopyWith<_$LoginImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -301,10 +305,11 @@ class _$RegisterCopyWithImpl<$Res, $Val extends Register>
 }
 
 /// @nodoc
-abstract class _$$_RegisterCopyWith<$Res> implements $RegisterCopyWith<$Res> {
-  factory _$$_RegisterCopyWith(
-          _$_Register value, $Res Function(_$_Register) then) =
-      __$$_RegisterCopyWithImpl<$Res>;
+abstract class _$$RegisterImplCopyWith<$Res>
+    implements $RegisterCopyWith<$Res> {
+  factory _$$RegisterImplCopyWith(
+          _$RegisterImpl value, $Res Function(_$RegisterImpl) then) =
+      __$$RegisterImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -320,11 +325,11 @@ abstract class _$$_RegisterCopyWith<$Res> implements $RegisterCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_RegisterCopyWithImpl<$Res>
-    extends _$RegisterCopyWithImpl<$Res, _$_Register>
-    implements _$$_RegisterCopyWith<$Res> {
-  __$$_RegisterCopyWithImpl(
-      _$_Register _value, $Res Function(_$_Register) _then)
+class __$$RegisterImplCopyWithImpl<$Res>
+    extends _$RegisterCopyWithImpl<$Res, _$RegisterImpl>
+    implements _$$RegisterImplCopyWith<$Res> {
+  __$$RegisterImplCopyWithImpl(
+      _$RegisterImpl _value, $Res Function(_$RegisterImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -340,7 +345,7 @@ class __$$_RegisterCopyWithImpl<$Res>
     Object? honeypot = freezed,
     Object? answer = freezed,
   }) {
-    return _then(_$_Register(
+    return _then(_$RegisterImpl(
       username: null == username
           ? _value.username
           : username // ignore: cast_nullable_to_non_nullable
@@ -384,8 +389,8 @@ class __$$_RegisterCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_Register extends _Register {
-  const _$_Register(
+class _$RegisterImpl extends _Register {
+  const _$RegisterImpl(
       {required this.username,
       this.email,
       required this.password,
@@ -397,8 +402,8 @@ class _$_Register extends _Register {
       this.answer})
       : super._();
 
-  factory _$_Register.fromJson(Map<String, dynamic> json) =>
-      _$$_RegisterFromJson(json);
+  factory _$RegisterImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RegisterImplFromJson(json);
 
   @override
   final String username;
@@ -428,7 +433,7 @@ class _$_Register extends _Register {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Register &&
+            other is _$RegisterImpl &&
             (identical(other.username, username) ||
                 other.username == username) &&
             (identical(other.email, email) || other.email == email) &&
@@ -455,12 +460,12 @@ class _$_Register extends _Register {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RegisterCopyWith<_$_Register> get copyWith =>
-      __$$_RegisterCopyWithImpl<_$_Register>(this, _$identity);
+  _$$RegisterImplCopyWith<_$RegisterImpl> get copyWith =>
+      __$$RegisterImplCopyWithImpl<_$RegisterImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RegisterToJson(
+    return _$$RegisterImplToJson(
       this,
     );
   }
@@ -476,10 +481,11 @@ abstract class _Register extends Register {
       final String? captchaUuid,
       final String? captchaAnswer,
       final String? honeypot,
-      final String? answer}) = _$_Register;
+      final String? answer}) = _$RegisterImpl;
   const _Register._() : super._();
 
-  factory _Register.fromJson(Map<String, dynamic> json) = _$_Register.fromJson;
+  factory _Register.fromJson(Map<String, dynamic> json) =
+      _$RegisterImpl.fromJson;
 
   @override
   String get username;
@@ -501,7 +507,7 @@ abstract class _Register extends Register {
   String? get answer;
   @override
   @JsonKey(ignore: true)
-  _$$_RegisterCopyWith<_$_Register> get copyWith =>
+  _$$RegisterImplCopyWith<_$RegisterImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -533,29 +539,29 @@ class _$GetCaptchaCopyWithImpl<$Res, $Val extends GetCaptcha>
 }
 
 /// @nodoc
-abstract class _$$_GetCaptchaCopyWith<$Res> {
-  factory _$$_GetCaptchaCopyWith(
-          _$_GetCaptcha value, $Res Function(_$_GetCaptcha) then) =
-      __$$_GetCaptchaCopyWithImpl<$Res>;
+abstract class _$$GetCaptchaImplCopyWith<$Res> {
+  factory _$$GetCaptchaImplCopyWith(
+          _$GetCaptchaImpl value, $Res Function(_$GetCaptchaImpl) then) =
+      __$$GetCaptchaImplCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$_GetCaptchaCopyWithImpl<$Res>
-    extends _$GetCaptchaCopyWithImpl<$Res, _$_GetCaptcha>
-    implements _$$_GetCaptchaCopyWith<$Res> {
-  __$$_GetCaptchaCopyWithImpl(
-      _$_GetCaptcha _value, $Res Function(_$_GetCaptcha) _then)
+class __$$GetCaptchaImplCopyWithImpl<$Res>
+    extends _$GetCaptchaCopyWithImpl<$Res, _$GetCaptchaImpl>
+    implements _$$GetCaptchaImplCopyWith<$Res> {
+  __$$GetCaptchaImplCopyWithImpl(
+      _$GetCaptchaImpl _value, $Res Function(_$GetCaptchaImpl) _then)
       : super(_value, _then);
 }
 
 /// @nodoc
 
 @apiSerde
-class _$_GetCaptcha extends _GetCaptcha {
-  const _$_GetCaptcha() : super._();
+class _$GetCaptchaImpl extends _GetCaptcha {
+  const _$GetCaptchaImpl() : super._();
 
-  factory _$_GetCaptcha.fromJson(Map<String, dynamic> json) =>
-      _$$_GetCaptchaFromJson(json);
+  factory _$GetCaptchaImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetCaptchaImplFromJson(json);
 
   @override
   String toString() {
@@ -565,7 +571,7 @@ class _$_GetCaptcha extends _GetCaptcha {
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$_GetCaptcha);
+        (other.runtimeType == runtimeType && other is _$GetCaptchaImpl);
   }
 
   @JsonKey(ignore: true)
@@ -574,18 +580,18 @@ class _$_GetCaptcha extends _GetCaptcha {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetCaptchaToJson(
+    return _$$GetCaptchaImplToJson(
       this,
     );
   }
 }
 
 abstract class _GetCaptcha extends GetCaptcha {
-  const factory _GetCaptcha() = _$_GetCaptcha;
+  const factory _GetCaptcha() = _$GetCaptchaImpl;
   const _GetCaptcha._() : super._();
 
   factory _GetCaptcha.fromJson(Map<String, dynamic> json) =
-      _$_GetCaptcha.fromJson;
+      _$GetCaptchaImpl.fromJson;
 }
 
 SaveUserSettings _$SaveUserSettingsFromJson(Map<String, dynamic> json) {
@@ -770,11 +776,11 @@ class _$SaveUserSettingsCopyWithImpl<$Res, $Val extends SaveUserSettings>
 }
 
 /// @nodoc
-abstract class _$$_SaveUserSettingsCopyWith<$Res>
+abstract class _$$SaveUserSettingsImplCopyWith<$Res>
     implements $SaveUserSettingsCopyWith<$Res> {
-  factory _$$_SaveUserSettingsCopyWith(
-          _$_SaveUserSettings value, $Res Function(_$_SaveUserSettings) then) =
-      __$$_SaveUserSettingsCopyWithImpl<$Res>;
+  factory _$$SaveUserSettingsImplCopyWith(_$SaveUserSettingsImpl value,
+          $Res Function(_$SaveUserSettingsImpl) then) =
+      __$$SaveUserSettingsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -801,11 +807,11 @@ abstract class _$$_SaveUserSettingsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_SaveUserSettingsCopyWithImpl<$Res>
-    extends _$SaveUserSettingsCopyWithImpl<$Res, _$_SaveUserSettings>
-    implements _$$_SaveUserSettingsCopyWith<$Res> {
-  __$$_SaveUserSettingsCopyWithImpl(
-      _$_SaveUserSettings _value, $Res Function(_$_SaveUserSettings) _then)
+class __$$SaveUserSettingsImplCopyWithImpl<$Res>
+    extends _$SaveUserSettingsCopyWithImpl<$Res, _$SaveUserSettingsImpl>
+    implements _$$SaveUserSettingsImplCopyWith<$Res> {
+  __$$SaveUserSettingsImplCopyWithImpl(_$SaveUserSettingsImpl _value,
+      $Res Function(_$SaveUserSettingsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -832,7 +838,7 @@ class __$$_SaveUserSettingsCopyWithImpl<$Res>
     Object? discussionLanguages = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_SaveUserSettings(
+    return _then(_$SaveUserSettingsImpl(
       showNsfw: freezed == showNsfw
           ? _value.showNsfw
           : showNsfw // ignore: cast_nullable_to_non_nullable
@@ -920,8 +926,8 @@ class __$$_SaveUserSettingsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_SaveUserSettings extends _SaveUserSettings {
-  const _$_SaveUserSettings(
+class _$SaveUserSettingsImpl extends _SaveUserSettings {
+  const _$SaveUserSettingsImpl(
       {this.showNsfw,
       this.theme,
       this.defaultSortType,
@@ -945,8 +951,8 @@ class _$_SaveUserSettings extends _SaveUserSettings {
       : _discussionLanguages = discussionLanguages,
         super._();
 
-  factory _$_SaveUserSettings.fromJson(Map<String, dynamic> json) =>
-      _$$_SaveUserSettingsFromJson(json);
+  factory _$SaveUserSettingsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SaveUserSettingsImplFromJson(json);
 
   @override
   final bool? showNsfw;
@@ -1007,7 +1013,7 @@ class _$_SaveUserSettings extends _SaveUserSettings {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SaveUserSettings &&
+            other is _$SaveUserSettingsImpl &&
             (identical(other.showNsfw, showNsfw) ||
                 other.showNsfw == showNsfw) &&
             (identical(other.theme, theme) || other.theme == theme) &&
@@ -1074,12 +1080,13 @@ class _$_SaveUserSettings extends _SaveUserSettings {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SaveUserSettingsCopyWith<_$_SaveUserSettings> get copyWith =>
-      __$$_SaveUserSettingsCopyWithImpl<_$_SaveUserSettings>(this, _$identity);
+  _$$SaveUserSettingsImplCopyWith<_$SaveUserSettingsImpl> get copyWith =>
+      __$$SaveUserSettingsImplCopyWithImpl<_$SaveUserSettingsImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SaveUserSettingsToJson(
+    return _$$SaveUserSettingsImplToJson(
       this,
     );
   }
@@ -1106,11 +1113,11 @@ abstract class _SaveUserSettings extends SaveUserSettings {
       final bool? showBotAccounts,
       final bool? showNewPostNotifs,
       final List<int>? discussionLanguages,
-      required final String auth}) = _$_SaveUserSettings;
+      required final String auth}) = _$SaveUserSettingsImpl;
   const _SaveUserSettings._() : super._();
 
   factory _SaveUserSettings.fromJson(Map<String, dynamic> json) =
-      _$_SaveUserSettings.fromJson;
+      _$SaveUserSettingsImpl.fromJson;
 
   @override
   bool? get showNsfw;
@@ -1154,7 +1161,7 @@ abstract class _SaveUserSettings extends SaveUserSettings {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_SaveUserSettingsCopyWith<_$_SaveUserSettings> get copyWith =>
+  _$$SaveUserSettingsImplCopyWith<_$SaveUserSettingsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1228,11 +1235,11 @@ class _$ChangePasswordCopyWithImpl<$Res, $Val extends ChangePassword>
 }
 
 /// @nodoc
-abstract class _$$_ChangePasswordCopyWith<$Res>
+abstract class _$$ChangePasswordImplCopyWith<$Res>
     implements $ChangePasswordCopyWith<$Res> {
-  factory _$$_ChangePasswordCopyWith(
-          _$_ChangePassword value, $Res Function(_$_ChangePassword) then) =
-      __$$_ChangePasswordCopyWithImpl<$Res>;
+  factory _$$ChangePasswordImplCopyWith(_$ChangePasswordImpl value,
+          $Res Function(_$ChangePasswordImpl) then) =
+      __$$ChangePasswordImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1243,11 +1250,11 @@ abstract class _$$_ChangePasswordCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ChangePasswordCopyWithImpl<$Res>
-    extends _$ChangePasswordCopyWithImpl<$Res, _$_ChangePassword>
-    implements _$$_ChangePasswordCopyWith<$Res> {
-  __$$_ChangePasswordCopyWithImpl(
-      _$_ChangePassword _value, $Res Function(_$_ChangePassword) _then)
+class __$$ChangePasswordImplCopyWithImpl<$Res>
+    extends _$ChangePasswordCopyWithImpl<$Res, _$ChangePasswordImpl>
+    implements _$$ChangePasswordImplCopyWith<$Res> {
+  __$$ChangePasswordImplCopyWithImpl(
+      _$ChangePasswordImpl _value, $Res Function(_$ChangePasswordImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1258,7 +1265,7 @@ class __$$_ChangePasswordCopyWithImpl<$Res>
     Object? oldPassword = null,
     Object? auth = null,
   }) {
-    return _then(_$_ChangePassword(
+    return _then(_$ChangePasswordImpl(
       newPassword: null == newPassword
           ? _value.newPassword
           : newPassword // ignore: cast_nullable_to_non_nullable
@@ -1282,16 +1289,16 @@ class __$$_ChangePasswordCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ChangePassword extends _ChangePassword {
-  const _$_ChangePassword(
+class _$ChangePasswordImpl extends _ChangePassword {
+  const _$ChangePasswordImpl(
       {required this.newPassword,
       required this.newPasswordVerify,
       required this.oldPassword,
       required this.auth})
       : super._();
 
-  factory _$_ChangePassword.fromJson(Map<String, dynamic> json) =>
-      _$$_ChangePasswordFromJson(json);
+  factory _$ChangePasswordImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ChangePasswordImplFromJson(json);
 
   @override
   final String newPassword;
@@ -1311,7 +1318,7 @@ class _$_ChangePassword extends _ChangePassword {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ChangePassword &&
+            other is _$ChangePasswordImpl &&
             (identical(other.newPassword, newPassword) ||
                 other.newPassword == newPassword) &&
             (identical(other.newPasswordVerify, newPasswordVerify) ||
@@ -1329,12 +1336,13 @@ class _$_ChangePassword extends _ChangePassword {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ChangePasswordCopyWith<_$_ChangePassword> get copyWith =>
-      __$$_ChangePasswordCopyWithImpl<_$_ChangePassword>(this, _$identity);
+  _$$ChangePasswordImplCopyWith<_$ChangePasswordImpl> get copyWith =>
+      __$$ChangePasswordImplCopyWithImpl<_$ChangePasswordImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ChangePasswordToJson(
+    return _$$ChangePasswordImplToJson(
       this,
     );
   }
@@ -1345,11 +1353,11 @@ abstract class _ChangePassword extends ChangePassword {
       {required final String newPassword,
       required final String newPasswordVerify,
       required final String oldPassword,
-      required final String auth}) = _$_ChangePassword;
+      required final String auth}) = _$ChangePasswordImpl;
   const _ChangePassword._() : super._();
 
   factory _ChangePassword.fromJson(Map<String, dynamic> json) =
-      _$_ChangePassword.fromJson;
+      _$ChangePasswordImpl.fromJson;
 
   @override
   String get newPassword;
@@ -1361,7 +1369,7 @@ abstract class _ChangePassword extends ChangePassword {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ChangePasswordCopyWith<_$_ChangePassword> get copyWith =>
+  _$$ChangePasswordImplCopyWith<_$ChangePasswordImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1463,11 +1471,11 @@ class _$GetPersonDetailsCopyWithImpl<$Res, $Val extends GetPersonDetails>
 }
 
 /// @nodoc
-abstract class _$$_GetPersonDetailsCopyWith<$Res>
+abstract class _$$GetPersonDetailsImplCopyWith<$Res>
     implements $GetPersonDetailsCopyWith<$Res> {
-  factory _$$_GetPersonDetailsCopyWith(
-          _$_GetPersonDetails value, $Res Function(_$_GetPersonDetails) then) =
-      __$$_GetPersonDetailsCopyWithImpl<$Res>;
+  factory _$$GetPersonDetailsImplCopyWith(_$GetPersonDetailsImpl value,
+          $Res Function(_$GetPersonDetailsImpl) then) =
+      __$$GetPersonDetailsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1482,11 +1490,11 @@ abstract class _$$_GetPersonDetailsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetPersonDetailsCopyWithImpl<$Res>
-    extends _$GetPersonDetailsCopyWithImpl<$Res, _$_GetPersonDetails>
-    implements _$$_GetPersonDetailsCopyWith<$Res> {
-  __$$_GetPersonDetailsCopyWithImpl(
-      _$_GetPersonDetails _value, $Res Function(_$_GetPersonDetails) _then)
+class __$$GetPersonDetailsImplCopyWithImpl<$Res>
+    extends _$GetPersonDetailsCopyWithImpl<$Res, _$GetPersonDetailsImpl>
+    implements _$$GetPersonDetailsImplCopyWith<$Res> {
+  __$$GetPersonDetailsImplCopyWithImpl(_$GetPersonDetailsImpl _value,
+      $Res Function(_$GetPersonDetailsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1501,7 +1509,7 @@ class __$$_GetPersonDetailsCopyWithImpl<$Res>
     Object? savedOnly = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetPersonDetails(
+    return _then(_$GetPersonDetailsImpl(
       personId: freezed == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -1541,8 +1549,8 @@ class __$$_GetPersonDetailsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetPersonDetails extends _GetPersonDetails {
-  const _$_GetPersonDetails(
+class _$GetPersonDetailsImpl extends _GetPersonDetails {
+  const _$GetPersonDetailsImpl(
       {this.personId,
       this.username,
       this.sort,
@@ -1553,8 +1561,8 @@ class _$_GetPersonDetails extends _GetPersonDetails {
       this.auth})
       : super._();
 
-  factory _$_GetPersonDetails.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPersonDetailsFromJson(json);
+  factory _$GetPersonDetailsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPersonDetailsImplFromJson(json);
 
   @override
   final int? personId;
@@ -1582,7 +1590,7 @@ class _$_GetPersonDetails extends _GetPersonDetails {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPersonDetails &&
+            other is _$GetPersonDetailsImpl &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.username, username) ||
@@ -1605,12 +1613,13 @@ class _$_GetPersonDetails extends _GetPersonDetails {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPersonDetailsCopyWith<_$_GetPersonDetails> get copyWith =>
-      __$$_GetPersonDetailsCopyWithImpl<_$_GetPersonDetails>(this, _$identity);
+  _$$GetPersonDetailsImplCopyWith<_$GetPersonDetailsImpl> get copyWith =>
+      __$$GetPersonDetailsImplCopyWithImpl<_$GetPersonDetailsImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPersonDetailsToJson(
+    return _$$GetPersonDetailsImplToJson(
       this,
     );
   }
@@ -1625,11 +1634,11 @@ abstract class _GetPersonDetails extends GetPersonDetails {
       final int? limit,
       final int? communityId,
       final bool? savedOnly,
-      final String? auth}) = _$_GetPersonDetails;
+      final String? auth}) = _$GetPersonDetailsImpl;
   const _GetPersonDetails._() : super._();
 
   factory _GetPersonDetails.fromJson(Map<String, dynamic> json) =
-      _$_GetPersonDetails.fromJson;
+      _$GetPersonDetailsImpl.fromJson;
 
   @override
   int? get personId;
@@ -1649,7 +1658,7 @@ abstract class _GetPersonDetails extends GetPersonDetails {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPersonDetailsCopyWith<_$_GetPersonDetails> get copyWith =>
+  _$$GetPersonDetailsImplCopyWith<_$GetPersonDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1701,22 +1710,22 @@ class _$MarkAllAsReadCopyWithImpl<$Res, $Val extends MarkAllAsRead>
 }
 
 /// @nodoc
-abstract class _$$_MarkAllAsReadCopyWith<$Res>
+abstract class _$$MarkAllAsReadImplCopyWith<$Res>
     implements $MarkAllAsReadCopyWith<$Res> {
-  factory _$$_MarkAllAsReadCopyWith(
-          _$_MarkAllAsRead value, $Res Function(_$_MarkAllAsRead) then) =
-      __$$_MarkAllAsReadCopyWithImpl<$Res>;
+  factory _$$MarkAllAsReadImplCopyWith(
+          _$MarkAllAsReadImpl value, $Res Function(_$MarkAllAsReadImpl) then) =
+      __$$MarkAllAsReadImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String auth});
 }
 
 /// @nodoc
-class __$$_MarkAllAsReadCopyWithImpl<$Res>
-    extends _$MarkAllAsReadCopyWithImpl<$Res, _$_MarkAllAsRead>
-    implements _$$_MarkAllAsReadCopyWith<$Res> {
-  __$$_MarkAllAsReadCopyWithImpl(
-      _$_MarkAllAsRead _value, $Res Function(_$_MarkAllAsRead) _then)
+class __$$MarkAllAsReadImplCopyWithImpl<$Res>
+    extends _$MarkAllAsReadCopyWithImpl<$Res, _$MarkAllAsReadImpl>
+    implements _$$MarkAllAsReadImplCopyWith<$Res> {
+  __$$MarkAllAsReadImplCopyWithImpl(
+      _$MarkAllAsReadImpl _value, $Res Function(_$MarkAllAsReadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1724,7 +1733,7 @@ class __$$_MarkAllAsReadCopyWithImpl<$Res>
   $Res call({
     Object? auth = null,
   }) {
-    return _then(_$_MarkAllAsRead(
+    return _then(_$MarkAllAsReadImpl(
       auth: null == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -1736,11 +1745,11 @@ class __$$_MarkAllAsReadCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_MarkAllAsRead extends _MarkAllAsRead {
-  const _$_MarkAllAsRead({required this.auth}) : super._();
+class _$MarkAllAsReadImpl extends _MarkAllAsRead {
+  const _$MarkAllAsReadImpl({required this.auth}) : super._();
 
-  factory _$_MarkAllAsRead.fromJson(Map<String, dynamic> json) =>
-      _$$_MarkAllAsReadFromJson(json);
+  factory _$MarkAllAsReadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MarkAllAsReadImplFromJson(json);
 
   @override
   final String auth;
@@ -1754,7 +1763,7 @@ class _$_MarkAllAsRead extends _MarkAllAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MarkAllAsRead &&
+            other is _$MarkAllAsReadImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -1765,29 +1774,30 @@ class _$_MarkAllAsRead extends _MarkAllAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MarkAllAsReadCopyWith<_$_MarkAllAsRead> get copyWith =>
-      __$$_MarkAllAsReadCopyWithImpl<_$_MarkAllAsRead>(this, _$identity);
+  _$$MarkAllAsReadImplCopyWith<_$MarkAllAsReadImpl> get copyWith =>
+      __$$MarkAllAsReadImplCopyWithImpl<_$MarkAllAsReadImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MarkAllAsReadToJson(
+    return _$$MarkAllAsReadImplToJson(
       this,
     );
   }
 }
 
 abstract class _MarkAllAsRead extends MarkAllAsRead {
-  const factory _MarkAllAsRead({required final String auth}) = _$_MarkAllAsRead;
+  const factory _MarkAllAsRead({required final String auth}) =
+      _$MarkAllAsReadImpl;
   const _MarkAllAsRead._() : super._();
 
   factory _MarkAllAsRead.fromJson(Map<String, dynamic> json) =
-      _$_MarkAllAsRead.fromJson;
+      _$MarkAllAsReadImpl.fromJson;
 
   @override
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_MarkAllAsReadCopyWith<_$_MarkAllAsRead> get copyWith =>
+  _$$MarkAllAsReadImplCopyWith<_$MarkAllAsReadImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1850,21 +1860,22 @@ class _$AddAdminCopyWithImpl<$Res, $Val extends AddAdmin>
 }
 
 /// @nodoc
-abstract class _$$_AddAdminCopyWith<$Res> implements $AddAdminCopyWith<$Res> {
-  factory _$$_AddAdminCopyWith(
-          _$_AddAdmin value, $Res Function(_$_AddAdmin) then) =
-      __$$_AddAdminCopyWithImpl<$Res>;
+abstract class _$$AddAdminImplCopyWith<$Res>
+    implements $AddAdminCopyWith<$Res> {
+  factory _$$AddAdminImplCopyWith(
+          _$AddAdminImpl value, $Res Function(_$AddAdminImpl) then) =
+      __$$AddAdminImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int personId, bool added, String auth});
 }
 
 /// @nodoc
-class __$$_AddAdminCopyWithImpl<$Res>
-    extends _$AddAdminCopyWithImpl<$Res, _$_AddAdmin>
-    implements _$$_AddAdminCopyWith<$Res> {
-  __$$_AddAdminCopyWithImpl(
-      _$_AddAdmin _value, $Res Function(_$_AddAdmin) _then)
+class __$$AddAdminImplCopyWithImpl<$Res>
+    extends _$AddAdminCopyWithImpl<$Res, _$AddAdminImpl>
+    implements _$$AddAdminImplCopyWith<$Res> {
+  __$$AddAdminImplCopyWithImpl(
+      _$AddAdminImpl _value, $Res Function(_$AddAdminImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1874,7 +1885,7 @@ class __$$_AddAdminCopyWithImpl<$Res>
     Object? added = null,
     Object? auth = null,
   }) {
-    return _then(_$_AddAdmin(
+    return _then(_$AddAdminImpl(
       personId: null == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -1894,13 +1905,13 @@ class __$$_AddAdminCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_AddAdmin extends _AddAdmin {
-  const _$_AddAdmin(
+class _$AddAdminImpl extends _AddAdmin {
+  const _$AddAdminImpl(
       {required this.personId, required this.added, required this.auth})
       : super._();
 
-  factory _$_AddAdmin.fromJson(Map<String, dynamic> json) =>
-      _$$_AddAdminFromJson(json);
+  factory _$AddAdminImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AddAdminImplFromJson(json);
 
   @override
   final int personId;
@@ -1918,7 +1929,7 @@ class _$_AddAdmin extends _AddAdmin {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AddAdmin &&
+            other is _$AddAdminImpl &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.added, added) || other.added == added) &&
@@ -1932,12 +1943,12 @@ class _$_AddAdmin extends _AddAdmin {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AddAdminCopyWith<_$_AddAdmin> get copyWith =>
-      __$$_AddAdminCopyWithImpl<_$_AddAdmin>(this, _$identity);
+  _$$AddAdminImplCopyWith<_$AddAdminImpl> get copyWith =>
+      __$$AddAdminImplCopyWithImpl<_$AddAdminImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AddAdminToJson(
+    return _$$AddAdminImplToJson(
       this,
     );
   }
@@ -1947,10 +1958,11 @@ abstract class _AddAdmin extends AddAdmin {
   const factory _AddAdmin(
       {required final int personId,
       required final bool added,
-      required final String auth}) = _$_AddAdmin;
+      required final String auth}) = _$AddAdminImpl;
   const _AddAdmin._() : super._();
 
-  factory _AddAdmin.fromJson(Map<String, dynamic> json) = _$_AddAdmin.fromJson;
+  factory _AddAdmin.fromJson(Map<String, dynamic> json) =
+      _$AddAdminImpl.fromJson;
 
   @override
   int get personId;
@@ -1960,7 +1972,7 @@ abstract class _AddAdmin extends AddAdmin {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_AddAdminCopyWith<_$_AddAdmin> get copyWith =>
+  _$$AddAdminImplCopyWith<_$AddAdminImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2047,10 +2059,11 @@ class _$BanPersonCopyWithImpl<$Res, $Val extends BanPerson>
 }
 
 /// @nodoc
-abstract class _$$_BanPersonCopyWith<$Res> implements $BanPersonCopyWith<$Res> {
-  factory _$$_BanPersonCopyWith(
-          _$_BanPerson value, $Res Function(_$_BanPerson) then) =
-      __$$_BanPersonCopyWithImpl<$Res>;
+abstract class _$$BanPersonImplCopyWith<$Res>
+    implements $BanPersonCopyWith<$Res> {
+  factory _$$BanPersonImplCopyWith(
+          _$BanPersonImpl value, $Res Function(_$BanPersonImpl) then) =
+      __$$BanPersonImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2063,11 +2076,11 @@ abstract class _$$_BanPersonCopyWith<$Res> implements $BanPersonCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_BanPersonCopyWithImpl<$Res>
-    extends _$BanPersonCopyWithImpl<$Res, _$_BanPerson>
-    implements _$$_BanPersonCopyWith<$Res> {
-  __$$_BanPersonCopyWithImpl(
-      _$_BanPerson _value, $Res Function(_$_BanPerson) _then)
+class __$$BanPersonImplCopyWithImpl<$Res>
+    extends _$BanPersonCopyWithImpl<$Res, _$BanPersonImpl>
+    implements _$$BanPersonImplCopyWith<$Res> {
+  __$$BanPersonImplCopyWithImpl(
+      _$BanPersonImpl _value, $Res Function(_$BanPersonImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2080,7 +2093,7 @@ class __$$_BanPersonCopyWithImpl<$Res>
     Object? expires = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_BanPerson(
+    return _then(_$BanPersonImpl(
       personId: null == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -2112,8 +2125,8 @@ class __$$_BanPersonCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_BanPerson extends _BanPerson {
-  const _$_BanPerson(
+class _$BanPersonImpl extends _BanPerson {
+  const _$BanPersonImpl(
       {required this.personId,
       required this.ban,
       this.removeData,
@@ -2122,8 +2135,8 @@ class _$_BanPerson extends _BanPerson {
       required this.auth})
       : super._();
 
-  factory _$_BanPerson.fromJson(Map<String, dynamic> json) =>
-      _$$_BanPersonFromJson(json);
+  factory _$BanPersonImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BanPersonImplFromJson(json);
 
   @override
   final int personId;
@@ -2147,7 +2160,7 @@ class _$_BanPerson extends _BanPerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BanPerson &&
+            other is _$BanPersonImpl &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.ban, ban) || other.ban == ban) &&
@@ -2166,12 +2179,12 @@ class _$_BanPerson extends _BanPerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BanPersonCopyWith<_$_BanPerson> get copyWith =>
-      __$$_BanPersonCopyWithImpl<_$_BanPerson>(this, _$identity);
+  _$$BanPersonImplCopyWith<_$BanPersonImpl> get copyWith =>
+      __$$BanPersonImplCopyWithImpl<_$BanPersonImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BanPersonToJson(
+    return _$$BanPersonImplToJson(
       this,
     );
   }
@@ -2184,11 +2197,11 @@ abstract class _BanPerson extends BanPerson {
       final bool? removeData,
       final String? reason,
       final int? expires,
-      required final String auth}) = _$_BanPerson;
+      required final String auth}) = _$BanPersonImpl;
   const _BanPerson._() : super._();
 
   factory _BanPerson.fromJson(Map<String, dynamic> json) =
-      _$_BanPerson.fromJson;
+      _$BanPersonImpl.fromJson;
 
   @override
   int get personId;
@@ -2204,7 +2217,7 @@ abstract class _BanPerson extends BanPerson {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_BanPersonCopyWith<_$_BanPerson> get copyWith =>
+  _$$BanPersonImplCopyWith<_$BanPersonImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2281,11 +2294,11 @@ class _$GetRepliesCopyWithImpl<$Res, $Val extends GetReplies>
 }
 
 /// @nodoc
-abstract class _$$_GetRepliesCopyWith<$Res>
+abstract class _$$GetRepliesImplCopyWith<$Res>
     implements $GetRepliesCopyWith<$Res> {
-  factory _$$_GetRepliesCopyWith(
-          _$_GetReplies value, $Res Function(_$_GetReplies) then) =
-      __$$_GetRepliesCopyWithImpl<$Res>;
+  factory _$$GetRepliesImplCopyWith(
+          _$GetRepliesImpl value, $Res Function(_$GetRepliesImpl) then) =
+      __$$GetRepliesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2293,11 +2306,11 @@ abstract class _$$_GetRepliesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetRepliesCopyWithImpl<$Res>
-    extends _$GetRepliesCopyWithImpl<$Res, _$_GetReplies>
-    implements _$$_GetRepliesCopyWith<$Res> {
-  __$$_GetRepliesCopyWithImpl(
-      _$_GetReplies _value, $Res Function(_$_GetReplies) _then)
+class __$$GetRepliesImplCopyWithImpl<$Res>
+    extends _$GetRepliesCopyWithImpl<$Res, _$GetRepliesImpl>
+    implements _$$GetRepliesImplCopyWith<$Res> {
+  __$$GetRepliesImplCopyWithImpl(
+      _$GetRepliesImpl _value, $Res Function(_$GetRepliesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2309,7 +2322,7 @@ class __$$_GetRepliesCopyWithImpl<$Res>
     Object? unreadOnly = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_GetReplies(
+    return _then(_$GetRepliesImpl(
       sort: freezed == sort
           ? _value.sort
           : sort // ignore: cast_nullable_to_non_nullable
@@ -2337,13 +2350,13 @@ class __$$_GetRepliesCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetReplies extends _GetReplies {
-  const _$_GetReplies(
+class _$GetRepliesImpl extends _GetReplies {
+  const _$GetRepliesImpl(
       {this.sort, this.page, this.limit, this.unreadOnly, required this.auth})
       : super._();
 
-  factory _$_GetReplies.fromJson(Map<String, dynamic> json) =>
-      _$$_GetRepliesFromJson(json);
+  factory _$GetRepliesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetRepliesImplFromJson(json);
 
   @override
   final SortType? sort;
@@ -2365,7 +2378,7 @@ class _$_GetReplies extends _GetReplies {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetReplies &&
+            other is _$GetRepliesImpl &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
@@ -2382,12 +2395,12 @@ class _$_GetReplies extends _GetReplies {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetRepliesCopyWith<_$_GetReplies> get copyWith =>
-      __$$_GetRepliesCopyWithImpl<_$_GetReplies>(this, _$identity);
+  _$$GetRepliesImplCopyWith<_$GetRepliesImpl> get copyWith =>
+      __$$GetRepliesImplCopyWithImpl<_$GetRepliesImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetRepliesToJson(
+    return _$$GetRepliesImplToJson(
       this,
     );
   }
@@ -2399,11 +2412,11 @@ abstract class _GetReplies extends GetReplies {
       final int? page,
       final int? limit,
       final bool? unreadOnly,
-      required final String auth}) = _$_GetReplies;
+      required final String auth}) = _$GetRepliesImpl;
   const _GetReplies._() : super._();
 
   factory _GetReplies.fromJson(Map<String, dynamic> json) =
-      _$_GetReplies.fromJson;
+      _$GetRepliesImpl.fromJson;
 
   @override
   SortType? get sort;
@@ -2417,7 +2430,7 @@ abstract class _GetReplies extends GetReplies {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetRepliesCopyWith<_$_GetReplies> get copyWith =>
+  _$$GetRepliesImplCopyWith<_$GetRepliesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2494,11 +2507,11 @@ class _$GetPersonMentionsCopyWithImpl<$Res, $Val extends GetPersonMentions>
 }
 
 /// @nodoc
-abstract class _$$_GetPersonMentionsCopyWith<$Res>
+abstract class _$$GetPersonMentionsImplCopyWith<$Res>
     implements $GetPersonMentionsCopyWith<$Res> {
-  factory _$$_GetPersonMentionsCopyWith(_$_GetPersonMentions value,
-          $Res Function(_$_GetPersonMentions) then) =
-      __$$_GetPersonMentionsCopyWithImpl<$Res>;
+  factory _$$GetPersonMentionsImplCopyWith(_$GetPersonMentionsImpl value,
+          $Res Function(_$GetPersonMentionsImpl) then) =
+      __$$GetPersonMentionsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2506,11 +2519,11 @@ abstract class _$$_GetPersonMentionsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetPersonMentionsCopyWithImpl<$Res>
-    extends _$GetPersonMentionsCopyWithImpl<$Res, _$_GetPersonMentions>
-    implements _$$_GetPersonMentionsCopyWith<$Res> {
-  __$$_GetPersonMentionsCopyWithImpl(
-      _$_GetPersonMentions _value, $Res Function(_$_GetPersonMentions) _then)
+class __$$GetPersonMentionsImplCopyWithImpl<$Res>
+    extends _$GetPersonMentionsCopyWithImpl<$Res, _$GetPersonMentionsImpl>
+    implements _$$GetPersonMentionsImplCopyWith<$Res> {
+  __$$GetPersonMentionsImplCopyWithImpl(_$GetPersonMentionsImpl _value,
+      $Res Function(_$GetPersonMentionsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2522,7 +2535,7 @@ class __$$_GetPersonMentionsCopyWithImpl<$Res>
     Object? unreadOnly = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_GetPersonMentions(
+    return _then(_$GetPersonMentionsImpl(
       sort: freezed == sort
           ? _value.sort
           : sort // ignore: cast_nullable_to_non_nullable
@@ -2550,13 +2563,13 @@ class __$$_GetPersonMentionsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetPersonMentions extends _GetPersonMentions {
-  const _$_GetPersonMentions(
+class _$GetPersonMentionsImpl extends _GetPersonMentions {
+  const _$GetPersonMentionsImpl(
       {this.sort, this.page, this.limit, this.unreadOnly, required this.auth})
       : super._();
 
-  factory _$_GetPersonMentions.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPersonMentionsFromJson(json);
+  factory _$GetPersonMentionsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPersonMentionsImplFromJson(json);
 
   @override
   final SortType? sort;
@@ -2578,7 +2591,7 @@ class _$_GetPersonMentions extends _GetPersonMentions {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPersonMentions &&
+            other is _$GetPersonMentionsImpl &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
@@ -2595,13 +2608,13 @@ class _$_GetPersonMentions extends _GetPersonMentions {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPersonMentionsCopyWith<_$_GetPersonMentions> get copyWith =>
-      __$$_GetPersonMentionsCopyWithImpl<_$_GetPersonMentions>(
+  _$$GetPersonMentionsImplCopyWith<_$GetPersonMentionsImpl> get copyWith =>
+      __$$GetPersonMentionsImplCopyWithImpl<_$GetPersonMentionsImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPersonMentionsToJson(
+    return _$$GetPersonMentionsImplToJson(
       this,
     );
   }
@@ -2613,11 +2626,11 @@ abstract class _GetPersonMentions extends GetPersonMentions {
       final int? page,
       final int? limit,
       final bool? unreadOnly,
-      required final String auth}) = _$_GetPersonMentions;
+      required final String auth}) = _$GetPersonMentionsImpl;
   const _GetPersonMentions._() : super._();
 
   factory _GetPersonMentions.fromJson(Map<String, dynamic> json) =
-      _$_GetPersonMentions.fromJson;
+      _$GetPersonMentionsImpl.fromJson;
 
   @override
   SortType? get sort;
@@ -2631,7 +2644,7 @@ abstract class _GetPersonMentions extends GetPersonMentions {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPersonMentionsCopyWith<_$_GetPersonMentions> get copyWith =>
+  _$$GetPersonMentionsImplCopyWith<_$GetPersonMentionsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2697,23 +2710,25 @@ class _$MarkPersonMentionAsReadCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_MarkPersonMentionAsReadCopyWith<$Res>
+abstract class _$$MarkPersonMentionAsReadImplCopyWith<$Res>
     implements $MarkPersonMentionAsReadCopyWith<$Res> {
-  factory _$$_MarkPersonMentionAsReadCopyWith(_$_MarkPersonMentionAsRead value,
-          $Res Function(_$_MarkPersonMentionAsRead) then) =
-      __$$_MarkPersonMentionAsReadCopyWithImpl<$Res>;
+  factory _$$MarkPersonMentionAsReadImplCopyWith(
+          _$MarkPersonMentionAsReadImpl value,
+          $Res Function(_$MarkPersonMentionAsReadImpl) then) =
+      __$$MarkPersonMentionAsReadImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int personMentionId, bool read, String auth});
 }
 
 /// @nodoc
-class __$$_MarkPersonMentionAsReadCopyWithImpl<$Res>
+class __$$MarkPersonMentionAsReadImplCopyWithImpl<$Res>
     extends _$MarkPersonMentionAsReadCopyWithImpl<$Res,
-        _$_MarkPersonMentionAsRead>
-    implements _$$_MarkPersonMentionAsReadCopyWith<$Res> {
-  __$$_MarkPersonMentionAsReadCopyWithImpl(_$_MarkPersonMentionAsRead _value,
-      $Res Function(_$_MarkPersonMentionAsRead) _then)
+        _$MarkPersonMentionAsReadImpl>
+    implements _$$MarkPersonMentionAsReadImplCopyWith<$Res> {
+  __$$MarkPersonMentionAsReadImplCopyWithImpl(
+      _$MarkPersonMentionAsReadImpl _value,
+      $Res Function(_$MarkPersonMentionAsReadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2723,7 +2738,7 @@ class __$$_MarkPersonMentionAsReadCopyWithImpl<$Res>
     Object? read = null,
     Object? auth = null,
   }) {
-    return _then(_$_MarkPersonMentionAsRead(
+    return _then(_$MarkPersonMentionAsReadImpl(
       personMentionId: null == personMentionId
           ? _value.personMentionId
           : personMentionId // ignore: cast_nullable_to_non_nullable
@@ -2743,13 +2758,13 @@ class __$$_MarkPersonMentionAsReadCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_MarkPersonMentionAsRead extends _MarkPersonMentionAsRead {
-  const _$_MarkPersonMentionAsRead(
+class _$MarkPersonMentionAsReadImpl extends _MarkPersonMentionAsRead {
+  const _$MarkPersonMentionAsReadImpl(
       {required this.personMentionId, required this.read, required this.auth})
       : super._();
 
-  factory _$_MarkPersonMentionAsRead.fromJson(Map<String, dynamic> json) =>
-      _$$_MarkPersonMentionAsReadFromJson(json);
+  factory _$MarkPersonMentionAsReadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MarkPersonMentionAsReadImplFromJson(json);
 
   @override
   final int personMentionId;
@@ -2767,7 +2782,7 @@ class _$_MarkPersonMentionAsRead extends _MarkPersonMentionAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MarkPersonMentionAsRead &&
+            other is _$MarkPersonMentionAsReadImpl &&
             (identical(other.personMentionId, personMentionId) ||
                 other.personMentionId == personMentionId) &&
             (identical(other.read, read) || other.read == read) &&
@@ -2781,14 +2796,13 @@ class _$_MarkPersonMentionAsRead extends _MarkPersonMentionAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MarkPersonMentionAsReadCopyWith<_$_MarkPersonMentionAsRead>
-      get copyWith =>
-          __$$_MarkPersonMentionAsReadCopyWithImpl<_$_MarkPersonMentionAsRead>(
-              this, _$identity);
+  _$$MarkPersonMentionAsReadImplCopyWith<_$MarkPersonMentionAsReadImpl>
+      get copyWith => __$$MarkPersonMentionAsReadImplCopyWithImpl<
+          _$MarkPersonMentionAsReadImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MarkPersonMentionAsReadToJson(
+    return _$$MarkPersonMentionAsReadImplToJson(
       this,
     );
   }
@@ -2798,11 +2812,11 @@ abstract class _MarkPersonMentionAsRead extends MarkPersonMentionAsRead {
   const factory _MarkPersonMentionAsRead(
       {required final int personMentionId,
       required final bool read,
-      required final String auth}) = _$_MarkPersonMentionAsRead;
+      required final String auth}) = _$MarkPersonMentionAsReadImpl;
   const _MarkPersonMentionAsRead._() : super._();
 
   factory _MarkPersonMentionAsRead.fromJson(Map<String, dynamic> json) =
-      _$_MarkPersonMentionAsRead.fromJson;
+      _$MarkPersonMentionAsReadImpl.fromJson;
 
   @override
   int get personMentionId;
@@ -2812,7 +2826,7 @@ abstract class _MarkPersonMentionAsRead extends MarkPersonMentionAsRead {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_MarkPersonMentionAsReadCopyWith<_$_MarkPersonMentionAsRead>
+  _$$MarkPersonMentionAsReadImplCopyWith<_$MarkPersonMentionAsReadImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -2870,22 +2884,22 @@ class _$DeleteAccountCopyWithImpl<$Res, $Val extends DeleteAccount>
 }
 
 /// @nodoc
-abstract class _$$_DeleteAccountCopyWith<$Res>
+abstract class _$$DeleteAccountImplCopyWith<$Res>
     implements $DeleteAccountCopyWith<$Res> {
-  factory _$$_DeleteAccountCopyWith(
-          _$_DeleteAccount value, $Res Function(_$_DeleteAccount) then) =
-      __$$_DeleteAccountCopyWithImpl<$Res>;
+  factory _$$DeleteAccountImplCopyWith(
+          _$DeleteAccountImpl value, $Res Function(_$DeleteAccountImpl) then) =
+      __$$DeleteAccountImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String password, String auth});
 }
 
 /// @nodoc
-class __$$_DeleteAccountCopyWithImpl<$Res>
-    extends _$DeleteAccountCopyWithImpl<$Res, _$_DeleteAccount>
-    implements _$$_DeleteAccountCopyWith<$Res> {
-  __$$_DeleteAccountCopyWithImpl(
-      _$_DeleteAccount _value, $Res Function(_$_DeleteAccount) _then)
+class __$$DeleteAccountImplCopyWithImpl<$Res>
+    extends _$DeleteAccountCopyWithImpl<$Res, _$DeleteAccountImpl>
+    implements _$$DeleteAccountImplCopyWith<$Res> {
+  __$$DeleteAccountImplCopyWithImpl(
+      _$DeleteAccountImpl _value, $Res Function(_$DeleteAccountImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2894,7 +2908,7 @@ class __$$_DeleteAccountCopyWithImpl<$Res>
     Object? password = null,
     Object? auth = null,
   }) {
-    return _then(_$_DeleteAccount(
+    return _then(_$DeleteAccountImpl(
       password: null == password
           ? _value.password
           : password // ignore: cast_nullable_to_non_nullable
@@ -2910,12 +2924,12 @@ class __$$_DeleteAccountCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_DeleteAccount extends _DeleteAccount {
-  const _$_DeleteAccount({required this.password, required this.auth})
+class _$DeleteAccountImpl extends _DeleteAccount {
+  const _$DeleteAccountImpl({required this.password, required this.auth})
       : super._();
 
-  factory _$_DeleteAccount.fromJson(Map<String, dynamic> json) =>
-      _$$_DeleteAccountFromJson(json);
+  factory _$DeleteAccountImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeleteAccountImplFromJson(json);
 
   @override
   final String password;
@@ -2931,7 +2945,7 @@ class _$_DeleteAccount extends _DeleteAccount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeleteAccount &&
+            other is _$DeleteAccountImpl &&
             (identical(other.password, password) ||
                 other.password == password) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -2944,12 +2958,12 @@ class _$_DeleteAccount extends _DeleteAccount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeleteAccountCopyWith<_$_DeleteAccount> get copyWith =>
-      __$$_DeleteAccountCopyWithImpl<_$_DeleteAccount>(this, _$identity);
+  _$$DeleteAccountImplCopyWith<_$DeleteAccountImpl> get copyWith =>
+      __$$DeleteAccountImplCopyWithImpl<_$DeleteAccountImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeleteAccountToJson(
+    return _$$DeleteAccountImplToJson(
       this,
     );
   }
@@ -2958,11 +2972,11 @@ class _$_DeleteAccount extends _DeleteAccount {
 abstract class _DeleteAccount extends DeleteAccount {
   const factory _DeleteAccount(
       {required final String password,
-      required final String auth}) = _$_DeleteAccount;
+      required final String auth}) = _$DeleteAccountImpl;
   const _DeleteAccount._() : super._();
 
   factory _DeleteAccount.fromJson(Map<String, dynamic> json) =
-      _$_DeleteAccount.fromJson;
+      _$DeleteAccountImpl.fromJson;
 
   @override
   String get password;
@@ -2970,7 +2984,7 @@ abstract class _DeleteAccount extends DeleteAccount {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_DeleteAccountCopyWith<_$_DeleteAccount> get copyWith =>
+  _$$DeleteAccountImplCopyWith<_$DeleteAccountImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3022,22 +3036,22 @@ class _$PasswordResetCopyWithImpl<$Res, $Val extends PasswordReset>
 }
 
 /// @nodoc
-abstract class _$$_PasswordResetCopyWith<$Res>
+abstract class _$$PasswordResetImplCopyWith<$Res>
     implements $PasswordResetCopyWith<$Res> {
-  factory _$$_PasswordResetCopyWith(
-          _$_PasswordReset value, $Res Function(_$_PasswordReset) then) =
-      __$$_PasswordResetCopyWithImpl<$Res>;
+  factory _$$PasswordResetImplCopyWith(
+          _$PasswordResetImpl value, $Res Function(_$PasswordResetImpl) then) =
+      __$$PasswordResetImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String email});
 }
 
 /// @nodoc
-class __$$_PasswordResetCopyWithImpl<$Res>
-    extends _$PasswordResetCopyWithImpl<$Res, _$_PasswordReset>
-    implements _$$_PasswordResetCopyWith<$Res> {
-  __$$_PasswordResetCopyWithImpl(
-      _$_PasswordReset _value, $Res Function(_$_PasswordReset) _then)
+class __$$PasswordResetImplCopyWithImpl<$Res>
+    extends _$PasswordResetCopyWithImpl<$Res, _$PasswordResetImpl>
+    implements _$$PasswordResetImplCopyWith<$Res> {
+  __$$PasswordResetImplCopyWithImpl(
+      _$PasswordResetImpl _value, $Res Function(_$PasswordResetImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3045,7 +3059,7 @@ class __$$_PasswordResetCopyWithImpl<$Res>
   $Res call({
     Object? email = null,
   }) {
-    return _then(_$_PasswordReset(
+    return _then(_$PasswordResetImpl(
       email: null == email
           ? _value.email
           : email // ignore: cast_nullable_to_non_nullable
@@ -3057,11 +3071,11 @@ class __$$_PasswordResetCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_PasswordReset extends _PasswordReset {
-  const _$_PasswordReset({required this.email}) : super._();
+class _$PasswordResetImpl extends _PasswordReset {
+  const _$PasswordResetImpl({required this.email}) : super._();
 
-  factory _$_PasswordReset.fromJson(Map<String, dynamic> json) =>
-      _$$_PasswordResetFromJson(json);
+  factory _$PasswordResetImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PasswordResetImplFromJson(json);
 
   @override
   final String email;
@@ -3075,7 +3089,7 @@ class _$_PasswordReset extends _PasswordReset {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PasswordReset &&
+            other is _$PasswordResetImpl &&
             (identical(other.email, email) || other.email == email));
   }
 
@@ -3086,12 +3100,12 @@ class _$_PasswordReset extends _PasswordReset {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PasswordResetCopyWith<_$_PasswordReset> get copyWith =>
-      __$$_PasswordResetCopyWithImpl<_$_PasswordReset>(this, _$identity);
+  _$$PasswordResetImplCopyWith<_$PasswordResetImpl> get copyWith =>
+      __$$PasswordResetImplCopyWithImpl<_$PasswordResetImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PasswordResetToJson(
+    return _$$PasswordResetImplToJson(
       this,
     );
   }
@@ -3099,17 +3113,17 @@ class _$_PasswordReset extends _PasswordReset {
 
 abstract class _PasswordReset extends PasswordReset {
   const factory _PasswordReset({required final String email}) =
-      _$_PasswordReset;
+      _$PasswordResetImpl;
   const _PasswordReset._() : super._();
 
   factory _PasswordReset.fromJson(Map<String, dynamic> json) =
-      _$_PasswordReset.fromJson;
+      _$PasswordResetImpl.fromJson;
 
   @override
   String get email;
   @override
   @JsonKey(ignore: true)
-  _$$_PasswordResetCopyWith<_$_PasswordReset> get copyWith =>
+  _$$PasswordResetImplCopyWith<_$PasswordResetImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3173,22 +3187,22 @@ class _$PasswordChangeCopyWithImpl<$Res, $Val extends PasswordChange>
 }
 
 /// @nodoc
-abstract class _$$_PasswordChangeCopyWith<$Res>
+abstract class _$$PasswordChangeImplCopyWith<$Res>
     implements $PasswordChangeCopyWith<$Res> {
-  factory _$$_PasswordChangeCopyWith(
-          _$_PasswordChange value, $Res Function(_$_PasswordChange) then) =
-      __$$_PasswordChangeCopyWithImpl<$Res>;
+  factory _$$PasswordChangeImplCopyWith(_$PasswordChangeImpl value,
+          $Res Function(_$PasswordChangeImpl) then) =
+      __$$PasswordChangeImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String token, String password, String passwordVerify});
 }
 
 /// @nodoc
-class __$$_PasswordChangeCopyWithImpl<$Res>
-    extends _$PasswordChangeCopyWithImpl<$Res, _$_PasswordChange>
-    implements _$$_PasswordChangeCopyWith<$Res> {
-  __$$_PasswordChangeCopyWithImpl(
-      _$_PasswordChange _value, $Res Function(_$_PasswordChange) _then)
+class __$$PasswordChangeImplCopyWithImpl<$Res>
+    extends _$PasswordChangeCopyWithImpl<$Res, _$PasswordChangeImpl>
+    implements _$$PasswordChangeImplCopyWith<$Res> {
+  __$$PasswordChangeImplCopyWithImpl(
+      _$PasswordChangeImpl _value, $Res Function(_$PasswordChangeImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3198,7 +3212,7 @@ class __$$_PasswordChangeCopyWithImpl<$Res>
     Object? password = null,
     Object? passwordVerify = null,
   }) {
-    return _then(_$_PasswordChange(
+    return _then(_$PasswordChangeImpl(
       token: null == token
           ? _value.token
           : token // ignore: cast_nullable_to_non_nullable
@@ -3218,15 +3232,15 @@ class __$$_PasswordChangeCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_PasswordChange extends _PasswordChange {
-  const _$_PasswordChange(
+class _$PasswordChangeImpl extends _PasswordChange {
+  const _$PasswordChangeImpl(
       {required this.token,
       required this.password,
       required this.passwordVerify})
       : super._();
 
-  factory _$_PasswordChange.fromJson(Map<String, dynamic> json) =>
-      _$$_PasswordChangeFromJson(json);
+  factory _$PasswordChangeImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PasswordChangeImplFromJson(json);
 
   @override
   final String token;
@@ -3244,7 +3258,7 @@ class _$_PasswordChange extends _PasswordChange {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PasswordChange &&
+            other is _$PasswordChangeImpl &&
             (identical(other.token, token) || other.token == token) &&
             (identical(other.password, password) ||
                 other.password == password) &&
@@ -3259,12 +3273,13 @@ class _$_PasswordChange extends _PasswordChange {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PasswordChangeCopyWith<_$_PasswordChange> get copyWith =>
-      __$$_PasswordChangeCopyWithImpl<_$_PasswordChange>(this, _$identity);
+  _$$PasswordChangeImplCopyWith<_$PasswordChangeImpl> get copyWith =>
+      __$$PasswordChangeImplCopyWithImpl<_$PasswordChangeImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PasswordChangeToJson(
+    return _$$PasswordChangeImplToJson(
       this,
     );
   }
@@ -3274,11 +3289,11 @@ abstract class _PasswordChange extends PasswordChange {
   const factory _PasswordChange(
       {required final String token,
       required final String password,
-      required final String passwordVerify}) = _$_PasswordChange;
+      required final String passwordVerify}) = _$PasswordChangeImpl;
   const _PasswordChange._() : super._();
 
   factory _PasswordChange.fromJson(Map<String, dynamic> json) =
-      _$_PasswordChange.fromJson;
+      _$PasswordChangeImpl.fromJson;
 
   @override
   String get token;
@@ -3288,7 +3303,7 @@ abstract class _PasswordChange extends PasswordChange {
   String get passwordVerify;
   @override
   @JsonKey(ignore: true)
-  _$$_PasswordChangeCopyWith<_$_PasswordChange> get copyWith =>
+  _$$PasswordChangeImplCopyWith<_$PasswordChangeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3353,22 +3368,22 @@ class _$CreatePrivateMessageCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_CreatePrivateMessageCopyWith<$Res>
+abstract class _$$CreatePrivateMessageImplCopyWith<$Res>
     implements $CreatePrivateMessageCopyWith<$Res> {
-  factory _$$_CreatePrivateMessageCopyWith(_$_CreatePrivateMessage value,
-          $Res Function(_$_CreatePrivateMessage) then) =
-      __$$_CreatePrivateMessageCopyWithImpl<$Res>;
+  factory _$$CreatePrivateMessageImplCopyWith(_$CreatePrivateMessageImpl value,
+          $Res Function(_$CreatePrivateMessageImpl) then) =
+      __$$CreatePrivateMessageImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String content, int recipientId, String auth});
 }
 
 /// @nodoc
-class __$$_CreatePrivateMessageCopyWithImpl<$Res>
-    extends _$CreatePrivateMessageCopyWithImpl<$Res, _$_CreatePrivateMessage>
-    implements _$$_CreatePrivateMessageCopyWith<$Res> {
-  __$$_CreatePrivateMessageCopyWithImpl(_$_CreatePrivateMessage _value,
-      $Res Function(_$_CreatePrivateMessage) _then)
+class __$$CreatePrivateMessageImplCopyWithImpl<$Res>
+    extends _$CreatePrivateMessageCopyWithImpl<$Res, _$CreatePrivateMessageImpl>
+    implements _$$CreatePrivateMessageImplCopyWith<$Res> {
+  __$$CreatePrivateMessageImplCopyWithImpl(_$CreatePrivateMessageImpl _value,
+      $Res Function(_$CreatePrivateMessageImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3378,7 +3393,7 @@ class __$$_CreatePrivateMessageCopyWithImpl<$Res>
     Object? recipientId = null,
     Object? auth = null,
   }) {
-    return _then(_$_CreatePrivateMessage(
+    return _then(_$CreatePrivateMessageImpl(
       content: null == content
           ? _value.content
           : content // ignore: cast_nullable_to_non_nullable
@@ -3398,13 +3413,13 @@ class __$$_CreatePrivateMessageCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreatePrivateMessage extends _CreatePrivateMessage {
-  const _$_CreatePrivateMessage(
+class _$CreatePrivateMessageImpl extends _CreatePrivateMessage {
+  const _$CreatePrivateMessageImpl(
       {required this.content, required this.recipientId, required this.auth})
       : super._();
 
-  factory _$_CreatePrivateMessage.fromJson(Map<String, dynamic> json) =>
-      _$$_CreatePrivateMessageFromJson(json);
+  factory _$CreatePrivateMessageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreatePrivateMessageImplFromJson(json);
 
   @override
   final String content;
@@ -3422,7 +3437,7 @@ class _$_CreatePrivateMessage extends _CreatePrivateMessage {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreatePrivateMessage &&
+            other is _$CreatePrivateMessageImpl &&
             (identical(other.content, content) || other.content == content) &&
             (identical(other.recipientId, recipientId) ||
                 other.recipientId == recipientId) &&
@@ -3436,13 +3451,14 @@ class _$_CreatePrivateMessage extends _CreatePrivateMessage {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreatePrivateMessageCopyWith<_$_CreatePrivateMessage> get copyWith =>
-      __$$_CreatePrivateMessageCopyWithImpl<_$_CreatePrivateMessage>(
-          this, _$identity);
+  _$$CreatePrivateMessageImplCopyWith<_$CreatePrivateMessageImpl>
+      get copyWith =>
+          __$$CreatePrivateMessageImplCopyWithImpl<_$CreatePrivateMessageImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreatePrivateMessageToJson(
+    return _$$CreatePrivateMessageImplToJson(
       this,
     );
   }
@@ -3452,11 +3468,11 @@ abstract class _CreatePrivateMessage extends CreatePrivateMessage {
   const factory _CreatePrivateMessage(
       {required final String content,
       required final int recipientId,
-      required final String auth}) = _$_CreatePrivateMessage;
+      required final String auth}) = _$CreatePrivateMessageImpl;
   const _CreatePrivateMessage._() : super._();
 
   factory _CreatePrivateMessage.fromJson(Map<String, dynamic> json) =
-      _$_CreatePrivateMessage.fromJson;
+      _$CreatePrivateMessageImpl.fromJson;
 
   @override
   String get content;
@@ -3466,8 +3482,8 @@ abstract class _CreatePrivateMessage extends CreatePrivateMessage {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreatePrivateMessageCopyWith<_$_CreatePrivateMessage> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$CreatePrivateMessageImplCopyWith<_$CreatePrivateMessageImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 EditPrivateMessage _$EditPrivateMessageFromJson(Map<String, dynamic> json) {
@@ -3530,22 +3546,22 @@ class _$EditPrivateMessageCopyWithImpl<$Res, $Val extends EditPrivateMessage>
 }
 
 /// @nodoc
-abstract class _$$_EditPrivateMessageCopyWith<$Res>
+abstract class _$$EditPrivateMessageImplCopyWith<$Res>
     implements $EditPrivateMessageCopyWith<$Res> {
-  factory _$$_EditPrivateMessageCopyWith(_$_EditPrivateMessage value,
-          $Res Function(_$_EditPrivateMessage) then) =
-      __$$_EditPrivateMessageCopyWithImpl<$Res>;
+  factory _$$EditPrivateMessageImplCopyWith(_$EditPrivateMessageImpl value,
+          $Res Function(_$EditPrivateMessageImpl) then) =
+      __$$EditPrivateMessageImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int privateMessageId, String content, String auth});
 }
 
 /// @nodoc
-class __$$_EditPrivateMessageCopyWithImpl<$Res>
-    extends _$EditPrivateMessageCopyWithImpl<$Res, _$_EditPrivateMessage>
-    implements _$$_EditPrivateMessageCopyWith<$Res> {
-  __$$_EditPrivateMessageCopyWithImpl(
-      _$_EditPrivateMessage _value, $Res Function(_$_EditPrivateMessage) _then)
+class __$$EditPrivateMessageImplCopyWithImpl<$Res>
+    extends _$EditPrivateMessageCopyWithImpl<$Res, _$EditPrivateMessageImpl>
+    implements _$$EditPrivateMessageImplCopyWith<$Res> {
+  __$$EditPrivateMessageImplCopyWithImpl(_$EditPrivateMessageImpl _value,
+      $Res Function(_$EditPrivateMessageImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3555,7 +3571,7 @@ class __$$_EditPrivateMessageCopyWithImpl<$Res>
     Object? content = null,
     Object? auth = null,
   }) {
-    return _then(_$_EditPrivateMessage(
+    return _then(_$EditPrivateMessageImpl(
       privateMessageId: null == privateMessageId
           ? _value.privateMessageId
           : privateMessageId // ignore: cast_nullable_to_non_nullable
@@ -3575,15 +3591,15 @@ class __$$_EditPrivateMessageCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_EditPrivateMessage extends _EditPrivateMessage {
-  const _$_EditPrivateMessage(
+class _$EditPrivateMessageImpl extends _EditPrivateMessage {
+  const _$EditPrivateMessageImpl(
       {required this.privateMessageId,
       required this.content,
       required this.auth})
       : super._();
 
-  factory _$_EditPrivateMessage.fromJson(Map<String, dynamic> json) =>
-      _$$_EditPrivateMessageFromJson(json);
+  factory _$EditPrivateMessageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EditPrivateMessageImplFromJson(json);
 
   @override
   final int privateMessageId;
@@ -3601,7 +3617,7 @@ class _$_EditPrivateMessage extends _EditPrivateMessage {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_EditPrivateMessage &&
+            other is _$EditPrivateMessageImpl &&
             (identical(other.privateMessageId, privateMessageId) ||
                 other.privateMessageId == privateMessageId) &&
             (identical(other.content, content) || other.content == content) &&
@@ -3615,13 +3631,13 @@ class _$_EditPrivateMessage extends _EditPrivateMessage {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_EditPrivateMessageCopyWith<_$_EditPrivateMessage> get copyWith =>
-      __$$_EditPrivateMessageCopyWithImpl<_$_EditPrivateMessage>(
+  _$$EditPrivateMessageImplCopyWith<_$EditPrivateMessageImpl> get copyWith =>
+      __$$EditPrivateMessageImplCopyWithImpl<_$EditPrivateMessageImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_EditPrivateMessageToJson(
+    return _$$EditPrivateMessageImplToJson(
       this,
     );
   }
@@ -3631,11 +3647,11 @@ abstract class _EditPrivateMessage extends EditPrivateMessage {
   const factory _EditPrivateMessage(
       {required final int privateMessageId,
       required final String content,
-      required final String auth}) = _$_EditPrivateMessage;
+      required final String auth}) = _$EditPrivateMessageImpl;
   const _EditPrivateMessage._() : super._();
 
   factory _EditPrivateMessage.fromJson(Map<String, dynamic> json) =
-      _$_EditPrivateMessage.fromJson;
+      _$EditPrivateMessageImpl.fromJson;
 
   @override
   int get privateMessageId;
@@ -3645,7 +3661,7 @@ abstract class _EditPrivateMessage extends EditPrivateMessage {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_EditPrivateMessageCopyWith<_$_EditPrivateMessage> get copyWith =>
+  _$$EditPrivateMessageImplCopyWith<_$EditPrivateMessageImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3710,22 +3726,22 @@ class _$DeletePrivateMessageCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_DeletePrivateMessageCopyWith<$Res>
+abstract class _$$DeletePrivateMessageImplCopyWith<$Res>
     implements $DeletePrivateMessageCopyWith<$Res> {
-  factory _$$_DeletePrivateMessageCopyWith(_$_DeletePrivateMessage value,
-          $Res Function(_$_DeletePrivateMessage) then) =
-      __$$_DeletePrivateMessageCopyWithImpl<$Res>;
+  factory _$$DeletePrivateMessageImplCopyWith(_$DeletePrivateMessageImpl value,
+          $Res Function(_$DeletePrivateMessageImpl) then) =
+      __$$DeletePrivateMessageImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int privateMessageId, bool deleted, String auth});
 }
 
 /// @nodoc
-class __$$_DeletePrivateMessageCopyWithImpl<$Res>
-    extends _$DeletePrivateMessageCopyWithImpl<$Res, _$_DeletePrivateMessage>
-    implements _$$_DeletePrivateMessageCopyWith<$Res> {
-  __$$_DeletePrivateMessageCopyWithImpl(_$_DeletePrivateMessage _value,
-      $Res Function(_$_DeletePrivateMessage) _then)
+class __$$DeletePrivateMessageImplCopyWithImpl<$Res>
+    extends _$DeletePrivateMessageCopyWithImpl<$Res, _$DeletePrivateMessageImpl>
+    implements _$$DeletePrivateMessageImplCopyWith<$Res> {
+  __$$DeletePrivateMessageImplCopyWithImpl(_$DeletePrivateMessageImpl _value,
+      $Res Function(_$DeletePrivateMessageImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3735,7 +3751,7 @@ class __$$_DeletePrivateMessageCopyWithImpl<$Res>
     Object? deleted = null,
     Object? auth = null,
   }) {
-    return _then(_$_DeletePrivateMessage(
+    return _then(_$DeletePrivateMessageImpl(
       privateMessageId: null == privateMessageId
           ? _value.privateMessageId
           : privateMessageId // ignore: cast_nullable_to_non_nullable
@@ -3755,15 +3771,15 @@ class __$$_DeletePrivateMessageCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_DeletePrivateMessage extends _DeletePrivateMessage {
-  const _$_DeletePrivateMessage(
+class _$DeletePrivateMessageImpl extends _DeletePrivateMessage {
+  const _$DeletePrivateMessageImpl(
       {required this.privateMessageId,
       required this.deleted,
       required this.auth})
       : super._();
 
-  factory _$_DeletePrivateMessage.fromJson(Map<String, dynamic> json) =>
-      _$$_DeletePrivateMessageFromJson(json);
+  factory _$DeletePrivateMessageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeletePrivateMessageImplFromJson(json);
 
   @override
   final int privateMessageId;
@@ -3781,7 +3797,7 @@ class _$_DeletePrivateMessage extends _DeletePrivateMessage {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeletePrivateMessage &&
+            other is _$DeletePrivateMessageImpl &&
             (identical(other.privateMessageId, privateMessageId) ||
                 other.privateMessageId == privateMessageId) &&
             (identical(other.deleted, deleted) || other.deleted == deleted) &&
@@ -3795,13 +3811,14 @@ class _$_DeletePrivateMessage extends _DeletePrivateMessage {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeletePrivateMessageCopyWith<_$_DeletePrivateMessage> get copyWith =>
-      __$$_DeletePrivateMessageCopyWithImpl<_$_DeletePrivateMessage>(
-          this, _$identity);
+  _$$DeletePrivateMessageImplCopyWith<_$DeletePrivateMessageImpl>
+      get copyWith =>
+          __$$DeletePrivateMessageImplCopyWithImpl<_$DeletePrivateMessageImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeletePrivateMessageToJson(
+    return _$$DeletePrivateMessageImplToJson(
       this,
     );
   }
@@ -3811,11 +3828,11 @@ abstract class _DeletePrivateMessage extends DeletePrivateMessage {
   const factory _DeletePrivateMessage(
       {required final int privateMessageId,
       required final bool deleted,
-      required final String auth}) = _$_DeletePrivateMessage;
+      required final String auth}) = _$DeletePrivateMessageImpl;
   const _DeletePrivateMessage._() : super._();
 
   factory _DeletePrivateMessage.fromJson(Map<String, dynamic> json) =
-      _$_DeletePrivateMessage.fromJson;
+      _$DeletePrivateMessageImpl.fromJson;
 
   @override
   int get privateMessageId;
@@ -3825,8 +3842,8 @@ abstract class _DeletePrivateMessage extends DeletePrivateMessage {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_DeletePrivateMessageCopyWith<_$_DeletePrivateMessage> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$DeletePrivateMessageImplCopyWith<_$DeletePrivateMessageImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 MarkPrivateMessageAsRead _$MarkPrivateMessageAsReadFromJson(
@@ -3891,24 +3908,25 @@ class _$MarkPrivateMessageAsReadCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_MarkPrivateMessageAsReadCopyWith<$Res>
+abstract class _$$MarkPrivateMessageAsReadImplCopyWith<$Res>
     implements $MarkPrivateMessageAsReadCopyWith<$Res> {
-  factory _$$_MarkPrivateMessageAsReadCopyWith(
-          _$_MarkPrivateMessageAsRead value,
-          $Res Function(_$_MarkPrivateMessageAsRead) then) =
-      __$$_MarkPrivateMessageAsReadCopyWithImpl<$Res>;
+  factory _$$MarkPrivateMessageAsReadImplCopyWith(
+          _$MarkPrivateMessageAsReadImpl value,
+          $Res Function(_$MarkPrivateMessageAsReadImpl) then) =
+      __$$MarkPrivateMessageAsReadImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int privateMessageId, bool read, String auth});
 }
 
 /// @nodoc
-class __$$_MarkPrivateMessageAsReadCopyWithImpl<$Res>
+class __$$MarkPrivateMessageAsReadImplCopyWithImpl<$Res>
     extends _$MarkPrivateMessageAsReadCopyWithImpl<$Res,
-        _$_MarkPrivateMessageAsRead>
-    implements _$$_MarkPrivateMessageAsReadCopyWith<$Res> {
-  __$$_MarkPrivateMessageAsReadCopyWithImpl(_$_MarkPrivateMessageAsRead _value,
-      $Res Function(_$_MarkPrivateMessageAsRead) _then)
+        _$MarkPrivateMessageAsReadImpl>
+    implements _$$MarkPrivateMessageAsReadImplCopyWith<$Res> {
+  __$$MarkPrivateMessageAsReadImplCopyWithImpl(
+      _$MarkPrivateMessageAsReadImpl _value,
+      $Res Function(_$MarkPrivateMessageAsReadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3918,7 +3936,7 @@ class __$$_MarkPrivateMessageAsReadCopyWithImpl<$Res>
     Object? read = null,
     Object? auth = null,
   }) {
-    return _then(_$_MarkPrivateMessageAsRead(
+    return _then(_$MarkPrivateMessageAsReadImpl(
       privateMessageId: null == privateMessageId
           ? _value.privateMessageId
           : privateMessageId // ignore: cast_nullable_to_non_nullable
@@ -3938,13 +3956,13 @@ class __$$_MarkPrivateMessageAsReadCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_MarkPrivateMessageAsRead extends _MarkPrivateMessageAsRead {
-  const _$_MarkPrivateMessageAsRead(
+class _$MarkPrivateMessageAsReadImpl extends _MarkPrivateMessageAsRead {
+  const _$MarkPrivateMessageAsReadImpl(
       {required this.privateMessageId, required this.read, required this.auth})
       : super._();
 
-  factory _$_MarkPrivateMessageAsRead.fromJson(Map<String, dynamic> json) =>
-      _$$_MarkPrivateMessageAsReadFromJson(json);
+  factory _$MarkPrivateMessageAsReadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MarkPrivateMessageAsReadImplFromJson(json);
 
   @override
   final int privateMessageId;
@@ -3962,7 +3980,7 @@ class _$_MarkPrivateMessageAsRead extends _MarkPrivateMessageAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MarkPrivateMessageAsRead &&
+            other is _$MarkPrivateMessageAsReadImpl &&
             (identical(other.privateMessageId, privateMessageId) ||
                 other.privateMessageId == privateMessageId) &&
             (identical(other.read, read) || other.read == read) &&
@@ -3976,13 +3994,13 @@ class _$_MarkPrivateMessageAsRead extends _MarkPrivateMessageAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MarkPrivateMessageAsReadCopyWith<_$_MarkPrivateMessageAsRead>
-      get copyWith => __$$_MarkPrivateMessageAsReadCopyWithImpl<
-          _$_MarkPrivateMessageAsRead>(this, _$identity);
+  _$$MarkPrivateMessageAsReadImplCopyWith<_$MarkPrivateMessageAsReadImpl>
+      get copyWith => __$$MarkPrivateMessageAsReadImplCopyWithImpl<
+          _$MarkPrivateMessageAsReadImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MarkPrivateMessageAsReadToJson(
+    return _$$MarkPrivateMessageAsReadImplToJson(
       this,
     );
   }
@@ -3992,11 +4010,11 @@ abstract class _MarkPrivateMessageAsRead extends MarkPrivateMessageAsRead {
   const factory _MarkPrivateMessageAsRead(
       {required final int privateMessageId,
       required final bool read,
-      required final String auth}) = _$_MarkPrivateMessageAsRead;
+      required final String auth}) = _$MarkPrivateMessageAsReadImpl;
   const _MarkPrivateMessageAsRead._() : super._();
 
   factory _MarkPrivateMessageAsRead.fromJson(Map<String, dynamic> json) =
-      _$_MarkPrivateMessageAsRead.fromJson;
+      _$MarkPrivateMessageAsReadImpl.fromJson;
 
   @override
   int get privateMessageId;
@@ -4006,7 +4024,7 @@ abstract class _MarkPrivateMessageAsRead extends MarkPrivateMessageAsRead {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_MarkPrivateMessageAsReadCopyWith<_$_MarkPrivateMessageAsRead>
+  _$$MarkPrivateMessageAsReadImplCopyWith<_$MarkPrivateMessageAsReadImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -4076,22 +4094,22 @@ class _$GetPrivateMessagesCopyWithImpl<$Res, $Val extends GetPrivateMessages>
 }
 
 /// @nodoc
-abstract class _$$_GetPrivateMessagesCopyWith<$Res>
+abstract class _$$GetPrivateMessagesImplCopyWith<$Res>
     implements $GetPrivateMessagesCopyWith<$Res> {
-  factory _$$_GetPrivateMessagesCopyWith(_$_GetPrivateMessages value,
-          $Res Function(_$_GetPrivateMessages) then) =
-      __$$_GetPrivateMessagesCopyWithImpl<$Res>;
+  factory _$$GetPrivateMessagesImplCopyWith(_$GetPrivateMessagesImpl value,
+          $Res Function(_$GetPrivateMessagesImpl) then) =
+      __$$GetPrivateMessagesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool? unreadOnly, int? page, int? limit, String auth});
 }
 
 /// @nodoc
-class __$$_GetPrivateMessagesCopyWithImpl<$Res>
-    extends _$GetPrivateMessagesCopyWithImpl<$Res, _$_GetPrivateMessages>
-    implements _$$_GetPrivateMessagesCopyWith<$Res> {
-  __$$_GetPrivateMessagesCopyWithImpl(
-      _$_GetPrivateMessages _value, $Res Function(_$_GetPrivateMessages) _then)
+class __$$GetPrivateMessagesImplCopyWithImpl<$Res>
+    extends _$GetPrivateMessagesCopyWithImpl<$Res, _$GetPrivateMessagesImpl>
+    implements _$$GetPrivateMessagesImplCopyWith<$Res> {
+  __$$GetPrivateMessagesImplCopyWithImpl(_$GetPrivateMessagesImpl _value,
+      $Res Function(_$GetPrivateMessagesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4102,7 +4120,7 @@ class __$$_GetPrivateMessagesCopyWithImpl<$Res>
     Object? limit = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_GetPrivateMessages(
+    return _then(_$GetPrivateMessagesImpl(
       unreadOnly: freezed == unreadOnly
           ? _value.unreadOnly
           : unreadOnly // ignore: cast_nullable_to_non_nullable
@@ -4126,13 +4144,13 @@ class __$$_GetPrivateMessagesCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetPrivateMessages extends _GetPrivateMessages {
-  const _$_GetPrivateMessages(
+class _$GetPrivateMessagesImpl extends _GetPrivateMessages {
+  const _$GetPrivateMessagesImpl(
       {this.unreadOnly, this.page, this.limit, required this.auth})
       : super._();
 
-  factory _$_GetPrivateMessages.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPrivateMessagesFromJson(json);
+  factory _$GetPrivateMessagesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPrivateMessagesImplFromJson(json);
 
   @override
   final bool? unreadOnly;
@@ -4152,7 +4170,7 @@ class _$_GetPrivateMessages extends _GetPrivateMessages {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPrivateMessages &&
+            other is _$GetPrivateMessagesImpl &&
             (identical(other.unreadOnly, unreadOnly) ||
                 other.unreadOnly == unreadOnly) &&
             (identical(other.page, page) || other.page == page) &&
@@ -4167,13 +4185,13 @@ class _$_GetPrivateMessages extends _GetPrivateMessages {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPrivateMessagesCopyWith<_$_GetPrivateMessages> get copyWith =>
-      __$$_GetPrivateMessagesCopyWithImpl<_$_GetPrivateMessages>(
+  _$$GetPrivateMessagesImplCopyWith<_$GetPrivateMessagesImpl> get copyWith =>
+      __$$GetPrivateMessagesImplCopyWithImpl<_$GetPrivateMessagesImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPrivateMessagesToJson(
+    return _$$GetPrivateMessagesImplToJson(
       this,
     );
   }
@@ -4184,11 +4202,11 @@ abstract class _GetPrivateMessages extends GetPrivateMessages {
       {final bool? unreadOnly,
       final int? page,
       final int? limit,
-      required final String auth}) = _$_GetPrivateMessages;
+      required final String auth}) = _$GetPrivateMessagesImpl;
   const _GetPrivateMessages._() : super._();
 
   factory _GetPrivateMessages.fromJson(Map<String, dynamic> json) =
-      _$_GetPrivateMessages.fromJson;
+      _$GetPrivateMessagesImpl.fromJson;
 
   @override
   bool? get unreadOnly;
@@ -4200,7 +4218,7 @@ abstract class _GetPrivateMessages extends GetPrivateMessages {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPrivateMessagesCopyWith<_$_GetPrivateMessages> get copyWith =>
+  _$$GetPrivateMessagesImplCopyWith<_$GetPrivateMessagesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4264,22 +4282,22 @@ class _$BlockPersonCopyWithImpl<$Res, $Val extends BlockPerson>
 }
 
 /// @nodoc
-abstract class _$$_BlockPersonCopyWith<$Res>
+abstract class _$$BlockPersonImplCopyWith<$Res>
     implements $BlockPersonCopyWith<$Res> {
-  factory _$$_BlockPersonCopyWith(
-          _$_BlockPerson value, $Res Function(_$_BlockPerson) then) =
-      __$$_BlockPersonCopyWithImpl<$Res>;
+  factory _$$BlockPersonImplCopyWith(
+          _$BlockPersonImpl value, $Res Function(_$BlockPersonImpl) then) =
+      __$$BlockPersonImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int personId, bool block, String auth});
 }
 
 /// @nodoc
-class __$$_BlockPersonCopyWithImpl<$Res>
-    extends _$BlockPersonCopyWithImpl<$Res, _$_BlockPerson>
-    implements _$$_BlockPersonCopyWith<$Res> {
-  __$$_BlockPersonCopyWithImpl(
-      _$_BlockPerson _value, $Res Function(_$_BlockPerson) _then)
+class __$$BlockPersonImplCopyWithImpl<$Res>
+    extends _$BlockPersonCopyWithImpl<$Res, _$BlockPersonImpl>
+    implements _$$BlockPersonImplCopyWith<$Res> {
+  __$$BlockPersonImplCopyWithImpl(
+      _$BlockPersonImpl _value, $Res Function(_$BlockPersonImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4289,7 +4307,7 @@ class __$$_BlockPersonCopyWithImpl<$Res>
     Object? block = null,
     Object? auth = null,
   }) {
-    return _then(_$_BlockPerson(
+    return _then(_$BlockPersonImpl(
       personId: null == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -4309,13 +4327,13 @@ class __$$_BlockPersonCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_BlockPerson extends _BlockPerson {
-  const _$_BlockPerson(
+class _$BlockPersonImpl extends _BlockPerson {
+  const _$BlockPersonImpl(
       {required this.personId, required this.block, required this.auth})
       : super._();
 
-  factory _$_BlockPerson.fromJson(Map<String, dynamic> json) =>
-      _$$_BlockPersonFromJson(json);
+  factory _$BlockPersonImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BlockPersonImplFromJson(json);
 
   @override
   final int personId;
@@ -4333,7 +4351,7 @@ class _$_BlockPerson extends _BlockPerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BlockPerson &&
+            other is _$BlockPersonImpl &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.block, block) || other.block == block) &&
@@ -4347,12 +4365,12 @@ class _$_BlockPerson extends _BlockPerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BlockPersonCopyWith<_$_BlockPerson> get copyWith =>
-      __$$_BlockPersonCopyWithImpl<_$_BlockPerson>(this, _$identity);
+  _$$BlockPersonImplCopyWith<_$BlockPersonImpl> get copyWith =>
+      __$$BlockPersonImplCopyWithImpl<_$BlockPersonImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BlockPersonToJson(
+    return _$$BlockPersonImplToJson(
       this,
     );
   }
@@ -4362,11 +4380,11 @@ abstract class _BlockPerson extends BlockPerson {
   const factory _BlockPerson(
       {required final int personId,
       required final bool block,
-      required final String auth}) = _$_BlockPerson;
+      required final String auth}) = _$BlockPersonImpl;
   const _BlockPerson._() : super._();
 
   factory _BlockPerson.fromJson(Map<String, dynamic> json) =
-      _$_BlockPerson.fromJson;
+      _$BlockPersonImpl.fromJson;
 
   @override
   int get personId;
@@ -4376,7 +4394,7 @@ abstract class _BlockPerson extends BlockPerson {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_BlockPersonCopyWith<_$_BlockPerson> get copyWith =>
+  _$$BlockPersonImplCopyWith<_$BlockPersonImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4428,22 +4446,22 @@ class _$GetUnreadCountCopyWithImpl<$Res, $Val extends GetUnreadCount>
 }
 
 /// @nodoc
-abstract class _$$_GetUnreadCountCopyWith<$Res>
+abstract class _$$GetUnreadCountImplCopyWith<$Res>
     implements $GetUnreadCountCopyWith<$Res> {
-  factory _$$_GetUnreadCountCopyWith(
-          _$_GetUnreadCount value, $Res Function(_$_GetUnreadCount) then) =
-      __$$_GetUnreadCountCopyWithImpl<$Res>;
+  factory _$$GetUnreadCountImplCopyWith(_$GetUnreadCountImpl value,
+          $Res Function(_$GetUnreadCountImpl) then) =
+      __$$GetUnreadCountImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String auth});
 }
 
 /// @nodoc
-class __$$_GetUnreadCountCopyWithImpl<$Res>
-    extends _$GetUnreadCountCopyWithImpl<$Res, _$_GetUnreadCount>
-    implements _$$_GetUnreadCountCopyWith<$Res> {
-  __$$_GetUnreadCountCopyWithImpl(
-      _$_GetUnreadCount _value, $Res Function(_$_GetUnreadCount) _then)
+class __$$GetUnreadCountImplCopyWithImpl<$Res>
+    extends _$GetUnreadCountCopyWithImpl<$Res, _$GetUnreadCountImpl>
+    implements _$$GetUnreadCountImplCopyWith<$Res> {
+  __$$GetUnreadCountImplCopyWithImpl(
+      _$GetUnreadCountImpl _value, $Res Function(_$GetUnreadCountImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4451,7 +4469,7 @@ class __$$_GetUnreadCountCopyWithImpl<$Res>
   $Res call({
     Object? auth = null,
   }) {
-    return _then(_$_GetUnreadCount(
+    return _then(_$GetUnreadCountImpl(
       auth: null == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -4463,11 +4481,11 @@ class __$$_GetUnreadCountCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetUnreadCount extends _GetUnreadCount {
-  const _$_GetUnreadCount({required this.auth}) : super._();
+class _$GetUnreadCountImpl extends _GetUnreadCount {
+  const _$GetUnreadCountImpl({required this.auth}) : super._();
 
-  factory _$_GetUnreadCount.fromJson(Map<String, dynamic> json) =>
-      _$$_GetUnreadCountFromJson(json);
+  factory _$GetUnreadCountImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetUnreadCountImplFromJson(json);
 
   @override
   final String auth;
@@ -4481,7 +4499,7 @@ class _$_GetUnreadCount extends _GetUnreadCount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetUnreadCount &&
+            other is _$GetUnreadCountImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -4492,12 +4510,13 @@ class _$_GetUnreadCount extends _GetUnreadCount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetUnreadCountCopyWith<_$_GetUnreadCount> get copyWith =>
-      __$$_GetUnreadCountCopyWithImpl<_$_GetUnreadCount>(this, _$identity);
+  _$$GetUnreadCountImplCopyWith<_$GetUnreadCountImpl> get copyWith =>
+      __$$GetUnreadCountImplCopyWithImpl<_$GetUnreadCountImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetUnreadCountToJson(
+    return _$$GetUnreadCountImplToJson(
       this,
     );
   }
@@ -4505,17 +4524,17 @@ class _$_GetUnreadCount extends _GetUnreadCount {
 
 abstract class _GetUnreadCount extends GetUnreadCount {
   const factory _GetUnreadCount({required final String auth}) =
-      _$_GetUnreadCount;
+      _$GetUnreadCountImpl;
   const _GetUnreadCount._() : super._();
 
   factory _GetUnreadCount.fromJson(Map<String, dynamic> json) =
-      _$_GetUnreadCount.fromJson;
+      _$GetUnreadCountImpl.fromJson;
 
   @override
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetUnreadCountCopyWith<_$_GetUnreadCount> get copyWith =>
+  _$$GetUnreadCountImplCopyWith<_$GetUnreadCountImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4573,22 +4592,22 @@ class _$GetReportCountCopyWithImpl<$Res, $Val extends GetReportCount>
 }
 
 /// @nodoc
-abstract class _$$_GetReportCountCopyWith<$Res>
+abstract class _$$GetReportCountImplCopyWith<$Res>
     implements $GetReportCountCopyWith<$Res> {
-  factory _$$_GetReportCountCopyWith(
-          _$_GetReportCount value, $Res Function(_$_GetReportCount) then) =
-      __$$_GetReportCountCopyWithImpl<$Res>;
+  factory _$$GetReportCountImplCopyWith(_$GetReportCountImpl value,
+          $Res Function(_$GetReportCountImpl) then) =
+      __$$GetReportCountImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int? communityId, String auth});
 }
 
 /// @nodoc
-class __$$_GetReportCountCopyWithImpl<$Res>
-    extends _$GetReportCountCopyWithImpl<$Res, _$_GetReportCount>
-    implements _$$_GetReportCountCopyWith<$Res> {
-  __$$_GetReportCountCopyWithImpl(
-      _$_GetReportCount _value, $Res Function(_$_GetReportCount) _then)
+class __$$GetReportCountImplCopyWithImpl<$Res>
+    extends _$GetReportCountCopyWithImpl<$Res, _$GetReportCountImpl>
+    implements _$$GetReportCountImplCopyWith<$Res> {
+  __$$GetReportCountImplCopyWithImpl(
+      _$GetReportCountImpl _value, $Res Function(_$GetReportCountImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4597,7 +4616,7 @@ class __$$_GetReportCountCopyWithImpl<$Res>
     Object? communityId = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_GetReportCount(
+    return _then(_$GetReportCountImpl(
       communityId: freezed == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -4613,11 +4632,12 @@ class __$$_GetReportCountCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetReportCount extends _GetReportCount {
-  const _$_GetReportCount({this.communityId, required this.auth}) : super._();
+class _$GetReportCountImpl extends _GetReportCount {
+  const _$GetReportCountImpl({this.communityId, required this.auth})
+      : super._();
 
-  factory _$_GetReportCount.fromJson(Map<String, dynamic> json) =>
-      _$$_GetReportCountFromJson(json);
+  factory _$GetReportCountImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetReportCountImplFromJson(json);
 
   @override
   final int? communityId;
@@ -4633,7 +4653,7 @@ class _$_GetReportCount extends _GetReportCount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetReportCount &&
+            other is _$GetReportCountImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -4646,12 +4666,13 @@ class _$_GetReportCount extends _GetReportCount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetReportCountCopyWith<_$_GetReportCount> get copyWith =>
-      __$$_GetReportCountCopyWithImpl<_$_GetReportCount>(this, _$identity);
+  _$$GetReportCountImplCopyWith<_$GetReportCountImpl> get copyWith =>
+      __$$GetReportCountImplCopyWithImpl<_$GetReportCountImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetReportCountToJson(
+    return _$$GetReportCountImplToJson(
       this,
     );
   }
@@ -4659,11 +4680,12 @@ class _$_GetReportCount extends _GetReportCount {
 
 abstract class _GetReportCount extends GetReportCount {
   const factory _GetReportCount(
-      {final int? communityId, required final String auth}) = _$_GetReportCount;
+      {final int? communityId,
+      required final String auth}) = _$GetReportCountImpl;
   const _GetReportCount._() : super._();
 
   factory _GetReportCount.fromJson(Map<String, dynamic> json) =
-      _$_GetReportCount.fromJson;
+      _$GetReportCountImpl.fromJson;
 
   @override
   int? get communityId;
@@ -4671,7 +4693,7 @@ abstract class _GetReportCount extends GetReportCount {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetReportCountCopyWith<_$_GetReportCount> get copyWith =>
+  _$$GetReportCountImplCopyWith<_$GetReportCountImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4723,22 +4745,22 @@ class _$GetBannedPersonsCopyWithImpl<$Res, $Val extends GetBannedPersons>
 }
 
 /// @nodoc
-abstract class _$$_GetBannedPersonsCopyWith<$Res>
+abstract class _$$GetBannedPersonsImplCopyWith<$Res>
     implements $GetBannedPersonsCopyWith<$Res> {
-  factory _$$_GetBannedPersonsCopyWith(
-          _$_GetBannedPersons value, $Res Function(_$_GetBannedPersons) then) =
-      __$$_GetBannedPersonsCopyWithImpl<$Res>;
+  factory _$$GetBannedPersonsImplCopyWith(_$GetBannedPersonsImpl value,
+          $Res Function(_$GetBannedPersonsImpl) then) =
+      __$$GetBannedPersonsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String auth});
 }
 
 /// @nodoc
-class __$$_GetBannedPersonsCopyWithImpl<$Res>
-    extends _$GetBannedPersonsCopyWithImpl<$Res, _$_GetBannedPersons>
-    implements _$$_GetBannedPersonsCopyWith<$Res> {
-  __$$_GetBannedPersonsCopyWithImpl(
-      _$_GetBannedPersons _value, $Res Function(_$_GetBannedPersons) _then)
+class __$$GetBannedPersonsImplCopyWithImpl<$Res>
+    extends _$GetBannedPersonsCopyWithImpl<$Res, _$GetBannedPersonsImpl>
+    implements _$$GetBannedPersonsImplCopyWith<$Res> {
+  __$$GetBannedPersonsImplCopyWithImpl(_$GetBannedPersonsImpl _value,
+      $Res Function(_$GetBannedPersonsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4746,7 +4768,7 @@ class __$$_GetBannedPersonsCopyWithImpl<$Res>
   $Res call({
     Object? auth = null,
   }) {
-    return _then(_$_GetBannedPersons(
+    return _then(_$GetBannedPersonsImpl(
       auth: null == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -4758,11 +4780,11 @@ class __$$_GetBannedPersonsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetBannedPersons extends _GetBannedPersons {
-  const _$_GetBannedPersons({required this.auth}) : super._();
+class _$GetBannedPersonsImpl extends _GetBannedPersons {
+  const _$GetBannedPersonsImpl({required this.auth}) : super._();
 
-  factory _$_GetBannedPersons.fromJson(Map<String, dynamic> json) =>
-      _$$_GetBannedPersonsFromJson(json);
+  factory _$GetBannedPersonsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetBannedPersonsImplFromJson(json);
 
   @override
   final String auth;
@@ -4776,7 +4798,7 @@ class _$_GetBannedPersons extends _GetBannedPersons {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetBannedPersons &&
+            other is _$GetBannedPersonsImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -4787,12 +4809,13 @@ class _$_GetBannedPersons extends _GetBannedPersons {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetBannedPersonsCopyWith<_$_GetBannedPersons> get copyWith =>
-      __$$_GetBannedPersonsCopyWithImpl<_$_GetBannedPersons>(this, _$identity);
+  _$$GetBannedPersonsImplCopyWith<_$GetBannedPersonsImpl> get copyWith =>
+      __$$GetBannedPersonsImplCopyWithImpl<_$GetBannedPersonsImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetBannedPersonsToJson(
+    return _$$GetBannedPersonsImplToJson(
       this,
     );
   }
@@ -4800,17 +4823,17 @@ class _$_GetBannedPersons extends _GetBannedPersons {
 
 abstract class _GetBannedPersons extends GetBannedPersons {
   const factory _GetBannedPersons({required final String auth}) =
-      _$_GetBannedPersons;
+      _$GetBannedPersonsImpl;
   const _GetBannedPersons._() : super._();
 
   factory _GetBannedPersons.fromJson(Map<String, dynamic> json) =
-      _$_GetBannedPersons.fromJson;
+      _$GetBannedPersonsImpl.fromJson;
 
   @override
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetBannedPersonsCopyWith<_$_GetBannedPersons> get copyWith =>
+  _$$GetBannedPersonsImplCopyWith<_$GetBannedPersonsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4862,22 +4885,22 @@ class _$VerifyEmailCopyWithImpl<$Res, $Val extends VerifyEmail>
 }
 
 /// @nodoc
-abstract class _$$_VerifyEmailCopyWith<$Res>
+abstract class _$$VerifyEmailImplCopyWith<$Res>
     implements $VerifyEmailCopyWith<$Res> {
-  factory _$$_VerifyEmailCopyWith(
-          _$_VerifyEmail value, $Res Function(_$_VerifyEmail) then) =
-      __$$_VerifyEmailCopyWithImpl<$Res>;
+  factory _$$VerifyEmailImplCopyWith(
+          _$VerifyEmailImpl value, $Res Function(_$VerifyEmailImpl) then) =
+      __$$VerifyEmailImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String token});
 }
 
 /// @nodoc
-class __$$_VerifyEmailCopyWithImpl<$Res>
-    extends _$VerifyEmailCopyWithImpl<$Res, _$_VerifyEmail>
-    implements _$$_VerifyEmailCopyWith<$Res> {
-  __$$_VerifyEmailCopyWithImpl(
-      _$_VerifyEmail _value, $Res Function(_$_VerifyEmail) _then)
+class __$$VerifyEmailImplCopyWithImpl<$Res>
+    extends _$VerifyEmailCopyWithImpl<$Res, _$VerifyEmailImpl>
+    implements _$$VerifyEmailImplCopyWith<$Res> {
+  __$$VerifyEmailImplCopyWithImpl(
+      _$VerifyEmailImpl _value, $Res Function(_$VerifyEmailImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4885,7 +4908,7 @@ class __$$_VerifyEmailCopyWithImpl<$Res>
   $Res call({
     Object? token = null,
   }) {
-    return _then(_$_VerifyEmail(
+    return _then(_$VerifyEmailImpl(
       token: null == token
           ? _value.token
           : token // ignore: cast_nullable_to_non_nullable
@@ -4897,11 +4920,11 @@ class __$$_VerifyEmailCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_VerifyEmail extends _VerifyEmail {
-  const _$_VerifyEmail({required this.token}) : super._();
+class _$VerifyEmailImpl extends _VerifyEmail {
+  const _$VerifyEmailImpl({required this.token}) : super._();
 
-  factory _$_VerifyEmail.fromJson(Map<String, dynamic> json) =>
-      _$$_VerifyEmailFromJson(json);
+  factory _$VerifyEmailImpl.fromJson(Map<String, dynamic> json) =>
+      _$$VerifyEmailImplFromJson(json);
 
   @override
   final String token;
@@ -4915,7 +4938,7 @@ class _$_VerifyEmail extends _VerifyEmail {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_VerifyEmail &&
+            other is _$VerifyEmailImpl &&
             (identical(other.token, token) || other.token == token));
   }
 
@@ -4926,28 +4949,28 @@ class _$_VerifyEmail extends _VerifyEmail {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_VerifyEmailCopyWith<_$_VerifyEmail> get copyWith =>
-      __$$_VerifyEmailCopyWithImpl<_$_VerifyEmail>(this, _$identity);
+  _$$VerifyEmailImplCopyWith<_$VerifyEmailImpl> get copyWith =>
+      __$$VerifyEmailImplCopyWithImpl<_$VerifyEmailImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_VerifyEmailToJson(
+    return _$$VerifyEmailImplToJson(
       this,
     );
   }
 }
 
 abstract class _VerifyEmail extends VerifyEmail {
-  const factory _VerifyEmail({required final String token}) = _$_VerifyEmail;
+  const factory _VerifyEmail({required final String token}) = _$VerifyEmailImpl;
   const _VerifyEmail._() : super._();
 
   factory _VerifyEmail.fromJson(Map<String, dynamic> json) =
-      _$_VerifyEmail.fromJson;
+      _$VerifyEmailImpl.fromJson;
 
   @override
   String get token;
   @override
   @JsonKey(ignore: true)
-  _$$_VerifyEmailCopyWith<_$_VerifyEmail> get copyWith =>
+  _$$VerifyEmailImplCopyWith<_$VerifyEmailImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/person.g.dart
+++ b/lib/src/v3/api/person.g.dart
@@ -6,13 +6,13 @@ part of 'person.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Login _$$_LoginFromJson(Map<String, dynamic> json) => _$_Login(
+_$LoginImpl _$$LoginImplFromJson(Map<String, dynamic> json) => _$LoginImpl(
       usernameOrEmail: json['username_or_email'] as String,
       password: json['password'] as String,
       totp2faToken: json['totp_2fa_token'] as String?,
     );
 
-Map<String, dynamic> _$$_LoginToJson(_$_Login instance) {
+Map<String, dynamic> _$$LoginImplToJson(_$LoginImpl instance) {
   final val = <String, dynamic>{
     'username_or_email': instance.usernameOrEmail,
     'password': instance.password,
@@ -28,7 +28,8 @@ Map<String, dynamic> _$$_LoginToJson(_$_Login instance) {
   return val;
 }
 
-_$_Register _$$_RegisterFromJson(Map<String, dynamic> json) => _$_Register(
+_$RegisterImpl _$$RegisterImplFromJson(Map<String, dynamic> json) =>
+    _$RegisterImpl(
       username: json['username'] as String,
       email: json['email'] as String?,
       password: json['password'] as String,
@@ -40,7 +41,7 @@ _$_Register _$$_RegisterFromJson(Map<String, dynamic> json) => _$_Register(
       answer: json['answer'] as String?,
     );
 
-Map<String, dynamic> _$$_RegisterToJson(_$_Register instance) {
+Map<String, dynamic> _$$RegisterImplToJson(_$RegisterImpl instance) {
   final val = <String, dynamic>{
     'username': instance.username,
   };
@@ -62,14 +63,15 @@ Map<String, dynamic> _$$_RegisterToJson(_$_Register instance) {
   return val;
 }
 
-_$_GetCaptcha _$$_GetCaptchaFromJson(Map<String, dynamic> json) =>
-    _$_GetCaptcha();
+_$GetCaptchaImpl _$$GetCaptchaImplFromJson(Map<String, dynamic> json) =>
+    _$GetCaptchaImpl();
 
-Map<String, dynamic> _$$_GetCaptchaToJson(_$_GetCaptcha instance) =>
+Map<String, dynamic> _$$GetCaptchaImplToJson(_$GetCaptchaImpl instance) =>
     <String, dynamic>{};
 
-_$_SaveUserSettings _$$_SaveUserSettingsFromJson(Map<String, dynamic> json) =>
-    _$_SaveUserSettings(
+_$SaveUserSettingsImpl _$$SaveUserSettingsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$SaveUserSettingsImpl(
       showNsfw: json['show_nsfw'] as bool?,
       theme: json['theme'] as String?,
       defaultSortType: json['default_sort_type'] == null
@@ -98,7 +100,8 @@ _$_SaveUserSettings _$$_SaveUserSettingsFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_SaveUserSettingsToJson(_$_SaveUserSettings instance) {
+Map<String, dynamic> _$$SaveUserSettingsImplToJson(
+    _$SaveUserSettingsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -131,15 +134,16 @@ Map<String, dynamic> _$$_SaveUserSettingsToJson(_$_SaveUserSettings instance) {
   return val;
 }
 
-_$_ChangePassword _$$_ChangePasswordFromJson(Map<String, dynamic> json) =>
-    _$_ChangePassword(
+_$ChangePasswordImpl _$$ChangePasswordImplFromJson(Map<String, dynamic> json) =>
+    _$ChangePasswordImpl(
       newPassword: json['new_password'] as String,
       newPasswordVerify: json['new_password_verify'] as String,
       oldPassword: json['old_password'] as String,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_ChangePasswordToJson(_$_ChangePassword instance) =>
+Map<String, dynamic> _$$ChangePasswordImplToJson(
+        _$ChangePasswordImpl instance) =>
     <String, dynamic>{
       'new_password': instance.newPassword,
       'new_password_verify': instance.newPasswordVerify,
@@ -147,8 +151,9 @@ Map<String, dynamic> _$$_ChangePasswordToJson(_$_ChangePassword instance) =>
       'auth': instance.auth,
     };
 
-_$_GetPersonDetails _$$_GetPersonDetailsFromJson(Map<String, dynamic> json) =>
-    _$_GetPersonDetails(
+_$GetPersonDetailsImpl _$$GetPersonDetailsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GetPersonDetailsImpl(
       personId: json['person_id'] as int?,
       username: json['username'] as String?,
       sort: json['sort'] == null ? null : SortType.fromJson(json['sort']),
@@ -159,7 +164,8 @@ _$_GetPersonDetails _$$_GetPersonDetailsFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetPersonDetailsToJson(_$_GetPersonDetails instance) {
+Map<String, dynamic> _$$GetPersonDetailsImplToJson(
+    _$GetPersonDetailsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -179,30 +185,32 @@ Map<String, dynamic> _$$_GetPersonDetailsToJson(_$_GetPersonDetails instance) {
   return val;
 }
 
-_$_MarkAllAsRead _$$_MarkAllAsReadFromJson(Map<String, dynamic> json) =>
-    _$_MarkAllAsRead(
+_$MarkAllAsReadImpl _$$MarkAllAsReadImplFromJson(Map<String, dynamic> json) =>
+    _$MarkAllAsReadImpl(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_MarkAllAsReadToJson(_$_MarkAllAsRead instance) =>
+Map<String, dynamic> _$$MarkAllAsReadImplToJson(_$MarkAllAsReadImpl instance) =>
     <String, dynamic>{
       'auth': instance.auth,
     };
 
-_$_AddAdmin _$$_AddAdminFromJson(Map<String, dynamic> json) => _$_AddAdmin(
+_$AddAdminImpl _$$AddAdminImplFromJson(Map<String, dynamic> json) =>
+    _$AddAdminImpl(
       personId: json['person_id'] as int,
       added: json['added'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_AddAdminToJson(_$_AddAdmin instance) =>
+Map<String, dynamic> _$$AddAdminImplToJson(_$AddAdminImpl instance) =>
     <String, dynamic>{
       'person_id': instance.personId,
       'added': instance.added,
       'auth': instance.auth,
     };
 
-_$_BanPerson _$$_BanPersonFromJson(Map<String, dynamic> json) => _$_BanPerson(
+_$BanPersonImpl _$$BanPersonImplFromJson(Map<String, dynamic> json) =>
+    _$BanPersonImpl(
       personId: json['person_id'] as int,
       ban: json['ban'] as bool,
       removeData: json['remove_data'] as bool?,
@@ -211,7 +219,7 @@ _$_BanPerson _$$_BanPersonFromJson(Map<String, dynamic> json) => _$_BanPerson(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_BanPersonToJson(_$_BanPerson instance) {
+Map<String, dynamic> _$$BanPersonImplToJson(_$BanPersonImpl instance) {
   final val = <String, dynamic>{
     'person_id': instance.personId,
     'ban': instance.ban,
@@ -230,8 +238,8 @@ Map<String, dynamic> _$$_BanPersonToJson(_$_BanPerson instance) {
   return val;
 }
 
-_$_GetReplies _$$_GetRepliesFromJson(Map<String, dynamic> json) =>
-    _$_GetReplies(
+_$GetRepliesImpl _$$GetRepliesImplFromJson(Map<String, dynamic> json) =>
+    _$GetRepliesImpl(
       sort: json['sort'] == null ? null : SortType.fromJson(json['sort']),
       page: json['page'] as int?,
       limit: json['limit'] as int?,
@@ -239,7 +247,7 @@ _$_GetReplies _$$_GetRepliesFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_GetRepliesToJson(_$_GetReplies instance) {
+Map<String, dynamic> _$$GetRepliesImplToJson(_$GetRepliesImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -256,160 +264,162 @@ Map<String, dynamic> _$$_GetRepliesToJson(_$_GetReplies instance) {
   return val;
 }
 
-_$_GetPersonMentions _$$_GetPersonMentionsFromJson(Map<String, dynamic> json) =>
-    _$_GetPersonMentions(
-      sort: json['sort'] == null ? null : SortType.fromJson(json['sort']),
-      page: json['page'] as int?,
-      limit: json['limit'] as int?,
-      unreadOnly: json['unread_only'] as bool?,
-      auth: json['auth'] as String,
-    );
-
-Map<String, dynamic> _$$_GetPersonMentionsToJson(
-    _$_GetPersonMentions instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('sort', instance.sort?.toJson());
-  writeNotNull('page', instance.page);
-  writeNotNull('limit', instance.limit);
-  writeNotNull('unread_only', instance.unreadOnly);
-  val['auth'] = instance.auth;
-  return val;
-}
-
-_$_MarkPersonMentionAsRead _$$_MarkPersonMentionAsReadFromJson(
+_$GetPersonMentionsImpl _$$GetPersonMentionsImplFromJson(
         Map<String, dynamic> json) =>
-    _$_MarkPersonMentionAsRead(
+    _$GetPersonMentionsImpl(
+      sort: json['sort'] == null ? null : SortType.fromJson(json['sort']),
+      page: json['page'] as int?,
+      limit: json['limit'] as int?,
+      unreadOnly: json['unread_only'] as bool?,
+      auth: json['auth'] as String,
+    );
+
+Map<String, dynamic> _$$GetPersonMentionsImplToJson(
+    _$GetPersonMentionsImpl instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('sort', instance.sort?.toJson());
+  writeNotNull('page', instance.page);
+  writeNotNull('limit', instance.limit);
+  writeNotNull('unread_only', instance.unreadOnly);
+  val['auth'] = instance.auth;
+  return val;
+}
+
+_$MarkPersonMentionAsReadImpl _$$MarkPersonMentionAsReadImplFromJson(
+        Map<String, dynamic> json) =>
+    _$MarkPersonMentionAsReadImpl(
       personMentionId: json['person_mention_id'] as int,
       read: json['read'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_MarkPersonMentionAsReadToJson(
-        _$_MarkPersonMentionAsRead instance) =>
+Map<String, dynamic> _$$MarkPersonMentionAsReadImplToJson(
+        _$MarkPersonMentionAsReadImpl instance) =>
     <String, dynamic>{
       'person_mention_id': instance.personMentionId,
       'read': instance.read,
       'auth': instance.auth,
     };
 
-_$_DeleteAccount _$$_DeleteAccountFromJson(Map<String, dynamic> json) =>
-    _$_DeleteAccount(
+_$DeleteAccountImpl _$$DeleteAccountImplFromJson(Map<String, dynamic> json) =>
+    _$DeleteAccountImpl(
       password: json['password'] as String,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_DeleteAccountToJson(_$_DeleteAccount instance) =>
+Map<String, dynamic> _$$DeleteAccountImplToJson(_$DeleteAccountImpl instance) =>
     <String, dynamic>{
       'password': instance.password,
       'auth': instance.auth,
     };
 
-_$_PasswordReset _$$_PasswordResetFromJson(Map<String, dynamic> json) =>
-    _$_PasswordReset(
+_$PasswordResetImpl _$$PasswordResetImplFromJson(Map<String, dynamic> json) =>
+    _$PasswordResetImpl(
       email: json['email'] as String,
     );
 
-Map<String, dynamic> _$$_PasswordResetToJson(_$_PasswordReset instance) =>
+Map<String, dynamic> _$$PasswordResetImplToJson(_$PasswordResetImpl instance) =>
     <String, dynamic>{
       'email': instance.email,
     };
 
-_$_PasswordChange _$$_PasswordChangeFromJson(Map<String, dynamic> json) =>
-    _$_PasswordChange(
+_$PasswordChangeImpl _$$PasswordChangeImplFromJson(Map<String, dynamic> json) =>
+    _$PasswordChangeImpl(
       token: json['token'] as String,
       password: json['password'] as String,
       passwordVerify: json['password_verify'] as String,
     );
 
-Map<String, dynamic> _$$_PasswordChangeToJson(_$_PasswordChange instance) =>
+Map<String, dynamic> _$$PasswordChangeImplToJson(
+        _$PasswordChangeImpl instance) =>
     <String, dynamic>{
       'token': instance.token,
       'password': instance.password,
       'password_verify': instance.passwordVerify,
     };
 
-_$_CreatePrivateMessage _$$_CreatePrivateMessageFromJson(
+_$CreatePrivateMessageImpl _$$CreatePrivateMessageImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CreatePrivateMessage(
+    _$CreatePrivateMessageImpl(
       content: json['content'] as String,
       recipientId: json['recipient_id'] as int,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_CreatePrivateMessageToJson(
-        _$_CreatePrivateMessage instance) =>
+Map<String, dynamic> _$$CreatePrivateMessageImplToJson(
+        _$CreatePrivateMessageImpl instance) =>
     <String, dynamic>{
       'content': instance.content,
       'recipient_id': instance.recipientId,
       'auth': instance.auth,
     };
 
-_$_EditPrivateMessage _$$_EditPrivateMessageFromJson(
+_$EditPrivateMessageImpl _$$EditPrivateMessageImplFromJson(
         Map<String, dynamic> json) =>
-    _$_EditPrivateMessage(
+    _$EditPrivateMessageImpl(
       privateMessageId: json['private_message_id'] as int,
       content: json['content'] as String,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_EditPrivateMessageToJson(
-        _$_EditPrivateMessage instance) =>
+Map<String, dynamic> _$$EditPrivateMessageImplToJson(
+        _$EditPrivateMessageImpl instance) =>
     <String, dynamic>{
       'private_message_id': instance.privateMessageId,
       'content': instance.content,
       'auth': instance.auth,
     };
 
-_$_DeletePrivateMessage _$$_DeletePrivateMessageFromJson(
+_$DeletePrivateMessageImpl _$$DeletePrivateMessageImplFromJson(
         Map<String, dynamic> json) =>
-    _$_DeletePrivateMessage(
+    _$DeletePrivateMessageImpl(
       privateMessageId: json['private_message_id'] as int,
       deleted: json['deleted'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_DeletePrivateMessageToJson(
-        _$_DeletePrivateMessage instance) =>
+Map<String, dynamic> _$$DeletePrivateMessageImplToJson(
+        _$DeletePrivateMessageImpl instance) =>
     <String, dynamic>{
       'private_message_id': instance.privateMessageId,
       'deleted': instance.deleted,
       'auth': instance.auth,
     };
 
-_$_MarkPrivateMessageAsRead _$$_MarkPrivateMessageAsReadFromJson(
+_$MarkPrivateMessageAsReadImpl _$$MarkPrivateMessageAsReadImplFromJson(
         Map<String, dynamic> json) =>
-    _$_MarkPrivateMessageAsRead(
+    _$MarkPrivateMessageAsReadImpl(
       privateMessageId: json['private_message_id'] as int,
       read: json['read'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_MarkPrivateMessageAsReadToJson(
-        _$_MarkPrivateMessageAsRead instance) =>
+Map<String, dynamic> _$$MarkPrivateMessageAsReadImplToJson(
+        _$MarkPrivateMessageAsReadImpl instance) =>
     <String, dynamic>{
       'private_message_id': instance.privateMessageId,
       'read': instance.read,
       'auth': instance.auth,
     };
 
-_$_GetPrivateMessages _$$_GetPrivateMessagesFromJson(
+_$GetPrivateMessagesImpl _$$GetPrivateMessagesImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GetPrivateMessages(
+    _$GetPrivateMessagesImpl(
       unreadOnly: json['unread_only'] as bool?,
       page: json['page'] as int?,
       limit: json['limit'] as int?,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_GetPrivateMessagesToJson(
-    _$_GetPrivateMessages instance) {
+Map<String, dynamic> _$$GetPrivateMessagesImplToJson(
+    _$GetPrivateMessagesImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -425,37 +435,39 @@ Map<String, dynamic> _$$_GetPrivateMessagesToJson(
   return val;
 }
 
-_$_BlockPerson _$$_BlockPersonFromJson(Map<String, dynamic> json) =>
-    _$_BlockPerson(
+_$BlockPersonImpl _$$BlockPersonImplFromJson(Map<String, dynamic> json) =>
+    _$BlockPersonImpl(
       personId: json['person_id'] as int,
       block: json['block'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_BlockPersonToJson(_$_BlockPerson instance) =>
+Map<String, dynamic> _$$BlockPersonImplToJson(_$BlockPersonImpl instance) =>
     <String, dynamic>{
       'person_id': instance.personId,
       'block': instance.block,
       'auth': instance.auth,
     };
 
-_$_GetUnreadCount _$$_GetUnreadCountFromJson(Map<String, dynamic> json) =>
-    _$_GetUnreadCount(
+_$GetUnreadCountImpl _$$GetUnreadCountImplFromJson(Map<String, dynamic> json) =>
+    _$GetUnreadCountImpl(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_GetUnreadCountToJson(_$_GetUnreadCount instance) =>
+Map<String, dynamic> _$$GetUnreadCountImplToJson(
+        _$GetUnreadCountImpl instance) =>
     <String, dynamic>{
       'auth': instance.auth,
     };
 
-_$_GetReportCount _$$_GetReportCountFromJson(Map<String, dynamic> json) =>
-    _$_GetReportCount(
+_$GetReportCountImpl _$$GetReportCountImplFromJson(Map<String, dynamic> json) =>
+    _$GetReportCountImpl(
       communityId: json['community_id'] as int?,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_GetReportCountToJson(_$_GetReportCount instance) {
+Map<String, dynamic> _$$GetReportCountImplToJson(
+    _$GetReportCountImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -469,22 +481,24 @@ Map<String, dynamic> _$$_GetReportCountToJson(_$_GetReportCount instance) {
   return val;
 }
 
-_$_GetBannedPersons _$$_GetBannedPersonsFromJson(Map<String, dynamic> json) =>
-    _$_GetBannedPersons(
+_$GetBannedPersonsImpl _$$GetBannedPersonsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GetBannedPersonsImpl(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_GetBannedPersonsToJson(_$_GetBannedPersons instance) =>
+Map<String, dynamic> _$$GetBannedPersonsImplToJson(
+        _$GetBannedPersonsImpl instance) =>
     <String, dynamic>{
       'auth': instance.auth,
     };
 
-_$_VerifyEmail _$$_VerifyEmailFromJson(Map<String, dynamic> json) =>
-    _$_VerifyEmail(
+_$VerifyEmailImpl _$$VerifyEmailImplFromJson(Map<String, dynamic> json) =>
+    _$VerifyEmailImpl(
       token: json['token'] as String,
     );
 
-Map<String, dynamic> _$$_VerifyEmailToJson(_$_VerifyEmail instance) =>
+Map<String, dynamic> _$$VerifyEmailImplToJson(_$VerifyEmailImpl instance) =>
     <String, dynamic>{
       'token': instance.token,
     };

--- a/lib/src/v3/api/post.freezed.dart
+++ b/lib/src/v3/api/post.freezed.dart
@@ -66,20 +66,21 @@ class _$GetPostCopyWithImpl<$Res, $Val extends GetPost>
 }
 
 /// @nodoc
-abstract class _$$_GetPostCopyWith<$Res> implements $GetPostCopyWith<$Res> {
-  factory _$$_GetPostCopyWith(
-          _$_GetPost value, $Res Function(_$_GetPost) then) =
-      __$$_GetPostCopyWithImpl<$Res>;
+abstract class _$$GetPostImplCopyWith<$Res> implements $GetPostCopyWith<$Res> {
+  factory _$$GetPostImplCopyWith(
+          _$GetPostImpl value, $Res Function(_$GetPostImpl) then) =
+      __$$GetPostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int id, String? auth});
 }
 
 /// @nodoc
-class __$$_GetPostCopyWithImpl<$Res>
-    extends _$GetPostCopyWithImpl<$Res, _$_GetPost>
-    implements _$$_GetPostCopyWith<$Res> {
-  __$$_GetPostCopyWithImpl(_$_GetPost _value, $Res Function(_$_GetPost) _then)
+class __$$GetPostImplCopyWithImpl<$Res>
+    extends _$GetPostCopyWithImpl<$Res, _$GetPostImpl>
+    implements _$$GetPostImplCopyWith<$Res> {
+  __$$GetPostImplCopyWithImpl(
+      _$GetPostImpl _value, $Res Function(_$GetPostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -88,7 +89,7 @@ class __$$_GetPostCopyWithImpl<$Res>
     Object? id = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetPost(
+    return _then(_$GetPostImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -104,11 +105,11 @@ class __$$_GetPostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetPost extends _GetPost {
-  const _$_GetPost({required this.id, this.auth}) : super._();
+class _$GetPostImpl extends _GetPost {
+  const _$GetPostImpl({required this.id, this.auth}) : super._();
 
-  factory _$_GetPost.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPostFromJson(json);
+  factory _$GetPostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPostImplFromJson(json);
 
   @override
   final int id;
@@ -124,7 +125,7 @@ class _$_GetPost extends _GetPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPost &&
+            other is _$GetPostImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.auth, auth) || other.auth == auth));
   }
@@ -136,12 +137,12 @@ class _$_GetPost extends _GetPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPostCopyWith<_$_GetPost> get copyWith =>
-      __$$_GetPostCopyWithImpl<_$_GetPost>(this, _$identity);
+  _$$GetPostImplCopyWith<_$GetPostImpl> get copyWith =>
+      __$$GetPostImplCopyWithImpl<_$GetPostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPostToJson(
+    return _$$GetPostImplToJson(
       this,
     );
   }
@@ -149,10 +150,10 @@ class _$_GetPost extends _GetPost {
 
 abstract class _GetPost extends GetPost {
   const factory _GetPost({required final int id, final String? auth}) =
-      _$_GetPost;
+      _$GetPostImpl;
   const _GetPost._() : super._();
 
-  factory _GetPost.fromJson(Map<String, dynamic> json) = _$_GetPost.fromJson;
+  factory _GetPost.fromJson(Map<String, dynamic> json) = _$GetPostImpl.fromJson;
 
   @override
   int get id;
@@ -160,7 +161,7 @@ abstract class _GetPost extends GetPost {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPostCopyWith<_$_GetPost> get copyWith =>
+  _$$GetPostImplCopyWith<_$GetPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -255,11 +256,11 @@ class _$CreatePostCopyWithImpl<$Res, $Val extends CreatePost>
 }
 
 /// @nodoc
-abstract class _$$_CreatePostCopyWith<$Res>
+abstract class _$$CreatePostImplCopyWith<$Res>
     implements $CreatePostCopyWith<$Res> {
-  factory _$$_CreatePostCopyWith(
-          _$_CreatePost value, $Res Function(_$_CreatePost) then) =
-      __$$_CreatePostCopyWithImpl<$Res>;
+  factory _$$CreatePostImplCopyWith(
+          _$CreatePostImpl value, $Res Function(_$CreatePostImpl) then) =
+      __$$CreatePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -273,11 +274,11 @@ abstract class _$$_CreatePostCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CreatePostCopyWithImpl<$Res>
-    extends _$CreatePostCopyWithImpl<$Res, _$_CreatePost>
-    implements _$$_CreatePostCopyWith<$Res> {
-  __$$_CreatePostCopyWithImpl(
-      _$_CreatePost _value, $Res Function(_$_CreatePost) _then)
+class __$$CreatePostImplCopyWithImpl<$Res>
+    extends _$CreatePostCopyWithImpl<$Res, _$CreatePostImpl>
+    implements _$$CreatePostImplCopyWith<$Res> {
+  __$$CreatePostImplCopyWithImpl(
+      _$CreatePostImpl _value, $Res Function(_$CreatePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -291,7 +292,7 @@ class __$$_CreatePostCopyWithImpl<$Res>
     Object? auth = null,
     Object? honeypot = freezed,
   }) {
-    return _then(_$_CreatePost(
+    return _then(_$CreatePostImpl(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -327,8 +328,8 @@ class __$$_CreatePostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreatePost extends _CreatePost {
-  const _$_CreatePost(
+class _$CreatePostImpl extends _CreatePost {
+  const _$CreatePostImpl(
       {required this.name,
       this.url,
       this.body,
@@ -338,8 +339,8 @@ class _$_CreatePost extends _CreatePost {
       this.honeypot})
       : super._();
 
-  factory _$_CreatePost.fromJson(Map<String, dynamic> json) =>
-      _$$_CreatePostFromJson(json);
+  factory _$CreatePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreatePostImplFromJson(json);
 
   @override
   final String name;
@@ -365,7 +366,7 @@ class _$_CreatePost extends _CreatePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreatePost &&
+            other is _$CreatePostImpl &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.url, url) || other.url == url) &&
             (identical(other.body, body) || other.body == body) &&
@@ -385,12 +386,12 @@ class _$_CreatePost extends _CreatePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreatePostCopyWith<_$_CreatePost> get copyWith =>
-      __$$_CreatePostCopyWithImpl<_$_CreatePost>(this, _$identity);
+  _$$CreatePostImplCopyWith<_$CreatePostImpl> get copyWith =>
+      __$$CreatePostImplCopyWithImpl<_$CreatePostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreatePostToJson(
+    return _$$CreatePostImplToJson(
       this,
     );
   }
@@ -404,11 +405,11 @@ abstract class _CreatePost extends CreatePost {
       final bool? nsfw,
       required final int communityId,
       required final String auth,
-      final String? honeypot}) = _$_CreatePost;
+      final String? honeypot}) = _$CreatePostImpl;
   const _CreatePost._() : super._();
 
   factory _CreatePost.fromJson(Map<String, dynamic> json) =
-      _$_CreatePost.fromJson;
+      _$CreatePostImpl.fromJson;
 
   @override
   String get name;
@@ -426,7 +427,7 @@ abstract class _CreatePost extends CreatePost {
   String? get honeypot;
   @override
   @JsonKey(ignore: true)
-  _$$_CreatePostCopyWith<_$_CreatePost> get copyWith =>
+  _$$CreatePostImplCopyWith<_$CreatePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -528,10 +529,11 @@ class _$GetPostsCopyWithImpl<$Res, $Val extends GetPosts>
 }
 
 /// @nodoc
-abstract class _$$_GetPostsCopyWith<$Res> implements $GetPostsCopyWith<$Res> {
-  factory _$$_GetPostsCopyWith(
-          _$_GetPosts value, $Res Function(_$_GetPosts) then) =
-      __$$_GetPostsCopyWithImpl<$Res>;
+abstract class _$$GetPostsImplCopyWith<$Res>
+    implements $GetPostsCopyWith<$Res> {
+  factory _$$GetPostsImplCopyWith(
+          _$GetPostsImpl value, $Res Function(_$GetPostsImpl) then) =
+      __$$GetPostsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -546,11 +548,11 @@ abstract class _$$_GetPostsCopyWith<$Res> implements $GetPostsCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_GetPostsCopyWithImpl<$Res>
-    extends _$GetPostsCopyWithImpl<$Res, _$_GetPosts>
-    implements _$$_GetPostsCopyWith<$Res> {
-  __$$_GetPostsCopyWithImpl(
-      _$_GetPosts _value, $Res Function(_$_GetPosts) _then)
+class __$$GetPostsImplCopyWithImpl<$Res>
+    extends _$GetPostsCopyWithImpl<$Res, _$GetPostsImpl>
+    implements _$$GetPostsImplCopyWith<$Res> {
+  __$$GetPostsImplCopyWithImpl(
+      _$GetPostsImpl _value, $Res Function(_$GetPostsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -565,7 +567,7 @@ class __$$_GetPostsCopyWithImpl<$Res>
     Object? savedOnly = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetPosts(
+    return _then(_$GetPostsImpl(
       type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -605,8 +607,8 @@ class __$$_GetPostsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetPosts extends _GetPosts {
-  const _$_GetPosts(
+class _$GetPostsImpl extends _GetPosts {
+  const _$GetPostsImpl(
       {@JsonKey(name: 'type_') this.type,
       this.sort,
       this.page,
@@ -617,8 +619,8 @@ class _$_GetPosts extends _GetPosts {
       this.auth})
       : super._();
 
-  factory _$_GetPosts.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPostsFromJson(json);
+  factory _$GetPostsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPostsImplFromJson(json);
 
   @override
   @JsonKey(name: 'type_')
@@ -647,7 +649,7 @@ class _$_GetPosts extends _GetPosts {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPosts &&
+            other is _$GetPostsImpl &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
@@ -669,12 +671,12 @@ class _$_GetPosts extends _GetPosts {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPostsCopyWith<_$_GetPosts> get copyWith =>
-      __$$_GetPostsCopyWithImpl<_$_GetPosts>(this, _$identity);
+  _$$GetPostsImplCopyWith<_$GetPostsImpl> get copyWith =>
+      __$$GetPostsImplCopyWithImpl<_$GetPostsImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPostsToJson(
+    return _$$GetPostsImplToJson(
       this,
     );
   }
@@ -689,10 +691,11 @@ abstract class _GetPosts extends GetPosts {
       final int? communityId,
       final String? communityName,
       final bool? savedOnly,
-      final String? auth}) = _$_GetPosts;
+      final String? auth}) = _$GetPostsImpl;
   const _GetPosts._() : super._();
 
-  factory _GetPosts.fromJson(Map<String, dynamic> json) = _$_GetPosts.fromJson;
+  factory _GetPosts.fromJson(Map<String, dynamic> json) =
+      _$GetPostsImpl.fromJson;
 
   @override
   @JsonKey(name: 'type_')
@@ -713,7 +716,7 @@ abstract class _GetPosts extends GetPosts {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPostsCopyWith<_$_GetPosts> get copyWith =>
+  _$$GetPostsImplCopyWith<_$GetPostsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -777,22 +780,22 @@ class _$CreatePostLikeCopyWithImpl<$Res, $Val extends CreatePostLike>
 }
 
 /// @nodoc
-abstract class _$$_CreatePostLikeCopyWith<$Res>
+abstract class _$$CreatePostLikeImplCopyWith<$Res>
     implements $CreatePostLikeCopyWith<$Res> {
-  factory _$$_CreatePostLikeCopyWith(
-          _$_CreatePostLike value, $Res Function(_$_CreatePostLike) then) =
-      __$$_CreatePostLikeCopyWithImpl<$Res>;
+  factory _$$CreatePostLikeImplCopyWith(_$CreatePostLikeImpl value,
+          $Res Function(_$CreatePostLikeImpl) then) =
+      __$$CreatePostLikeImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, VoteType score, String auth});
 }
 
 /// @nodoc
-class __$$_CreatePostLikeCopyWithImpl<$Res>
-    extends _$CreatePostLikeCopyWithImpl<$Res, _$_CreatePostLike>
-    implements _$$_CreatePostLikeCopyWith<$Res> {
-  __$$_CreatePostLikeCopyWithImpl(
-      _$_CreatePostLike _value, $Res Function(_$_CreatePostLike) _then)
+class __$$CreatePostLikeImplCopyWithImpl<$Res>
+    extends _$CreatePostLikeCopyWithImpl<$Res, _$CreatePostLikeImpl>
+    implements _$$CreatePostLikeImplCopyWith<$Res> {
+  __$$CreatePostLikeImplCopyWithImpl(
+      _$CreatePostLikeImpl _value, $Res Function(_$CreatePostLikeImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -802,7 +805,7 @@ class __$$_CreatePostLikeCopyWithImpl<$Res>
     Object? score = null,
     Object? auth = null,
   }) {
-    return _then(_$_CreatePostLike(
+    return _then(_$CreatePostLikeImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -822,13 +825,13 @@ class __$$_CreatePostLikeCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreatePostLike extends _CreatePostLike {
-  const _$_CreatePostLike(
+class _$CreatePostLikeImpl extends _CreatePostLike {
+  const _$CreatePostLikeImpl(
       {required this.postId, required this.score, required this.auth})
       : super._();
 
-  factory _$_CreatePostLike.fromJson(Map<String, dynamic> json) =>
-      _$$_CreatePostLikeFromJson(json);
+  factory _$CreatePostLikeImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreatePostLikeImplFromJson(json);
 
   @override
   final int postId;
@@ -846,7 +849,7 @@ class _$_CreatePostLike extends _CreatePostLike {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreatePostLike &&
+            other is _$CreatePostLikeImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.score, score) || other.score == score) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -859,12 +862,13 @@ class _$_CreatePostLike extends _CreatePostLike {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreatePostLikeCopyWith<_$_CreatePostLike> get copyWith =>
-      __$$_CreatePostLikeCopyWithImpl<_$_CreatePostLike>(this, _$identity);
+  _$$CreatePostLikeImplCopyWith<_$CreatePostLikeImpl> get copyWith =>
+      __$$CreatePostLikeImplCopyWithImpl<_$CreatePostLikeImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreatePostLikeToJson(
+    return _$$CreatePostLikeImplToJson(
       this,
     );
   }
@@ -874,11 +878,11 @@ abstract class _CreatePostLike extends CreatePostLike {
   const factory _CreatePostLike(
       {required final int postId,
       required final VoteType score,
-      required final String auth}) = _$_CreatePostLike;
+      required final String auth}) = _$CreatePostLikeImpl;
   const _CreatePostLike._() : super._();
 
   factory _CreatePostLike.fromJson(Map<String, dynamic> json) =
-      _$_CreatePostLike.fromJson;
+      _$CreatePostLikeImpl.fromJson;
 
   @override
   int get postId;
@@ -888,7 +892,7 @@ abstract class _CreatePostLike extends CreatePostLike {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreatePostLikeCopyWith<_$_CreatePostLike> get copyWith =>
+  _$$CreatePostLikeImplCopyWith<_$CreatePostLikeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -975,10 +979,11 @@ class _$EditPostCopyWithImpl<$Res, $Val extends EditPost>
 }
 
 /// @nodoc
-abstract class _$$_EditPostCopyWith<$Res> implements $EditPostCopyWith<$Res> {
-  factory _$$_EditPostCopyWith(
-          _$_EditPost value, $Res Function(_$_EditPost) then) =
-      __$$_EditPostCopyWithImpl<$Res>;
+abstract class _$$EditPostImplCopyWith<$Res>
+    implements $EditPostCopyWith<$Res> {
+  factory _$$EditPostImplCopyWith(
+          _$EditPostImpl value, $Res Function(_$EditPostImpl) then) =
+      __$$EditPostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -991,11 +996,11 @@ abstract class _$$_EditPostCopyWith<$Res> implements $EditPostCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_EditPostCopyWithImpl<$Res>
-    extends _$EditPostCopyWithImpl<$Res, _$_EditPost>
-    implements _$$_EditPostCopyWith<$Res> {
-  __$$_EditPostCopyWithImpl(
-      _$_EditPost _value, $Res Function(_$_EditPost) _then)
+class __$$EditPostImplCopyWithImpl<$Res>
+    extends _$EditPostCopyWithImpl<$Res, _$EditPostImpl>
+    implements _$$EditPostImplCopyWith<$Res> {
+  __$$EditPostImplCopyWithImpl(
+      _$EditPostImpl _value, $Res Function(_$EditPostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1008,7 +1013,7 @@ class __$$_EditPostCopyWithImpl<$Res>
     Object? nsfw = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_EditPost(
+    return _then(_$EditPostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1040,8 +1045,8 @@ class __$$_EditPostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_EditPost extends _EditPost {
-  const _$_EditPost(
+class _$EditPostImpl extends _EditPost {
+  const _$EditPostImpl(
       {required this.postId,
       this.name,
       this.url,
@@ -1050,8 +1055,8 @@ class _$_EditPost extends _EditPost {
       required this.auth})
       : super._();
 
-  factory _$_EditPost.fromJson(Map<String, dynamic> json) =>
-      _$$_EditPostFromJson(json);
+  factory _$EditPostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EditPostImplFromJson(json);
 
   @override
   final int postId;
@@ -1075,7 +1080,7 @@ class _$_EditPost extends _EditPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_EditPost &&
+            other is _$EditPostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.url, url) || other.url == url) &&
@@ -1092,12 +1097,12 @@ class _$_EditPost extends _EditPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_EditPostCopyWith<_$_EditPost> get copyWith =>
-      __$$_EditPostCopyWithImpl<_$_EditPost>(this, _$identity);
+  _$$EditPostImplCopyWith<_$EditPostImpl> get copyWith =>
+      __$$EditPostImplCopyWithImpl<_$EditPostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_EditPostToJson(
+    return _$$EditPostImplToJson(
       this,
     );
   }
@@ -1110,10 +1115,11 @@ abstract class _EditPost extends EditPost {
       final String? url,
       final String? body,
       final bool? nsfw,
-      required final String auth}) = _$_EditPost;
+      required final String auth}) = _$EditPostImpl;
   const _EditPost._() : super._();
 
-  factory _EditPost.fromJson(Map<String, dynamic> json) = _$_EditPost.fromJson;
+  factory _EditPost.fromJson(Map<String, dynamic> json) =
+      _$EditPostImpl.fromJson;
 
   @override
   int get postId;
@@ -1129,7 +1135,7 @@ abstract class _EditPost extends EditPost {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_EditPostCopyWith<_$_EditPost> get copyWith =>
+  _$$EditPostImplCopyWith<_$EditPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1193,22 +1199,22 @@ class _$DeletePostCopyWithImpl<$Res, $Val extends DeletePost>
 }
 
 /// @nodoc
-abstract class _$$_DeletePostCopyWith<$Res>
+abstract class _$$DeletePostImplCopyWith<$Res>
     implements $DeletePostCopyWith<$Res> {
-  factory _$$_DeletePostCopyWith(
-          _$_DeletePost value, $Res Function(_$_DeletePost) then) =
-      __$$_DeletePostCopyWithImpl<$Res>;
+  factory _$$DeletePostImplCopyWith(
+          _$DeletePostImpl value, $Res Function(_$DeletePostImpl) then) =
+      __$$DeletePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool deleted, String auth});
 }
 
 /// @nodoc
-class __$$_DeletePostCopyWithImpl<$Res>
-    extends _$DeletePostCopyWithImpl<$Res, _$_DeletePost>
-    implements _$$_DeletePostCopyWith<$Res> {
-  __$$_DeletePostCopyWithImpl(
-      _$_DeletePost _value, $Res Function(_$_DeletePost) _then)
+class __$$DeletePostImplCopyWithImpl<$Res>
+    extends _$DeletePostCopyWithImpl<$Res, _$DeletePostImpl>
+    implements _$$DeletePostImplCopyWith<$Res> {
+  __$$DeletePostImplCopyWithImpl(
+      _$DeletePostImpl _value, $Res Function(_$DeletePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1218,7 +1224,7 @@ class __$$_DeletePostCopyWithImpl<$Res>
     Object? deleted = null,
     Object? auth = null,
   }) {
-    return _then(_$_DeletePost(
+    return _then(_$DeletePostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1238,13 +1244,13 @@ class __$$_DeletePostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_DeletePost extends _DeletePost {
-  const _$_DeletePost(
+class _$DeletePostImpl extends _DeletePost {
+  const _$DeletePostImpl(
       {required this.postId, required this.deleted, required this.auth})
       : super._();
 
-  factory _$_DeletePost.fromJson(Map<String, dynamic> json) =>
-      _$$_DeletePostFromJson(json);
+  factory _$DeletePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeletePostImplFromJson(json);
 
   @override
   final int postId;
@@ -1262,7 +1268,7 @@ class _$_DeletePost extends _DeletePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeletePost &&
+            other is _$DeletePostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.deleted, deleted) || other.deleted == deleted) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -1275,12 +1281,12 @@ class _$_DeletePost extends _DeletePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeletePostCopyWith<_$_DeletePost> get copyWith =>
-      __$$_DeletePostCopyWithImpl<_$_DeletePost>(this, _$identity);
+  _$$DeletePostImplCopyWith<_$DeletePostImpl> get copyWith =>
+      __$$DeletePostImplCopyWithImpl<_$DeletePostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeletePostToJson(
+    return _$$DeletePostImplToJson(
       this,
     );
   }
@@ -1290,11 +1296,11 @@ abstract class _DeletePost extends DeletePost {
   const factory _DeletePost(
       {required final int postId,
       required final bool deleted,
-      required final String auth}) = _$_DeletePost;
+      required final String auth}) = _$DeletePostImpl;
   const _DeletePost._() : super._();
 
   factory _DeletePost.fromJson(Map<String, dynamic> json) =
-      _$_DeletePost.fromJson;
+      _$DeletePostImpl.fromJson;
 
   @override
   int get postId;
@@ -1304,7 +1310,7 @@ abstract class _DeletePost extends DeletePost {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_DeletePostCopyWith<_$_DeletePost> get copyWith =>
+  _$$DeletePostImplCopyWith<_$DeletePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1374,22 +1380,22 @@ class _$RemovePostCopyWithImpl<$Res, $Val extends RemovePost>
 }
 
 /// @nodoc
-abstract class _$$_RemovePostCopyWith<$Res>
+abstract class _$$RemovePostImplCopyWith<$Res>
     implements $RemovePostCopyWith<$Res> {
-  factory _$$_RemovePostCopyWith(
-          _$_RemovePost value, $Res Function(_$_RemovePost) then) =
-      __$$_RemovePostCopyWithImpl<$Res>;
+  factory _$$RemovePostImplCopyWith(
+          _$RemovePostImpl value, $Res Function(_$RemovePostImpl) then) =
+      __$$RemovePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool removed, String? reason, String auth});
 }
 
 /// @nodoc
-class __$$_RemovePostCopyWithImpl<$Res>
-    extends _$RemovePostCopyWithImpl<$Res, _$_RemovePost>
-    implements _$$_RemovePostCopyWith<$Res> {
-  __$$_RemovePostCopyWithImpl(
-      _$_RemovePost _value, $Res Function(_$_RemovePost) _then)
+class __$$RemovePostImplCopyWithImpl<$Res>
+    extends _$RemovePostCopyWithImpl<$Res, _$RemovePostImpl>
+    implements _$$RemovePostImplCopyWith<$Res> {
+  __$$RemovePostImplCopyWithImpl(
+      _$RemovePostImpl _value, $Res Function(_$RemovePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1400,7 +1406,7 @@ class __$$_RemovePostCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_RemovePost(
+    return _then(_$RemovePostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1424,16 +1430,16 @@ class __$$_RemovePostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_RemovePost extends _RemovePost {
-  const _$_RemovePost(
+class _$RemovePostImpl extends _RemovePost {
+  const _$RemovePostImpl(
       {required this.postId,
       required this.removed,
       this.reason,
       required this.auth})
       : super._();
 
-  factory _$_RemovePost.fromJson(Map<String, dynamic> json) =>
-      _$$_RemovePostFromJson(json);
+  factory _$RemovePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RemovePostImplFromJson(json);
 
   @override
   final int postId;
@@ -1453,7 +1459,7 @@ class _$_RemovePost extends _RemovePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_RemovePost &&
+            other is _$RemovePostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.removed, removed) || other.removed == removed) &&
             (identical(other.reason, reason) || other.reason == reason) &&
@@ -1467,12 +1473,12 @@ class _$_RemovePost extends _RemovePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RemovePostCopyWith<_$_RemovePost> get copyWith =>
-      __$$_RemovePostCopyWithImpl<_$_RemovePost>(this, _$identity);
+  _$$RemovePostImplCopyWith<_$RemovePostImpl> get copyWith =>
+      __$$RemovePostImplCopyWithImpl<_$RemovePostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RemovePostToJson(
+    return _$$RemovePostImplToJson(
       this,
     );
   }
@@ -1483,11 +1489,11 @@ abstract class _RemovePost extends RemovePost {
       {required final int postId,
       required final bool removed,
       final String? reason,
-      required final String auth}) = _$_RemovePost;
+      required final String auth}) = _$RemovePostImpl;
   const _RemovePost._() : super._();
 
   factory _RemovePost.fromJson(Map<String, dynamic> json) =
-      _$_RemovePost.fromJson;
+      _$RemovePostImpl.fromJson;
 
   @override
   int get postId;
@@ -1499,7 +1505,7 @@ abstract class _RemovePost extends RemovePost {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_RemovePostCopyWith<_$_RemovePost> get copyWith =>
+  _$$RemovePostImplCopyWith<_$RemovePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1562,21 +1568,22 @@ class _$LockPostCopyWithImpl<$Res, $Val extends LockPost>
 }
 
 /// @nodoc
-abstract class _$$_LockPostCopyWith<$Res> implements $LockPostCopyWith<$Res> {
-  factory _$$_LockPostCopyWith(
-          _$_LockPost value, $Res Function(_$_LockPost) then) =
-      __$$_LockPostCopyWithImpl<$Res>;
+abstract class _$$LockPostImplCopyWith<$Res>
+    implements $LockPostCopyWith<$Res> {
+  factory _$$LockPostImplCopyWith(
+          _$LockPostImpl value, $Res Function(_$LockPostImpl) then) =
+      __$$LockPostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool locked, String auth});
 }
 
 /// @nodoc
-class __$$_LockPostCopyWithImpl<$Res>
-    extends _$LockPostCopyWithImpl<$Res, _$_LockPost>
-    implements _$$_LockPostCopyWith<$Res> {
-  __$$_LockPostCopyWithImpl(
-      _$_LockPost _value, $Res Function(_$_LockPost) _then)
+class __$$LockPostImplCopyWithImpl<$Res>
+    extends _$LockPostCopyWithImpl<$Res, _$LockPostImpl>
+    implements _$$LockPostImplCopyWith<$Res> {
+  __$$LockPostImplCopyWithImpl(
+      _$LockPostImpl _value, $Res Function(_$LockPostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1586,7 +1593,7 @@ class __$$_LockPostCopyWithImpl<$Res>
     Object? locked = null,
     Object? auth = null,
   }) {
-    return _then(_$_LockPost(
+    return _then(_$LockPostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1606,13 +1613,13 @@ class __$$_LockPostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_LockPost extends _LockPost {
-  const _$_LockPost(
+class _$LockPostImpl extends _LockPost {
+  const _$LockPostImpl(
       {required this.postId, required this.locked, required this.auth})
       : super._();
 
-  factory _$_LockPost.fromJson(Map<String, dynamic> json) =>
-      _$$_LockPostFromJson(json);
+  factory _$LockPostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LockPostImplFromJson(json);
 
   @override
   final int postId;
@@ -1630,7 +1637,7 @@ class _$_LockPost extends _LockPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LockPost &&
+            other is _$LockPostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.locked, locked) || other.locked == locked) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -1643,12 +1650,12 @@ class _$_LockPost extends _LockPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LockPostCopyWith<_$_LockPost> get copyWith =>
-      __$$_LockPostCopyWithImpl<_$_LockPost>(this, _$identity);
+  _$$LockPostImplCopyWith<_$LockPostImpl> get copyWith =>
+      __$$LockPostImplCopyWithImpl<_$LockPostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LockPostToJson(
+    return _$$LockPostImplToJson(
       this,
     );
   }
@@ -1658,10 +1665,11 @@ abstract class _LockPost extends LockPost {
   const factory _LockPost(
       {required final int postId,
       required final bool locked,
-      required final String auth}) = _$_LockPost;
+      required final String auth}) = _$LockPostImpl;
   const _LockPost._() : super._();
 
-  factory _LockPost.fromJson(Map<String, dynamic> json) = _$_LockPost.fromJson;
+  factory _LockPost.fromJson(Map<String, dynamic> json) =
+      _$LockPostImpl.fromJson;
 
   @override
   int get postId;
@@ -1671,7 +1679,7 @@ abstract class _LockPost extends LockPost {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_LockPostCopyWith<_$_LockPost> get copyWith =>
+  _$$LockPostImplCopyWith<_$LockPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1735,22 +1743,22 @@ class _$StickyPostCopyWithImpl<$Res, $Val extends StickyPost>
 }
 
 /// @nodoc
-abstract class _$$_StickyPostCopyWith<$Res>
+abstract class _$$StickyPostImplCopyWith<$Res>
     implements $StickyPostCopyWith<$Res> {
-  factory _$$_StickyPostCopyWith(
-          _$_StickyPost value, $Res Function(_$_StickyPost) then) =
-      __$$_StickyPostCopyWithImpl<$Res>;
+  factory _$$StickyPostImplCopyWith(
+          _$StickyPostImpl value, $Res Function(_$StickyPostImpl) then) =
+      __$$StickyPostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool stickied, String auth});
 }
 
 /// @nodoc
-class __$$_StickyPostCopyWithImpl<$Res>
-    extends _$StickyPostCopyWithImpl<$Res, _$_StickyPost>
-    implements _$$_StickyPostCopyWith<$Res> {
-  __$$_StickyPostCopyWithImpl(
-      _$_StickyPost _value, $Res Function(_$_StickyPost) _then)
+class __$$StickyPostImplCopyWithImpl<$Res>
+    extends _$StickyPostCopyWithImpl<$Res, _$StickyPostImpl>
+    implements _$$StickyPostImplCopyWith<$Res> {
+  __$$StickyPostImplCopyWithImpl(
+      _$StickyPostImpl _value, $Res Function(_$StickyPostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1760,7 +1768,7 @@ class __$$_StickyPostCopyWithImpl<$Res>
     Object? stickied = null,
     Object? auth = null,
   }) {
-    return _then(_$_StickyPost(
+    return _then(_$StickyPostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1780,13 +1788,13 @@ class __$$_StickyPostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_StickyPost extends _StickyPost {
-  const _$_StickyPost(
+class _$StickyPostImpl extends _StickyPost {
+  const _$StickyPostImpl(
       {required this.postId, required this.stickied, required this.auth})
       : super._();
 
-  factory _$_StickyPost.fromJson(Map<String, dynamic> json) =>
-      _$$_StickyPostFromJson(json);
+  factory _$StickyPostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$StickyPostImplFromJson(json);
 
   @override
   final int postId;
@@ -1804,7 +1812,7 @@ class _$_StickyPost extends _StickyPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_StickyPost &&
+            other is _$StickyPostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.stickied, stickied) ||
                 other.stickied == stickied) &&
@@ -1818,12 +1826,12 @@ class _$_StickyPost extends _StickyPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_StickyPostCopyWith<_$_StickyPost> get copyWith =>
-      __$$_StickyPostCopyWithImpl<_$_StickyPost>(this, _$identity);
+  _$$StickyPostImplCopyWith<_$StickyPostImpl> get copyWith =>
+      __$$StickyPostImplCopyWithImpl<_$StickyPostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_StickyPostToJson(
+    return _$$StickyPostImplToJson(
       this,
     );
   }
@@ -1833,11 +1841,11 @@ abstract class _StickyPost extends StickyPost {
   const factory _StickyPost(
       {required final int postId,
       required final bool stickied,
-      required final String auth}) = _$_StickyPost;
+      required final String auth}) = _$StickyPostImpl;
   const _StickyPost._() : super._();
 
   factory _StickyPost.fromJson(Map<String, dynamic> json) =
-      _$_StickyPost.fromJson;
+      _$StickyPostImpl.fromJson;
 
   @override
   int get postId;
@@ -1847,7 +1855,7 @@ abstract class _StickyPost extends StickyPost {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_StickyPostCopyWith<_$_StickyPost> get copyWith =>
+  _$$StickyPostImplCopyWith<_$StickyPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1910,21 +1918,22 @@ class _$SavePostCopyWithImpl<$Res, $Val extends SavePost>
 }
 
 /// @nodoc
-abstract class _$$_SavePostCopyWith<$Res> implements $SavePostCopyWith<$Res> {
-  factory _$$_SavePostCopyWith(
-          _$_SavePost value, $Res Function(_$_SavePost) then) =
-      __$$_SavePostCopyWithImpl<$Res>;
+abstract class _$$SavePostImplCopyWith<$Res>
+    implements $SavePostCopyWith<$Res> {
+  factory _$$SavePostImplCopyWith(
+          _$SavePostImpl value, $Res Function(_$SavePostImpl) then) =
+      __$$SavePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool save, String auth});
 }
 
 /// @nodoc
-class __$$_SavePostCopyWithImpl<$Res>
-    extends _$SavePostCopyWithImpl<$Res, _$_SavePost>
-    implements _$$_SavePostCopyWith<$Res> {
-  __$$_SavePostCopyWithImpl(
-      _$_SavePost _value, $Res Function(_$_SavePost) _then)
+class __$$SavePostImplCopyWithImpl<$Res>
+    extends _$SavePostCopyWithImpl<$Res, _$SavePostImpl>
+    implements _$$SavePostImplCopyWith<$Res> {
+  __$$SavePostImplCopyWithImpl(
+      _$SavePostImpl _value, $Res Function(_$SavePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1934,7 +1943,7 @@ class __$$_SavePostCopyWithImpl<$Res>
     Object? save = null,
     Object? auth = null,
   }) {
-    return _then(_$_SavePost(
+    return _then(_$SavePostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1954,13 +1963,13 @@ class __$$_SavePostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_SavePost extends _SavePost {
-  const _$_SavePost(
+class _$SavePostImpl extends _SavePost {
+  const _$SavePostImpl(
       {required this.postId, required this.save, required this.auth})
       : super._();
 
-  factory _$_SavePost.fromJson(Map<String, dynamic> json) =>
-      _$$_SavePostFromJson(json);
+  factory _$SavePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SavePostImplFromJson(json);
 
   @override
   final int postId;
@@ -1978,7 +1987,7 @@ class _$_SavePost extends _SavePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SavePost &&
+            other is _$SavePostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.save, save) || other.save == save) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -1991,12 +2000,12 @@ class _$_SavePost extends _SavePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SavePostCopyWith<_$_SavePost> get copyWith =>
-      __$$_SavePostCopyWithImpl<_$_SavePost>(this, _$identity);
+  _$$SavePostImplCopyWith<_$SavePostImpl> get copyWith =>
+      __$$SavePostImplCopyWithImpl<_$SavePostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SavePostToJson(
+    return _$$SavePostImplToJson(
       this,
     );
   }
@@ -2006,10 +2015,11 @@ abstract class _SavePost extends SavePost {
   const factory _SavePost(
       {required final int postId,
       required final bool save,
-      required final String auth}) = _$_SavePost;
+      required final String auth}) = _$SavePostImpl;
   const _SavePost._() : super._();
 
-  factory _SavePost.fromJson(Map<String, dynamic> json) = _$_SavePost.fromJson;
+  factory _SavePost.fromJson(Map<String, dynamic> json) =
+      _$SavePostImpl.fromJson;
 
   @override
   int get postId;
@@ -2019,7 +2029,7 @@ abstract class _SavePost extends SavePost {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_SavePostCopyWith<_$_SavePost> get copyWith =>
+  _$$SavePostImplCopyWith<_$SavePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2071,22 +2081,22 @@ class _$GetSiteMetadataCopyWithImpl<$Res, $Val extends GetSiteMetadata>
 }
 
 /// @nodoc
-abstract class _$$_GetSiteMetadataCopyWith<$Res>
+abstract class _$$GetSiteMetadataImplCopyWith<$Res>
     implements $GetSiteMetadataCopyWith<$Res> {
-  factory _$$_GetSiteMetadataCopyWith(
-          _$_GetSiteMetadata value, $Res Function(_$_GetSiteMetadata) then) =
-      __$$_GetSiteMetadataCopyWithImpl<$Res>;
+  factory _$$GetSiteMetadataImplCopyWith(_$GetSiteMetadataImpl value,
+          $Res Function(_$GetSiteMetadataImpl) then) =
+      __$$GetSiteMetadataImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String url});
 }
 
 /// @nodoc
-class __$$_GetSiteMetadataCopyWithImpl<$Res>
-    extends _$GetSiteMetadataCopyWithImpl<$Res, _$_GetSiteMetadata>
-    implements _$$_GetSiteMetadataCopyWith<$Res> {
-  __$$_GetSiteMetadataCopyWithImpl(
-      _$_GetSiteMetadata _value, $Res Function(_$_GetSiteMetadata) _then)
+class __$$GetSiteMetadataImplCopyWithImpl<$Res>
+    extends _$GetSiteMetadataCopyWithImpl<$Res, _$GetSiteMetadataImpl>
+    implements _$$GetSiteMetadataImplCopyWith<$Res> {
+  __$$GetSiteMetadataImplCopyWithImpl(
+      _$GetSiteMetadataImpl _value, $Res Function(_$GetSiteMetadataImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2094,7 +2104,7 @@ class __$$_GetSiteMetadataCopyWithImpl<$Res>
   $Res call({
     Object? url = null,
   }) {
-    return _then(_$_GetSiteMetadata(
+    return _then(_$GetSiteMetadataImpl(
       url: null == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
@@ -2106,11 +2116,11 @@ class __$$_GetSiteMetadataCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetSiteMetadata extends _GetSiteMetadata {
-  const _$_GetSiteMetadata({required this.url}) : super._();
+class _$GetSiteMetadataImpl extends _GetSiteMetadata {
+  const _$GetSiteMetadataImpl({required this.url}) : super._();
 
-  factory _$_GetSiteMetadata.fromJson(Map<String, dynamic> json) =>
-      _$$_GetSiteMetadataFromJson(json);
+  factory _$GetSiteMetadataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetSiteMetadataImplFromJson(json);
 
   @override
   final String url;
@@ -2124,7 +2134,7 @@ class _$_GetSiteMetadata extends _GetSiteMetadata {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetSiteMetadata &&
+            other is _$GetSiteMetadataImpl &&
             (identical(other.url, url) || other.url == url));
   }
 
@@ -2135,12 +2145,13 @@ class _$_GetSiteMetadata extends _GetSiteMetadata {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetSiteMetadataCopyWith<_$_GetSiteMetadata> get copyWith =>
-      __$$_GetSiteMetadataCopyWithImpl<_$_GetSiteMetadata>(this, _$identity);
+  _$$GetSiteMetadataImplCopyWith<_$GetSiteMetadataImpl> get copyWith =>
+      __$$GetSiteMetadataImplCopyWithImpl<_$GetSiteMetadataImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetSiteMetadataToJson(
+    return _$$GetSiteMetadataImplToJson(
       this,
     );
   }
@@ -2148,17 +2159,17 @@ class _$_GetSiteMetadata extends _GetSiteMetadata {
 
 abstract class _GetSiteMetadata extends GetSiteMetadata {
   const factory _GetSiteMetadata({required final String url}) =
-      _$_GetSiteMetadata;
+      _$GetSiteMetadataImpl;
   const _GetSiteMetadata._() : super._();
 
   factory _GetSiteMetadata.fromJson(Map<String, dynamic> json) =
-      _$_GetSiteMetadata.fromJson;
+      _$GetSiteMetadataImpl.fromJson;
 
   @override
   String get url;
   @override
   @JsonKey(ignore: true)
-  _$$_GetSiteMetadataCopyWith<_$_GetSiteMetadata> get copyWith =>
+  _$$GetSiteMetadataImplCopyWith<_$GetSiteMetadataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2222,22 +2233,22 @@ class _$CreatePostReportCopyWithImpl<$Res, $Val extends CreatePostReport>
 }
 
 /// @nodoc
-abstract class _$$_CreatePostReportCopyWith<$Res>
+abstract class _$$CreatePostReportImplCopyWith<$Res>
     implements $CreatePostReportCopyWith<$Res> {
-  factory _$$_CreatePostReportCopyWith(
-          _$_CreatePostReport value, $Res Function(_$_CreatePostReport) then) =
-      __$$_CreatePostReportCopyWithImpl<$Res>;
+  factory _$$CreatePostReportImplCopyWith(_$CreatePostReportImpl value,
+          $Res Function(_$CreatePostReportImpl) then) =
+      __$$CreatePostReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, String reason, String auth});
 }
 
 /// @nodoc
-class __$$_CreatePostReportCopyWithImpl<$Res>
-    extends _$CreatePostReportCopyWithImpl<$Res, _$_CreatePostReport>
-    implements _$$_CreatePostReportCopyWith<$Res> {
-  __$$_CreatePostReportCopyWithImpl(
-      _$_CreatePostReport _value, $Res Function(_$_CreatePostReport) _then)
+class __$$CreatePostReportImplCopyWithImpl<$Res>
+    extends _$CreatePostReportCopyWithImpl<$Res, _$CreatePostReportImpl>
+    implements _$$CreatePostReportImplCopyWith<$Res> {
+  __$$CreatePostReportImplCopyWithImpl(_$CreatePostReportImpl _value,
+      $Res Function(_$CreatePostReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2247,7 +2258,7 @@ class __$$_CreatePostReportCopyWithImpl<$Res>
     Object? reason = null,
     Object? auth = null,
   }) {
-    return _then(_$_CreatePostReport(
+    return _then(_$CreatePostReportImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -2267,13 +2278,13 @@ class __$$_CreatePostReportCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreatePostReport extends _CreatePostReport {
-  const _$_CreatePostReport(
+class _$CreatePostReportImpl extends _CreatePostReport {
+  const _$CreatePostReportImpl(
       {required this.postId, required this.reason, required this.auth})
       : super._();
 
-  factory _$_CreatePostReport.fromJson(Map<String, dynamic> json) =>
-      _$$_CreatePostReportFromJson(json);
+  factory _$CreatePostReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreatePostReportImplFromJson(json);
 
   @override
   final int postId;
@@ -2291,7 +2302,7 @@ class _$_CreatePostReport extends _CreatePostReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreatePostReport &&
+            other is _$CreatePostReportImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.reason, reason) || other.reason == reason) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -2304,12 +2315,13 @@ class _$_CreatePostReport extends _CreatePostReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreatePostReportCopyWith<_$_CreatePostReport> get copyWith =>
-      __$$_CreatePostReportCopyWithImpl<_$_CreatePostReport>(this, _$identity);
+  _$$CreatePostReportImplCopyWith<_$CreatePostReportImpl> get copyWith =>
+      __$$CreatePostReportImplCopyWithImpl<_$CreatePostReportImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreatePostReportToJson(
+    return _$$CreatePostReportImplToJson(
       this,
     );
   }
@@ -2319,11 +2331,11 @@ abstract class _CreatePostReport extends CreatePostReport {
   const factory _CreatePostReport(
       {required final int postId,
       required final String reason,
-      required final String auth}) = _$_CreatePostReport;
+      required final String auth}) = _$CreatePostReportImpl;
   const _CreatePostReport._() : super._();
 
   factory _CreatePostReport.fromJson(Map<String, dynamic> json) =
-      _$_CreatePostReport.fromJson;
+      _$CreatePostReportImpl.fromJson;
 
   @override
   int get postId;
@@ -2333,7 +2345,7 @@ abstract class _CreatePostReport extends CreatePostReport {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreatePostReportCopyWith<_$_CreatePostReport> get copyWith =>
+  _$$CreatePostReportImplCopyWith<_$CreatePostReportImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2397,22 +2409,22 @@ class _$ResolvePostReportCopyWithImpl<$Res, $Val extends ResolvePostReport>
 }
 
 /// @nodoc
-abstract class _$$_ResolvePostReportCopyWith<$Res>
+abstract class _$$ResolvePostReportImplCopyWith<$Res>
     implements $ResolvePostReportCopyWith<$Res> {
-  factory _$$_ResolvePostReportCopyWith(_$_ResolvePostReport value,
-          $Res Function(_$_ResolvePostReport) then) =
-      __$$_ResolvePostReportCopyWithImpl<$Res>;
+  factory _$$ResolvePostReportImplCopyWith(_$ResolvePostReportImpl value,
+          $Res Function(_$ResolvePostReportImpl) then) =
+      __$$ResolvePostReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int reportId, bool resolved, String auth});
 }
 
 /// @nodoc
-class __$$_ResolvePostReportCopyWithImpl<$Res>
-    extends _$ResolvePostReportCopyWithImpl<$Res, _$_ResolvePostReport>
-    implements _$$_ResolvePostReportCopyWith<$Res> {
-  __$$_ResolvePostReportCopyWithImpl(
-      _$_ResolvePostReport _value, $Res Function(_$_ResolvePostReport) _then)
+class __$$ResolvePostReportImplCopyWithImpl<$Res>
+    extends _$ResolvePostReportCopyWithImpl<$Res, _$ResolvePostReportImpl>
+    implements _$$ResolvePostReportImplCopyWith<$Res> {
+  __$$ResolvePostReportImplCopyWithImpl(_$ResolvePostReportImpl _value,
+      $Res Function(_$ResolvePostReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2422,7 +2434,7 @@ class __$$_ResolvePostReportCopyWithImpl<$Res>
     Object? resolved = null,
     Object? auth = null,
   }) {
-    return _then(_$_ResolvePostReport(
+    return _then(_$ResolvePostReportImpl(
       reportId: null == reportId
           ? _value.reportId
           : reportId // ignore: cast_nullable_to_non_nullable
@@ -2442,13 +2454,13 @@ class __$$_ResolvePostReportCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ResolvePostReport extends _ResolvePostReport {
-  const _$_ResolvePostReport(
+class _$ResolvePostReportImpl extends _ResolvePostReport {
+  const _$ResolvePostReportImpl(
       {required this.reportId, required this.resolved, required this.auth})
       : super._();
 
-  factory _$_ResolvePostReport.fromJson(Map<String, dynamic> json) =>
-      _$$_ResolvePostReportFromJson(json);
+  factory _$ResolvePostReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ResolvePostReportImplFromJson(json);
 
   @override
   final int reportId;
@@ -2466,7 +2478,7 @@ class _$_ResolvePostReport extends _ResolvePostReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ResolvePostReport &&
+            other is _$ResolvePostReportImpl &&
             (identical(other.reportId, reportId) ||
                 other.reportId == reportId) &&
             (identical(other.resolved, resolved) ||
@@ -2481,13 +2493,13 @@ class _$_ResolvePostReport extends _ResolvePostReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ResolvePostReportCopyWith<_$_ResolvePostReport> get copyWith =>
-      __$$_ResolvePostReportCopyWithImpl<_$_ResolvePostReport>(
+  _$$ResolvePostReportImplCopyWith<_$ResolvePostReportImpl> get copyWith =>
+      __$$ResolvePostReportImplCopyWithImpl<_$ResolvePostReportImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ResolvePostReportToJson(
+    return _$$ResolvePostReportImplToJson(
       this,
     );
   }
@@ -2497,11 +2509,11 @@ abstract class _ResolvePostReport extends ResolvePostReport {
   const factory _ResolvePostReport(
       {required final int reportId,
       required final bool resolved,
-      required final String auth}) = _$_ResolvePostReport;
+      required final String auth}) = _$ResolvePostReportImpl;
   const _ResolvePostReport._() : super._();
 
   factory _ResolvePostReport.fromJson(Map<String, dynamic> json) =
-      _$_ResolvePostReport.fromJson;
+      _$ResolvePostReportImpl.fromJson;
 
   @override
   int get reportId;
@@ -2511,7 +2523,7 @@ abstract class _ResolvePostReport extends ResolvePostReport {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ResolvePostReportCopyWith<_$_ResolvePostReport> get copyWith =>
+  _$$ResolvePostReportImplCopyWith<_$ResolvePostReportImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2592,11 +2604,11 @@ class _$ListPostReportsCopyWithImpl<$Res, $Val extends ListPostReports>
 }
 
 /// @nodoc
-abstract class _$$_ListPostReportsCopyWith<$Res>
+abstract class _$$ListPostReportsImplCopyWith<$Res>
     implements $ListPostReportsCopyWith<$Res> {
-  factory _$$_ListPostReportsCopyWith(
-          _$_ListPostReports value, $Res Function(_$_ListPostReports) then) =
-      __$$_ListPostReportsCopyWithImpl<$Res>;
+  factory _$$ListPostReportsImplCopyWith(_$ListPostReportsImpl value,
+          $Res Function(_$ListPostReportsImpl) then) =
+      __$$ListPostReportsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2608,11 +2620,11 @@ abstract class _$$_ListPostReportsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ListPostReportsCopyWithImpl<$Res>
-    extends _$ListPostReportsCopyWithImpl<$Res, _$_ListPostReports>
-    implements _$$_ListPostReportsCopyWith<$Res> {
-  __$$_ListPostReportsCopyWithImpl(
-      _$_ListPostReports _value, $Res Function(_$_ListPostReports) _then)
+class __$$ListPostReportsImplCopyWithImpl<$Res>
+    extends _$ListPostReportsCopyWithImpl<$Res, _$ListPostReportsImpl>
+    implements _$$ListPostReportsImplCopyWith<$Res> {
+  __$$ListPostReportsImplCopyWithImpl(
+      _$ListPostReportsImpl _value, $Res Function(_$ListPostReportsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2624,7 +2636,7 @@ class __$$_ListPostReportsCopyWithImpl<$Res>
     Object? unresolvedOnly = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_ListPostReports(
+    return _then(_$ListPostReportsImpl(
       page: freezed == page
           ? _value.page
           : page // ignore: cast_nullable_to_non_nullable
@@ -2652,8 +2664,8 @@ class __$$_ListPostReportsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ListPostReports extends _ListPostReports {
-  const _$_ListPostReports(
+class _$ListPostReportsImpl extends _ListPostReports {
+  const _$ListPostReportsImpl(
       {this.page,
       this.limit,
       this.communityId,
@@ -2661,8 +2673,8 @@ class _$_ListPostReports extends _ListPostReports {
       required this.auth})
       : super._();
 
-  factory _$_ListPostReports.fromJson(Map<String, dynamic> json) =>
-      _$$_ListPostReportsFromJson(json);
+  factory _$ListPostReportsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ListPostReportsImplFromJson(json);
 
   @override
   final int? page;
@@ -2684,7 +2696,7 @@ class _$_ListPostReports extends _ListPostReports {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListPostReports &&
+            other is _$ListPostReportsImpl &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
             (identical(other.communityId, communityId) ||
@@ -2702,12 +2714,13 @@ class _$_ListPostReports extends _ListPostReports {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListPostReportsCopyWith<_$_ListPostReports> get copyWith =>
-      __$$_ListPostReportsCopyWithImpl<_$_ListPostReports>(this, _$identity);
+  _$$ListPostReportsImplCopyWith<_$ListPostReportsImpl> get copyWith =>
+      __$$ListPostReportsImplCopyWithImpl<_$ListPostReportsImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListPostReportsToJson(
+    return _$$ListPostReportsImplToJson(
       this,
     );
   }
@@ -2719,11 +2732,11 @@ abstract class _ListPostReports extends ListPostReports {
       final int? limit,
       final int? communityId,
       final bool? unresolvedOnly,
-      required final String auth}) = _$_ListPostReports;
+      required final String auth}) = _$ListPostReportsImpl;
   const _ListPostReports._() : super._();
 
   factory _ListPostReports.fromJson(Map<String, dynamic> json) =
-      _$_ListPostReports.fromJson;
+      _$ListPostReportsImpl.fromJson;
 
   @override
   int? get page;
@@ -2737,7 +2750,7 @@ abstract class _ListPostReports extends ListPostReports {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ListPostReportsCopyWith<_$_ListPostReports> get copyWith =>
+  _$$ListPostReportsImplCopyWith<_$ListPostReportsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2801,22 +2814,22 @@ class _$MarkPostAsReadCopyWithImpl<$Res, $Val extends MarkPostAsRead>
 }
 
 /// @nodoc
-abstract class _$$_MarkPostAsReadCopyWith<$Res>
+abstract class _$$MarkPostAsReadImplCopyWith<$Res>
     implements $MarkPostAsReadCopyWith<$Res> {
-  factory _$$_MarkPostAsReadCopyWith(
-          _$_MarkPostAsRead value, $Res Function(_$_MarkPostAsRead) then) =
-      __$$_MarkPostAsReadCopyWithImpl<$Res>;
+  factory _$$MarkPostAsReadImplCopyWith(_$MarkPostAsReadImpl value,
+          $Res Function(_$MarkPostAsReadImpl) then) =
+      __$$MarkPostAsReadImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool read, String auth});
 }
 
 /// @nodoc
-class __$$_MarkPostAsReadCopyWithImpl<$Res>
-    extends _$MarkPostAsReadCopyWithImpl<$Res, _$_MarkPostAsRead>
-    implements _$$_MarkPostAsReadCopyWith<$Res> {
-  __$$_MarkPostAsReadCopyWithImpl(
-      _$_MarkPostAsRead _value, $Res Function(_$_MarkPostAsRead) _then)
+class __$$MarkPostAsReadImplCopyWithImpl<$Res>
+    extends _$MarkPostAsReadCopyWithImpl<$Res, _$MarkPostAsReadImpl>
+    implements _$$MarkPostAsReadImplCopyWith<$Res> {
+  __$$MarkPostAsReadImplCopyWithImpl(
+      _$MarkPostAsReadImpl _value, $Res Function(_$MarkPostAsReadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2826,7 +2839,7 @@ class __$$_MarkPostAsReadCopyWithImpl<$Res>
     Object? read = null,
     Object? auth = null,
   }) {
-    return _then(_$_MarkPostAsRead(
+    return _then(_$MarkPostAsReadImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -2846,13 +2859,13 @@ class __$$_MarkPostAsReadCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_MarkPostAsRead extends _MarkPostAsRead {
-  const _$_MarkPostAsRead(
+class _$MarkPostAsReadImpl extends _MarkPostAsRead {
+  const _$MarkPostAsReadImpl(
       {required this.postId, required this.read, required this.auth})
       : super._();
 
-  factory _$_MarkPostAsRead.fromJson(Map<String, dynamic> json) =>
-      _$$_MarkPostAsReadFromJson(json);
+  factory _$MarkPostAsReadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MarkPostAsReadImplFromJson(json);
 
   @override
   final int postId;
@@ -2870,7 +2883,7 @@ class _$_MarkPostAsRead extends _MarkPostAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MarkPostAsRead &&
+            other is _$MarkPostAsReadImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.read, read) || other.read == read) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -2883,12 +2896,13 @@ class _$_MarkPostAsRead extends _MarkPostAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MarkPostAsReadCopyWith<_$_MarkPostAsRead> get copyWith =>
-      __$$_MarkPostAsReadCopyWithImpl<_$_MarkPostAsRead>(this, _$identity);
+  _$$MarkPostAsReadImplCopyWith<_$MarkPostAsReadImpl> get copyWith =>
+      __$$MarkPostAsReadImplCopyWithImpl<_$MarkPostAsReadImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MarkPostAsReadToJson(
+    return _$$MarkPostAsReadImplToJson(
       this,
     );
   }
@@ -2898,11 +2912,11 @@ abstract class _MarkPostAsRead extends MarkPostAsRead {
   const factory _MarkPostAsRead(
       {required final int postId,
       required final bool read,
-      required final String auth}) = _$_MarkPostAsRead;
+      required final String auth}) = _$MarkPostAsReadImpl;
   const _MarkPostAsRead._() : super._();
 
   factory _MarkPostAsRead.fromJson(Map<String, dynamic> json) =
-      _$_MarkPostAsRead.fromJson;
+      _$MarkPostAsReadImpl.fromJson;
 
   @override
   int get postId;
@@ -2912,6 +2926,6 @@ abstract class _MarkPostAsRead extends MarkPostAsRead {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_MarkPostAsReadCopyWith<_$_MarkPostAsRead> get copyWith =>
+  _$$MarkPostAsReadImplCopyWith<_$MarkPostAsReadImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/post.g.dart
+++ b/lib/src/v3/api/post.g.dart
@@ -6,12 +6,13 @@ part of 'post.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetPost _$$_GetPostFromJson(Map<String, dynamic> json) => _$_GetPost(
+_$GetPostImpl _$$GetPostImplFromJson(Map<String, dynamic> json) =>
+    _$GetPostImpl(
       id: json['id'] as int,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetPostToJson(_$_GetPost instance) {
+Map<String, dynamic> _$$GetPostImplToJson(_$GetPostImpl instance) {
   final val = <String, dynamic>{
     'id': instance.id,
   };
@@ -26,8 +27,8 @@ Map<String, dynamic> _$$_GetPostToJson(_$_GetPost instance) {
   return val;
 }
 
-_$_CreatePost _$$_CreatePostFromJson(Map<String, dynamic> json) =>
-    _$_CreatePost(
+_$CreatePostImpl _$$CreatePostImplFromJson(Map<String, dynamic> json) =>
+    _$CreatePostImpl(
       name: json['name'] as String,
       url: json['url'] as String?,
       body: json['body'] as String?,
@@ -37,7 +38,7 @@ _$_CreatePost _$$_CreatePostFromJson(Map<String, dynamic> json) =>
       honeypot: json['honeypot'] as String?,
     );
 
-Map<String, dynamic> _$$_CreatePostToJson(_$_CreatePost instance) {
+Map<String, dynamic> _$$CreatePostImplToJson(_$CreatePostImpl instance) {
   final val = <String, dynamic>{
     'name': instance.name,
   };
@@ -57,7 +58,8 @@ Map<String, dynamic> _$$_CreatePostToJson(_$_CreatePost instance) {
   return val;
 }
 
-_$_GetPosts _$$_GetPostsFromJson(Map<String, dynamic> json) => _$_GetPosts(
+_$GetPostsImpl _$$GetPostsImplFromJson(Map<String, dynamic> json) =>
+    _$GetPostsImpl(
       type: json['type_'] == null
           ? null
           : PostListingType.fromJson(json['type_']),
@@ -70,7 +72,7 @@ _$_GetPosts _$$_GetPostsFromJson(Map<String, dynamic> json) => _$_GetPosts(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetPostsToJson(_$_GetPosts instance) {
+Map<String, dynamic> _$$GetPostsImplToJson(_$GetPostsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -90,21 +92,23 @@ Map<String, dynamic> _$$_GetPostsToJson(_$_GetPosts instance) {
   return val;
 }
 
-_$_CreatePostLike _$$_CreatePostLikeFromJson(Map<String, dynamic> json) =>
-    _$_CreatePostLike(
+_$CreatePostLikeImpl _$$CreatePostLikeImplFromJson(Map<String, dynamic> json) =>
+    _$CreatePostLikeImpl(
       postId: json['post_id'] as int,
       score: VoteType.fromJson(json['score'] as int),
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_CreatePostLikeToJson(_$_CreatePostLike instance) =>
+Map<String, dynamic> _$$CreatePostLikeImplToJson(
+        _$CreatePostLikeImpl instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'score': instance.score.toJson(),
       'auth': instance.auth,
     };
 
-_$_EditPost _$$_EditPostFromJson(Map<String, dynamic> json) => _$_EditPost(
+_$EditPostImpl _$$EditPostImplFromJson(Map<String, dynamic> json) =>
+    _$EditPostImpl(
       postId: json['post_id'] as int,
       name: json['name'] as String?,
       url: json['url'] as String?,
@@ -113,7 +117,7 @@ _$_EditPost _$$_EditPostFromJson(Map<String, dynamic> json) => _$_EditPost(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_EditPostToJson(_$_EditPost instance) {
+Map<String, dynamic> _$$EditPostImplToJson(_$EditPostImpl instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
   };
@@ -132,29 +136,29 @@ Map<String, dynamic> _$$_EditPostToJson(_$_EditPost instance) {
   return val;
 }
 
-_$_DeletePost _$$_DeletePostFromJson(Map<String, dynamic> json) =>
-    _$_DeletePost(
+_$DeletePostImpl _$$DeletePostImplFromJson(Map<String, dynamic> json) =>
+    _$DeletePostImpl(
       postId: json['post_id'] as int,
       deleted: json['deleted'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_DeletePostToJson(_$_DeletePost instance) =>
+Map<String, dynamic> _$$DeletePostImplToJson(_$DeletePostImpl instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'deleted': instance.deleted,
       'auth': instance.auth,
     };
 
-_$_RemovePost _$$_RemovePostFromJson(Map<String, dynamic> json) =>
-    _$_RemovePost(
+_$RemovePostImpl _$$RemovePostImplFromJson(Map<String, dynamic> json) =>
+    _$RemovePostImpl(
       postId: json['post_id'] as int,
       removed: json['removed'] as bool,
       reason: json['reason'] as String?,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_RemovePostToJson(_$_RemovePost instance) {
+Map<String, dynamic> _$$RemovePostImplToJson(_$RemovePostImpl instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
     'removed': instance.removed,
@@ -171,87 +175,95 @@ Map<String, dynamic> _$$_RemovePostToJson(_$_RemovePost instance) {
   return val;
 }
 
-_$_LockPost _$$_LockPostFromJson(Map<String, dynamic> json) => _$_LockPost(
+_$LockPostImpl _$$LockPostImplFromJson(Map<String, dynamic> json) =>
+    _$LockPostImpl(
       postId: json['post_id'] as int,
       locked: json['locked'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_LockPostToJson(_$_LockPost instance) =>
+Map<String, dynamic> _$$LockPostImplToJson(_$LockPostImpl instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'locked': instance.locked,
       'auth': instance.auth,
     };
 
-_$_StickyPost _$$_StickyPostFromJson(Map<String, dynamic> json) =>
-    _$_StickyPost(
+_$StickyPostImpl _$$StickyPostImplFromJson(Map<String, dynamic> json) =>
+    _$StickyPostImpl(
       postId: json['post_id'] as int,
       stickied: json['stickied'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_StickyPostToJson(_$_StickyPost instance) =>
+Map<String, dynamic> _$$StickyPostImplToJson(_$StickyPostImpl instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'stickied': instance.stickied,
       'auth': instance.auth,
     };
 
-_$_SavePost _$$_SavePostFromJson(Map<String, dynamic> json) => _$_SavePost(
+_$SavePostImpl _$$SavePostImplFromJson(Map<String, dynamic> json) =>
+    _$SavePostImpl(
       postId: json['post_id'] as int,
       save: json['save'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_SavePostToJson(_$_SavePost instance) =>
+Map<String, dynamic> _$$SavePostImplToJson(_$SavePostImpl instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'save': instance.save,
       'auth': instance.auth,
     };
 
-_$_GetSiteMetadata _$$_GetSiteMetadataFromJson(Map<String, dynamic> json) =>
-    _$_GetSiteMetadata(
+_$GetSiteMetadataImpl _$$GetSiteMetadataImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GetSiteMetadataImpl(
       url: json['url'] as String,
     );
 
-Map<String, dynamic> _$$_GetSiteMetadataToJson(_$_GetSiteMetadata instance) =>
+Map<String, dynamic> _$$GetSiteMetadataImplToJson(
+        _$GetSiteMetadataImpl instance) =>
     <String, dynamic>{
       'url': instance.url,
     };
 
-_$_CreatePostReport _$$_CreatePostReportFromJson(Map<String, dynamic> json) =>
-    _$_CreatePostReport(
+_$CreatePostReportImpl _$$CreatePostReportImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CreatePostReportImpl(
       postId: json['post_id'] as int,
       reason: json['reason'] as String,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_CreatePostReportToJson(_$_CreatePostReport instance) =>
+Map<String, dynamic> _$$CreatePostReportImplToJson(
+        _$CreatePostReportImpl instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'reason': instance.reason,
       'auth': instance.auth,
     };
 
-_$_ResolvePostReport _$$_ResolvePostReportFromJson(Map<String, dynamic> json) =>
-    _$_ResolvePostReport(
+_$ResolvePostReportImpl _$$ResolvePostReportImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ResolvePostReportImpl(
       reportId: json['report_id'] as int,
       resolved: json['resolved'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_ResolvePostReportToJson(
-        _$_ResolvePostReport instance) =>
+Map<String, dynamic> _$$ResolvePostReportImplToJson(
+        _$ResolvePostReportImpl instance) =>
     <String, dynamic>{
       'report_id': instance.reportId,
       'resolved': instance.resolved,
       'auth': instance.auth,
     };
 
-_$_ListPostReports _$$_ListPostReportsFromJson(Map<String, dynamic> json) =>
-    _$_ListPostReports(
+_$ListPostReportsImpl _$$ListPostReportsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ListPostReportsImpl(
       page: json['page'] as int?,
       limit: json['limit'] as int?,
       communityId: json['community_id'] as int?,
@@ -259,7 +271,8 @@ _$_ListPostReports _$$_ListPostReportsFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_ListPostReportsToJson(_$_ListPostReports instance) {
+Map<String, dynamic> _$$ListPostReportsImplToJson(
+    _$ListPostReportsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -276,14 +289,15 @@ Map<String, dynamic> _$$_ListPostReportsToJson(_$_ListPostReports instance) {
   return val;
 }
 
-_$_MarkPostAsRead _$$_MarkPostAsReadFromJson(Map<String, dynamic> json) =>
-    _$_MarkPostAsRead(
+_$MarkPostAsReadImpl _$$MarkPostAsReadImplFromJson(Map<String, dynamic> json) =>
+    _$MarkPostAsReadImpl(
       postId: json['post_id'] as int,
       read: json['read'] as bool,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_MarkPostAsReadToJson(_$_MarkPostAsRead instance) =>
+Map<String, dynamic> _$$MarkPostAsReadImplToJson(
+        _$MarkPostAsReadImpl instance) =>
     <String, dynamic>{
       'post_id': instance.postId,
       'read': instance.read,

--- a/lib/src/v3/api/site.freezed.dart
+++ b/lib/src/v3/api/site.freezed.dart
@@ -125,9 +125,10 @@ class _$SearchCopyWithImpl<$Res, $Val extends Search>
 }
 
 /// @nodoc
-abstract class _$$_SearchCopyWith<$Res> implements $SearchCopyWith<$Res> {
-  factory _$$_SearchCopyWith(_$_Search value, $Res Function(_$_Search) then) =
-      __$$_SearchCopyWithImpl<$Res>;
+abstract class _$$SearchImplCopyWith<$Res> implements $SearchCopyWith<$Res> {
+  factory _$$SearchImplCopyWith(
+          _$SearchImpl value, $Res Function(_$SearchImpl) then) =
+      __$$SearchImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -144,10 +145,11 @@ abstract class _$$_SearchCopyWith<$Res> implements $SearchCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_SearchCopyWithImpl<$Res>
-    extends _$SearchCopyWithImpl<$Res, _$_Search>
-    implements _$$_SearchCopyWith<$Res> {
-  __$$_SearchCopyWithImpl(_$_Search _value, $Res Function(_$_Search) _then)
+class __$$SearchImplCopyWithImpl<$Res>
+    extends _$SearchCopyWithImpl<$Res, _$SearchImpl>
+    implements _$$SearchImplCopyWith<$Res> {
+  __$$SearchImplCopyWithImpl(
+      _$SearchImpl _value, $Res Function(_$SearchImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -164,7 +166,7 @@ class __$$_SearchCopyWithImpl<$Res>
     Object? creatorId = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_Search(
+    return _then(_$SearchImpl(
       q: null == q
           ? _value.q
           : q // ignore: cast_nullable_to_non_nullable
@@ -212,8 +214,8 @@ class __$$_SearchCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_Search extends _Search {
-  const _$_Search(
+class _$SearchImpl extends _Search {
+  const _$SearchImpl(
       {required this.q,
       @JsonKey(name: 'type_') this.type,
       this.listingType,
@@ -226,8 +228,8 @@ class _$_Search extends _Search {
       this.auth})
       : super._();
 
-  factory _$_Search.fromJson(Map<String, dynamic> json) =>
-      _$$_SearchFromJson(json);
+  factory _$SearchImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SearchImplFromJson(json);
 
   @override
   final String q;
@@ -260,7 +262,7 @@ class _$_Search extends _Search {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Search &&
+            other is _$SearchImpl &&
             (identical(other.q, q) || other.q == q) &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.listingType, listingType) ||
@@ -285,12 +287,12 @@ class _$_Search extends _Search {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SearchCopyWith<_$_Search> get copyWith =>
-      __$$_SearchCopyWithImpl<_$_Search>(this, _$identity);
+  _$$SearchImplCopyWith<_$SearchImpl> get copyWith =>
+      __$$SearchImplCopyWithImpl<_$SearchImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SearchToJson(
+    return _$$SearchImplToJson(
       this,
     );
   }
@@ -307,10 +309,10 @@ abstract class _Search extends Search {
       final int? page,
       final int? limit,
       final int? creatorId,
-      final String? auth}) = _$_Search;
+      final String? auth}) = _$SearchImpl;
   const _Search._() : super._();
 
-  factory _Search.fromJson(Map<String, dynamic> json) = _$_Search.fromJson;
+  factory _Search.fromJson(Map<String, dynamic> json) = _$SearchImpl.fromJson;
 
   @override
   String get q;
@@ -335,7 +337,7 @@ abstract class _Search extends Search {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_SearchCopyWith<_$_Search> get copyWith =>
+  _$$SearchImplCopyWith<_$SearchImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -430,10 +432,11 @@ class _$GetModlogCopyWithImpl<$Res, $Val extends GetModlog>
 }
 
 /// @nodoc
-abstract class _$$_GetModlogCopyWith<$Res> implements $GetModlogCopyWith<$Res> {
-  factory _$$_GetModlogCopyWith(
-          _$_GetModlog value, $Res Function(_$_GetModlog) then) =
-      __$$_GetModlogCopyWithImpl<$Res>;
+abstract class _$$GetModlogImplCopyWith<$Res>
+    implements $GetModlogCopyWith<$Res> {
+  factory _$$GetModlogImplCopyWith(
+          _$GetModlogImpl value, $Res Function(_$GetModlogImpl) then) =
+      __$$GetModlogImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -447,11 +450,11 @@ abstract class _$$_GetModlogCopyWith<$Res> implements $GetModlogCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_GetModlogCopyWithImpl<$Res>
-    extends _$GetModlogCopyWithImpl<$Res, _$_GetModlog>
-    implements _$$_GetModlogCopyWith<$Res> {
-  __$$_GetModlogCopyWithImpl(
-      _$_GetModlog _value, $Res Function(_$_GetModlog) _then)
+class __$$GetModlogImplCopyWithImpl<$Res>
+    extends _$GetModlogCopyWithImpl<$Res, _$GetModlogImpl>
+    implements _$$GetModlogImplCopyWith<$Res> {
+  __$$GetModlogImplCopyWithImpl(
+      _$GetModlogImpl _value, $Res Function(_$GetModlogImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -465,7 +468,7 @@ class __$$_GetModlogCopyWithImpl<$Res>
     Object? auth = freezed,
     Object? type = freezed,
   }) {
-    return _then(_$_GetModlog(
+    return _then(_$GetModlogImpl(
       modPersonId: freezed == modPersonId
           ? _value.modPersonId
           : modPersonId // ignore: cast_nullable_to_non_nullable
@@ -501,8 +504,8 @@ class __$$_GetModlogCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetModlog extends _GetModlog {
-  const _$_GetModlog(
+class _$GetModlogImpl extends _GetModlog {
+  const _$GetModlogImpl(
       {this.modPersonId,
       this.communityId,
       this.otherPersonId,
@@ -512,8 +515,8 @@ class _$_GetModlog extends _GetModlog {
       @JsonKey(name: 'type_') this.type})
       : super._();
 
-  factory _$_GetModlog.fromJson(Map<String, dynamic> json) =>
-      _$$_GetModlogFromJson(json);
+  factory _$GetModlogImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetModlogImplFromJson(json);
 
   @override
   final int? modPersonId;
@@ -540,7 +543,7 @@ class _$_GetModlog extends _GetModlog {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetModlog &&
+            other is _$GetModlogImpl &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
             (identical(other.communityId, communityId) ||
@@ -561,12 +564,12 @@ class _$_GetModlog extends _GetModlog {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetModlogCopyWith<_$_GetModlog> get copyWith =>
-      __$$_GetModlogCopyWithImpl<_$_GetModlog>(this, _$identity);
+  _$$GetModlogImplCopyWith<_$GetModlogImpl> get copyWith =>
+      __$$GetModlogImplCopyWithImpl<_$GetModlogImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetModlogToJson(
+    return _$$GetModlogImplToJson(
       this,
     );
   }
@@ -580,11 +583,11 @@ abstract class _GetModlog extends GetModlog {
       final int? page,
       final int? limit,
       final String? auth,
-      @JsonKey(name: 'type_') final ModlogActionType? type}) = _$_GetModlog;
+      @JsonKey(name: 'type_') final ModlogActionType? type}) = _$GetModlogImpl;
   const _GetModlog._() : super._();
 
   factory _GetModlog.fromJson(Map<String, dynamic> json) =
-      _$_GetModlog.fromJson;
+      _$GetModlogImpl.fromJson;
 
   @override
   int? get modPersonId;
@@ -603,7 +606,7 @@ abstract class _GetModlog extends GetModlog {
   ModlogActionType? get type;
   @override
   @JsonKey(ignore: true)
-  _$$_GetModlogCopyWith<_$_GetModlog> get copyWith =>
+  _$$GetModlogImplCopyWith<_$GetModlogImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -619,7 +622,7 @@ mixin _$BlockInstance {
   /// Whether to block or unblock the given instance
   bool get block => throw _privateConstructorUsedError;
 
-  /// The auth token. This only works if auth is set within the header
+  /// The auth token. This parameter is passed in the header
   String? get auth => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -672,22 +675,22 @@ class _$BlockInstanceCopyWithImpl<$Res, $Val extends BlockInstance>
 }
 
 /// @nodoc
-abstract class _$$_BlockInstanceCopyWith<$Res>
+abstract class _$$BlockInstanceImplCopyWith<$Res>
     implements $BlockInstanceCopyWith<$Res> {
-  factory _$$_BlockInstanceCopyWith(
-          _$_BlockInstance value, $Res Function(_$_BlockInstance) then) =
-      __$$_BlockInstanceCopyWithImpl<$Res>;
+  factory _$$BlockInstanceImplCopyWith(
+          _$BlockInstanceImpl value, $Res Function(_$BlockInstanceImpl) then) =
+      __$$BlockInstanceImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int instanceId, bool block, String? auth});
 }
 
 /// @nodoc
-class __$$_BlockInstanceCopyWithImpl<$Res>
-    extends _$BlockInstanceCopyWithImpl<$Res, _$_BlockInstance>
-    implements _$$_BlockInstanceCopyWith<$Res> {
-  __$$_BlockInstanceCopyWithImpl(
-      _$_BlockInstance _value, $Res Function(_$_BlockInstance) _then)
+class __$$BlockInstanceImplCopyWithImpl<$Res>
+    extends _$BlockInstanceCopyWithImpl<$Res, _$BlockInstanceImpl>
+    implements _$$BlockInstanceImplCopyWith<$Res> {
+  __$$BlockInstanceImplCopyWithImpl(
+      _$BlockInstanceImpl _value, $Res Function(_$BlockInstanceImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -697,7 +700,7 @@ class __$$_BlockInstanceCopyWithImpl<$Res>
     Object? block = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_BlockInstance(
+    return _then(_$BlockInstanceImpl(
       instanceId: null == instanceId
           ? _value.instanceId
           : instanceId // ignore: cast_nullable_to_non_nullable
@@ -717,13 +720,13 @@ class __$$_BlockInstanceCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_BlockInstance extends _BlockInstance {
-  const _$_BlockInstance(
+class _$BlockInstanceImpl extends _BlockInstance {
+  const _$BlockInstanceImpl(
       {required this.instanceId, required this.block, this.auth})
       : super._();
 
-  factory _$_BlockInstance.fromJson(Map<String, dynamic> json) =>
-      _$$_BlockInstanceFromJson(json);
+  factory _$BlockInstanceImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BlockInstanceImplFromJson(json);
 
   /// The ID of the instance
   @override
@@ -733,7 +736,7 @@ class _$_BlockInstance extends _BlockInstance {
   @override
   final bool block;
 
-  /// The auth token. This only works if auth is set within the header
+  /// The auth token. This parameter is passed in the header
   @override
   final String? auth;
 
@@ -746,7 +749,7 @@ class _$_BlockInstance extends _BlockInstance {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BlockInstance &&
+            other is _$BlockInstanceImpl &&
             (identical(other.instanceId, instanceId) ||
                 other.instanceId == instanceId) &&
             (identical(other.block, block) || other.block == block) &&
@@ -760,12 +763,12 @@ class _$_BlockInstance extends _BlockInstance {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BlockInstanceCopyWith<_$_BlockInstance> get copyWith =>
-      __$$_BlockInstanceCopyWithImpl<_$_BlockInstance>(this, _$identity);
+  _$$BlockInstanceImplCopyWith<_$BlockInstanceImpl> get copyWith =>
+      __$$BlockInstanceImplCopyWithImpl<_$BlockInstanceImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BlockInstanceToJson(
+    return _$$BlockInstanceImplToJson(
       this,
     );
   }
@@ -775,11 +778,11 @@ abstract class _BlockInstance extends BlockInstance {
   const factory _BlockInstance(
       {required final int instanceId,
       required final bool block,
-      final String? auth}) = _$_BlockInstance;
+      final String? auth}) = _$BlockInstanceImpl;
   const _BlockInstance._() : super._();
 
   factory _BlockInstance.fromJson(Map<String, dynamic> json) =
-      _$_BlockInstance.fromJson;
+      _$BlockInstanceImpl.fromJson;
 
   @override
 
@@ -791,11 +794,11 @@ abstract class _BlockInstance extends BlockInstance {
   bool get block;
   @override
 
-  /// The auth token. This only works if auth is set within the header
+  /// The auth token. This parameter is passed in the header
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_BlockInstanceCopyWith<_$_BlockInstance> get copyWith =>
+  _$$BlockInstanceImplCopyWith<_$BlockInstanceImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -946,11 +949,11 @@ class _$CreateSiteCopyWithImpl<$Res, $Val extends CreateSite>
 }
 
 /// @nodoc
-abstract class _$$_CreateSiteCopyWith<$Res>
+abstract class _$$CreateSiteImplCopyWith<$Res>
     implements $CreateSiteCopyWith<$Res> {
-  factory _$$_CreateSiteCopyWith(
-          _$_CreateSite value, $Res Function(_$_CreateSite) then) =
-      __$$_CreateSiteCopyWithImpl<$Res>;
+  factory _$$CreateSiteImplCopyWith(
+          _$CreateSiteImpl value, $Res Function(_$CreateSiteImpl) then) =
+      __$$CreateSiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -972,11 +975,11 @@ abstract class _$$_CreateSiteCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CreateSiteCopyWithImpl<$Res>
-    extends _$CreateSiteCopyWithImpl<$Res, _$_CreateSite>
-    implements _$$_CreateSiteCopyWith<$Res> {
-  __$$_CreateSiteCopyWithImpl(
-      _$_CreateSite _value, $Res Function(_$_CreateSite) _then)
+class __$$CreateSiteImplCopyWithImpl<$Res>
+    extends _$CreateSiteCopyWithImpl<$Res, _$CreateSiteImpl>
+    implements _$$CreateSiteImplCopyWith<$Res> {
+  __$$CreateSiteImplCopyWithImpl(
+      _$CreateSiteImpl _value, $Res Function(_$CreateSiteImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -998,7 +1001,7 @@ class __$$_CreateSiteCopyWithImpl<$Res>
     Object? auth = null,
     Object? defaultTheme = freezed,
   }) {
-    return _then(_$_CreateSite(
+    return _then(_$CreateSiteImpl(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -1066,8 +1069,8 @@ class __$$_CreateSiteCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreateSite extends _CreateSite {
-  const _$_CreateSite(
+class _$CreateSiteImpl extends _CreateSite {
+  const _$CreateSiteImpl(
       {required this.name,
       this.sidebar,
       this.description,
@@ -1085,8 +1088,8 @@ class _$_CreateSite extends _CreateSite {
       this.defaultTheme})
       : super._();
 
-  factory _$_CreateSite.fromJson(Map<String, dynamic> json) =>
-      _$$_CreateSiteFromJson(json);
+  factory _$CreateSiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreateSiteImplFromJson(json);
 
   @override
   final String name;
@@ -1128,7 +1131,7 @@ class _$_CreateSite extends _CreateSite {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreateSite &&
+            other is _$CreateSiteImpl &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.sidebar, sidebar) || other.sidebar == sidebar) &&
             (identical(other.description, description) ||
@@ -1182,12 +1185,12 @@ class _$_CreateSite extends _CreateSite {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreateSiteCopyWith<_$_CreateSite> get copyWith =>
-      __$$_CreateSiteCopyWithImpl<_$_CreateSite>(this, _$identity);
+  _$$CreateSiteImplCopyWith<_$CreateSiteImpl> get copyWith =>
+      __$$CreateSiteImplCopyWithImpl<_$CreateSiteImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreateSiteToJson(
+    return _$$CreateSiteImplToJson(
       this,
     );
   }
@@ -1209,11 +1212,11 @@ abstract class _CreateSite extends CreateSite {
       final String? applicationQuestion,
       final bool? privateInstance,
       required final String auth,
-      final String? defaultTheme}) = _$_CreateSite;
+      final String? defaultTheme}) = _$CreateSiteImpl;
   const _CreateSite._() : super._();
 
   factory _CreateSite.fromJson(Map<String, dynamic> json) =
-      _$_CreateSite.fromJson;
+      _$CreateSiteImpl.fromJson;
 
   @override
   String get name;
@@ -1247,7 +1250,7 @@ abstract class _CreateSite extends CreateSite {
   String? get defaultTheme;
   @override
   @JsonKey(ignore: true)
-  _$$_CreateSiteCopyWith<_$_CreateSite> get copyWith =>
+  _$$CreateSiteImplCopyWith<_$CreateSiteImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1397,10 +1400,11 @@ class _$EditSiteCopyWithImpl<$Res, $Val extends EditSite>
 }
 
 /// @nodoc
-abstract class _$$_EditSiteCopyWith<$Res> implements $EditSiteCopyWith<$Res> {
-  factory _$$_EditSiteCopyWith(
-          _$_EditSite value, $Res Function(_$_EditSite) then) =
-      __$$_EditSiteCopyWithImpl<$Res>;
+abstract class _$$EditSiteImplCopyWith<$Res>
+    implements $EditSiteCopyWith<$Res> {
+  factory _$$EditSiteImplCopyWith(
+          _$EditSiteImpl value, $Res Function(_$EditSiteImpl) then) =
+      __$$EditSiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1422,11 +1426,11 @@ abstract class _$$_EditSiteCopyWith<$Res> implements $EditSiteCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_EditSiteCopyWithImpl<$Res>
-    extends _$EditSiteCopyWithImpl<$Res, _$_EditSite>
-    implements _$$_EditSiteCopyWith<$Res> {
-  __$$_EditSiteCopyWithImpl(
-      _$_EditSite _value, $Res Function(_$_EditSite) _then)
+class __$$EditSiteImplCopyWithImpl<$Res>
+    extends _$EditSiteCopyWithImpl<$Res, _$EditSiteImpl>
+    implements _$$EditSiteImplCopyWith<$Res> {
+  __$$EditSiteImplCopyWithImpl(
+      _$EditSiteImpl _value, $Res Function(_$EditSiteImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1448,7 +1452,7 @@ class __$$_EditSiteCopyWithImpl<$Res>
     Object? auth = null,
     Object? defaultTheme = freezed,
   }) {
-    return _then(_$_EditSite(
+    return _then(_$EditSiteImpl(
       name: freezed == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -1516,8 +1520,8 @@ class __$$_EditSiteCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_EditSite extends _EditSite {
-  const _$_EditSite(
+class _$EditSiteImpl extends _EditSite {
+  const _$EditSiteImpl(
       {this.name,
       this.sidebar,
       this.description,
@@ -1535,8 +1539,8 @@ class _$_EditSite extends _EditSite {
       this.defaultTheme})
       : super._();
 
-  factory _$_EditSite.fromJson(Map<String, dynamic> json) =>
-      _$$_EditSiteFromJson(json);
+  factory _$EditSiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EditSiteImplFromJson(json);
 
   @override
   final String? name;
@@ -1578,7 +1582,7 @@ class _$_EditSite extends _EditSite {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_EditSite &&
+            other is _$EditSiteImpl &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.sidebar, sidebar) || other.sidebar == sidebar) &&
             (identical(other.description, description) ||
@@ -1632,12 +1636,12 @@ class _$_EditSite extends _EditSite {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_EditSiteCopyWith<_$_EditSite> get copyWith =>
-      __$$_EditSiteCopyWithImpl<_$_EditSite>(this, _$identity);
+  _$$EditSiteImplCopyWith<_$EditSiteImpl> get copyWith =>
+      __$$EditSiteImplCopyWithImpl<_$EditSiteImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_EditSiteToJson(
+    return _$$EditSiteImplToJson(
       this,
     );
   }
@@ -1659,10 +1663,11 @@ abstract class _EditSite extends EditSite {
       final String? applicationQuestion,
       final bool? privateInstance,
       required final String auth,
-      final String? defaultTheme}) = _$_EditSite;
+      final String? defaultTheme}) = _$EditSiteImpl;
   const _EditSite._() : super._();
 
-  factory _EditSite.fromJson(Map<String, dynamic> json) = _$_EditSite.fromJson;
+  factory _EditSite.fromJson(Map<String, dynamic> json) =
+      _$EditSiteImpl.fromJson;
 
   @override
   String? get name;
@@ -1696,7 +1701,7 @@ abstract class _EditSite extends EditSite {
   String? get defaultTheme;
   @override
   @JsonKey(ignore: true)
-  _$$_EditSiteCopyWith<_$_EditSite> get copyWith =>
+  _$$EditSiteImplCopyWith<_$EditSiteImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1746,20 +1751,21 @@ class _$GetSiteCopyWithImpl<$Res, $Val extends GetSite>
 }
 
 /// @nodoc
-abstract class _$$_GetSiteCopyWith<$Res> implements $GetSiteCopyWith<$Res> {
-  factory _$$_GetSiteCopyWith(
-          _$_GetSite value, $Res Function(_$_GetSite) then) =
-      __$$_GetSiteCopyWithImpl<$Res>;
+abstract class _$$GetSiteImplCopyWith<$Res> implements $GetSiteCopyWith<$Res> {
+  factory _$$GetSiteImplCopyWith(
+          _$GetSiteImpl value, $Res Function(_$GetSiteImpl) then) =
+      __$$GetSiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$_GetSiteCopyWithImpl<$Res>
-    extends _$GetSiteCopyWithImpl<$Res, _$_GetSite>
-    implements _$$_GetSiteCopyWith<$Res> {
-  __$$_GetSiteCopyWithImpl(_$_GetSite _value, $Res Function(_$_GetSite) _then)
+class __$$GetSiteImplCopyWithImpl<$Res>
+    extends _$GetSiteCopyWithImpl<$Res, _$GetSiteImpl>
+    implements _$$GetSiteImplCopyWith<$Res> {
+  __$$GetSiteImplCopyWithImpl(
+      _$GetSiteImpl _value, $Res Function(_$GetSiteImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1767,7 +1773,7 @@ class __$$_GetSiteCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$_GetSite(
+    return _then(_$GetSiteImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -1779,11 +1785,11 @@ class __$$_GetSiteCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetSite extends _GetSite {
-  const _$_GetSite({this.auth}) : super._();
+class _$GetSiteImpl extends _GetSite {
+  const _$GetSiteImpl({this.auth}) : super._();
 
-  factory _$_GetSite.fromJson(Map<String, dynamic> json) =>
-      _$$_GetSiteFromJson(json);
+  factory _$GetSiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetSiteImplFromJson(json);
 
   @override
   final String? auth;
@@ -1797,7 +1803,7 @@ class _$_GetSite extends _GetSite {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetSite &&
+            other is _$GetSiteImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -1808,28 +1814,28 @@ class _$_GetSite extends _GetSite {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetSiteCopyWith<_$_GetSite> get copyWith =>
-      __$$_GetSiteCopyWithImpl<_$_GetSite>(this, _$identity);
+  _$$GetSiteImplCopyWith<_$GetSiteImpl> get copyWith =>
+      __$$GetSiteImplCopyWithImpl<_$GetSiteImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetSiteToJson(
+    return _$$GetSiteImplToJson(
       this,
     );
   }
 }
 
 abstract class _GetSite extends GetSite {
-  const factory _GetSite({final String? auth}) = _$_GetSite;
+  const factory _GetSite({final String? auth}) = _$GetSiteImpl;
   const _GetSite._() : super._();
 
-  factory _GetSite.fromJson(Map<String, dynamic> json) = _$_GetSite.fromJson;
+  factory _GetSite.fromJson(Map<String, dynamic> json) = _$GetSiteImpl.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetSiteCopyWith<_$_GetSite> get copyWith =>
+  _$$GetSiteImplCopyWith<_$GetSiteImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1881,22 +1887,22 @@ class _$LeaveAdminCopyWithImpl<$Res, $Val extends LeaveAdmin>
 }
 
 /// @nodoc
-abstract class _$$_LeaveAdminCopyWith<$Res>
+abstract class _$$LeaveAdminImplCopyWith<$Res>
     implements $LeaveAdminCopyWith<$Res> {
-  factory _$$_LeaveAdminCopyWith(
-          _$_LeaveAdmin value, $Res Function(_$_LeaveAdmin) then) =
-      __$$_LeaveAdminCopyWithImpl<$Res>;
+  factory _$$LeaveAdminImplCopyWith(
+          _$LeaveAdminImpl value, $Res Function(_$LeaveAdminImpl) then) =
+      __$$LeaveAdminImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String auth});
 }
 
 /// @nodoc
-class __$$_LeaveAdminCopyWithImpl<$Res>
-    extends _$LeaveAdminCopyWithImpl<$Res, _$_LeaveAdmin>
-    implements _$$_LeaveAdminCopyWith<$Res> {
-  __$$_LeaveAdminCopyWithImpl(
-      _$_LeaveAdmin _value, $Res Function(_$_LeaveAdmin) _then)
+class __$$LeaveAdminImplCopyWithImpl<$Res>
+    extends _$LeaveAdminCopyWithImpl<$Res, _$LeaveAdminImpl>
+    implements _$$LeaveAdminImplCopyWith<$Res> {
+  __$$LeaveAdminImplCopyWithImpl(
+      _$LeaveAdminImpl _value, $Res Function(_$LeaveAdminImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1904,7 +1910,7 @@ class __$$_LeaveAdminCopyWithImpl<$Res>
   $Res call({
     Object? auth = null,
   }) {
-    return _then(_$_LeaveAdmin(
+    return _then(_$LeaveAdminImpl(
       auth: null == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -1916,11 +1922,11 @@ class __$$_LeaveAdminCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_LeaveAdmin extends _LeaveAdmin {
-  const _$_LeaveAdmin({required this.auth}) : super._();
+class _$LeaveAdminImpl extends _LeaveAdmin {
+  const _$LeaveAdminImpl({required this.auth}) : super._();
 
-  factory _$_LeaveAdmin.fromJson(Map<String, dynamic> json) =>
-      _$$_LeaveAdminFromJson(json);
+  factory _$LeaveAdminImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LeaveAdminImplFromJson(json);
 
   @override
   final String auth;
@@ -1934,7 +1940,7 @@ class _$_LeaveAdmin extends _LeaveAdmin {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LeaveAdmin &&
+            other is _$LeaveAdminImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -1945,29 +1951,29 @@ class _$_LeaveAdmin extends _LeaveAdmin {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LeaveAdminCopyWith<_$_LeaveAdmin> get copyWith =>
-      __$$_LeaveAdminCopyWithImpl<_$_LeaveAdmin>(this, _$identity);
+  _$$LeaveAdminImplCopyWith<_$LeaveAdminImpl> get copyWith =>
+      __$$LeaveAdminImplCopyWithImpl<_$LeaveAdminImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LeaveAdminToJson(
+    return _$$LeaveAdminImplToJson(
       this,
     );
   }
 }
 
 abstract class _LeaveAdmin extends LeaveAdmin {
-  const factory _LeaveAdmin({required final String auth}) = _$_LeaveAdmin;
+  const factory _LeaveAdmin({required final String auth}) = _$LeaveAdminImpl;
   const _LeaveAdmin._() : super._();
 
   factory _LeaveAdmin.fromJson(Map<String, dynamic> json) =
-      _$_LeaveAdmin.fromJson;
+      _$LeaveAdminImpl.fromJson;
 
   @override
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_LeaveAdminCopyWith<_$_LeaveAdmin> get copyWith =>
+  _$$LeaveAdminImplCopyWith<_$LeaveAdminImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2019,22 +2025,22 @@ class _$GetSiteConfigCopyWithImpl<$Res, $Val extends GetSiteConfig>
 }
 
 /// @nodoc
-abstract class _$$_GetSiteConfigCopyWith<$Res>
+abstract class _$$GetSiteConfigImplCopyWith<$Res>
     implements $GetSiteConfigCopyWith<$Res> {
-  factory _$$_GetSiteConfigCopyWith(
-          _$_GetSiteConfig value, $Res Function(_$_GetSiteConfig) then) =
-      __$$_GetSiteConfigCopyWithImpl<$Res>;
+  factory _$$GetSiteConfigImplCopyWith(
+          _$GetSiteConfigImpl value, $Res Function(_$GetSiteConfigImpl) then) =
+      __$$GetSiteConfigImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String auth});
 }
 
 /// @nodoc
-class __$$_GetSiteConfigCopyWithImpl<$Res>
-    extends _$GetSiteConfigCopyWithImpl<$Res, _$_GetSiteConfig>
-    implements _$$_GetSiteConfigCopyWith<$Res> {
-  __$$_GetSiteConfigCopyWithImpl(
-      _$_GetSiteConfig _value, $Res Function(_$_GetSiteConfig) _then)
+class __$$GetSiteConfigImplCopyWithImpl<$Res>
+    extends _$GetSiteConfigCopyWithImpl<$Res, _$GetSiteConfigImpl>
+    implements _$$GetSiteConfigImplCopyWith<$Res> {
+  __$$GetSiteConfigImplCopyWithImpl(
+      _$GetSiteConfigImpl _value, $Res Function(_$GetSiteConfigImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2042,7 +2048,7 @@ class __$$_GetSiteConfigCopyWithImpl<$Res>
   $Res call({
     Object? auth = null,
   }) {
-    return _then(_$_GetSiteConfig(
+    return _then(_$GetSiteConfigImpl(
       auth: null == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -2054,11 +2060,11 @@ class __$$_GetSiteConfigCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetSiteConfig extends _GetSiteConfig {
-  const _$_GetSiteConfig({required this.auth}) : super._();
+class _$GetSiteConfigImpl extends _GetSiteConfig {
+  const _$GetSiteConfigImpl({required this.auth}) : super._();
 
-  factory _$_GetSiteConfig.fromJson(Map<String, dynamic> json) =>
-      _$$_GetSiteConfigFromJson(json);
+  factory _$GetSiteConfigImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetSiteConfigImplFromJson(json);
 
   @override
   final String auth;
@@ -2072,7 +2078,7 @@ class _$_GetSiteConfig extends _GetSiteConfig {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetSiteConfig &&
+            other is _$GetSiteConfigImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -2083,29 +2089,30 @@ class _$_GetSiteConfig extends _GetSiteConfig {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetSiteConfigCopyWith<_$_GetSiteConfig> get copyWith =>
-      __$$_GetSiteConfigCopyWithImpl<_$_GetSiteConfig>(this, _$identity);
+  _$$GetSiteConfigImplCopyWith<_$GetSiteConfigImpl> get copyWith =>
+      __$$GetSiteConfigImplCopyWithImpl<_$GetSiteConfigImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetSiteConfigToJson(
+    return _$$GetSiteConfigImplToJson(
       this,
     );
   }
 }
 
 abstract class _GetSiteConfig extends GetSiteConfig {
-  const factory _GetSiteConfig({required final String auth}) = _$_GetSiteConfig;
+  const factory _GetSiteConfig({required final String auth}) =
+      _$GetSiteConfigImpl;
   const _GetSiteConfig._() : super._();
 
   factory _GetSiteConfig.fromJson(Map<String, dynamic> json) =
-      _$_GetSiteConfig.fromJson;
+      _$GetSiteConfigImpl.fromJson;
 
   @override
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetSiteConfigCopyWith<_$_GetSiteConfig> get copyWith =>
+  _$$GetSiteConfigImplCopyWith<_$GetSiteConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2163,22 +2170,22 @@ class _$SaveSiteConfigCopyWithImpl<$Res, $Val extends SaveSiteConfig>
 }
 
 /// @nodoc
-abstract class _$$_SaveSiteConfigCopyWith<$Res>
+abstract class _$$SaveSiteConfigImplCopyWith<$Res>
     implements $SaveSiteConfigCopyWith<$Res> {
-  factory _$$_SaveSiteConfigCopyWith(
-          _$_SaveSiteConfig value, $Res Function(_$_SaveSiteConfig) then) =
-      __$$_SaveSiteConfigCopyWithImpl<$Res>;
+  factory _$$SaveSiteConfigImplCopyWith(_$SaveSiteConfigImpl value,
+          $Res Function(_$SaveSiteConfigImpl) then) =
+      __$$SaveSiteConfigImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String configHjson, String auth});
 }
 
 /// @nodoc
-class __$$_SaveSiteConfigCopyWithImpl<$Res>
-    extends _$SaveSiteConfigCopyWithImpl<$Res, _$_SaveSiteConfig>
-    implements _$$_SaveSiteConfigCopyWith<$Res> {
-  __$$_SaveSiteConfigCopyWithImpl(
-      _$_SaveSiteConfig _value, $Res Function(_$_SaveSiteConfig) _then)
+class __$$SaveSiteConfigImplCopyWithImpl<$Res>
+    extends _$SaveSiteConfigCopyWithImpl<$Res, _$SaveSiteConfigImpl>
+    implements _$$SaveSiteConfigImplCopyWith<$Res> {
+  __$$SaveSiteConfigImplCopyWithImpl(
+      _$SaveSiteConfigImpl _value, $Res Function(_$SaveSiteConfigImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2187,7 +2194,7 @@ class __$$_SaveSiteConfigCopyWithImpl<$Res>
     Object? configHjson = null,
     Object? auth = null,
   }) {
-    return _then(_$_SaveSiteConfig(
+    return _then(_$SaveSiteConfigImpl(
       configHjson: null == configHjson
           ? _value.configHjson
           : configHjson // ignore: cast_nullable_to_non_nullable
@@ -2203,12 +2210,12 @@ class __$$_SaveSiteConfigCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_SaveSiteConfig extends _SaveSiteConfig {
-  const _$_SaveSiteConfig({required this.configHjson, required this.auth})
+class _$SaveSiteConfigImpl extends _SaveSiteConfig {
+  const _$SaveSiteConfigImpl({required this.configHjson, required this.auth})
       : super._();
 
-  factory _$_SaveSiteConfig.fromJson(Map<String, dynamic> json) =>
-      _$$_SaveSiteConfigFromJson(json);
+  factory _$SaveSiteConfigImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SaveSiteConfigImplFromJson(json);
 
   @override
   final String configHjson;
@@ -2224,7 +2231,7 @@ class _$_SaveSiteConfig extends _SaveSiteConfig {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SaveSiteConfig &&
+            other is _$SaveSiteConfigImpl &&
             (identical(other.configHjson, configHjson) ||
                 other.configHjson == configHjson) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -2237,12 +2244,13 @@ class _$_SaveSiteConfig extends _SaveSiteConfig {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SaveSiteConfigCopyWith<_$_SaveSiteConfig> get copyWith =>
-      __$$_SaveSiteConfigCopyWithImpl<_$_SaveSiteConfig>(this, _$identity);
+  _$$SaveSiteConfigImplCopyWith<_$SaveSiteConfigImpl> get copyWith =>
+      __$$SaveSiteConfigImplCopyWithImpl<_$SaveSiteConfigImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SaveSiteConfigToJson(
+    return _$$SaveSiteConfigImplToJson(
       this,
     );
   }
@@ -2251,11 +2259,11 @@ class _$_SaveSiteConfig extends _SaveSiteConfig {
 abstract class _SaveSiteConfig extends SaveSiteConfig {
   const factory _SaveSiteConfig(
       {required final String configHjson,
-      required final String auth}) = _$_SaveSiteConfig;
+      required final String auth}) = _$SaveSiteConfigImpl;
   const _SaveSiteConfig._() : super._();
 
   factory _SaveSiteConfig.fromJson(Map<String, dynamic> json) =
-      _$_SaveSiteConfig.fromJson;
+      _$SaveSiteConfigImpl.fromJson;
 
   @override
   String get configHjson;
@@ -2263,7 +2271,7 @@ abstract class _SaveSiteConfig extends SaveSiteConfig {
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_SaveSiteConfigCopyWith<_$_SaveSiteConfig> get copyWith =>
+  _$$SaveSiteConfigImplCopyWith<_$SaveSiteConfigImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2321,22 +2329,22 @@ class _$ResolveObjectCopyWithImpl<$Res, $Val extends ResolveObject>
 }
 
 /// @nodoc
-abstract class _$$_ResolveObjectCopyWith<$Res>
+abstract class _$$ResolveObjectImplCopyWith<$Res>
     implements $ResolveObjectCopyWith<$Res> {
-  factory _$$_ResolveObjectCopyWith(
-          _$_ResolveObject value, $Res Function(_$_ResolveObject) then) =
-      __$$_ResolveObjectCopyWithImpl<$Res>;
+  factory _$$ResolveObjectImplCopyWith(
+          _$ResolveObjectImpl value, $Res Function(_$ResolveObjectImpl) then) =
+      __$$ResolveObjectImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String q, String? auth});
 }
 
 /// @nodoc
-class __$$_ResolveObjectCopyWithImpl<$Res>
-    extends _$ResolveObjectCopyWithImpl<$Res, _$_ResolveObject>
-    implements _$$_ResolveObjectCopyWith<$Res> {
-  __$$_ResolveObjectCopyWithImpl(
-      _$_ResolveObject _value, $Res Function(_$_ResolveObject) _then)
+class __$$ResolveObjectImplCopyWithImpl<$Res>
+    extends _$ResolveObjectCopyWithImpl<$Res, _$ResolveObjectImpl>
+    implements _$$ResolveObjectImplCopyWith<$Res> {
+  __$$ResolveObjectImplCopyWithImpl(
+      _$ResolveObjectImpl _value, $Res Function(_$ResolveObjectImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2345,7 +2353,7 @@ class __$$_ResolveObjectCopyWithImpl<$Res>
     Object? q = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_ResolveObject(
+    return _then(_$ResolveObjectImpl(
       q: null == q
           ? _value.q
           : q // ignore: cast_nullable_to_non_nullable
@@ -2361,11 +2369,11 @@ class __$$_ResolveObjectCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ResolveObject extends _ResolveObject {
-  const _$_ResolveObject({required this.q, this.auth}) : super._();
+class _$ResolveObjectImpl extends _ResolveObject {
+  const _$ResolveObjectImpl({required this.q, this.auth}) : super._();
 
-  factory _$_ResolveObject.fromJson(Map<String, dynamic> json) =>
-      _$$_ResolveObjectFromJson(json);
+  factory _$ResolveObjectImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ResolveObjectImplFromJson(json);
 
   @override
   final String q;
@@ -2381,7 +2389,7 @@ class _$_ResolveObject extends _ResolveObject {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ResolveObject &&
+            other is _$ResolveObjectImpl &&
             (identical(other.q, q) || other.q == q) &&
             (identical(other.auth, auth) || other.auth == auth));
   }
@@ -2393,12 +2401,12 @@ class _$_ResolveObject extends _ResolveObject {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ResolveObjectCopyWith<_$_ResolveObject> get copyWith =>
-      __$$_ResolveObjectCopyWithImpl<_$_ResolveObject>(this, _$identity);
+  _$$ResolveObjectImplCopyWith<_$ResolveObjectImpl> get copyWith =>
+      __$$ResolveObjectImplCopyWithImpl<_$ResolveObjectImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ResolveObjectToJson(
+    return _$$ResolveObjectImplToJson(
       this,
     );
   }
@@ -2406,11 +2414,11 @@ class _$_ResolveObject extends _ResolveObject {
 
 abstract class _ResolveObject extends ResolveObject {
   const factory _ResolveObject({required final String q, final String? auth}) =
-      _$_ResolveObject;
+      _$ResolveObjectImpl;
   const _ResolveObject._() : super._();
 
   factory _ResolveObject.fromJson(Map<String, dynamic> json) =
-      _$_ResolveObject.fromJson;
+      _$ResolveObjectImpl.fromJson;
 
   @override
   String get q;
@@ -2418,7 +2426,7 @@ abstract class _ResolveObject extends ResolveObject {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ResolveObjectCopyWith<_$_ResolveObject> get copyWith =>
+  _$$ResolveObjectImplCopyWith<_$ResolveObjectImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2475,25 +2483,25 @@ class _$GetUnreadRegistrationApplicationCountCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_GetUnreadRegistrationApplicationCountCopyWith<$Res>
+abstract class _$$GetUnreadRegistrationApplicationCountImplCopyWith<$Res>
     implements $GetUnreadRegistrationApplicationCountCopyWith<$Res> {
-  factory _$$_GetUnreadRegistrationApplicationCountCopyWith(
-          _$_GetUnreadRegistrationApplicationCount value,
-          $Res Function(_$_GetUnreadRegistrationApplicationCount) then) =
-      __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<$Res>;
+  factory _$$GetUnreadRegistrationApplicationCountImplCopyWith(
+          _$GetUnreadRegistrationApplicationCountImpl value,
+          $Res Function(_$GetUnreadRegistrationApplicationCountImpl) then) =
+      __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String auth});
 }
 
 /// @nodoc
-class __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<$Res>
+class __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl<$Res>
     extends _$GetUnreadRegistrationApplicationCountCopyWithImpl<$Res,
-        _$_GetUnreadRegistrationApplicationCount>
-    implements _$$_GetUnreadRegistrationApplicationCountCopyWith<$Res> {
-  __$$_GetUnreadRegistrationApplicationCountCopyWithImpl(
-      _$_GetUnreadRegistrationApplicationCount _value,
-      $Res Function(_$_GetUnreadRegistrationApplicationCount) _then)
+        _$GetUnreadRegistrationApplicationCountImpl>
+    implements _$$GetUnreadRegistrationApplicationCountImplCopyWith<$Res> {
+  __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl(
+      _$GetUnreadRegistrationApplicationCountImpl _value,
+      $Res Function(_$GetUnreadRegistrationApplicationCountImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2501,7 +2509,7 @@ class __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<$Res>
   $Res call({
     Object? auth = null,
   }) {
-    return _then(_$_GetUnreadRegistrationApplicationCount(
+    return _then(_$GetUnreadRegistrationApplicationCountImpl(
       auth: null == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -2513,14 +2521,14 @@ class __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetUnreadRegistrationApplicationCount
+class _$GetUnreadRegistrationApplicationCountImpl
     extends _GetUnreadRegistrationApplicationCount {
-  const _$_GetUnreadRegistrationApplicationCount({required this.auth})
+  const _$GetUnreadRegistrationApplicationCountImpl({required this.auth})
       : super._();
 
-  factory _$_GetUnreadRegistrationApplicationCount.fromJson(
+  factory _$GetUnreadRegistrationApplicationCountImpl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_GetUnreadRegistrationApplicationCountFromJson(json);
+      _$$GetUnreadRegistrationApplicationCountImplFromJson(json);
 
   @override
   final String auth;
@@ -2534,7 +2542,7 @@ class _$_GetUnreadRegistrationApplicationCount
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetUnreadRegistrationApplicationCount &&
+            other is _$GetUnreadRegistrationApplicationCountImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -2545,14 +2553,14 @@ class _$_GetUnreadRegistrationApplicationCount
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetUnreadRegistrationApplicationCountCopyWith<
-          _$_GetUnreadRegistrationApplicationCount>
-      get copyWith => __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<
-          _$_GetUnreadRegistrationApplicationCount>(this, _$identity);
+  _$$GetUnreadRegistrationApplicationCountImplCopyWith<
+          _$GetUnreadRegistrationApplicationCountImpl>
+      get copyWith => __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl<
+          _$GetUnreadRegistrationApplicationCountImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetUnreadRegistrationApplicationCountToJson(
+    return _$$GetUnreadRegistrationApplicationCountImplToJson(
       this,
     );
   }
@@ -2561,19 +2569,20 @@ class _$_GetUnreadRegistrationApplicationCount
 abstract class _GetUnreadRegistrationApplicationCount
     extends GetUnreadRegistrationApplicationCount {
   const factory _GetUnreadRegistrationApplicationCount(
-      {required final String auth}) = _$_GetUnreadRegistrationApplicationCount;
+          {required final String auth}) =
+      _$GetUnreadRegistrationApplicationCountImpl;
   const _GetUnreadRegistrationApplicationCount._() : super._();
 
   factory _GetUnreadRegistrationApplicationCount.fromJson(
           Map<String, dynamic> json) =
-      _$_GetUnreadRegistrationApplicationCount.fromJson;
+      _$GetUnreadRegistrationApplicationCountImpl.fromJson;
 
   @override
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetUnreadRegistrationApplicationCountCopyWith<
-          _$_GetUnreadRegistrationApplicationCount>
+  _$$GetUnreadRegistrationApplicationCountImplCopyWith<
+          _$GetUnreadRegistrationApplicationCountImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -2647,25 +2656,25 @@ class _$ListRegistrationApplicationsCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ListRegistrationApplicationsCopyWith<$Res>
+abstract class _$$ListRegistrationApplicationsImplCopyWith<$Res>
     implements $ListRegistrationApplicationsCopyWith<$Res> {
-  factory _$$_ListRegistrationApplicationsCopyWith(
-          _$_ListRegistrationApplications value,
-          $Res Function(_$_ListRegistrationApplications) then) =
-      __$$_ListRegistrationApplicationsCopyWithImpl<$Res>;
+  factory _$$ListRegistrationApplicationsImplCopyWith(
+          _$ListRegistrationApplicationsImpl value,
+          $Res Function(_$ListRegistrationApplicationsImpl) then) =
+      __$$ListRegistrationApplicationsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool? unreadOnly, int? page, int? limit, String auth});
 }
 
 /// @nodoc
-class __$$_ListRegistrationApplicationsCopyWithImpl<$Res>
+class __$$ListRegistrationApplicationsImplCopyWithImpl<$Res>
     extends _$ListRegistrationApplicationsCopyWithImpl<$Res,
-        _$_ListRegistrationApplications>
-    implements _$$_ListRegistrationApplicationsCopyWith<$Res> {
-  __$$_ListRegistrationApplicationsCopyWithImpl(
-      _$_ListRegistrationApplications _value,
-      $Res Function(_$_ListRegistrationApplications) _then)
+        _$ListRegistrationApplicationsImpl>
+    implements _$$ListRegistrationApplicationsImplCopyWith<$Res> {
+  __$$ListRegistrationApplicationsImplCopyWithImpl(
+      _$ListRegistrationApplicationsImpl _value,
+      $Res Function(_$ListRegistrationApplicationsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2676,7 +2685,7 @@ class __$$_ListRegistrationApplicationsCopyWithImpl<$Res>
     Object? limit = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_ListRegistrationApplications(
+    return _then(_$ListRegistrationApplicationsImpl(
       unreadOnly: freezed == unreadOnly
           ? _value.unreadOnly
           : unreadOnly // ignore: cast_nullable_to_non_nullable
@@ -2700,13 +2709,14 @@ class __$$_ListRegistrationApplicationsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ListRegistrationApplications extends _ListRegistrationApplications {
-  const _$_ListRegistrationApplications(
+class _$ListRegistrationApplicationsImpl extends _ListRegistrationApplications {
+  const _$ListRegistrationApplicationsImpl(
       {this.unreadOnly, this.page, this.limit, required this.auth})
       : super._();
 
-  factory _$_ListRegistrationApplications.fromJson(Map<String, dynamic> json) =>
-      _$$_ListRegistrationApplicationsFromJson(json);
+  factory _$ListRegistrationApplicationsImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$ListRegistrationApplicationsImplFromJson(json);
 
   @override
   final bool? unreadOnly;
@@ -2726,7 +2736,7 @@ class _$_ListRegistrationApplications extends _ListRegistrationApplications {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListRegistrationApplications &&
+            other is _$ListRegistrationApplicationsImpl &&
             (identical(other.unreadOnly, unreadOnly) ||
                 other.unreadOnly == unreadOnly) &&
             (identical(other.page, page) || other.page == page) &&
@@ -2741,13 +2751,14 @@ class _$_ListRegistrationApplications extends _ListRegistrationApplications {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListRegistrationApplicationsCopyWith<_$_ListRegistrationApplications>
-      get copyWith => __$$_ListRegistrationApplicationsCopyWithImpl<
-          _$_ListRegistrationApplications>(this, _$identity);
+  _$$ListRegistrationApplicationsImplCopyWith<
+          _$ListRegistrationApplicationsImpl>
+      get copyWith => __$$ListRegistrationApplicationsImplCopyWithImpl<
+          _$ListRegistrationApplicationsImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListRegistrationApplicationsToJson(
+    return _$$ListRegistrationApplicationsImplToJson(
       this,
     );
   }
@@ -2759,11 +2770,11 @@ abstract class _ListRegistrationApplications
       {final bool? unreadOnly,
       final int? page,
       final int? limit,
-      required final String auth}) = _$_ListRegistrationApplications;
+      required final String auth}) = _$ListRegistrationApplicationsImpl;
   const _ListRegistrationApplications._() : super._();
 
   factory _ListRegistrationApplications.fromJson(Map<String, dynamic> json) =
-      _$_ListRegistrationApplications.fromJson;
+      _$ListRegistrationApplicationsImpl.fromJson;
 
   @override
   bool? get unreadOnly;
@@ -2775,7 +2786,8 @@ abstract class _ListRegistrationApplications
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ListRegistrationApplicationsCopyWith<_$_ListRegistrationApplications>
+  _$$ListRegistrationApplicationsImplCopyWith<
+          _$ListRegistrationApplicationsImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -2849,25 +2861,25 @@ class _$ApproveRegistrationApplicationCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ApproveRegistrationApplicationCopyWith<$Res>
+abstract class _$$ApproveRegistrationApplicationImplCopyWith<$Res>
     implements $ApproveRegistrationApplicationCopyWith<$Res> {
-  factory _$$_ApproveRegistrationApplicationCopyWith(
-          _$_ApproveRegistrationApplication value,
-          $Res Function(_$_ApproveRegistrationApplication) then) =
-      __$$_ApproveRegistrationApplicationCopyWithImpl<$Res>;
+  factory _$$ApproveRegistrationApplicationImplCopyWith(
+          _$ApproveRegistrationApplicationImpl value,
+          $Res Function(_$ApproveRegistrationApplicationImpl) then) =
+      __$$ApproveRegistrationApplicationImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int id, bool approve, String? denyReason, String auth});
 }
 
 /// @nodoc
-class __$$_ApproveRegistrationApplicationCopyWithImpl<$Res>
+class __$$ApproveRegistrationApplicationImplCopyWithImpl<$Res>
     extends _$ApproveRegistrationApplicationCopyWithImpl<$Res,
-        _$_ApproveRegistrationApplication>
-    implements _$$_ApproveRegistrationApplicationCopyWith<$Res> {
-  __$$_ApproveRegistrationApplicationCopyWithImpl(
-      _$_ApproveRegistrationApplication _value,
-      $Res Function(_$_ApproveRegistrationApplication) _then)
+        _$ApproveRegistrationApplicationImpl>
+    implements _$$ApproveRegistrationApplicationImplCopyWith<$Res> {
+  __$$ApproveRegistrationApplicationImplCopyWithImpl(
+      _$ApproveRegistrationApplicationImpl _value,
+      $Res Function(_$ApproveRegistrationApplicationImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2878,7 +2890,7 @@ class __$$_ApproveRegistrationApplicationCopyWithImpl<$Res>
     Object? denyReason = freezed,
     Object? auth = null,
   }) {
-    return _then(_$_ApproveRegistrationApplication(
+    return _then(_$ApproveRegistrationApplicationImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -2902,18 +2914,18 @@ class __$$_ApproveRegistrationApplicationCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ApproveRegistrationApplication
+class _$ApproveRegistrationApplicationImpl
     extends _ApproveRegistrationApplication {
-  const _$_ApproveRegistrationApplication(
+  const _$ApproveRegistrationApplicationImpl(
       {required this.id,
       required this.approve,
       this.denyReason,
       required this.auth})
       : super._();
 
-  factory _$_ApproveRegistrationApplication.fromJson(
+  factory _$ApproveRegistrationApplicationImpl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_ApproveRegistrationApplicationFromJson(json);
+      _$$ApproveRegistrationApplicationImplFromJson(json);
 
   @override
   final int id;
@@ -2933,7 +2945,7 @@ class _$_ApproveRegistrationApplication
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ApproveRegistrationApplication &&
+            other is _$ApproveRegistrationApplicationImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.approve, approve) || other.approve == approve) &&
             (identical(other.denyReason, denyReason) ||
@@ -2948,13 +2960,14 @@ class _$_ApproveRegistrationApplication
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ApproveRegistrationApplicationCopyWith<_$_ApproveRegistrationApplication>
-      get copyWith => __$$_ApproveRegistrationApplicationCopyWithImpl<
-          _$_ApproveRegistrationApplication>(this, _$identity);
+  _$$ApproveRegistrationApplicationImplCopyWith<
+          _$ApproveRegistrationApplicationImpl>
+      get copyWith => __$$ApproveRegistrationApplicationImplCopyWithImpl<
+          _$ApproveRegistrationApplicationImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ApproveRegistrationApplicationToJson(
+    return _$$ApproveRegistrationApplicationImplToJson(
       this,
     );
   }
@@ -2966,11 +2979,11 @@ abstract class _ApproveRegistrationApplication
       {required final int id,
       required final bool approve,
       final String? denyReason,
-      required final String auth}) = _$_ApproveRegistrationApplication;
+      required final String auth}) = _$ApproveRegistrationApplicationImpl;
   const _ApproveRegistrationApplication._() : super._();
 
   factory _ApproveRegistrationApplication.fromJson(Map<String, dynamic> json) =
-      _$_ApproveRegistrationApplication.fromJson;
+      _$ApproveRegistrationApplicationImpl.fromJson;
 
   @override
   int get id;
@@ -2982,6 +2995,7 @@ abstract class _ApproveRegistrationApplication
   String get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ApproveRegistrationApplicationCopyWith<_$_ApproveRegistrationApplication>
+  _$$ApproveRegistrationApplicationImplCopyWith<
+          _$ApproveRegistrationApplicationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/site.g.dart
+++ b/lib/src/v3/api/site.g.dart
@@ -6,7 +6,7 @@ part of 'site.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Search _$$_SearchFromJson(Map<String, dynamic> json) => _$_Search(
+_$SearchImpl _$$SearchImplFromJson(Map<String, dynamic> json) => _$SearchImpl(
       q: json['q'] as String,
       type: json['type_'] == null
           ? null
@@ -23,7 +23,7 @@ _$_Search _$$_SearchFromJson(Map<String, dynamic> json) => _$_Search(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_SearchToJson(_$_Search instance) {
+Map<String, dynamic> _$$SearchImplToJson(_$SearchImpl instance) {
   final val = <String, dynamic>{
     'q': instance.q,
   };
@@ -46,7 +46,8 @@ Map<String, dynamic> _$$_SearchToJson(_$_Search instance) {
   return val;
 }
 
-_$_GetModlog _$$_GetModlogFromJson(Map<String, dynamic> json) => _$_GetModlog(
+_$GetModlogImpl _$$GetModlogImplFromJson(Map<String, dynamic> json) =>
+    _$GetModlogImpl(
       modPersonId: json['mod_person_id'] as int?,
       communityId: json['community_id'] as int?,
       otherPersonId: json['other_person_id'] as int?,
@@ -58,7 +59,7 @@ _$_GetModlog _$$_GetModlogFromJson(Map<String, dynamic> json) => _$_GetModlog(
           : ModlogActionType.fromJson(json['type_'] as String),
     );
 
-Map<String, dynamic> _$$_GetModlogToJson(_$_GetModlog instance) {
+Map<String, dynamic> _$$GetModlogImplToJson(_$GetModlogImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -77,14 +78,14 @@ Map<String, dynamic> _$$_GetModlogToJson(_$_GetModlog instance) {
   return val;
 }
 
-_$_BlockInstance _$$_BlockInstanceFromJson(Map<String, dynamic> json) =>
-    _$_BlockInstance(
+_$BlockInstanceImpl _$$BlockInstanceImplFromJson(Map<String, dynamic> json) =>
+    _$BlockInstanceImpl(
       instanceId: json['instance_id'] as int,
       block: json['block'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_BlockInstanceToJson(_$_BlockInstance instance) {
+Map<String, dynamic> _$$BlockInstanceImplToJson(_$BlockInstanceImpl instance) {
   final val = <String, dynamic>{
     'instance_id': instance.instanceId,
     'block': instance.block,
@@ -100,8 +101,8 @@ Map<String, dynamic> _$$_BlockInstanceToJson(_$_BlockInstance instance) {
   return val;
 }
 
-_$_CreateSite _$$_CreateSiteFromJson(Map<String, dynamic> json) =>
-    _$_CreateSite(
+_$CreateSiteImpl _$$CreateSiteImplFromJson(Map<String, dynamic> json) =>
+    _$CreateSiteImpl(
       name: json['name'] as String,
       sidebar: json['sidebar'] as String?,
       description: json['description'] as String?,
@@ -120,7 +121,7 @@ _$_CreateSite _$$_CreateSiteFromJson(Map<String, dynamic> json) =>
       defaultTheme: json['default_theme'] as String?,
     );
 
-Map<String, dynamic> _$$_CreateSiteToJson(_$_CreateSite instance) {
+Map<String, dynamic> _$$CreateSiteImplToJson(_$CreateSiteImpl instance) {
   final val = <String, dynamic>{
     'name': instance.name,
   };
@@ -149,7 +150,8 @@ Map<String, dynamic> _$$_CreateSiteToJson(_$_CreateSite instance) {
   return val;
 }
 
-_$_EditSite _$$_EditSiteFromJson(Map<String, dynamic> json) => _$_EditSite(
+_$EditSiteImpl _$$EditSiteImplFromJson(Map<String, dynamic> json) =>
+    _$EditSiteImpl(
       name: json['name'] as String?,
       sidebar: json['sidebar'] as String?,
       description: json['description'] as String?,
@@ -168,7 +170,7 @@ _$_EditSite _$$_EditSiteFromJson(Map<String, dynamic> json) => _$_EditSite(
       defaultTheme: json['default_theme'] as String?,
     );
 
-Map<String, dynamic> _$$_EditSiteToJson(_$_EditSite instance) {
+Map<String, dynamic> _$$EditSiteImplToJson(_$EditSiteImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -196,11 +198,12 @@ Map<String, dynamic> _$$_EditSiteToJson(_$_EditSite instance) {
   return val;
 }
 
-_$_GetSite _$$_GetSiteFromJson(Map<String, dynamic> json) => _$_GetSite(
+_$GetSiteImpl _$$GetSiteImplFromJson(Map<String, dynamic> json) =>
+    _$GetSiteImpl(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetSiteToJson(_$_GetSite instance) {
+Map<String, dynamic> _$$GetSiteImplToJson(_$GetSiteImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -213,45 +216,46 @@ Map<String, dynamic> _$$_GetSiteToJson(_$_GetSite instance) {
   return val;
 }
 
-_$_LeaveAdmin _$$_LeaveAdminFromJson(Map<String, dynamic> json) =>
-    _$_LeaveAdmin(
+_$LeaveAdminImpl _$$LeaveAdminImplFromJson(Map<String, dynamic> json) =>
+    _$LeaveAdminImpl(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_LeaveAdminToJson(_$_LeaveAdmin instance) =>
+Map<String, dynamic> _$$LeaveAdminImplToJson(_$LeaveAdminImpl instance) =>
     <String, dynamic>{
       'auth': instance.auth,
     };
 
-_$_GetSiteConfig _$$_GetSiteConfigFromJson(Map<String, dynamic> json) =>
-    _$_GetSiteConfig(
+_$GetSiteConfigImpl _$$GetSiteConfigImplFromJson(Map<String, dynamic> json) =>
+    _$GetSiteConfigImpl(
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_GetSiteConfigToJson(_$_GetSiteConfig instance) =>
+Map<String, dynamic> _$$GetSiteConfigImplToJson(_$GetSiteConfigImpl instance) =>
     <String, dynamic>{
       'auth': instance.auth,
     };
 
-_$_SaveSiteConfig _$$_SaveSiteConfigFromJson(Map<String, dynamic> json) =>
-    _$_SaveSiteConfig(
+_$SaveSiteConfigImpl _$$SaveSiteConfigImplFromJson(Map<String, dynamic> json) =>
+    _$SaveSiteConfigImpl(
       configHjson: json['config_hjson'] as String,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_SaveSiteConfigToJson(_$_SaveSiteConfig instance) =>
+Map<String, dynamic> _$$SaveSiteConfigImplToJson(
+        _$SaveSiteConfigImpl instance) =>
     <String, dynamic>{
       'config_hjson': instance.configHjson,
       'auth': instance.auth,
     };
 
-_$_ResolveObject _$$_ResolveObjectFromJson(Map<String, dynamic> json) =>
-    _$_ResolveObject(
+_$ResolveObjectImpl _$$ResolveObjectImplFromJson(Map<String, dynamic> json) =>
+    _$ResolveObjectImpl(
       q: json['q'] as String,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ResolveObjectToJson(_$_ResolveObject instance) {
+Map<String, dynamic> _$$ResolveObjectImplToJson(_$ResolveObjectImpl instance) {
   final val = <String, dynamic>{
     'q': instance.q,
   };
@@ -266,30 +270,30 @@ Map<String, dynamic> _$$_ResolveObjectToJson(_$_ResolveObject instance) {
   return val;
 }
 
-_$_GetUnreadRegistrationApplicationCount
-    _$$_GetUnreadRegistrationApplicationCountFromJson(
+_$GetUnreadRegistrationApplicationCountImpl
+    _$$GetUnreadRegistrationApplicationCountImplFromJson(
             Map<String, dynamic> json) =>
-        _$_GetUnreadRegistrationApplicationCount(
+        _$GetUnreadRegistrationApplicationCountImpl(
           auth: json['auth'] as String,
         );
 
-Map<String, dynamic> _$$_GetUnreadRegistrationApplicationCountToJson(
-        _$_GetUnreadRegistrationApplicationCount instance) =>
+Map<String, dynamic> _$$GetUnreadRegistrationApplicationCountImplToJson(
+        _$GetUnreadRegistrationApplicationCountImpl instance) =>
     <String, dynamic>{
       'auth': instance.auth,
     };
 
-_$_ListRegistrationApplications _$$_ListRegistrationApplicationsFromJson(
+_$ListRegistrationApplicationsImpl _$$ListRegistrationApplicationsImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ListRegistrationApplications(
+    _$ListRegistrationApplicationsImpl(
       unreadOnly: json['unread_only'] as bool?,
       page: json['page'] as int?,
       limit: json['limit'] as int?,
       auth: json['auth'] as String,
     );
 
-Map<String, dynamic> _$$_ListRegistrationApplicationsToJson(
-    _$_ListRegistrationApplications instance) {
+Map<String, dynamic> _$$ListRegistrationApplicationsImplToJson(
+    _$ListRegistrationApplicationsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -305,17 +309,17 @@ Map<String, dynamic> _$$_ListRegistrationApplicationsToJson(
   return val;
 }
 
-_$_ApproveRegistrationApplication _$$_ApproveRegistrationApplicationFromJson(
-        Map<String, dynamic> json) =>
-    _$_ApproveRegistrationApplication(
-      id: json['id'] as int,
-      approve: json['approve'] as bool,
-      denyReason: json['deny_reason'] as String?,
-      auth: json['auth'] as String,
-    );
+_$ApproveRegistrationApplicationImpl
+    _$$ApproveRegistrationApplicationImplFromJson(Map<String, dynamic> json) =>
+        _$ApproveRegistrationApplicationImpl(
+          id: json['id'] as int,
+          approve: json['approve'] as bool,
+          denyReason: json['deny_reason'] as String?,
+          auth: json['auth'] as String,
+        );
 
-Map<String, dynamic> _$$_ApproveRegistrationApplicationToJson(
-    _$_ApproveRegistrationApplication instance) {
+Map<String, dynamic> _$$ApproveRegistrationApplicationImplToJson(
+    _$ApproveRegistrationApplicationImpl instance) {
   final val = <String, dynamic>{
     'id': instance.id,
     'approve': instance.approve,

--- a/lib/src/v3/models/aggregates.dart
+++ b/lib/src/v3/models/aggregates.dart
@@ -54,8 +54,8 @@ class PostAggregates with _$PostAggregates {
     required int score,
     required int upvotes,
     required int downvotes,
-    required DateTime newestCommentTime,
-    required DateTime newestCommentTimeNecro,
+    required DateTime? newestCommentTime,
+    required DateTime? newestCommentTimeNecro,
   }) = _PostAggregates;
 
   const PostAggregates._();

--- a/lib/src/v3/models/aggregates.dart
+++ b/lib/src/v3/models/aggregates.dart
@@ -54,8 +54,8 @@ class PostAggregates with _$PostAggregates {
     required int score,
     required int upvotes,
     required int downvotes,
-    required DateTime? newestCommentTime,
-    required DateTime? newestCommentTimeNecro,
+    @deprecated DateTime? newestCommentTime,
+    @deprecated DateTime? newestCommentTimeNecro,
   }) = _PostAggregates;
 
   const PostAggregates._();

--- a/lib/src/v3/models/aggregates.freezed.dart
+++ b/lib/src/v3/models/aggregates.freezed.dart
@@ -98,11 +98,11 @@ class _$PersonAggregatesCopyWithImpl<$Res, $Val extends PersonAggregates>
 }
 
 /// @nodoc
-abstract class _$$_PersonAggregatesCopyWith<$Res>
+abstract class _$$PersonAggregatesImplCopyWith<$Res>
     implements $PersonAggregatesCopyWith<$Res> {
-  factory _$$_PersonAggregatesCopyWith(
-          _$_PersonAggregates value, $Res Function(_$_PersonAggregates) then) =
-      __$$_PersonAggregatesCopyWithImpl<$Res>;
+  factory _$$PersonAggregatesImplCopyWith(_$PersonAggregatesImpl value,
+          $Res Function(_$PersonAggregatesImpl) then) =
+      __$$PersonAggregatesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -115,11 +115,11 @@ abstract class _$$_PersonAggregatesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PersonAggregatesCopyWithImpl<$Res>
-    extends _$PersonAggregatesCopyWithImpl<$Res, _$_PersonAggregates>
-    implements _$$_PersonAggregatesCopyWith<$Res> {
-  __$$_PersonAggregatesCopyWithImpl(
-      _$_PersonAggregates _value, $Res Function(_$_PersonAggregates) _then)
+class __$$PersonAggregatesImplCopyWithImpl<$Res>
+    extends _$PersonAggregatesCopyWithImpl<$Res, _$PersonAggregatesImpl>
+    implements _$$PersonAggregatesImplCopyWith<$Res> {
+  __$$PersonAggregatesImplCopyWithImpl(_$PersonAggregatesImpl _value,
+      $Res Function(_$PersonAggregatesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -132,7 +132,7 @@ class __$$_PersonAggregatesCopyWithImpl<$Res>
     Object? commentCount = null,
     Object? commentScore = null,
   }) {
-    return _then(_$_PersonAggregates(
+    return _then(_$PersonAggregatesImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -164,8 +164,8 @@ class __$$_PersonAggregatesCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PersonAggregates extends _PersonAggregates {
-  const _$_PersonAggregates(
+class _$PersonAggregatesImpl extends _PersonAggregates {
+  const _$PersonAggregatesImpl(
       {required this.id,
       required this.personId,
       required this.postCount,
@@ -174,8 +174,8 @@ class _$_PersonAggregates extends _PersonAggregates {
       required this.commentScore})
       : super._();
 
-  factory _$_PersonAggregates.fromJson(Map<String, dynamic> json) =>
-      _$$_PersonAggregatesFromJson(json);
+  factory _$PersonAggregatesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonAggregatesImplFromJson(json);
 
   @override
   final int id;
@@ -199,7 +199,7 @@ class _$_PersonAggregates extends _PersonAggregates {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PersonAggregates &&
+            other is _$PersonAggregatesImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
@@ -221,12 +221,13 @@ class _$_PersonAggregates extends _PersonAggregates {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PersonAggregatesCopyWith<_$_PersonAggregates> get copyWith =>
-      __$$_PersonAggregatesCopyWithImpl<_$_PersonAggregates>(this, _$identity);
+  _$$PersonAggregatesImplCopyWith<_$PersonAggregatesImpl> get copyWith =>
+      __$$PersonAggregatesImplCopyWithImpl<_$PersonAggregatesImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PersonAggregatesToJson(
+    return _$$PersonAggregatesImplToJson(
       this,
     );
   }
@@ -239,11 +240,11 @@ abstract class _PersonAggregates extends PersonAggregates {
       required final int postCount,
       required final int postScore,
       required final int commentCount,
-      required final int commentScore}) = _$_PersonAggregates;
+      required final int commentScore}) = _$PersonAggregatesImpl;
   const _PersonAggregates._() : super._();
 
   factory _PersonAggregates.fromJson(Map<String, dynamic> json) =
-      _$_PersonAggregates.fromJson;
+      _$PersonAggregatesImpl.fromJson;
 
   @override
   int get id;
@@ -259,7 +260,7 @@ abstract class _PersonAggregates extends PersonAggregates {
   int get commentScore;
   @override
   @JsonKey(ignore: true)
-  _$$_PersonAggregatesCopyWith<_$_PersonAggregates> get copyWith =>
+  _$$PersonAggregatesImplCopyWith<_$PersonAggregatesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -375,11 +376,11 @@ class _$SiteAggregatesCopyWithImpl<$Res, $Val extends SiteAggregates>
 }
 
 /// @nodoc
-abstract class _$$_SiteAggregatesCopyWith<$Res>
+abstract class _$$SiteAggregatesImplCopyWith<$Res>
     implements $SiteAggregatesCopyWith<$Res> {
-  factory _$$_SiteAggregatesCopyWith(
-          _$_SiteAggregates value, $Res Function(_$_SiteAggregates) then) =
-      __$$_SiteAggregatesCopyWithImpl<$Res>;
+  factory _$$SiteAggregatesImplCopyWith(_$SiteAggregatesImpl value,
+          $Res Function(_$SiteAggregatesImpl) then) =
+      __$$SiteAggregatesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -396,11 +397,11 @@ abstract class _$$_SiteAggregatesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_SiteAggregatesCopyWithImpl<$Res>
-    extends _$SiteAggregatesCopyWithImpl<$Res, _$_SiteAggregates>
-    implements _$$_SiteAggregatesCopyWith<$Res> {
-  __$$_SiteAggregatesCopyWithImpl(
-      _$_SiteAggregates _value, $Res Function(_$_SiteAggregates) _then)
+class __$$SiteAggregatesImplCopyWithImpl<$Res>
+    extends _$SiteAggregatesCopyWithImpl<$Res, _$SiteAggregatesImpl>
+    implements _$$SiteAggregatesImplCopyWith<$Res> {
+  __$$SiteAggregatesImplCopyWithImpl(
+      _$SiteAggregatesImpl _value, $Res Function(_$SiteAggregatesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -417,7 +418,7 @@ class __$$_SiteAggregatesCopyWithImpl<$Res>
     Object? usersActiveMonth = null,
     Object? usersActiveHalfYear = null,
   }) {
-    return _then(_$_SiteAggregates(
+    return _then(_$SiteAggregatesImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -465,8 +466,8 @@ class __$$_SiteAggregatesCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_SiteAggregates extends _SiteAggregates {
-  const _$_SiteAggregates(
+class _$SiteAggregatesImpl extends _SiteAggregates {
+  const _$SiteAggregatesImpl(
       {required this.id,
       required this.siteId,
       required this.users,
@@ -479,8 +480,8 @@ class _$_SiteAggregates extends _SiteAggregates {
       required this.usersActiveHalfYear})
       : super._();
 
-  factory _$_SiteAggregates.fromJson(Map<String, dynamic> json) =>
-      _$$_SiteAggregatesFromJson(json);
+  factory _$SiteAggregatesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SiteAggregatesImplFromJson(json);
 
   @override
   final int id;
@@ -512,7 +513,7 @@ class _$_SiteAggregates extends _SiteAggregates {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SiteAggregates &&
+            other is _$SiteAggregatesImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.siteId, siteId) || other.siteId == siteId) &&
             (identical(other.users, users) || other.users == users) &&
@@ -549,12 +550,13 @@ class _$_SiteAggregates extends _SiteAggregates {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SiteAggregatesCopyWith<_$_SiteAggregates> get copyWith =>
-      __$$_SiteAggregatesCopyWithImpl<_$_SiteAggregates>(this, _$identity);
+  _$$SiteAggregatesImplCopyWith<_$SiteAggregatesImpl> get copyWith =>
+      __$$SiteAggregatesImplCopyWithImpl<_$SiteAggregatesImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SiteAggregatesToJson(
+    return _$$SiteAggregatesImplToJson(
       this,
     );
   }
@@ -571,11 +573,11 @@ abstract class _SiteAggregates extends SiteAggregates {
       required final int usersActiveDay,
       required final int usersActiveWeek,
       required final int usersActiveMonth,
-      required final int usersActiveHalfYear}) = _$_SiteAggregates;
+      required final int usersActiveHalfYear}) = _$SiteAggregatesImpl;
   const _SiteAggregates._() : super._();
 
   factory _SiteAggregates.fromJson(Map<String, dynamic> json) =
-      _$_SiteAggregates.fromJson;
+      _$SiteAggregatesImpl.fromJson;
 
   @override
   int get id;
@@ -599,7 +601,7 @@ abstract class _SiteAggregates extends SiteAggregates {
   int get usersActiveHalfYear;
   @override
   @JsonKey(ignore: true)
-  _$$_SiteAggregatesCopyWith<_$_SiteAggregates> get copyWith =>
+  _$$SiteAggregatesImplCopyWith<_$SiteAggregatesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -615,8 +617,8 @@ mixin _$PostAggregates {
   int get score => throw _privateConstructorUsedError;
   int get upvotes => throw _privateConstructorUsedError;
   int get downvotes => throw _privateConstructorUsedError;
-  DateTime get newestCommentTime => throw _privateConstructorUsedError;
-  DateTime get newestCommentTimeNecro => throw _privateConstructorUsedError;
+  DateTime? get newestCommentTime => throw _privateConstructorUsedError;
+  DateTime? get newestCommentTimeNecro => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -637,8 +639,8 @@ abstract class $PostAggregatesCopyWith<$Res> {
       int score,
       int upvotes,
       int downvotes,
-      DateTime newestCommentTime,
-      DateTime newestCommentTimeNecro});
+      DateTime? newestCommentTime,
+      DateTime? newestCommentTimeNecro});
 }
 
 /// @nodoc
@@ -660,8 +662,8 @@ class _$PostAggregatesCopyWithImpl<$Res, $Val extends PostAggregates>
     Object? score = null,
     Object? upvotes = null,
     Object? downvotes = null,
-    Object? newestCommentTime = null,
-    Object? newestCommentTimeNecro = null,
+    Object? newestCommentTime = freezed,
+    Object? newestCommentTimeNecro = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -688,24 +690,24 @@ class _$PostAggregatesCopyWithImpl<$Res, $Val extends PostAggregates>
           ? _value.downvotes
           : downvotes // ignore: cast_nullable_to_non_nullable
               as int,
-      newestCommentTime: null == newestCommentTime
+      newestCommentTime: freezed == newestCommentTime
           ? _value.newestCommentTime
           : newestCommentTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      newestCommentTimeNecro: null == newestCommentTimeNecro
+              as DateTime?,
+      newestCommentTimeNecro: freezed == newestCommentTimeNecro
           ? _value.newestCommentTimeNecro
           : newestCommentTimeNecro // ignore: cast_nullable_to_non_nullable
-              as DateTime,
+              as DateTime?,
     ) as $Val);
   }
 }
 
 /// @nodoc
-abstract class _$$_PostAggregatesCopyWith<$Res>
+abstract class _$$PostAggregatesImplCopyWith<$Res>
     implements $PostAggregatesCopyWith<$Res> {
-  factory _$$_PostAggregatesCopyWith(
-          _$_PostAggregates value, $Res Function(_$_PostAggregates) then) =
-      __$$_PostAggregatesCopyWithImpl<$Res>;
+  factory _$$PostAggregatesImplCopyWith(_$PostAggregatesImpl value,
+          $Res Function(_$PostAggregatesImpl) then) =
+      __$$PostAggregatesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -715,16 +717,16 @@ abstract class _$$_PostAggregatesCopyWith<$Res>
       int score,
       int upvotes,
       int downvotes,
-      DateTime newestCommentTime,
-      DateTime newestCommentTimeNecro});
+      DateTime? newestCommentTime,
+      DateTime? newestCommentTimeNecro});
 }
 
 /// @nodoc
-class __$$_PostAggregatesCopyWithImpl<$Res>
-    extends _$PostAggregatesCopyWithImpl<$Res, _$_PostAggregates>
-    implements _$$_PostAggregatesCopyWith<$Res> {
-  __$$_PostAggregatesCopyWithImpl(
-      _$_PostAggregates _value, $Res Function(_$_PostAggregates) _then)
+class __$$PostAggregatesImplCopyWithImpl<$Res>
+    extends _$PostAggregatesCopyWithImpl<$Res, _$PostAggregatesImpl>
+    implements _$$PostAggregatesImplCopyWith<$Res> {
+  __$$PostAggregatesImplCopyWithImpl(
+      _$PostAggregatesImpl _value, $Res Function(_$PostAggregatesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -736,10 +738,10 @@ class __$$_PostAggregatesCopyWithImpl<$Res>
     Object? score = null,
     Object? upvotes = null,
     Object? downvotes = null,
-    Object? newestCommentTime = null,
-    Object? newestCommentTimeNecro = null,
+    Object? newestCommentTime = freezed,
+    Object? newestCommentTimeNecro = freezed,
   }) {
-    return _then(_$_PostAggregates(
+    return _then(_$PostAggregatesImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -764,14 +766,14 @@ class __$$_PostAggregatesCopyWithImpl<$Res>
           ? _value.downvotes
           : downvotes // ignore: cast_nullable_to_non_nullable
               as int,
-      newestCommentTime: null == newestCommentTime
+      newestCommentTime: freezed == newestCommentTime
           ? _value.newestCommentTime
           : newestCommentTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      newestCommentTimeNecro: null == newestCommentTimeNecro
+              as DateTime?,
+      newestCommentTimeNecro: freezed == newestCommentTimeNecro
           ? _value.newestCommentTimeNecro
           : newestCommentTimeNecro // ignore: cast_nullable_to_non_nullable
-              as DateTime,
+              as DateTime?,
     ));
   }
 }
@@ -779,8 +781,8 @@ class __$$_PostAggregatesCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PostAggregates extends _PostAggregates {
-  const _$_PostAggregates(
+class _$PostAggregatesImpl extends _PostAggregates {
+  const _$PostAggregatesImpl(
       {required this.id,
       required this.postId,
       required this.comments,
@@ -791,8 +793,8 @@ class _$_PostAggregates extends _PostAggregates {
       required this.newestCommentTimeNecro})
       : super._();
 
-  factory _$_PostAggregates.fromJson(Map<String, dynamic> json) =>
-      _$$_PostAggregatesFromJson(json);
+  factory _$PostAggregatesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PostAggregatesImplFromJson(json);
 
   @override
   final int id;
@@ -807,9 +809,9 @@ class _$_PostAggregates extends _PostAggregates {
   @override
   final int downvotes;
   @override
-  final DateTime newestCommentTime;
+  final DateTime? newestCommentTime;
   @override
-  final DateTime newestCommentTimeNecro;
+  final DateTime? newestCommentTimeNecro;
 
   @override
   String toString() {
@@ -820,7 +822,7 @@ class _$_PostAggregates extends _PostAggregates {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PostAggregates &&
+            other is _$PostAggregatesImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.comments, comments) ||
@@ -843,12 +845,13 @@ class _$_PostAggregates extends _PostAggregates {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PostAggregatesCopyWith<_$_PostAggregates> get copyWith =>
-      __$$_PostAggregatesCopyWithImpl<_$_PostAggregates>(this, _$identity);
+  _$$PostAggregatesImplCopyWith<_$PostAggregatesImpl> get copyWith =>
+      __$$PostAggregatesImplCopyWithImpl<_$PostAggregatesImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PostAggregatesToJson(
+    return _$$PostAggregatesImplToJson(
       this,
     );
   }
@@ -862,12 +865,12 @@ abstract class _PostAggregates extends PostAggregates {
       required final int score,
       required final int upvotes,
       required final int downvotes,
-      required final DateTime newestCommentTime,
-      required final DateTime newestCommentTimeNecro}) = _$_PostAggregates;
+      required final DateTime? newestCommentTime,
+      required final DateTime? newestCommentTimeNecro}) = _$PostAggregatesImpl;
   const _PostAggregates._() : super._();
 
   factory _PostAggregates.fromJson(Map<String, dynamic> json) =
-      _$_PostAggregates.fromJson;
+      _$PostAggregatesImpl.fromJson;
 
   @override
   int get id;
@@ -882,12 +885,12 @@ abstract class _PostAggregates extends PostAggregates {
   @override
   int get downvotes;
   @override
-  DateTime get newestCommentTime;
+  DateTime? get newestCommentTime;
   @override
-  DateTime get newestCommentTimeNecro;
+  DateTime? get newestCommentTimeNecro;
   @override
   @JsonKey(ignore: true)
-  _$$_PostAggregatesCopyWith<_$_PostAggregates> get copyWith =>
+  _$$PostAggregatesImplCopyWith<_$PostAggregatesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -996,11 +999,11 @@ class _$CommunityAggregatesCopyWithImpl<$Res, $Val extends CommunityAggregates>
 }
 
 /// @nodoc
-abstract class _$$_CommunityAggregatesCopyWith<$Res>
+abstract class _$$CommunityAggregatesImplCopyWith<$Res>
     implements $CommunityAggregatesCopyWith<$Res> {
-  factory _$$_CommunityAggregatesCopyWith(_$_CommunityAggregates value,
-          $Res Function(_$_CommunityAggregates) then) =
-      __$$_CommunityAggregatesCopyWithImpl<$Res>;
+  factory _$$CommunityAggregatesImplCopyWith(_$CommunityAggregatesImpl value,
+          $Res Function(_$CommunityAggregatesImpl) then) =
+      __$$CommunityAggregatesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1016,11 +1019,11 @@ abstract class _$$_CommunityAggregatesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunityAggregatesCopyWithImpl<$Res>
-    extends _$CommunityAggregatesCopyWithImpl<$Res, _$_CommunityAggregates>
-    implements _$$_CommunityAggregatesCopyWith<$Res> {
-  __$$_CommunityAggregatesCopyWithImpl(_$_CommunityAggregates _value,
-      $Res Function(_$_CommunityAggregates) _then)
+class __$$CommunityAggregatesImplCopyWithImpl<$Res>
+    extends _$CommunityAggregatesCopyWithImpl<$Res, _$CommunityAggregatesImpl>
+    implements _$$CommunityAggregatesImplCopyWith<$Res> {
+  __$$CommunityAggregatesImplCopyWithImpl(_$CommunityAggregatesImpl _value,
+      $Res Function(_$CommunityAggregatesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1036,7 +1039,7 @@ class __$$_CommunityAggregatesCopyWithImpl<$Res>
     Object? usersActiveMonth = null,
     Object? usersActiveHalfYear = null,
   }) {
-    return _then(_$_CommunityAggregates(
+    return _then(_$CommunityAggregatesImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -1080,8 +1083,8 @@ class __$$_CommunityAggregatesCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunityAggregates extends _CommunityAggregates {
-  const _$_CommunityAggregates(
+class _$CommunityAggregatesImpl extends _CommunityAggregates {
+  const _$CommunityAggregatesImpl(
       {required this.id,
       required this.communityId,
       required this.subscribers,
@@ -1093,8 +1096,8 @@ class _$_CommunityAggregates extends _CommunityAggregates {
       required this.usersActiveHalfYear})
       : super._();
 
-  factory _$_CommunityAggregates.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityAggregatesFromJson(json);
+  factory _$CommunityAggregatesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityAggregatesImplFromJson(json);
 
   @override
   final int id;
@@ -1124,7 +1127,7 @@ class _$_CommunityAggregates extends _CommunityAggregates {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunityAggregates &&
+            other is _$CommunityAggregatesImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
@@ -1160,13 +1163,13 @@ class _$_CommunityAggregates extends _CommunityAggregates {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityAggregatesCopyWith<_$_CommunityAggregates> get copyWith =>
-      __$$_CommunityAggregatesCopyWithImpl<_$_CommunityAggregates>(
+  _$$CommunityAggregatesImplCopyWith<_$CommunityAggregatesImpl> get copyWith =>
+      __$$CommunityAggregatesImplCopyWithImpl<_$CommunityAggregatesImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityAggregatesToJson(
+    return _$$CommunityAggregatesImplToJson(
       this,
     );
   }
@@ -1182,11 +1185,11 @@ abstract class _CommunityAggregates extends CommunityAggregates {
       required final int usersActiveDay,
       required final int usersActiveWeek,
       required final int usersActiveMonth,
-      required final int usersActiveHalfYear}) = _$_CommunityAggregates;
+      required final int usersActiveHalfYear}) = _$CommunityAggregatesImpl;
   const _CommunityAggregates._() : super._();
 
   factory _CommunityAggregates.fromJson(Map<String, dynamic> json) =
-      _$_CommunityAggregates.fromJson;
+      _$CommunityAggregatesImpl.fromJson;
 
   @override
   int get id;
@@ -1208,7 +1211,7 @@ abstract class _CommunityAggregates extends CommunityAggregates {
   int get usersActiveHalfYear;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityAggregatesCopyWith<_$_CommunityAggregates> get copyWith =>
+  _$$CommunityAggregatesImplCopyWith<_$CommunityAggregatesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1296,11 +1299,11 @@ class _$CommentAggregatesCopyWithImpl<$Res, $Val extends CommentAggregates>
 }
 
 /// @nodoc
-abstract class _$$_CommentAggregatesCopyWith<$Res>
+abstract class _$$CommentAggregatesImplCopyWith<$Res>
     implements $CommentAggregatesCopyWith<$Res> {
-  factory _$$_CommentAggregatesCopyWith(_$_CommentAggregates value,
-          $Res Function(_$_CommentAggregates) then) =
-      __$$_CommentAggregatesCopyWithImpl<$Res>;
+  factory _$$CommentAggregatesImplCopyWith(_$CommentAggregatesImpl value,
+          $Res Function(_$CommentAggregatesImpl) then) =
+      __$$CommentAggregatesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1313,11 +1316,11 @@ abstract class _$$_CommentAggregatesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentAggregatesCopyWithImpl<$Res>
-    extends _$CommentAggregatesCopyWithImpl<$Res, _$_CommentAggregates>
-    implements _$$_CommentAggregatesCopyWith<$Res> {
-  __$$_CommentAggregatesCopyWithImpl(
-      _$_CommentAggregates _value, $Res Function(_$_CommentAggregates) _then)
+class __$$CommentAggregatesImplCopyWithImpl<$Res>
+    extends _$CommentAggregatesCopyWithImpl<$Res, _$CommentAggregatesImpl>
+    implements _$$CommentAggregatesImplCopyWith<$Res> {
+  __$$CommentAggregatesImplCopyWithImpl(_$CommentAggregatesImpl _value,
+      $Res Function(_$CommentAggregatesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1330,7 +1333,7 @@ class __$$_CommentAggregatesCopyWithImpl<$Res>
     Object? downvotes = null,
     Object? childCount = null,
   }) {
-    return _then(_$_CommentAggregates(
+    return _then(_$CommentAggregatesImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -1362,8 +1365,8 @@ class __$$_CommentAggregatesCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentAggregates extends _CommentAggregates {
-  const _$_CommentAggregates(
+class _$CommentAggregatesImpl extends _CommentAggregates {
+  const _$CommentAggregatesImpl(
       {required this.id,
       required this.commentId,
       required this.score,
@@ -1372,8 +1375,8 @@ class _$_CommentAggregates extends _CommentAggregates {
       required this.childCount})
       : super._();
 
-  factory _$_CommentAggregates.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentAggregatesFromJson(json);
+  factory _$CommentAggregatesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentAggregatesImplFromJson(json);
 
   @override
   final int id;
@@ -1397,7 +1400,7 @@ class _$_CommentAggregates extends _CommentAggregates {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentAggregates &&
+            other is _$CommentAggregatesImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
@@ -1417,13 +1420,13 @@ class _$_CommentAggregates extends _CommentAggregates {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentAggregatesCopyWith<_$_CommentAggregates> get copyWith =>
-      __$$_CommentAggregatesCopyWithImpl<_$_CommentAggregates>(
+  _$$CommentAggregatesImplCopyWith<_$CommentAggregatesImpl> get copyWith =>
+      __$$CommentAggregatesImplCopyWithImpl<_$CommentAggregatesImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentAggregatesToJson(
+    return _$$CommentAggregatesImplToJson(
       this,
     );
   }
@@ -1436,11 +1439,11 @@ abstract class _CommentAggregates extends CommentAggregates {
       required final int score,
       required final int upvotes,
       required final int downvotes,
-      required final int childCount}) = _$_CommentAggregates;
+      required final int childCount}) = _$CommentAggregatesImpl;
   const _CommentAggregates._() : super._();
 
   factory _CommentAggregates.fromJson(Map<String, dynamic> json) =
-      _$_CommentAggregates.fromJson;
+      _$CommentAggregatesImpl.fromJson;
 
   @override
   int get id;
@@ -1456,6 +1459,6 @@ abstract class _CommentAggregates extends CommentAggregates {
   int get childCount;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentAggregatesCopyWith<_$_CommentAggregates> get copyWith =>
+  _$$CommentAggregatesImplCopyWith<_$CommentAggregatesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/aggregates.freezed.dart
+++ b/lib/src/v3/models/aggregates.freezed.dart
@@ -617,7 +617,9 @@ mixin _$PostAggregates {
   int get score => throw _privateConstructorUsedError;
   int get upvotes => throw _privateConstructorUsedError;
   int get downvotes => throw _privateConstructorUsedError;
+  @deprecated
   DateTime? get newestCommentTime => throw _privateConstructorUsedError;
+  @deprecated
   DateTime? get newestCommentTimeNecro => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -639,8 +641,8 @@ abstract class $PostAggregatesCopyWith<$Res> {
       int score,
       int upvotes,
       int downvotes,
-      DateTime? newestCommentTime,
-      DateTime? newestCommentTimeNecro});
+      @deprecated DateTime? newestCommentTime,
+      @deprecated DateTime? newestCommentTimeNecro});
 }
 
 /// @nodoc
@@ -717,8 +719,8 @@ abstract class _$$PostAggregatesImplCopyWith<$Res>
       int score,
       int upvotes,
       int downvotes,
-      DateTime? newestCommentTime,
-      DateTime? newestCommentTimeNecro});
+      @deprecated DateTime? newestCommentTime,
+      @deprecated DateTime? newestCommentTimeNecro});
 }
 
 /// @nodoc
@@ -789,8 +791,8 @@ class _$PostAggregatesImpl extends _PostAggregates {
       required this.score,
       required this.upvotes,
       required this.downvotes,
-      required this.newestCommentTime,
-      required this.newestCommentTimeNecro})
+      @deprecated this.newestCommentTime,
+      @deprecated this.newestCommentTimeNecro})
       : super._();
 
   factory _$PostAggregatesImpl.fromJson(Map<String, dynamic> json) =>
@@ -809,8 +811,10 @@ class _$PostAggregatesImpl extends _PostAggregates {
   @override
   final int downvotes;
   @override
+  @deprecated
   final DateTime? newestCommentTime;
   @override
+  @deprecated
   final DateTime? newestCommentTimeNecro;
 
   @override
@@ -859,14 +863,15 @@ class _$PostAggregatesImpl extends _PostAggregates {
 
 abstract class _PostAggregates extends PostAggregates {
   const factory _PostAggregates(
-      {required final int id,
-      required final int postId,
-      required final int comments,
-      required final int score,
-      required final int upvotes,
-      required final int downvotes,
-      required final DateTime? newestCommentTime,
-      required final DateTime? newestCommentTimeNecro}) = _$PostAggregatesImpl;
+          {required final int id,
+          required final int postId,
+          required final int comments,
+          required final int score,
+          required final int upvotes,
+          required final int downvotes,
+          @deprecated final DateTime? newestCommentTime,
+          @deprecated final DateTime? newestCommentTimeNecro}) =
+      _$PostAggregatesImpl;
   const _PostAggregates._() : super._();
 
   factory _PostAggregates.fromJson(Map<String, dynamic> json) =
@@ -885,8 +890,10 @@ abstract class _PostAggregates extends PostAggregates {
   @override
   int get downvotes;
   @override
+  @deprecated
   DateTime? get newestCommentTime;
   @override
+  @deprecated
   DateTime? get newestCommentTimeNecro;
   @override
   @JsonKey(ignore: true)

--- a/lib/src/v3/models/aggregates.g.dart
+++ b/lib/src/v3/models/aggregates.g.dart
@@ -6,8 +6,9 @@ part of 'aggregates.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PersonAggregates _$$_PersonAggregatesFromJson(Map<String, dynamic> json) =>
-    _$_PersonAggregates(
+_$PersonAggregatesImpl _$$PersonAggregatesImplFromJson(
+        Map<String, dynamic> json) =>
+    _$PersonAggregatesImpl(
       id: json['id'] as int,
       personId: json['person_id'] as int,
       postCount: json['post_count'] as int,
@@ -16,7 +17,8 @@ _$_PersonAggregates _$$_PersonAggregatesFromJson(Map<String, dynamic> json) =>
       commentScore: json['comment_score'] as int,
     );
 
-Map<String, dynamic> _$$_PersonAggregatesToJson(_$_PersonAggregates instance) =>
+Map<String, dynamic> _$$PersonAggregatesImplToJson(
+        _$PersonAggregatesImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'person_id': instance.personId,
@@ -26,8 +28,8 @@ Map<String, dynamic> _$$_PersonAggregatesToJson(_$_PersonAggregates instance) =>
       'comment_score': instance.commentScore,
     };
 
-_$_SiteAggregates _$$_SiteAggregatesFromJson(Map<String, dynamic> json) =>
-    _$_SiteAggregates(
+_$SiteAggregatesImpl _$$SiteAggregatesImplFromJson(Map<String, dynamic> json) =>
+    _$SiteAggregatesImpl(
       id: json['id'] as int,
       siteId: json['site_id'] as int,
       users: json['users'] as int,
@@ -40,7 +42,8 @@ _$_SiteAggregates _$$_SiteAggregatesFromJson(Map<String, dynamic> json) =>
       usersActiveHalfYear: json['users_active_half_year'] as int,
     );
 
-Map<String, dynamic> _$$_SiteAggregatesToJson(_$_SiteAggregates instance) =>
+Map<String, dynamic> _$$SiteAggregatesImplToJson(
+        _$SiteAggregatesImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'site_id': instance.siteId,
@@ -54,21 +57,22 @@ Map<String, dynamic> _$$_SiteAggregatesToJson(_$_SiteAggregates instance) =>
       'users_active_half_year': instance.usersActiveHalfYear,
     };
 
-_$_PostAggregates _$$_PostAggregatesFromJson(Map<String, dynamic> json) =>
-    _$_PostAggregates(
+_$PostAggregatesImpl _$$PostAggregatesImplFromJson(Map<String, dynamic> json) =>
+    _$PostAggregatesImpl(
       id: json['id'] as int,
       postId: json['post_id'] as int,
       comments: json['comments'] as int,
       score: json['score'] as int,
       upvotes: json['upvotes'] as int,
       downvotes: json['downvotes'] as int,
-      newestCommentTime: const ForceUtcDateTime()
-          .fromJson(json['newest_comment_time'] as String),
-      newestCommentTimeNecro: const ForceUtcDateTime()
-          .fromJson(json['newest_comment_time_necro'] as String),
+      newestCommentTime: _$JsonConverterFromJson<String, DateTime>(
+          json['newest_comment_time'], const ForceUtcDateTime().fromJson),
+      newestCommentTimeNecro: _$JsonConverterFromJson<String, DateTime>(
+          json['newest_comment_time_necro'], const ForceUtcDateTime().fromJson),
     );
 
-Map<String, dynamic> _$$_PostAggregatesToJson(_$_PostAggregates instance) =>
+Map<String, dynamic> _$$PostAggregatesImplToJson(
+        _$PostAggregatesImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'post_id': instance.postId,
@@ -76,15 +80,27 @@ Map<String, dynamic> _$$_PostAggregatesToJson(_$_PostAggregates instance) =>
       'score': instance.score,
       'upvotes': instance.upvotes,
       'downvotes': instance.downvotes,
-      'newest_comment_time':
-          const ForceUtcDateTime().toJson(instance.newestCommentTime),
-      'newest_comment_time_necro':
-          const ForceUtcDateTime().toJson(instance.newestCommentTimeNecro),
+      'newest_comment_time': _$JsonConverterToJson<String, DateTime>(
+          instance.newestCommentTime, const ForceUtcDateTime().toJson),
+      'newest_comment_time_necro': _$JsonConverterToJson<String, DateTime>(
+          instance.newestCommentTimeNecro, const ForceUtcDateTime().toJson),
     };
 
-_$_CommunityAggregates _$$_CommunityAggregatesFromJson(
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) =>
+    json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) =>
+    value == null ? null : toJson(value);
+
+_$CommunityAggregatesImpl _$$CommunityAggregatesImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CommunityAggregates(
+    _$CommunityAggregatesImpl(
       id: json['id'] as int,
       communityId: json['community_id'] as int,
       subscribers: json['subscribers'] as int,
@@ -96,8 +112,8 @@ _$_CommunityAggregates _$$_CommunityAggregatesFromJson(
       usersActiveHalfYear: json['users_active_half_year'] as int,
     );
 
-Map<String, dynamic> _$$_CommunityAggregatesToJson(
-        _$_CommunityAggregates instance) =>
+Map<String, dynamic> _$$CommunityAggregatesImplToJson(
+        _$CommunityAggregatesImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'community_id': instance.communityId,
@@ -110,8 +126,9 @@ Map<String, dynamic> _$$_CommunityAggregatesToJson(
       'users_active_half_year': instance.usersActiveHalfYear,
     };
 
-_$_CommentAggregates _$$_CommentAggregatesFromJson(Map<String, dynamic> json) =>
-    _$_CommentAggregates(
+_$CommentAggregatesImpl _$$CommentAggregatesImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CommentAggregatesImpl(
       id: json['id'] as int,
       commentId: json['comment_id'] as int,
       score: json['score'] as int,
@@ -120,8 +137,8 @@ _$_CommentAggregates _$$_CommentAggregatesFromJson(Map<String, dynamic> json) =>
       childCount: json['child_count'] as int,
     );
 
-Map<String, dynamic> _$$_CommentAggregatesToJson(
-        _$_CommentAggregates instance) =>
+Map<String, dynamic> _$$CommentAggregatesImplToJson(
+        _$CommentAggregatesImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'comment_id': instance.commentId,

--- a/lib/src/v3/models/api.freezed.dart
+++ b/lib/src/v3/models/api.freezed.dart
@@ -115,11 +115,11 @@ class _$FullCommunityViewCopyWithImpl<$Res, $Val extends FullCommunityView>
 }
 
 /// @nodoc
-abstract class _$$_FullCommunityViewCopyWith<$Res>
+abstract class _$$FullCommunityViewImplCopyWith<$Res>
     implements $FullCommunityViewCopyWith<$Res> {
-  factory _$$_FullCommunityViewCopyWith(_$_FullCommunityView value,
-          $Res Function(_$_FullCommunityView) then) =
-      __$$_FullCommunityViewCopyWithImpl<$Res>;
+  factory _$$FullCommunityViewImplCopyWith(_$FullCommunityViewImpl value,
+          $Res Function(_$FullCommunityViewImpl) then) =
+      __$$FullCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -136,11 +136,11 @@ abstract class _$$_FullCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_FullCommunityViewCopyWithImpl<$Res>
-    extends _$FullCommunityViewCopyWithImpl<$Res, _$_FullCommunityView>
-    implements _$$_FullCommunityViewCopyWith<$Res> {
-  __$$_FullCommunityViewCopyWithImpl(
-      _$_FullCommunityView _value, $Res Function(_$_FullCommunityView) _then)
+class __$$FullCommunityViewImplCopyWithImpl<$Res>
+    extends _$FullCommunityViewCopyWithImpl<$Res, _$FullCommunityViewImpl>
+    implements _$$FullCommunityViewImplCopyWith<$Res> {
+  __$$FullCommunityViewImplCopyWithImpl(_$FullCommunityViewImpl _value,
+      $Res Function(_$FullCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -152,7 +152,7 @@ class __$$_FullCommunityViewCopyWithImpl<$Res>
     Object? online = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_FullCommunityView(
+    return _then(_$FullCommunityViewImpl(
       communityView: null == communityView
           ? _value.communityView
           : communityView // ignore: cast_nullable_to_non_nullable
@@ -180,8 +180,8 @@ class __$$_FullCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_FullCommunityView extends _FullCommunityView {
-  const _$_FullCommunityView(
+class _$FullCommunityViewImpl extends _FullCommunityView {
+  const _$FullCommunityViewImpl(
       {required this.communityView,
       required this.site,
       required final List<CommunityModeratorView> moderators,
@@ -190,8 +190,8 @@ class _$_FullCommunityView extends _FullCommunityView {
       : _moderators = moderators,
         super._();
 
-  factory _$_FullCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_FullCommunityViewFromJson(json);
+  factory _$FullCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FullCommunityViewImplFromJson(json);
 
   @override
   final CommunityView communityView;
@@ -219,7 +219,7 @@ class _$_FullCommunityView extends _FullCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FullCommunityView &&
+            other is _$FullCommunityViewImpl &&
             (identical(other.communityView, communityView) ||
                 other.communityView == communityView) &&
             (identical(other.site, site) || other.site == site) &&
@@ -238,13 +238,13 @@ class _$_FullCommunityView extends _FullCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FullCommunityViewCopyWith<_$_FullCommunityView> get copyWith =>
-      __$$_FullCommunityViewCopyWithImpl<_$_FullCommunityView>(
+  _$$FullCommunityViewImplCopyWith<_$FullCommunityViewImpl> get copyWith =>
+      __$$FullCommunityViewImplCopyWithImpl<_$FullCommunityViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FullCommunityViewToJson(
+    return _$$FullCommunityViewImplToJson(
       this,
     );
   }
@@ -256,11 +256,11 @@ abstract class _FullCommunityView extends FullCommunityView {
       required final Site? site,
       required final List<CommunityModeratorView> moderators,
       final int? online,
-      required final String instanceHost}) = _$_FullCommunityView;
+      required final String instanceHost}) = _$FullCommunityViewImpl;
   const _FullCommunityView._() : super._();
 
   factory _FullCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_FullCommunityView.fromJson;
+      _$FullCommunityViewImpl.fromJson;
 
   @override
   CommunityView get communityView;
@@ -274,7 +274,7 @@ abstract class _FullCommunityView extends FullCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_FullCommunityViewCopyWith<_$_FullCommunityView> get copyWith =>
+  _$$FullCommunityViewImplCopyWith<_$FullCommunityViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -375,11 +375,11 @@ class _$FullPostViewCopyWithImpl<$Res, $Val extends FullPostView>
 }
 
 /// @nodoc
-abstract class _$$_FullPostViewCopyWith<$Res>
+abstract class _$$FullPostViewImplCopyWith<$Res>
     implements $FullPostViewCopyWith<$Res> {
-  factory _$$_FullPostViewCopyWith(
-          _$_FullPostView value, $Res Function(_$_FullPostView) then) =
-      __$$_FullPostViewCopyWithImpl<$Res>;
+  factory _$$FullPostViewImplCopyWith(
+          _$FullPostViewImpl value, $Res Function(_$FullPostViewImpl) then) =
+      __$$FullPostViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -396,11 +396,11 @@ abstract class _$$_FullPostViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_FullPostViewCopyWithImpl<$Res>
-    extends _$FullPostViewCopyWithImpl<$Res, _$_FullPostView>
-    implements _$$_FullPostViewCopyWith<$Res> {
-  __$$_FullPostViewCopyWithImpl(
-      _$_FullPostView _value, $Res Function(_$_FullPostView) _then)
+class __$$FullPostViewImplCopyWithImpl<$Res>
+    extends _$FullPostViewCopyWithImpl<$Res, _$FullPostViewImpl>
+    implements _$$FullPostViewImplCopyWith<$Res> {
+  __$$FullPostViewImplCopyWithImpl(
+      _$FullPostViewImpl _value, $Res Function(_$FullPostViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -412,7 +412,7 @@ class __$$_FullPostViewCopyWithImpl<$Res>
     Object? online = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_FullPostView(
+    return _then(_$FullPostViewImpl(
       postView: null == postView
           ? _value.postView
           : postView // ignore: cast_nullable_to_non_nullable
@@ -440,8 +440,8 @@ class __$$_FullPostViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_FullPostView extends _FullPostView {
-  const _$_FullPostView(
+class _$FullPostViewImpl extends _FullPostView {
+  const _$FullPostViewImpl(
       {required this.postView,
       required this.communityView,
       required final List<CommunityModeratorView> moderators,
@@ -450,8 +450,8 @@ class _$_FullPostView extends _FullPostView {
       : _moderators = moderators,
         super._();
 
-  factory _$_FullPostView.fromJson(Map<String, dynamic> json) =>
-      _$$_FullPostViewFromJson(json);
+  factory _$FullPostViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FullPostViewImplFromJson(json);
 
   @override
   final PostView postView;
@@ -479,7 +479,7 @@ class _$_FullPostView extends _FullPostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FullPostView &&
+            other is _$FullPostViewImpl &&
             (identical(other.postView, postView) ||
                 other.postView == postView) &&
             (identical(other.communityView, communityView) ||
@@ -499,12 +499,12 @@ class _$_FullPostView extends _FullPostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FullPostViewCopyWith<_$_FullPostView> get copyWith =>
-      __$$_FullPostViewCopyWithImpl<_$_FullPostView>(this, _$identity);
+  _$$FullPostViewImplCopyWith<_$FullPostViewImpl> get copyWith =>
+      __$$FullPostViewImplCopyWithImpl<_$FullPostViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FullPostViewToJson(
+    return _$$FullPostViewImplToJson(
       this,
     );
   }
@@ -516,11 +516,11 @@ abstract class _FullPostView extends FullPostView {
       required final CommunityView communityView,
       required final List<CommunityModeratorView> moderators,
       final int? online,
-      required final String instanceHost}) = _$_FullPostView;
+      required final String instanceHost}) = _$FullPostViewImpl;
   const _FullPostView._() : super._();
 
   factory _FullPostView.fromJson(Map<String, dynamic> json) =
-      _$_FullPostView.fromJson;
+      _$FullPostViewImpl.fromJson;
 
   @override
   PostView get postView;
@@ -534,7 +534,7 @@ abstract class _FullPostView extends FullPostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_FullPostViewCopyWith<_$_FullPostView> get copyWith =>
+  _$$FullPostViewImplCopyWith<_$FullPostViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -623,11 +623,11 @@ class _$SearchResultsCopyWithImpl<$Res, $Val extends SearchResults>
 }
 
 /// @nodoc
-abstract class _$$_SearchResultsCopyWith<$Res>
+abstract class _$$SearchResultsImplCopyWith<$Res>
     implements $SearchResultsCopyWith<$Res> {
-  factory _$$_SearchResultsCopyWith(
-          _$_SearchResults value, $Res Function(_$_SearchResults) then) =
-      __$$_SearchResultsCopyWithImpl<$Res>;
+  factory _$$SearchResultsImplCopyWith(
+          _$SearchResultsImpl value, $Res Function(_$SearchResultsImpl) then) =
+      __$$SearchResultsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -640,11 +640,11 @@ abstract class _$$_SearchResultsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_SearchResultsCopyWithImpl<$Res>
-    extends _$SearchResultsCopyWithImpl<$Res, _$_SearchResults>
-    implements _$$_SearchResultsCopyWith<$Res> {
-  __$$_SearchResultsCopyWithImpl(
-      _$_SearchResults _value, $Res Function(_$_SearchResults) _then)
+class __$$SearchResultsImplCopyWithImpl<$Res>
+    extends _$SearchResultsCopyWithImpl<$Res, _$SearchResultsImpl>
+    implements _$$SearchResultsImplCopyWith<$Res> {
+  __$$SearchResultsImplCopyWithImpl(
+      _$SearchResultsImpl _value, $Res Function(_$SearchResultsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -657,7 +657,7 @@ class __$$_SearchResultsCopyWithImpl<$Res>
     Object? users = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_SearchResults(
+    return _then(_$SearchResultsImpl(
       type: null == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -689,8 +689,8 @@ class __$$_SearchResultsCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_SearchResults extends _SearchResults {
-  const _$_SearchResults(
+class _$SearchResultsImpl extends _SearchResults {
+  const _$SearchResultsImpl(
       {@JsonKey(name: 'type_') required this.type,
       required final List<CommentView> comments,
       required final List<PostView> posts,
@@ -703,8 +703,8 @@ class _$_SearchResults extends _SearchResults {
         _users = users,
         super._();
 
-  factory _$_SearchResults.fromJson(Map<String, dynamic> json) =>
-      _$$_SearchResultsFromJson(json);
+  factory _$SearchResultsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SearchResultsImplFromJson(json);
 
   @override
   @JsonKey(name: 'type_')
@@ -753,7 +753,7 @@ class _$_SearchResults extends _SearchResults {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SearchResults &&
+            other is _$SearchResultsImpl &&
             (identical(other.type, type) || other.type == type) &&
             const DeepCollectionEquality().equals(other._comments, _comments) &&
             const DeepCollectionEquality().equals(other._posts, _posts) &&
@@ -778,12 +778,12 @@ class _$_SearchResults extends _SearchResults {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SearchResultsCopyWith<_$_SearchResults> get copyWith =>
-      __$$_SearchResultsCopyWithImpl<_$_SearchResults>(this, _$identity);
+  _$$SearchResultsImplCopyWith<_$SearchResultsImpl> get copyWith =>
+      __$$SearchResultsImplCopyWithImpl<_$SearchResultsImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SearchResultsToJson(
+    return _$$SearchResultsImplToJson(
       this,
     );
   }
@@ -796,11 +796,11 @@ abstract class _SearchResults extends SearchResults {
       required final List<PostView> posts,
       required final List<CommunityView> communities,
       required final List<PersonViewSafe> users,
-      required final String instanceHost}) = _$_SearchResults;
+      required final String instanceHost}) = _$SearchResultsImpl;
   const _SearchResults._() : super._();
 
   factory _SearchResults.fromJson(Map<String, dynamic> json) =
-      _$_SearchResults.fromJson;
+      _$SearchResultsImpl.fromJson;
 
   @override
   @JsonKey(name: 'type_')
@@ -817,7 +817,7 @@ abstract class _SearchResults extends SearchResults {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_SearchResultsCopyWith<_$_SearchResults> get copyWith =>
+  _$$SearchResultsImplCopyWith<_$SearchResultsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -985,9 +985,10 @@ class _$ModlogCopyWithImpl<$Res, $Val extends Modlog>
 }
 
 /// @nodoc
-abstract class _$$_ModlogCopyWith<$Res> implements $ModlogCopyWith<$Res> {
-  factory _$$_ModlogCopyWith(_$_Modlog value, $Res Function(_$_Modlog) then) =
-      __$$_ModlogCopyWithImpl<$Res>;
+abstract class _$$ModlogImplCopyWith<$Res> implements $ModlogCopyWith<$Res> {
+  factory _$$ModlogImplCopyWith(
+          _$ModlogImpl value, $Res Function(_$ModlogImpl) then) =
+      __$$ModlogImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1010,10 +1011,11 @@ abstract class _$$_ModlogCopyWith<$Res> implements $ModlogCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_ModlogCopyWithImpl<$Res>
-    extends _$ModlogCopyWithImpl<$Res, _$_Modlog>
-    implements _$$_ModlogCopyWith<$Res> {
-  __$$_ModlogCopyWithImpl(_$_Modlog _value, $Res Function(_$_Modlog) _then)
+class __$$ModlogImplCopyWithImpl<$Res>
+    extends _$ModlogCopyWithImpl<$Res, _$ModlogImpl>
+    implements _$$ModlogImplCopyWith<$Res> {
+  __$$ModlogImplCopyWithImpl(
+      _$ModlogImpl _value, $Res Function(_$ModlogImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1036,7 +1038,7 @@ class __$$_ModlogCopyWithImpl<$Res>
     Object? adminPurgedPosts = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_Modlog(
+    return _then(_$ModlogImpl(
       removedPosts: null == removedPosts
           ? _value._removedPosts
           : removedPosts // ignore: cast_nullable_to_non_nullable
@@ -1108,8 +1110,8 @@ class __$$_ModlogCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_Modlog extends _Modlog {
-  const _$_Modlog(
+class _$ModlogImpl extends _Modlog {
+  const _$ModlogImpl(
       {required final List<ModRemovePostView> removedPosts,
       required final List<ModLockPostView> lockedPosts,
       required final List<ModFeaturePostView> featuredPosts,
@@ -1143,8 +1145,8 @@ class _$_Modlog extends _Modlog {
         _adminPurgedPosts = adminPurgedPosts,
         super._();
 
-  factory _$_Modlog.fromJson(Map<String, dynamic> json) =>
-      _$$_ModlogFromJson(json);
+  factory _$ModlogImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModlogImplFromJson(json);
 
   final List<ModRemovePostView> _removedPosts;
   @override
@@ -1287,7 +1289,7 @@ class _$_Modlog extends _Modlog {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Modlog &&
+            other is _$ModlogImpl &&
             const DeepCollectionEquality()
                 .equals(other._removedPosts, _removedPosts) &&
             const DeepCollectionEquality()
@@ -1344,12 +1346,12 @@ class _$_Modlog extends _Modlog {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModlogCopyWith<_$_Modlog> get copyWith =>
-      __$$_ModlogCopyWithImpl<_$_Modlog>(this, _$identity);
+  _$$ModlogImplCopyWith<_$ModlogImpl> get copyWith =>
+      __$$ModlogImplCopyWithImpl<_$ModlogImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModlogToJson(
+    return _$$ModlogImplToJson(
       this,
     );
   }
@@ -1372,10 +1374,10 @@ abstract class _Modlog extends Modlog {
       required final List<AdminPurgePersonView> adminPurgedPersons,
       required final List<AdminPurgeCommunityView> adminPurgedCommunities,
       required final List<AdminPurgePostView> adminPurgedPosts,
-      required final String instanceHost}) = _$_Modlog;
+      required final String instanceHost}) = _$ModlogImpl;
   const _Modlog._() : super._();
 
-  factory _Modlog.fromJson(Map<String, dynamic> json) = _$_Modlog.fromJson;
+  factory _Modlog.fromJson(Map<String, dynamic> json) = _$ModlogImpl.fromJson;
 
   @override
   List<ModRemovePostView> get removedPosts;
@@ -1411,7 +1413,7 @@ abstract class _Modlog extends Modlog {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModlogCopyWith<_$_Modlog> get copyWith =>
+  _$$ModlogImplCopyWith<_$ModlogImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1495,11 +1497,11 @@ class _$FullCommentViewCopyWithImpl<$Res, $Val extends FullCommentView>
 }
 
 /// @nodoc
-abstract class _$$_FullCommentViewCopyWith<$Res>
+abstract class _$$FullCommentViewImplCopyWith<$Res>
     implements $FullCommentViewCopyWith<$Res> {
-  factory _$$_FullCommentViewCopyWith(
-          _$_FullCommentView value, $Res Function(_$_FullCommentView) then) =
-      __$$_FullCommentViewCopyWithImpl<$Res>;
+  factory _$$FullCommentViewImplCopyWith(_$FullCommentViewImpl value,
+          $Res Function(_$FullCommentViewImpl) then) =
+      __$$FullCommentViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1513,11 +1515,11 @@ abstract class _$$_FullCommentViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_FullCommentViewCopyWithImpl<$Res>
-    extends _$FullCommentViewCopyWithImpl<$Res, _$_FullCommentView>
-    implements _$$_FullCommentViewCopyWith<$Res> {
-  __$$_FullCommentViewCopyWithImpl(
-      _$_FullCommentView _value, $Res Function(_$_FullCommentView) _then)
+class __$$FullCommentViewImplCopyWithImpl<$Res>
+    extends _$FullCommentViewCopyWithImpl<$Res, _$FullCommentViewImpl>
+    implements _$$FullCommentViewImplCopyWith<$Res> {
+  __$$FullCommentViewImplCopyWithImpl(
+      _$FullCommentViewImpl _value, $Res Function(_$FullCommentViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1528,7 +1530,7 @@ class __$$_FullCommentViewCopyWithImpl<$Res>
     Object? formId = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_FullCommentView(
+    return _then(_$FullCommentViewImpl(
       commentView: null == commentView
           ? _value.commentView
           : commentView // ignore: cast_nullable_to_non_nullable
@@ -1552,8 +1554,8 @@ class __$$_FullCommentViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_FullCommentView extends _FullCommentView {
-  const _$_FullCommentView(
+class _$FullCommentViewImpl extends _FullCommentView {
+  const _$FullCommentViewImpl(
       {required this.commentView,
       required final List<int> recipientIds,
       this.formId,
@@ -1561,8 +1563,8 @@ class _$_FullCommentView extends _FullCommentView {
       : _recipientIds = recipientIds,
         super._();
 
-  factory _$_FullCommentView.fromJson(Map<String, dynamic> json) =>
-      _$$_FullCommentViewFromJson(json);
+  factory _$FullCommentViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FullCommentViewImplFromJson(json);
 
   @override
   final CommentView commentView;
@@ -1588,7 +1590,7 @@ class _$_FullCommentView extends _FullCommentView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FullCommentView &&
+            other is _$FullCommentViewImpl &&
             (identical(other.commentView, commentView) ||
                 other.commentView == commentView) &&
             const DeepCollectionEquality()
@@ -1606,12 +1608,13 @@ class _$_FullCommentView extends _FullCommentView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FullCommentViewCopyWith<_$_FullCommentView> get copyWith =>
-      __$$_FullCommentViewCopyWithImpl<_$_FullCommentView>(this, _$identity);
+  _$$FullCommentViewImplCopyWith<_$FullCommentViewImpl> get copyWith =>
+      __$$FullCommentViewImplCopyWithImpl<_$FullCommentViewImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FullCommentViewToJson(
+    return _$$FullCommentViewImplToJson(
       this,
     );
   }
@@ -1622,11 +1625,11 @@ abstract class _FullCommentView extends FullCommentView {
       {required final CommentView commentView,
       required final List<int> recipientIds,
       final String? formId,
-      required final String instanceHost}) = _$_FullCommentView;
+      required final String instanceHost}) = _$FullCommentViewImpl;
   const _FullCommentView._() : super._();
 
   factory _FullCommentView.fromJson(Map<String, dynamic> json) =
-      _$_FullCommentView.fromJson;
+      _$FullCommentViewImpl.fromJson;
 
   @override
   CommentView get commentView;
@@ -1638,7 +1641,7 @@ abstract class _FullCommentView extends FullCommentView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_FullCommentViewCopyWith<_$_FullCommentView> get copyWith =>
+  _$$FullCommentViewImplCopyWith<_$FullCommentViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1707,11 +1710,11 @@ class _$FullCommentReplyViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_FullCommentReplyViewCopyWith<$Res>
+abstract class _$$FullCommentReplyViewImplCopyWith<$Res>
     implements $FullCommentReplyViewCopyWith<$Res> {
-  factory _$$_FullCommentReplyViewCopyWith(_$_FullCommentReplyView value,
-          $Res Function(_$_FullCommentReplyView) then) =
-      __$$_FullCommentReplyViewCopyWithImpl<$Res>;
+  factory _$$FullCommentReplyViewImplCopyWith(_$FullCommentReplyViewImpl value,
+          $Res Function(_$FullCommentReplyViewImpl) then) =
+      __$$FullCommentReplyViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CommentReplyView commentReplyView, String instanceHost});
@@ -1721,11 +1724,11 @@ abstract class _$$_FullCommentReplyViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_FullCommentReplyViewCopyWithImpl<$Res>
-    extends _$FullCommentReplyViewCopyWithImpl<$Res, _$_FullCommentReplyView>
-    implements _$$_FullCommentReplyViewCopyWith<$Res> {
-  __$$_FullCommentReplyViewCopyWithImpl(_$_FullCommentReplyView _value,
-      $Res Function(_$_FullCommentReplyView) _then)
+class __$$FullCommentReplyViewImplCopyWithImpl<$Res>
+    extends _$FullCommentReplyViewCopyWithImpl<$Res, _$FullCommentReplyViewImpl>
+    implements _$$FullCommentReplyViewImplCopyWith<$Res> {
+  __$$FullCommentReplyViewImplCopyWithImpl(_$FullCommentReplyViewImpl _value,
+      $Res Function(_$FullCommentReplyViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1734,7 +1737,7 @@ class __$$_FullCommentReplyViewCopyWithImpl<$Res>
     Object? commentReplyView = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_FullCommentReplyView(
+    return _then(_$FullCommentReplyViewImpl(
       commentReplyView: null == commentReplyView
           ? _value.commentReplyView
           : commentReplyView // ignore: cast_nullable_to_non_nullable
@@ -1750,13 +1753,13 @@ class __$$_FullCommentReplyViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_FullCommentReplyView extends _FullCommentReplyView {
-  const _$_FullCommentReplyView(
+class _$FullCommentReplyViewImpl extends _FullCommentReplyView {
+  const _$FullCommentReplyViewImpl(
       {required this.commentReplyView, required this.instanceHost})
       : super._();
 
-  factory _$_FullCommentReplyView.fromJson(Map<String, dynamic> json) =>
-      _$$_FullCommentReplyViewFromJson(json);
+  factory _$FullCommentReplyViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FullCommentReplyViewImplFromJson(json);
 
   @override
   final CommentReplyView commentReplyView;
@@ -1772,7 +1775,7 @@ class _$_FullCommentReplyView extends _FullCommentReplyView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FullCommentReplyView &&
+            other is _$FullCommentReplyViewImpl &&
             (identical(other.commentReplyView, commentReplyView) ||
                 other.commentReplyView == commentReplyView) &&
             (identical(other.instanceHost, instanceHost) ||
@@ -1786,13 +1789,14 @@ class _$_FullCommentReplyView extends _FullCommentReplyView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FullCommentReplyViewCopyWith<_$_FullCommentReplyView> get copyWith =>
-      __$$_FullCommentReplyViewCopyWithImpl<_$_FullCommentReplyView>(
-          this, _$identity);
+  _$$FullCommentReplyViewImplCopyWith<_$FullCommentReplyViewImpl>
+      get copyWith =>
+          __$$FullCommentReplyViewImplCopyWithImpl<_$FullCommentReplyViewImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FullCommentReplyViewToJson(
+    return _$$FullCommentReplyViewImplToJson(
       this,
     );
   }
@@ -1801,11 +1805,11 @@ class _$_FullCommentReplyView extends _FullCommentReplyView {
 abstract class _FullCommentReplyView extends FullCommentReplyView {
   const factory _FullCommentReplyView(
       {required final CommentReplyView commentReplyView,
-      required final String instanceHost}) = _$_FullCommentReplyView;
+      required final String instanceHost}) = _$FullCommentReplyViewImpl;
   const _FullCommentReplyView._() : super._();
 
   factory _FullCommentReplyView.fromJson(Map<String, dynamic> json) =
-      _$_FullCommentReplyView.fromJson;
+      _$FullCommentReplyViewImpl.fromJson;
 
   @override
   CommentReplyView get commentReplyView;
@@ -1813,8 +1817,8 @@ abstract class _FullCommentReplyView extends FullCommentReplyView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_FullCommentReplyViewCopyWith<_$_FullCommentReplyView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$FullCommentReplyViewImplCopyWith<_$FullCommentReplyViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 FullSiteView _$FullSiteViewFromJson(Map<String, dynamic> json) {
@@ -1957,11 +1961,11 @@ class _$FullSiteViewCopyWithImpl<$Res, $Val extends FullSiteView>
 }
 
 /// @nodoc
-abstract class _$$_FullSiteViewCopyWith<$Res>
+abstract class _$$FullSiteViewImplCopyWith<$Res>
     implements $FullSiteViewCopyWith<$Res> {
-  factory _$$_FullSiteViewCopyWith(
-          _$_FullSiteView value, $Res Function(_$_FullSiteView) then) =
-      __$$_FullSiteViewCopyWithImpl<$Res>;
+  factory _$$FullSiteViewImplCopyWith(
+          _$FullSiteViewImpl value, $Res Function(_$FullSiteViewImpl) then) =
+      __$$FullSiteViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1983,11 +1987,11 @@ abstract class _$$_FullSiteViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_FullSiteViewCopyWithImpl<$Res>
-    extends _$FullSiteViewCopyWithImpl<$Res, _$_FullSiteView>
-    implements _$$_FullSiteViewCopyWith<$Res> {
-  __$$_FullSiteViewCopyWithImpl(
-      _$_FullSiteView _value, $Res Function(_$_FullSiteView) _then)
+class __$$FullSiteViewImplCopyWithImpl<$Res>
+    extends _$FullSiteViewCopyWithImpl<$Res, _$FullSiteViewImpl>
+    implements _$$FullSiteViewImplCopyWith<$Res> {
+  __$$FullSiteViewImplCopyWithImpl(
+      _$FullSiteViewImpl _value, $Res Function(_$FullSiteViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2002,7 +2006,7 @@ class __$$_FullSiteViewCopyWithImpl<$Res>
     Object? instanceHost = null,
     Object? taglines = null,
   }) {
-    return _then(_$_FullSiteView(
+    return _then(_$FullSiteViewImpl(
       siteView: freezed == siteView
           ? _value.siteView
           : siteView // ignore: cast_nullable_to_non_nullable
@@ -2042,8 +2046,8 @@ class __$$_FullSiteViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_FullSiteView extends _FullSiteView {
-  const _$_FullSiteView(
+class _$FullSiteViewImpl extends _FullSiteView {
+  const _$FullSiteViewImpl(
       {this.siteView,
       required final List<PersonViewSafe> admins,
       this.online,
@@ -2056,8 +2060,8 @@ class _$_FullSiteView extends _FullSiteView {
         _taglines = taglines,
         super._();
 
-  factory _$_FullSiteView.fromJson(Map<String, dynamic> json) =>
-      _$$_FullSiteViewFromJson(json);
+  factory _$FullSiteViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FullSiteViewImplFromJson(json);
 
   @override
   final SiteView? siteView;
@@ -2096,7 +2100,7 @@ class _$_FullSiteView extends _FullSiteView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FullSiteView &&
+            other is _$FullSiteViewImpl &&
             (identical(other.siteView, siteView) ||
                 other.siteView == siteView) &&
             const DeepCollectionEquality().equals(other._admins, _admins) &&
@@ -2126,12 +2130,12 @@ class _$_FullSiteView extends _FullSiteView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FullSiteViewCopyWith<_$_FullSiteView> get copyWith =>
-      __$$_FullSiteViewCopyWithImpl<_$_FullSiteView>(this, _$identity);
+  _$$FullSiteViewImplCopyWith<_$FullSiteViewImpl> get copyWith =>
+      __$$FullSiteViewImplCopyWithImpl<_$FullSiteViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FullSiteViewToJson(
+    return _$$FullSiteViewImplToJson(
       this,
     );
   }
@@ -2146,11 +2150,11 @@ abstract class _FullSiteView extends FullSiteView {
       final MyUserInfo? myUser,
       final FederatedInstances? federatedInstances,
       required final String instanceHost,
-      required final List<Tagline> taglines}) = _$_FullSiteView;
+      required final List<Tagline> taglines}) = _$FullSiteViewImpl;
   const _FullSiteView._() : super._();
 
   factory _FullSiteView.fromJson(Map<String, dynamic> json) =
-      _$_FullSiteView.fromJson;
+      _$FullSiteViewImpl.fromJson;
 
   @override
   SiteView? get siteView;
@@ -2170,7 +2174,7 @@ abstract class _FullSiteView extends FullSiteView {
   List<Tagline> get taglines;
   @override
   @JsonKey(ignore: true)
-  _$$_FullSiteViewCopyWith<_$_FullSiteView> get copyWith =>
+  _$$FullSiteViewImplCopyWith<_$FullSiteViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2256,10 +2260,10 @@ class _$TaglineCopyWithImpl<$Res, $Val extends Tagline>
 }
 
 /// @nodoc
-abstract class _$$_TaglineCopyWith<$Res> implements $TaglineCopyWith<$Res> {
-  factory _$$_TaglineCopyWith(
-          _$_Tagline value, $Res Function(_$_Tagline) then) =
-      __$$_TaglineCopyWithImpl<$Res>;
+abstract class _$$TaglineImplCopyWith<$Res> implements $TaglineCopyWith<$Res> {
+  factory _$$TaglineImplCopyWith(
+          _$TaglineImpl value, $Res Function(_$TaglineImpl) then) =
+      __$$TaglineImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2272,10 +2276,11 @@ abstract class _$$_TaglineCopyWith<$Res> implements $TaglineCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_TaglineCopyWithImpl<$Res>
-    extends _$TaglineCopyWithImpl<$Res, _$_Tagline>
-    implements _$$_TaglineCopyWith<$Res> {
-  __$$_TaglineCopyWithImpl(_$_Tagline _value, $Res Function(_$_Tagline) _then)
+class __$$TaglineImplCopyWithImpl<$Res>
+    extends _$TaglineCopyWithImpl<$Res, _$TaglineImpl>
+    implements _$$TaglineImplCopyWith<$Res> {
+  __$$TaglineImplCopyWithImpl(
+      _$TaglineImpl _value, $Res Function(_$TaglineImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2288,7 +2293,7 @@ class __$$_TaglineCopyWithImpl<$Res>
     Object? instanceHost = null,
     Object? updated = freezed,
   }) {
-    return _then(_$_Tagline(
+    return _then(_$TaglineImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -2320,8 +2325,8 @@ class __$$_TaglineCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_Tagline extends _Tagline {
-  const _$_Tagline(
+class _$TaglineImpl extends _Tagline {
+  const _$TaglineImpl(
       {required this.id,
       required this.localSiteId,
       required this.content,
@@ -2330,8 +2335,8 @@ class _$_Tagline extends _Tagline {
       this.updated})
       : super._();
 
-  factory _$_Tagline.fromJson(Map<String, dynamic> json) =>
-      _$$_TaglineFromJson(json);
+  factory _$TaglineImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TaglineImplFromJson(json);
 
   @override
   final int id;
@@ -2355,7 +2360,7 @@ class _$_Tagline extends _Tagline {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Tagline &&
+            other is _$TaglineImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.localSiteId, localSiteId) ||
                 other.localSiteId == localSiteId) &&
@@ -2375,12 +2380,12 @@ class _$_Tagline extends _Tagline {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_TaglineCopyWith<_$_Tagline> get copyWith =>
-      __$$_TaglineCopyWithImpl<_$_Tagline>(this, _$identity);
+  _$$TaglineImplCopyWith<_$TaglineImpl> get copyWith =>
+      __$$TaglineImplCopyWithImpl<_$TaglineImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_TaglineToJson(
+    return _$$TaglineImplToJson(
       this,
     );
   }
@@ -2393,10 +2398,10 @@ abstract class _Tagline extends Tagline {
       required final String content,
       required final DateTime published,
       required final String instanceHost,
-      final DateTime? updated}) = _$_Tagline;
+      final DateTime? updated}) = _$TaglineImpl;
   const _Tagline._() : super._();
 
-  factory _Tagline.fromJson(Map<String, dynamic> json) = _$_Tagline.fromJson;
+  factory _Tagline.fromJson(Map<String, dynamic> json) = _$TaglineImpl.fromJson;
 
   @override
   int get id;
@@ -2412,7 +2417,7 @@ abstract class _Tagline extends Tagline {
   DateTime? get updated;
   @override
   @JsonKey(ignore: true)
-  _$$_TaglineCopyWith<_$_Tagline> get copyWith =>
+  _$$TaglineImplCopyWith<_$TaglineImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2512,11 +2517,11 @@ class _$MyUserInfoCopyWithImpl<$Res, $Val extends MyUserInfo>
 }
 
 /// @nodoc
-abstract class _$$_MyUserInfoCopyWith<$Res>
+abstract class _$$MyUserInfoImplCopyWith<$Res>
     implements $MyUserInfoCopyWith<$Res> {
-  factory _$$_MyUserInfoCopyWith(
-          _$_MyUserInfo value, $Res Function(_$_MyUserInfo) then) =
-      __$$_MyUserInfoCopyWithImpl<$Res>;
+  factory _$$MyUserInfoImplCopyWith(
+          _$MyUserInfoImpl value, $Res Function(_$MyUserInfoImpl) then) =
+      __$$MyUserInfoImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2532,11 +2537,11 @@ abstract class _$$_MyUserInfoCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_MyUserInfoCopyWithImpl<$Res>
-    extends _$MyUserInfoCopyWithImpl<$Res, _$_MyUserInfo>
-    implements _$$_MyUserInfoCopyWith<$Res> {
-  __$$_MyUserInfoCopyWithImpl(
-      _$_MyUserInfo _value, $Res Function(_$_MyUserInfo) _then)
+class __$$MyUserInfoImplCopyWithImpl<$Res>
+    extends _$MyUserInfoCopyWithImpl<$Res, _$MyUserInfoImpl>
+    implements _$$MyUserInfoImplCopyWith<$Res> {
+  __$$MyUserInfoImplCopyWithImpl(
+      _$MyUserInfoImpl _value, $Res Function(_$MyUserInfoImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2549,7 +2554,7 @@ class __$$_MyUserInfoCopyWithImpl<$Res>
     Object? personBlocks = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_MyUserInfo(
+    return _then(_$MyUserInfoImpl(
       localUserView: null == localUserView
           ? _value.localUserView
           : localUserView // ignore: cast_nullable_to_non_nullable
@@ -2581,8 +2586,8 @@ class __$$_MyUserInfoCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_MyUserInfo extends _MyUserInfo {
-  const _$_MyUserInfo(
+class _$MyUserInfoImpl extends _MyUserInfo {
+  const _$MyUserInfoImpl(
       {required this.localUserView,
       required final List<CommunityFollowerView> follows,
       required final List<CommunityModeratorView> moderates,
@@ -2595,8 +2600,8 @@ class _$_MyUserInfo extends _MyUserInfo {
         _personBlocks = personBlocks,
         super._();
 
-  factory _$_MyUserInfo.fromJson(Map<String, dynamic> json) =>
-      _$$_MyUserInfoFromJson(json);
+  factory _$MyUserInfoImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MyUserInfoImplFromJson(json);
 
   @override
   final LocalUserSettingsView localUserView;
@@ -2644,7 +2649,7 @@ class _$_MyUserInfo extends _MyUserInfo {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MyUserInfo &&
+            other is _$MyUserInfoImpl &&
             (identical(other.localUserView, localUserView) ||
                 other.localUserView == localUserView) &&
             const DeepCollectionEquality().equals(other._follows, _follows) &&
@@ -2672,12 +2677,12 @@ class _$_MyUserInfo extends _MyUserInfo {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MyUserInfoCopyWith<_$_MyUserInfo> get copyWith =>
-      __$$_MyUserInfoCopyWithImpl<_$_MyUserInfo>(this, _$identity);
+  _$$MyUserInfoImplCopyWith<_$MyUserInfoImpl> get copyWith =>
+      __$$MyUserInfoImplCopyWithImpl<_$MyUserInfoImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MyUserInfoToJson(
+    return _$$MyUserInfoImplToJson(
       this,
     );
   }
@@ -2690,11 +2695,11 @@ abstract class _MyUserInfo extends MyUserInfo {
       required final List<CommunityModeratorView> moderates,
       required final List<CommunityBlockView> communityBlocks,
       required final List<PersonBlockView> personBlocks,
-      required final String instanceHost}) = _$_MyUserInfo;
+      required final String instanceHost}) = _$MyUserInfoImpl;
   const _MyUserInfo._() : super._();
 
   factory _MyUserInfo.fromJson(Map<String, dynamic> json) =
-      _$_MyUserInfo.fromJson;
+      _$MyUserInfoImpl.fromJson;
 
   @override
   LocalUserSettingsView get localUserView;
@@ -2710,7 +2715,7 @@ abstract class _MyUserInfo extends MyUserInfo {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_MyUserInfoCopyWith<_$_MyUserInfo> get copyWith =>
+  _$$MyUserInfoImplCopyWith<_$MyUserInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2784,11 +2789,11 @@ class _$FederatedInstancesCopyWithImpl<$Res, $Val extends FederatedInstances>
 }
 
 /// @nodoc
-abstract class _$$_FederatedInstancesCopyWith<$Res>
+abstract class _$$FederatedInstancesImplCopyWith<$Res>
     implements $FederatedInstancesCopyWith<$Res> {
-  factory _$$_FederatedInstancesCopyWith(_$_FederatedInstances value,
-          $Res Function(_$_FederatedInstances) then) =
-      __$$_FederatedInstancesCopyWithImpl<$Res>;
+  factory _$$FederatedInstancesImplCopyWith(_$FederatedInstancesImpl value,
+          $Res Function(_$FederatedInstancesImpl) then) =
+      __$$FederatedInstancesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2799,11 +2804,11 @@ abstract class _$$_FederatedInstancesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_FederatedInstancesCopyWithImpl<$Res>
-    extends _$FederatedInstancesCopyWithImpl<$Res, _$_FederatedInstances>
-    implements _$$_FederatedInstancesCopyWith<$Res> {
-  __$$_FederatedInstancesCopyWithImpl(
-      _$_FederatedInstances _value, $Res Function(_$_FederatedInstances) _then)
+class __$$FederatedInstancesImplCopyWithImpl<$Res>
+    extends _$FederatedInstancesCopyWithImpl<$Res, _$FederatedInstancesImpl>
+    implements _$$FederatedInstancesImplCopyWith<$Res> {
+  __$$FederatedInstancesImplCopyWithImpl(_$FederatedInstancesImpl _value,
+      $Res Function(_$FederatedInstancesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2814,7 +2819,7 @@ class __$$_FederatedInstancesCopyWithImpl<$Res>
     Object? blocked = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_FederatedInstances(
+    return _then(_$FederatedInstancesImpl(
       linked: null == linked
           ? _value._linked
           : linked // ignore: cast_nullable_to_non_nullable
@@ -2838,8 +2843,8 @@ class __$$_FederatedInstancesCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_FederatedInstances extends _FederatedInstances {
-  const _$_FederatedInstances(
+class _$FederatedInstancesImpl extends _FederatedInstances {
+  const _$FederatedInstancesImpl(
       {required final List<String> linked,
       final List<String>? allowed,
       final List<String>? blocked,
@@ -2849,8 +2854,8 @@ class _$_FederatedInstances extends _FederatedInstances {
         _blocked = blocked,
         super._();
 
-  factory _$_FederatedInstances.fromJson(Map<String, dynamic> json) =>
-      _$$_FederatedInstancesFromJson(json);
+  factory _$FederatedInstancesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FederatedInstancesImplFromJson(json);
 
   final List<String> _linked;
   @override
@@ -2892,7 +2897,7 @@ class _$_FederatedInstances extends _FederatedInstances {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FederatedInstances &&
+            other is _$FederatedInstancesImpl &&
             const DeepCollectionEquality().equals(other._linked, _linked) &&
             const DeepCollectionEquality().equals(other._allowed, _allowed) &&
             const DeepCollectionEquality().equals(other._blocked, _blocked) &&
@@ -2912,13 +2917,13 @@ class _$_FederatedInstances extends _FederatedInstances {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FederatedInstancesCopyWith<_$_FederatedInstances> get copyWith =>
-      __$$_FederatedInstancesCopyWithImpl<_$_FederatedInstances>(
+  _$$FederatedInstancesImplCopyWith<_$FederatedInstancesImpl> get copyWith =>
+      __$$FederatedInstancesImplCopyWithImpl<_$FederatedInstancesImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FederatedInstancesToJson(
+    return _$$FederatedInstancesImplToJson(
       this,
     );
   }
@@ -2929,11 +2934,11 @@ abstract class _FederatedInstances extends FederatedInstances {
       {required final List<String> linked,
       final List<String>? allowed,
       final List<String>? blocked,
-      required final String instanceHost}) = _$_FederatedInstances;
+      required final String instanceHost}) = _$FederatedInstancesImpl;
   const _FederatedInstances._() : super._();
 
   factory _FederatedInstances.fromJson(Map<String, dynamic> json) =
-      _$_FederatedInstances.fromJson;
+      _$FederatedInstancesImpl.fromJson;
 
   @override
   List<String> get linked;
@@ -2945,7 +2950,7 @@ abstract class _FederatedInstances extends FederatedInstances {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_FederatedInstancesCopyWith<_$_FederatedInstances> get copyWith =>
+  _$$FederatedInstancesImplCopyWith<_$FederatedInstancesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3010,20 +3015,21 @@ class _$CaptchaCopyWithImpl<$Res, $Val extends Captcha>
 }
 
 /// @nodoc
-abstract class _$$_CaptchaCopyWith<$Res> implements $CaptchaCopyWith<$Res> {
-  factory _$$_CaptchaCopyWith(
-          _$_Captcha value, $Res Function(_$_Captcha) then) =
-      __$$_CaptchaCopyWithImpl<$Res>;
+abstract class _$$CaptchaImplCopyWith<$Res> implements $CaptchaCopyWith<$Res> {
+  factory _$$CaptchaImplCopyWith(
+          _$CaptchaImpl value, $Res Function(_$CaptchaImpl) then) =
+      __$$CaptchaImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String png, String? wav, String uuid});
 }
 
 /// @nodoc
-class __$$_CaptchaCopyWithImpl<$Res>
-    extends _$CaptchaCopyWithImpl<$Res, _$_Captcha>
-    implements _$$_CaptchaCopyWith<$Res> {
-  __$$_CaptchaCopyWithImpl(_$_Captcha _value, $Res Function(_$_Captcha) _then)
+class __$$CaptchaImplCopyWithImpl<$Res>
+    extends _$CaptchaCopyWithImpl<$Res, _$CaptchaImpl>
+    implements _$$CaptchaImplCopyWith<$Res> {
+  __$$CaptchaImplCopyWithImpl(
+      _$CaptchaImpl _value, $Res Function(_$CaptchaImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3033,7 +3039,7 @@ class __$$_CaptchaCopyWithImpl<$Res>
     Object? wav = freezed,
     Object? uuid = null,
   }) {
-    return _then(_$_Captcha(
+    return _then(_$CaptchaImpl(
       png: null == png
           ? _value.png
           : png // ignore: cast_nullable_to_non_nullable
@@ -3053,12 +3059,12 @@ class __$$_CaptchaCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_Captcha extends _Captcha {
-  const _$_Captcha({required this.png, this.wav, required this.uuid})
+class _$CaptchaImpl extends _Captcha {
+  const _$CaptchaImpl({required this.png, this.wav, required this.uuid})
       : super._();
 
-  factory _$_Captcha.fromJson(Map<String, dynamic> json) =>
-      _$$_CaptchaFromJson(json);
+  factory _$CaptchaImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CaptchaImplFromJson(json);
 
   /// A Base64 encoded png
   @override
@@ -3079,7 +3085,7 @@ class _$_Captcha extends _Captcha {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Captcha &&
+            other is _$CaptchaImpl &&
             (identical(other.png, png) || other.png == png) &&
             (identical(other.wav, wav) || other.wav == wav) &&
             (identical(other.uuid, uuid) || other.uuid == uuid));
@@ -3092,12 +3098,12 @@ class _$_Captcha extends _Captcha {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CaptchaCopyWith<_$_Captcha> get copyWith =>
-      __$$_CaptchaCopyWithImpl<_$_Captcha>(this, _$identity);
+  _$$CaptchaImplCopyWith<_$CaptchaImpl> get copyWith =>
+      __$$CaptchaImplCopyWithImpl<_$CaptchaImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CaptchaToJson(
+    return _$$CaptchaImplToJson(
       this,
     );
   }
@@ -3107,10 +3113,10 @@ abstract class _Captcha extends Captcha {
   const factory _Captcha(
       {required final String png,
       final String? wav,
-      required final String uuid}) = _$_Captcha;
+      required final String uuid}) = _$CaptchaImpl;
   const _Captcha._() : super._();
 
-  factory _Captcha.fromJson(Map<String, dynamic> json) = _$_Captcha.fromJson;
+  factory _Captcha.fromJson(Map<String, dynamic> json) = _$CaptchaImpl.fromJson;
 
   @override
 
@@ -3124,7 +3130,7 @@ abstract class _Captcha extends Captcha {
   String get uuid;
   @override
   @JsonKey(ignore: true)
-  _$$_CaptchaCopyWith<_$_Captcha> get copyWith =>
+  _$$CaptchaImplCopyWith<_$CaptchaImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3216,11 +3222,11 @@ class _$FullPersonViewCopyWithImpl<$Res, $Val extends FullPersonView>
 }
 
 /// @nodoc
-abstract class _$$_FullPersonViewCopyWith<$Res>
+abstract class _$$FullPersonViewImplCopyWith<$Res>
     implements $FullPersonViewCopyWith<$Res> {
-  factory _$$_FullPersonViewCopyWith(
-          _$_FullPersonView value, $Res Function(_$_FullPersonView) then) =
-      __$$_FullPersonViewCopyWithImpl<$Res>;
+  factory _$$FullPersonViewImplCopyWith(_$FullPersonViewImpl value,
+          $Res Function(_$FullPersonViewImpl) then) =
+      __$$FullPersonViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3235,11 +3241,11 @@ abstract class _$$_FullPersonViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_FullPersonViewCopyWithImpl<$Res>
-    extends _$FullPersonViewCopyWithImpl<$Res, _$_FullPersonView>
-    implements _$$_FullPersonViewCopyWith<$Res> {
-  __$$_FullPersonViewCopyWithImpl(
-      _$_FullPersonView _value, $Res Function(_$_FullPersonView) _then)
+class __$$FullPersonViewImplCopyWithImpl<$Res>
+    extends _$FullPersonViewCopyWithImpl<$Res, _$FullPersonViewImpl>
+    implements _$$FullPersonViewImplCopyWith<$Res> {
+  __$$FullPersonViewImplCopyWithImpl(
+      _$FullPersonViewImpl _value, $Res Function(_$FullPersonViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3251,7 +3257,7 @@ class __$$_FullPersonViewCopyWithImpl<$Res>
     Object? posts = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_FullPersonView(
+    return _then(_$FullPersonViewImpl(
       personView: null == personView
           ? _value.personView
           : personView // ignore: cast_nullable_to_non_nullable
@@ -3279,8 +3285,8 @@ class __$$_FullPersonViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_FullPersonView extends _FullPersonView {
-  const _$_FullPersonView(
+class _$FullPersonViewImpl extends _FullPersonView {
+  const _$FullPersonViewImpl(
       {required this.personView,
       required final List<CommunityModeratorView> moderates,
       required final List<CommentView> comments,
@@ -3291,8 +3297,8 @@ class _$_FullPersonView extends _FullPersonView {
         _posts = posts,
         super._();
 
-  factory _$_FullPersonView.fromJson(Map<String, dynamic> json) =>
-      _$$_FullPersonViewFromJson(json);
+  factory _$FullPersonViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FullPersonViewImplFromJson(json);
 
   @override
   final PersonViewSafe personView;
@@ -3332,7 +3338,7 @@ class _$_FullPersonView extends _FullPersonView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FullPersonView &&
+            other is _$FullPersonViewImpl &&
             (identical(other.personView, personView) ||
                 other.personView == personView) &&
             const DeepCollectionEquality()
@@ -3356,12 +3362,13 @@ class _$_FullPersonView extends _FullPersonView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FullPersonViewCopyWith<_$_FullPersonView> get copyWith =>
-      __$$_FullPersonViewCopyWithImpl<_$_FullPersonView>(this, _$identity);
+  _$$FullPersonViewImplCopyWith<_$FullPersonViewImpl> get copyWith =>
+      __$$FullPersonViewImplCopyWithImpl<_$FullPersonViewImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FullPersonViewToJson(
+    return _$$FullPersonViewImplToJson(
       this,
     );
   }
@@ -3373,11 +3380,11 @@ abstract class _FullPersonView extends FullPersonView {
       required final List<CommunityModeratorView> moderates,
       required final List<CommentView> comments,
       required final List<PostView> posts,
-      required final String instanceHost}) = _$_FullPersonView;
+      required final String instanceHost}) = _$FullPersonViewImpl;
   const _FullPersonView._() : super._();
 
   factory _FullPersonView.fromJson(Map<String, dynamic> json) =
-      _$_FullPersonView.fromJson;
+      _$FullPersonViewImpl.fromJson;
 
   @override
   PersonViewSafe get personView;
@@ -3391,7 +3398,7 @@ abstract class _FullPersonView extends FullPersonView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_FullPersonViewCopyWith<_$_FullPersonView> get copyWith =>
+  _$$FullPersonViewImplCopyWith<_$FullPersonViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3465,11 +3472,11 @@ class _$BannedCommunityUserCopyWithImpl<$Res, $Val extends BannedCommunityUser>
 }
 
 /// @nodoc
-abstract class _$$_BannedCommunityUserCopyWith<$Res>
+abstract class _$$BannedCommunityUserImplCopyWith<$Res>
     implements $BannedCommunityUserCopyWith<$Res> {
-  factory _$$_BannedCommunityUserCopyWith(_$_BannedCommunityUser value,
-          $Res Function(_$_BannedCommunityUser) then) =
-      __$$_BannedCommunityUserCopyWithImpl<$Res>;
+  factory _$$BannedCommunityUserImplCopyWith(_$BannedCommunityUserImpl value,
+          $Res Function(_$BannedCommunityUserImpl) then) =
+      __$$BannedCommunityUserImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonViewSafe personView, bool banned, String instanceHost});
@@ -3479,11 +3486,11 @@ abstract class _$$_BannedCommunityUserCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_BannedCommunityUserCopyWithImpl<$Res>
-    extends _$BannedCommunityUserCopyWithImpl<$Res, _$_BannedCommunityUser>
-    implements _$$_BannedCommunityUserCopyWith<$Res> {
-  __$$_BannedCommunityUserCopyWithImpl(_$_BannedCommunityUser _value,
-      $Res Function(_$_BannedCommunityUser) _then)
+class __$$BannedCommunityUserImplCopyWithImpl<$Res>
+    extends _$BannedCommunityUserCopyWithImpl<$Res, _$BannedCommunityUserImpl>
+    implements _$$BannedCommunityUserImplCopyWith<$Res> {
+  __$$BannedCommunityUserImplCopyWithImpl(_$BannedCommunityUserImpl _value,
+      $Res Function(_$BannedCommunityUserImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3493,7 +3500,7 @@ class __$$_BannedCommunityUserCopyWithImpl<$Res>
     Object? banned = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_BannedCommunityUser(
+    return _then(_$BannedCommunityUserImpl(
       personView: null == personView
           ? _value.personView
           : personView // ignore: cast_nullable_to_non_nullable
@@ -3513,15 +3520,15 @@ class __$$_BannedCommunityUserCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_BannedCommunityUser extends _BannedCommunityUser {
-  const _$_BannedCommunityUser(
+class _$BannedCommunityUserImpl extends _BannedCommunityUser {
+  const _$BannedCommunityUserImpl(
       {required this.personView,
       required this.banned,
       required this.instanceHost})
       : super._();
 
-  factory _$_BannedCommunityUser.fromJson(Map<String, dynamic> json) =>
-      _$$_BannedCommunityUserFromJson(json);
+  factory _$BannedCommunityUserImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BannedCommunityUserImplFromJson(json);
 
   @override
   final PersonViewSafe personView;
@@ -3539,7 +3546,7 @@ class _$_BannedCommunityUser extends _BannedCommunityUser {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BannedCommunityUser &&
+            other is _$BannedCommunityUserImpl &&
             (identical(other.personView, personView) ||
                 other.personView == personView) &&
             (identical(other.banned, banned) || other.banned == banned) &&
@@ -3555,13 +3562,13 @@ class _$_BannedCommunityUser extends _BannedCommunityUser {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BannedCommunityUserCopyWith<_$_BannedCommunityUser> get copyWith =>
-      __$$_BannedCommunityUserCopyWithImpl<_$_BannedCommunityUser>(
+  _$$BannedCommunityUserImplCopyWith<_$BannedCommunityUserImpl> get copyWith =>
+      __$$BannedCommunityUserImplCopyWithImpl<_$BannedCommunityUserImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BannedCommunityUserToJson(
+    return _$$BannedCommunityUserImplToJson(
       this,
     );
   }
@@ -3571,11 +3578,11 @@ abstract class _BannedCommunityUser extends BannedCommunityUser {
   const factory _BannedCommunityUser(
       {required final PersonViewSafe personView,
       required final bool banned,
-      required final String instanceHost}) = _$_BannedCommunityUser;
+      required final String instanceHost}) = _$BannedCommunityUserImpl;
   const _BannedCommunityUser._() : super._();
 
   factory _BannedCommunityUser.fromJson(Map<String, dynamic> json) =
-      _$_BannedCommunityUser.fromJson;
+      _$BannedCommunityUserImpl.fromJson;
 
   @override
   PersonViewSafe get personView;
@@ -3585,7 +3592,7 @@ abstract class _BannedCommunityUser extends BannedCommunityUser {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_BannedCommunityUserCopyWith<_$_BannedCommunityUser> get copyWith =>
+  _$$BannedCommunityUserImplCopyWith<_$BannedCommunityUserImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3659,11 +3666,11 @@ class _$BannedPersonCopyWithImpl<$Res, $Val extends BannedPerson>
 }
 
 /// @nodoc
-abstract class _$$_BannedPersonCopyWith<$Res>
+abstract class _$$BannedPersonImplCopyWith<$Res>
     implements $BannedPersonCopyWith<$Res> {
-  factory _$$_BannedPersonCopyWith(
-          _$_BannedPerson value, $Res Function(_$_BannedPerson) then) =
-      __$$_BannedPersonCopyWithImpl<$Res>;
+  factory _$$BannedPersonImplCopyWith(
+          _$BannedPersonImpl value, $Res Function(_$BannedPersonImpl) then) =
+      __$$BannedPersonImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonViewSafe personView, bool banned, String instanceHost});
@@ -3673,11 +3680,11 @@ abstract class _$$_BannedPersonCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_BannedPersonCopyWithImpl<$Res>
-    extends _$BannedPersonCopyWithImpl<$Res, _$_BannedPerson>
-    implements _$$_BannedPersonCopyWith<$Res> {
-  __$$_BannedPersonCopyWithImpl(
-      _$_BannedPerson _value, $Res Function(_$_BannedPerson) _then)
+class __$$BannedPersonImplCopyWithImpl<$Res>
+    extends _$BannedPersonCopyWithImpl<$Res, _$BannedPersonImpl>
+    implements _$$BannedPersonImplCopyWith<$Res> {
+  __$$BannedPersonImplCopyWithImpl(
+      _$BannedPersonImpl _value, $Res Function(_$BannedPersonImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3687,7 +3694,7 @@ class __$$_BannedPersonCopyWithImpl<$Res>
     Object? banned = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_BannedPerson(
+    return _then(_$BannedPersonImpl(
       personView: null == personView
           ? _value.personView
           : personView // ignore: cast_nullable_to_non_nullable
@@ -3707,15 +3714,15 @@ class __$$_BannedPersonCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_BannedPerson extends _BannedPerson {
-  const _$_BannedPerson(
+class _$BannedPersonImpl extends _BannedPerson {
+  const _$BannedPersonImpl(
       {required this.personView,
       required this.banned,
       required this.instanceHost})
       : super._();
 
-  factory _$_BannedPerson.fromJson(Map<String, dynamic> json) =>
-      _$$_BannedPersonFromJson(json);
+  factory _$BannedPersonImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BannedPersonImplFromJson(json);
 
   @override
   final PersonViewSafe personView;
@@ -3733,7 +3740,7 @@ class _$_BannedPerson extends _BannedPerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BannedPerson &&
+            other is _$BannedPersonImpl &&
             (identical(other.personView, personView) ||
                 other.personView == personView) &&
             (identical(other.banned, banned) || other.banned == banned) &&
@@ -3749,12 +3756,12 @@ class _$_BannedPerson extends _BannedPerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BannedPersonCopyWith<_$_BannedPerson> get copyWith =>
-      __$$_BannedPersonCopyWithImpl<_$_BannedPerson>(this, _$identity);
+  _$$BannedPersonImplCopyWith<_$BannedPersonImpl> get copyWith =>
+      __$$BannedPersonImplCopyWithImpl<_$BannedPersonImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BannedPersonToJson(
+    return _$$BannedPersonImplToJson(
       this,
     );
   }
@@ -3764,11 +3771,11 @@ abstract class _BannedPerson extends BannedPerson {
   const factory _BannedPerson(
       {required final PersonViewSafe personView,
       required final bool banned,
-      required final String instanceHost}) = _$_BannedPerson;
+      required final String instanceHost}) = _$BannedPersonImpl;
   const _BannedPerson._() : super._();
 
   factory _BannedPerson.fromJson(Map<String, dynamic> json) =
-      _$_BannedPerson.fromJson;
+      _$BannedPersonImpl.fromJson;
 
   @override
   PersonViewSafe get personView;
@@ -3778,7 +3785,7 @@ abstract class _BannedPerson extends BannedPerson {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_BannedPersonCopyWith<_$_BannedPerson> get copyWith =>
+  _$$BannedPersonImplCopyWith<_$BannedPersonImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3914,11 +3921,12 @@ class _$ResolveObjectResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ResolveObjectResponseCopyWith<$Res>
+abstract class _$$ResolveObjectResponseImplCopyWith<$Res>
     implements $ResolveObjectResponseCopyWith<$Res> {
-  factory _$$_ResolveObjectResponseCopyWith(_$_ResolveObjectResponse value,
-          $Res Function(_$_ResolveObjectResponse) then) =
-      __$$_ResolveObjectResponseCopyWithImpl<$Res>;
+  factory _$$ResolveObjectResponseImplCopyWith(
+          _$ResolveObjectResponseImpl value,
+          $Res Function(_$ResolveObjectResponseImpl) then) =
+      __$$ResolveObjectResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3939,11 +3947,12 @@ abstract class _$$_ResolveObjectResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ResolveObjectResponseCopyWithImpl<$Res>
-    extends _$ResolveObjectResponseCopyWithImpl<$Res, _$_ResolveObjectResponse>
-    implements _$$_ResolveObjectResponseCopyWith<$Res> {
-  __$$_ResolveObjectResponseCopyWithImpl(_$_ResolveObjectResponse _value,
-      $Res Function(_$_ResolveObjectResponse) _then)
+class __$$ResolveObjectResponseImplCopyWithImpl<$Res>
+    extends _$ResolveObjectResponseCopyWithImpl<$Res,
+        _$ResolveObjectResponseImpl>
+    implements _$$ResolveObjectResponseImplCopyWith<$Res> {
+  __$$ResolveObjectResponseImplCopyWithImpl(_$ResolveObjectResponseImpl _value,
+      $Res Function(_$ResolveObjectResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3955,7 +3964,7 @@ class __$$_ResolveObjectResponseCopyWithImpl<$Res>
     Object? person = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ResolveObjectResponse(
+    return _then(_$ResolveObjectResponseImpl(
       comment: freezed == comment
           ? _value.comment
           : comment // ignore: cast_nullable_to_non_nullable
@@ -3983,8 +3992,8 @@ class __$$_ResolveObjectResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ResolveObjectResponse extends _ResolveObjectResponse {
-  const _$_ResolveObjectResponse(
+class _$ResolveObjectResponseImpl extends _ResolveObjectResponse {
+  const _$ResolveObjectResponseImpl(
       {this.comment,
       this.post,
       this.community,
@@ -3992,8 +4001,8 @@ class _$_ResolveObjectResponse extends _ResolveObjectResponse {
       required this.instanceHost})
       : super._();
 
-  factory _$_ResolveObjectResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_ResolveObjectResponseFromJson(json);
+  factory _$ResolveObjectResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ResolveObjectResponseImplFromJson(json);
 
   @override
   final CommentView? comment;
@@ -4015,7 +4024,7 @@ class _$_ResolveObjectResponse extends _ResolveObjectResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ResolveObjectResponse &&
+            other is _$ResolveObjectResponseImpl &&
             (identical(other.comment, comment) || other.comment == comment) &&
             (identical(other.post, post) || other.post == post) &&
             (identical(other.community, community) ||
@@ -4033,13 +4042,13 @@ class _$_ResolveObjectResponse extends _ResolveObjectResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ResolveObjectResponseCopyWith<_$_ResolveObjectResponse> get copyWith =>
-      __$$_ResolveObjectResponseCopyWithImpl<_$_ResolveObjectResponse>(
-          this, _$identity);
+  _$$ResolveObjectResponseImplCopyWith<_$ResolveObjectResponseImpl>
+      get copyWith => __$$ResolveObjectResponseImplCopyWithImpl<
+          _$ResolveObjectResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ResolveObjectResponseToJson(
+    return _$$ResolveObjectResponseImplToJson(
       this,
     );
   }
@@ -4051,11 +4060,11 @@ abstract class _ResolveObjectResponse extends ResolveObjectResponse {
       final PostView? post,
       final CommunityView? community,
       final PersonViewSafe? person,
-      required final String instanceHost}) = _$_ResolveObjectResponse;
+      required final String instanceHost}) = _$ResolveObjectResponseImpl;
   const _ResolveObjectResponse._() : super._();
 
   factory _ResolveObjectResponse.fromJson(Map<String, dynamic> json) =
-      _$_ResolveObjectResponse.fromJson;
+      _$ResolveObjectResponseImpl.fromJson;
 
   @override
   CommentView? get comment;
@@ -4069,8 +4078,8 @@ abstract class _ResolveObjectResponse extends ResolveObjectResponse {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ResolveObjectResponseCopyWith<_$_ResolveObjectResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ResolveObjectResponseImplCopyWith<_$ResolveObjectResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 SiteMetadata _$SiteMetadataFromJson(Map<String, dynamic> json) {
@@ -4150,11 +4159,11 @@ class _$SiteMetadataCopyWithImpl<$Res, $Val extends SiteMetadata>
 }
 
 /// @nodoc
-abstract class _$$_SiteMetadataCopyWith<$Res>
+abstract class _$$SiteMetadataImplCopyWith<$Res>
     implements $SiteMetadataCopyWith<$Res> {
-  factory _$$_SiteMetadataCopyWith(
-          _$_SiteMetadata value, $Res Function(_$_SiteMetadata) then) =
-      __$$_SiteMetadataCopyWithImpl<$Res>;
+  factory _$$SiteMetadataImplCopyWith(
+          _$SiteMetadataImpl value, $Res Function(_$SiteMetadataImpl) then) =
+      __$$SiteMetadataImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4166,11 +4175,11 @@ abstract class _$$_SiteMetadataCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_SiteMetadataCopyWithImpl<$Res>
-    extends _$SiteMetadataCopyWithImpl<$Res, _$_SiteMetadata>
-    implements _$$_SiteMetadataCopyWith<$Res> {
-  __$$_SiteMetadataCopyWithImpl(
-      _$_SiteMetadata _value, $Res Function(_$_SiteMetadata) _then)
+class __$$SiteMetadataImplCopyWithImpl<$Res>
+    extends _$SiteMetadataCopyWithImpl<$Res, _$SiteMetadataImpl>
+    implements _$$SiteMetadataImplCopyWith<$Res> {
+  __$$SiteMetadataImplCopyWithImpl(
+      _$SiteMetadataImpl _value, $Res Function(_$SiteMetadataImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4182,7 +4191,7 @@ class __$$_SiteMetadataCopyWithImpl<$Res>
     Object? html = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_SiteMetadata(
+    return _then(_$SiteMetadataImpl(
       title: freezed == title
           ? _value.title
           : title // ignore: cast_nullable_to_non_nullable
@@ -4210,8 +4219,8 @@ class __$$_SiteMetadataCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_SiteMetadata extends _SiteMetadata {
-  const _$_SiteMetadata(
+class _$SiteMetadataImpl extends _SiteMetadata {
+  const _$SiteMetadataImpl(
       {this.title,
       this.description,
       this.image,
@@ -4219,8 +4228,8 @@ class _$_SiteMetadata extends _SiteMetadata {
       required this.instanceHost})
       : super._();
 
-  factory _$_SiteMetadata.fromJson(Map<String, dynamic> json) =>
-      _$$_SiteMetadataFromJson(json);
+  factory _$SiteMetadataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SiteMetadataImplFromJson(json);
 
   @override
   final String? title;
@@ -4242,7 +4251,7 @@ class _$_SiteMetadata extends _SiteMetadata {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SiteMetadata &&
+            other is _$SiteMetadataImpl &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.description, description) ||
                 other.description == description) &&
@@ -4260,12 +4269,12 @@ class _$_SiteMetadata extends _SiteMetadata {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SiteMetadataCopyWith<_$_SiteMetadata> get copyWith =>
-      __$$_SiteMetadataCopyWithImpl<_$_SiteMetadata>(this, _$identity);
+  _$$SiteMetadataImplCopyWith<_$SiteMetadataImpl> get copyWith =>
+      __$$SiteMetadataImplCopyWithImpl<_$SiteMetadataImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SiteMetadataToJson(
+    return _$$SiteMetadataImplToJson(
       this,
     );
   }
@@ -4277,11 +4286,11 @@ abstract class _SiteMetadata extends SiteMetadata {
       final String? description,
       final String? image,
       final String? html,
-      required final String instanceHost}) = _$_SiteMetadata;
+      required final String instanceHost}) = _$SiteMetadataImpl;
   const _SiteMetadata._() : super._();
 
   factory _SiteMetadata.fromJson(Map<String, dynamic> json) =
-      _$_SiteMetadata.fromJson;
+      _$SiteMetadataImpl.fromJson;
 
   @override
   String? get title;
@@ -4295,7 +4304,7 @@ abstract class _SiteMetadata extends SiteMetadata {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_SiteMetadataCopyWith<_$_SiteMetadata> get copyWith =>
+  _$$SiteMetadataImplCopyWith<_$SiteMetadataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4369,11 +4378,11 @@ class _$BlockedPersonCopyWithImpl<$Res, $Val extends BlockedPerson>
 }
 
 /// @nodoc
-abstract class _$$_BlockedPersonCopyWith<$Res>
+abstract class _$$BlockedPersonImplCopyWith<$Res>
     implements $BlockedPersonCopyWith<$Res> {
-  factory _$$_BlockedPersonCopyWith(
-          _$_BlockedPerson value, $Res Function(_$_BlockedPerson) then) =
-      __$$_BlockedPersonCopyWithImpl<$Res>;
+  factory _$$BlockedPersonImplCopyWith(
+          _$BlockedPersonImpl value, $Res Function(_$BlockedPersonImpl) then) =
+      __$$BlockedPersonImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonViewSafe personView, bool blocked, String instanceHost});
@@ -4383,11 +4392,11 @@ abstract class _$$_BlockedPersonCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_BlockedPersonCopyWithImpl<$Res>
-    extends _$BlockedPersonCopyWithImpl<$Res, _$_BlockedPerson>
-    implements _$$_BlockedPersonCopyWith<$Res> {
-  __$$_BlockedPersonCopyWithImpl(
-      _$_BlockedPerson _value, $Res Function(_$_BlockedPerson) _then)
+class __$$BlockedPersonImplCopyWithImpl<$Res>
+    extends _$BlockedPersonCopyWithImpl<$Res, _$BlockedPersonImpl>
+    implements _$$BlockedPersonImplCopyWith<$Res> {
+  __$$BlockedPersonImplCopyWithImpl(
+      _$BlockedPersonImpl _value, $Res Function(_$BlockedPersonImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4397,7 +4406,7 @@ class __$$_BlockedPersonCopyWithImpl<$Res>
     Object? blocked = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_BlockedPerson(
+    return _then(_$BlockedPersonImpl(
       personView: null == personView
           ? _value.personView
           : personView // ignore: cast_nullable_to_non_nullable
@@ -4417,15 +4426,15 @@ class __$$_BlockedPersonCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_BlockedPerson extends _BlockedPerson {
-  const _$_BlockedPerson(
+class _$BlockedPersonImpl extends _BlockedPerson {
+  const _$BlockedPersonImpl(
       {required this.personView,
       required this.blocked,
       required this.instanceHost})
       : super._();
 
-  factory _$_BlockedPerson.fromJson(Map<String, dynamic> json) =>
-      _$$_BlockedPersonFromJson(json);
+  factory _$BlockedPersonImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BlockedPersonImplFromJson(json);
 
   @override
   final PersonViewSafe personView;
@@ -4443,7 +4452,7 @@ class _$_BlockedPerson extends _BlockedPerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BlockedPerson &&
+            other is _$BlockedPersonImpl &&
             (identical(other.personView, personView) ||
                 other.personView == personView) &&
             (identical(other.blocked, blocked) || other.blocked == blocked) &&
@@ -4459,12 +4468,12 @@ class _$_BlockedPerson extends _BlockedPerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BlockedPersonCopyWith<_$_BlockedPerson> get copyWith =>
-      __$$_BlockedPersonCopyWithImpl<_$_BlockedPerson>(this, _$identity);
+  _$$BlockedPersonImplCopyWith<_$BlockedPersonImpl> get copyWith =>
+      __$$BlockedPersonImplCopyWithImpl<_$BlockedPersonImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BlockedPersonToJson(
+    return _$$BlockedPersonImplToJson(
       this,
     );
   }
@@ -4474,11 +4483,11 @@ abstract class _BlockedPerson extends BlockedPerson {
   const factory _BlockedPerson(
       {required final PersonViewSafe personView,
       required final bool blocked,
-      required final String instanceHost}) = _$_BlockedPerson;
+      required final String instanceHost}) = _$BlockedPersonImpl;
   const _BlockedPerson._() : super._();
 
   factory _BlockedPerson.fromJson(Map<String, dynamic> json) =
-      _$_BlockedPerson.fromJson;
+      _$BlockedPersonImpl.fromJson;
 
   @override
   PersonViewSafe get personView;
@@ -4488,7 +4497,7 @@ abstract class _BlockedPerson extends BlockedPerson {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_BlockedPersonCopyWith<_$_BlockedPerson> get copyWith =>
+  _$$BlockedPersonImplCopyWith<_$BlockedPersonImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4562,11 +4571,11 @@ class _$BlockedCommunityCopyWithImpl<$Res, $Val extends BlockedCommunity>
 }
 
 /// @nodoc
-abstract class _$$_BlockedCommunityCopyWith<$Res>
+abstract class _$$BlockedCommunityImplCopyWith<$Res>
     implements $BlockedCommunityCopyWith<$Res> {
-  factory _$$_BlockedCommunityCopyWith(
-          _$_BlockedCommunity value, $Res Function(_$_BlockedCommunity) then) =
-      __$$_BlockedCommunityCopyWithImpl<$Res>;
+  factory _$$BlockedCommunityImplCopyWith(_$BlockedCommunityImpl value,
+          $Res Function(_$BlockedCommunityImpl) then) =
+      __$$BlockedCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CommunityView communityView, bool blocked, String instanceHost});
@@ -4576,11 +4585,11 @@ abstract class _$$_BlockedCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_BlockedCommunityCopyWithImpl<$Res>
-    extends _$BlockedCommunityCopyWithImpl<$Res, _$_BlockedCommunity>
-    implements _$$_BlockedCommunityCopyWith<$Res> {
-  __$$_BlockedCommunityCopyWithImpl(
-      _$_BlockedCommunity _value, $Res Function(_$_BlockedCommunity) _then)
+class __$$BlockedCommunityImplCopyWithImpl<$Res>
+    extends _$BlockedCommunityCopyWithImpl<$Res, _$BlockedCommunityImpl>
+    implements _$$BlockedCommunityImplCopyWith<$Res> {
+  __$$BlockedCommunityImplCopyWithImpl(_$BlockedCommunityImpl _value,
+      $Res Function(_$BlockedCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4590,7 +4599,7 @@ class __$$_BlockedCommunityCopyWithImpl<$Res>
     Object? blocked = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_BlockedCommunity(
+    return _then(_$BlockedCommunityImpl(
       communityView: null == communityView
           ? _value.communityView
           : communityView // ignore: cast_nullable_to_non_nullable
@@ -4610,15 +4619,15 @@ class __$$_BlockedCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_BlockedCommunity extends _BlockedCommunity {
-  const _$_BlockedCommunity(
+class _$BlockedCommunityImpl extends _BlockedCommunity {
+  const _$BlockedCommunityImpl(
       {required this.communityView,
       required this.blocked,
       required this.instanceHost})
       : super._();
 
-  factory _$_BlockedCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_BlockedCommunityFromJson(json);
+  factory _$BlockedCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BlockedCommunityImplFromJson(json);
 
   @override
   final CommunityView communityView;
@@ -4636,7 +4645,7 @@ class _$_BlockedCommunity extends _BlockedCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BlockedCommunity &&
+            other is _$BlockedCommunityImpl &&
             (identical(other.communityView, communityView) ||
                 other.communityView == communityView) &&
             (identical(other.blocked, blocked) || other.blocked == blocked) &&
@@ -4652,12 +4661,13 @@ class _$_BlockedCommunity extends _BlockedCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BlockedCommunityCopyWith<_$_BlockedCommunity> get copyWith =>
-      __$$_BlockedCommunityCopyWithImpl<_$_BlockedCommunity>(this, _$identity);
+  _$$BlockedCommunityImplCopyWith<_$BlockedCommunityImpl> get copyWith =>
+      __$$BlockedCommunityImplCopyWithImpl<_$BlockedCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BlockedCommunityToJson(
+    return _$$BlockedCommunityImplToJson(
       this,
     );
   }
@@ -4667,11 +4677,11 @@ abstract class _BlockedCommunity extends BlockedCommunity {
   const factory _BlockedCommunity(
       {required final CommunityView communityView,
       required final bool blocked,
-      required final String instanceHost}) = _$_BlockedCommunity;
+      required final String instanceHost}) = _$BlockedCommunityImpl;
   const _BlockedCommunity._() : super._();
 
   factory _BlockedCommunity.fromJson(Map<String, dynamic> json) =
-      _$_BlockedCommunity.fromJson;
+      _$BlockedCommunityImpl.fromJson;
 
   @override
   CommunityView get communityView;
@@ -4681,7 +4691,7 @@ abstract class _BlockedCommunity extends BlockedCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_BlockedCommunityCopyWith<_$_BlockedCommunity> get copyWith =>
+  _$$BlockedCommunityImplCopyWith<_$BlockedCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4755,11 +4765,11 @@ class _$ReportCountCopyWithImpl<$Res, $Val extends ReportCount>
 }
 
 /// @nodoc
-abstract class _$$_ReportCountCopyWith<$Res>
+abstract class _$$ReportCountImplCopyWith<$Res>
     implements $ReportCountCopyWith<$Res> {
-  factory _$$_ReportCountCopyWith(
-          _$_ReportCount value, $Res Function(_$_ReportCount) then) =
-      __$$_ReportCountCopyWithImpl<$Res>;
+  factory _$$ReportCountImplCopyWith(
+          _$ReportCountImpl value, $Res Function(_$ReportCountImpl) then) =
+      __$$ReportCountImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4770,11 +4780,11 @@ abstract class _$$_ReportCountCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ReportCountCopyWithImpl<$Res>
-    extends _$ReportCountCopyWithImpl<$Res, _$_ReportCount>
-    implements _$$_ReportCountCopyWith<$Res> {
-  __$$_ReportCountCopyWithImpl(
-      _$_ReportCount _value, $Res Function(_$_ReportCount) _then)
+class __$$ReportCountImplCopyWithImpl<$Res>
+    extends _$ReportCountCopyWithImpl<$Res, _$ReportCountImpl>
+    implements _$$ReportCountImplCopyWith<$Res> {
+  __$$ReportCountImplCopyWithImpl(
+      _$ReportCountImpl _value, $Res Function(_$ReportCountImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4785,7 +4795,7 @@ class __$$_ReportCountCopyWithImpl<$Res>
     Object? postReports = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ReportCount(
+    return _then(_$ReportCountImpl(
       communityId: freezed == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -4809,16 +4819,16 @@ class __$$_ReportCountCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ReportCount extends _ReportCount {
-  const _$_ReportCount(
+class _$ReportCountImpl extends _ReportCount {
+  const _$ReportCountImpl(
       {this.communityId,
       required this.commentReports,
       required this.postReports,
       required this.instanceHost})
       : super._();
 
-  factory _$_ReportCount.fromJson(Map<String, dynamic> json) =>
-      _$$_ReportCountFromJson(json);
+  factory _$ReportCountImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ReportCountImplFromJson(json);
 
   @override
   final int? communityId;
@@ -4838,7 +4848,7 @@ class _$_ReportCount extends _ReportCount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ReportCount &&
+            other is _$ReportCountImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.commentReports, commentReports) ||
@@ -4857,12 +4867,12 @@ class _$_ReportCount extends _ReportCount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ReportCountCopyWith<_$_ReportCount> get copyWith =>
-      __$$_ReportCountCopyWithImpl<_$_ReportCount>(this, _$identity);
+  _$$ReportCountImplCopyWith<_$ReportCountImpl> get copyWith =>
+      __$$ReportCountImplCopyWithImpl<_$ReportCountImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ReportCountToJson(
+    return _$$ReportCountImplToJson(
       this,
     );
   }
@@ -4873,11 +4883,11 @@ abstract class _ReportCount extends ReportCount {
       {final int? communityId,
       required final int commentReports,
       required final int postReports,
-      required final String instanceHost}) = _$_ReportCount;
+      required final String instanceHost}) = _$ReportCountImpl;
   const _ReportCount._() : super._();
 
   factory _ReportCount.fromJson(Map<String, dynamic> json) =
-      _$_ReportCount.fromJson;
+      _$ReportCountImpl.fromJson;
 
   @override
   int? get communityId;
@@ -4889,7 +4899,7 @@ abstract class _ReportCount extends ReportCount {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ReportCountCopyWith<_$_ReportCount> get copyWith =>
+  _$$ReportCountImplCopyWith<_$ReportCountImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4960,11 +4970,11 @@ class _$UnreadCountCopyWithImpl<$Res, $Val extends UnreadCount>
 }
 
 /// @nodoc
-abstract class _$$_UnreadCountCopyWith<$Res>
+abstract class _$$UnreadCountImplCopyWith<$Res>
     implements $UnreadCountCopyWith<$Res> {
-  factory _$$_UnreadCountCopyWith(
-          _$_UnreadCount value, $Res Function(_$_UnreadCount) then) =
-      __$$_UnreadCountCopyWithImpl<$Res>;
+  factory _$$UnreadCountImplCopyWith(
+          _$UnreadCountImpl value, $Res Function(_$UnreadCountImpl) then) =
+      __$$UnreadCountImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4972,11 +4982,11 @@ abstract class _$$_UnreadCountCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_UnreadCountCopyWithImpl<$Res>
-    extends _$UnreadCountCopyWithImpl<$Res, _$_UnreadCount>
-    implements _$$_UnreadCountCopyWith<$Res> {
-  __$$_UnreadCountCopyWithImpl(
-      _$_UnreadCount _value, $Res Function(_$_UnreadCount) _then)
+class __$$UnreadCountImplCopyWithImpl<$Res>
+    extends _$UnreadCountCopyWithImpl<$Res, _$UnreadCountImpl>
+    implements _$$UnreadCountImplCopyWith<$Res> {
+  __$$UnreadCountImplCopyWithImpl(
+      _$UnreadCountImpl _value, $Res Function(_$UnreadCountImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4987,7 +4997,7 @@ class __$$_UnreadCountCopyWithImpl<$Res>
     Object? privateMessages = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_UnreadCount(
+    return _then(_$UnreadCountImpl(
       replies: null == replies
           ? _value.replies
           : replies // ignore: cast_nullable_to_non_nullable
@@ -5011,16 +5021,16 @@ class __$$_UnreadCountCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_UnreadCount extends _UnreadCount {
-  const _$_UnreadCount(
+class _$UnreadCountImpl extends _UnreadCount {
+  const _$UnreadCountImpl(
       {required this.replies,
       required this.mentions,
       required this.privateMessages,
       required this.instanceHost})
       : super._();
 
-  factory _$_UnreadCount.fromJson(Map<String, dynamic> json) =>
-      _$$_UnreadCountFromJson(json);
+  factory _$UnreadCountImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UnreadCountImplFromJson(json);
 
   @override
   final int replies;
@@ -5040,7 +5050,7 @@ class _$_UnreadCount extends _UnreadCount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_UnreadCount &&
+            other is _$UnreadCountImpl &&
             (identical(other.replies, replies) || other.replies == replies) &&
             (identical(other.mentions, mentions) ||
                 other.mentions == mentions) &&
@@ -5058,12 +5068,12 @@ class _$_UnreadCount extends _UnreadCount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_UnreadCountCopyWith<_$_UnreadCount> get copyWith =>
-      __$$_UnreadCountCopyWithImpl<_$_UnreadCount>(this, _$identity);
+  _$$UnreadCountImplCopyWith<_$UnreadCountImpl> get copyWith =>
+      __$$UnreadCountImplCopyWithImpl<_$UnreadCountImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_UnreadCountToJson(
+    return _$$UnreadCountImplToJson(
       this,
     );
   }
@@ -5074,11 +5084,11 @@ abstract class _UnreadCount extends UnreadCount {
       {required final int replies,
       required final int mentions,
       required final int privateMessages,
-      required final String instanceHost}) = _$_UnreadCount;
+      required final String instanceHost}) = _$UnreadCountImpl;
   const _UnreadCount._() : super._();
 
   factory _UnreadCount.fromJson(Map<String, dynamic> json) =
-      _$_UnreadCount.fromJson;
+      _$UnreadCountImpl.fromJson;
 
   @override
   int get replies;
@@ -5090,7 +5100,7 @@ abstract class _UnreadCount extends UnreadCount {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_UnreadCountCopyWith<_$_UnreadCount> get copyWith =>
+  _$$UnreadCountImplCopyWith<_$UnreadCountImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5164,11 +5174,11 @@ class _$LoginResponseCopyWithImpl<$Res, $Val extends LoginResponse>
 }
 
 /// @nodoc
-abstract class _$$_LoginResponseCopyWith<$Res>
+abstract class _$$LoginResponseImplCopyWith<$Res>
     implements $LoginResponseCopyWith<$Res> {
-  factory _$$_LoginResponseCopyWith(
-          _$_LoginResponse value, $Res Function(_$_LoginResponse) then) =
-      __$$_LoginResponseCopyWithImpl<$Res>;
+  factory _$$LoginResponseImplCopyWith(
+          _$LoginResponseImpl value, $Res Function(_$LoginResponseImpl) then) =
+      __$$LoginResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5179,11 +5189,11 @@ abstract class _$$_LoginResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_LoginResponseCopyWithImpl<$Res>
-    extends _$LoginResponseCopyWithImpl<$Res, _$_LoginResponse>
-    implements _$$_LoginResponseCopyWith<$Res> {
-  __$$_LoginResponseCopyWithImpl(
-      _$_LoginResponse _value, $Res Function(_$_LoginResponse) _then)
+class __$$LoginResponseImplCopyWithImpl<$Res>
+    extends _$LoginResponseCopyWithImpl<$Res, _$LoginResponseImpl>
+    implements _$$LoginResponseImplCopyWith<$Res> {
+  __$$LoginResponseImplCopyWithImpl(
+      _$LoginResponseImpl _value, $Res Function(_$LoginResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5194,7 +5204,7 @@ class __$$_LoginResponseCopyWithImpl<$Res>
     Object? registrationCreated = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_LoginResponse(
+    return _then(_$LoginResponseImpl(
       jwt: freezed == jwt
           ? _value.jwt
           : jwt // ignore: cast_nullable_to_non_nullable
@@ -5218,16 +5228,16 @@ class __$$_LoginResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_LoginResponse extends _LoginResponse {
-  const _$_LoginResponse(
+class _$LoginResponseImpl extends _LoginResponse {
+  const _$LoginResponseImpl(
       {this.jwt,
       required this.verifyEmailSent,
       required this.registrationCreated,
       required this.instanceHost})
       : super._();
 
-  factory _$_LoginResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_LoginResponseFromJson(json);
+  factory _$LoginResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LoginResponseImplFromJson(json);
 
   @override
   final Jwt? jwt;
@@ -5247,7 +5257,7 @@ class _$_LoginResponse extends _LoginResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LoginResponse &&
+            other is _$LoginResponseImpl &&
             (identical(other.jwt, jwt) || other.jwt == jwt) &&
             (identical(other.verifyEmailSent, verifyEmailSent) ||
                 other.verifyEmailSent == verifyEmailSent) &&
@@ -5265,12 +5275,12 @@ class _$_LoginResponse extends _LoginResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LoginResponseCopyWith<_$_LoginResponse> get copyWith =>
-      __$$_LoginResponseCopyWithImpl<_$_LoginResponse>(this, _$identity);
+  _$$LoginResponseImplCopyWith<_$LoginResponseImpl> get copyWith =>
+      __$$LoginResponseImplCopyWithImpl<_$LoginResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LoginResponseToJson(
+    return _$$LoginResponseImplToJson(
       this,
     );
   }
@@ -5281,11 +5291,11 @@ abstract class _LoginResponse extends LoginResponse {
       {final Jwt? jwt,
       required final bool verifyEmailSent,
       required final bool registrationCreated,
-      required final String instanceHost}) = _$_LoginResponse;
+      required final String instanceHost}) = _$LoginResponseImpl;
   const _LoginResponse._() : super._();
 
   factory _LoginResponse.fromJson(Map<String, dynamic> json) =
-      _$_LoginResponse.fromJson;
+      _$LoginResponseImpl.fromJson;
 
   @override
   Jwt? get jwt;
@@ -5297,7 +5307,7 @@ abstract class _LoginResponse extends LoginResponse {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_LoginResponseCopyWith<_$_LoginResponse> get copyWith =>
+  _$$LoginResponseImplCopyWith<_$LoginResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5351,22 +5361,24 @@ class _$BlockInstanceResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_BlockInstanceResponseCopyWith<$Res>
+abstract class _$$BlockInstanceResponseImplCopyWith<$Res>
     implements $BlockInstanceResponseCopyWith<$Res> {
-  factory _$$_BlockInstanceResponseCopyWith(_$_BlockInstanceResponse value,
-          $Res Function(_$_BlockInstanceResponse) then) =
-      __$$_BlockInstanceResponseCopyWithImpl<$Res>;
+  factory _$$BlockInstanceResponseImplCopyWith(
+          _$BlockInstanceResponseImpl value,
+          $Res Function(_$BlockInstanceResponseImpl) then) =
+      __$$BlockInstanceResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool blocked});
 }
 
 /// @nodoc
-class __$$_BlockInstanceResponseCopyWithImpl<$Res>
-    extends _$BlockInstanceResponseCopyWithImpl<$Res, _$_BlockInstanceResponse>
-    implements _$$_BlockInstanceResponseCopyWith<$Res> {
-  __$$_BlockInstanceResponseCopyWithImpl(_$_BlockInstanceResponse _value,
-      $Res Function(_$_BlockInstanceResponse) _then)
+class __$$BlockInstanceResponseImplCopyWithImpl<$Res>
+    extends _$BlockInstanceResponseCopyWithImpl<$Res,
+        _$BlockInstanceResponseImpl>
+    implements _$$BlockInstanceResponseImplCopyWith<$Res> {
+  __$$BlockInstanceResponseImplCopyWithImpl(_$BlockInstanceResponseImpl _value,
+      $Res Function(_$BlockInstanceResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5374,7 +5386,7 @@ class __$$_BlockInstanceResponseCopyWithImpl<$Res>
   $Res call({
     Object? blocked = null,
   }) {
-    return _then(_$_BlockInstanceResponse(
+    return _then(_$BlockInstanceResponseImpl(
       blocked: null == blocked
           ? _value.blocked
           : blocked // ignore: cast_nullable_to_non_nullable
@@ -5386,11 +5398,11 @@ class __$$_BlockInstanceResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_BlockInstanceResponse extends _BlockInstanceResponse {
-  const _$_BlockInstanceResponse({required this.blocked}) : super._();
+class _$BlockInstanceResponseImpl extends _BlockInstanceResponse {
+  const _$BlockInstanceResponseImpl({required this.blocked}) : super._();
 
-  factory _$_BlockInstanceResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_BlockInstanceResponseFromJson(json);
+  factory _$BlockInstanceResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BlockInstanceResponseImplFromJson(json);
 
   @override
   final bool blocked;
@@ -5404,7 +5416,7 @@ class _$_BlockInstanceResponse extends _BlockInstanceResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BlockInstanceResponse &&
+            other is _$BlockInstanceResponseImpl &&
             (identical(other.blocked, blocked) || other.blocked == blocked));
   }
 
@@ -5415,13 +5427,13 @@ class _$_BlockInstanceResponse extends _BlockInstanceResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BlockInstanceResponseCopyWith<_$_BlockInstanceResponse> get copyWith =>
-      __$$_BlockInstanceResponseCopyWithImpl<_$_BlockInstanceResponse>(
-          this, _$identity);
+  _$$BlockInstanceResponseImplCopyWith<_$BlockInstanceResponseImpl>
+      get copyWith => __$$BlockInstanceResponseImplCopyWithImpl<
+          _$BlockInstanceResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BlockInstanceResponseToJson(
+    return _$$BlockInstanceResponseImplToJson(
       this,
     );
   }
@@ -5429,16 +5441,16 @@ class _$_BlockInstanceResponse extends _BlockInstanceResponse {
 
 abstract class _BlockInstanceResponse extends BlockInstanceResponse {
   const factory _BlockInstanceResponse({required final bool blocked}) =
-      _$_BlockInstanceResponse;
+      _$BlockInstanceResponseImpl;
   const _BlockInstanceResponse._() : super._();
 
   factory _BlockInstanceResponse.fromJson(Map<String, dynamic> json) =
-      _$_BlockInstanceResponse.fromJson;
+      _$BlockInstanceResponseImpl.fromJson;
 
   @override
   bool get blocked;
   @override
   @JsonKey(ignore: true)
-  _$$_BlockInstanceResponseCopyWith<_$_BlockInstanceResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$BlockInstanceResponseImplCopyWith<_$BlockInstanceResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/api.g.dart
+++ b/lib/src/v3/models/api.g.dart
@@ -6,8 +6,9 @@ part of 'api.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_FullCommunityView _$$_FullCommunityViewFromJson(Map<String, dynamic> json) =>
-    _$_FullCommunityView(
+_$FullCommunityViewImpl _$$FullCommunityViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$FullCommunityViewImpl(
       communityView: CommunityView.fromJson(
           json['community_view'] as Map<String, dynamic>),
       site: json['site'] == null
@@ -21,8 +22,8 @@ _$_FullCommunityView _$$_FullCommunityViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_FullCommunityViewToJson(
-        _$_FullCommunityView instance) =>
+Map<String, dynamic> _$$FullCommunityViewImplToJson(
+        _$FullCommunityViewImpl instance) =>
     <String, dynamic>{
       'community_view': instance.communityView.toJson(),
       'site': instance.site?.toJson(),
@@ -31,8 +32,8 @@ Map<String, dynamic> _$$_FullCommunityViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_FullPostView _$$_FullPostViewFromJson(Map<String, dynamic> json) =>
-    _$_FullPostView(
+_$FullPostViewImpl _$$FullPostViewImplFromJson(Map<String, dynamic> json) =>
+    _$FullPostViewImpl(
       postView: PostView.fromJson(json['post_view'] as Map<String, dynamic>),
       communityView: CommunityView.fromJson(
           json['community_view'] as Map<String, dynamic>),
@@ -44,7 +45,7 @@ _$_FullPostView _$$_FullPostViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_FullPostViewToJson(_$_FullPostView instance) =>
+Map<String, dynamic> _$$FullPostViewImplToJson(_$FullPostViewImpl instance) =>
     <String, dynamic>{
       'post_view': instance.postView.toJson(),
       'community_view': instance.communityView.toJson(),
@@ -53,8 +54,8 @@ Map<String, dynamic> _$$_FullPostViewToJson(_$_FullPostView instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_SearchResults _$$_SearchResultsFromJson(Map<String, dynamic> json) =>
-    _$_SearchResults(
+_$SearchResultsImpl _$$SearchResultsImplFromJson(Map<String, dynamic> json) =>
+    _$SearchResultsImpl(
       type: SearchType.fromJson(json['type_'] as String),
       comments: (json['comments'] as List<dynamic>)
           .map((e) => CommentView.fromJson(e as Map<String, dynamic>))
@@ -71,7 +72,7 @@ _$_SearchResults _$$_SearchResultsFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_SearchResultsToJson(_$_SearchResults instance) =>
+Map<String, dynamic> _$$SearchResultsImplToJson(_$SearchResultsImpl instance) =>
     <String, dynamic>{
       'type_': instance.type.toJson(),
       'comments': instance.comments.map((e) => e.toJson()).toList(),
@@ -81,7 +82,7 @@ Map<String, dynamic> _$$_SearchResultsToJson(_$_SearchResults instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_Modlog _$$_ModlogFromJson(Map<String, dynamic> json) => _$_Modlog(
+_$ModlogImpl _$$ModlogImplFromJson(Map<String, dynamic> json) => _$ModlogImpl(
       removedPosts: (json['removed_posts'] as List<dynamic>)
           .map((e) => ModRemovePostView.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -136,7 +137,8 @@ _$_Modlog _$$_ModlogFromJson(Map<String, dynamic> json) => _$_Modlog(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModlogToJson(_$_Modlog instance) => <String, dynamic>{
+Map<String, dynamic> _$$ModlogImplToJson(_$ModlogImpl instance) =>
+    <String, dynamic>{
       'removed_posts': instance.removedPosts.map((e) => e.toJson()).toList(),
       'locked_posts': instance.lockedPosts.map((e) => e.toJson()).toList(),
       'featured_posts': instance.featuredPosts.map((e) => e.toJson()).toList(),
@@ -165,8 +167,9 @@ Map<String, dynamic> _$$_ModlogToJson(_$_Modlog instance) => <String, dynamic>{
       'instance_host': instance.instanceHost,
     };
 
-_$_FullCommentView _$$_FullCommentViewFromJson(Map<String, dynamic> json) =>
-    _$_FullCommentView(
+_$FullCommentViewImpl _$$FullCommentViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$FullCommentViewImpl(
       commentView:
           CommentView.fromJson(json['comment_view'] as Map<String, dynamic>),
       recipientIds: (json['recipient_ids'] as List<dynamic>)
@@ -176,7 +179,8 @@ _$_FullCommentView _$$_FullCommentViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_FullCommentViewToJson(_$_FullCommentView instance) =>
+Map<String, dynamic> _$$FullCommentViewImplToJson(
+        _$FullCommentViewImpl instance) =>
     <String, dynamic>{
       'comment_view': instance.commentView.toJson(),
       'recipient_ids': instance.recipientIds,
@@ -184,23 +188,23 @@ Map<String, dynamic> _$$_FullCommentViewToJson(_$_FullCommentView instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_FullCommentReplyView _$$_FullCommentReplyViewFromJson(
+_$FullCommentReplyViewImpl _$$FullCommentReplyViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_FullCommentReplyView(
+    _$FullCommentReplyViewImpl(
       commentReplyView: CommentReplyView.fromJson(
           json['comment_reply_view'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_FullCommentReplyViewToJson(
-        _$_FullCommentReplyView instance) =>
+Map<String, dynamic> _$$FullCommentReplyViewImplToJson(
+        _$FullCommentReplyViewImpl instance) =>
     <String, dynamic>{
       'comment_reply_view': instance.commentReplyView.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$_FullSiteView _$$_FullSiteViewFromJson(Map<String, dynamic> json) =>
-    _$_FullSiteView(
+_$FullSiteViewImpl _$$FullSiteViewImplFromJson(Map<String, dynamic> json) =>
+    _$FullSiteViewImpl(
       siteView: json['site_view'] == null
           ? null
           : SiteView.fromJson(json['site_view'] as Map<String, dynamic>),
@@ -222,7 +226,7 @@ _$_FullSiteView _$$_FullSiteViewFromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
-Map<String, dynamic> _$$_FullSiteViewToJson(_$_FullSiteView instance) =>
+Map<String, dynamic> _$$FullSiteViewImplToJson(_$FullSiteViewImpl instance) =>
     <String, dynamic>{
       'site_view': instance.siteView?.toJson(),
       'admins': instance.admins.map((e) => e.toJson()).toList(),
@@ -234,7 +238,8 @@ Map<String, dynamic> _$$_FullSiteViewToJson(_$_FullSiteView instance) =>
       'taglines': instance.taglines.map((e) => e.toJson()).toList(),
     };
 
-_$_Tagline _$$_TaglineFromJson(Map<String, dynamic> json) => _$_Tagline(
+_$TaglineImpl _$$TaglineImplFromJson(Map<String, dynamic> json) =>
+    _$TaglineImpl(
       id: json['id'] as int,
       localSiteId: json['local_site_id'] as int,
       content: json['content'] as String,
@@ -244,7 +249,7 @@ _$_Tagline _$$_TaglineFromJson(Map<String, dynamic> json) => _$_Tagline(
           json['updated'], const ForceUtcDateTime().fromJson),
     );
 
-Map<String, dynamic> _$$_TaglineToJson(_$_Tagline instance) =>
+Map<String, dynamic> _$$TaglineImplToJson(_$TaglineImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'local_site_id': instance.localSiteId,
@@ -267,8 +272,8 @@ Json? _$JsonConverterToJson<Json, Value>(
 ) =>
     value == null ? null : toJson(value);
 
-_$_MyUserInfo _$$_MyUserInfoFromJson(Map<String, dynamic> json) =>
-    _$_MyUserInfo(
+_$MyUserInfoImpl _$$MyUserInfoImplFromJson(Map<String, dynamic> json) =>
+    _$MyUserInfoImpl(
       localUserView: LocalUserSettingsView.fromJson(
           json['local_user_view'] as Map<String, dynamic>),
       follows: (json['follows'] as List<dynamic>)
@@ -287,7 +292,7 @@ _$_MyUserInfo _$$_MyUserInfoFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_MyUserInfoToJson(_$_MyUserInfo instance) =>
+Map<String, dynamic> _$$MyUserInfoImplToJson(_$MyUserInfoImpl instance) =>
     <String, dynamic>{
       'local_user_view': instance.localUserView.toJson(),
       'follows': instance.follows.map((e) => e.toJson()).toList(),
@@ -298,9 +303,9 @@ Map<String, dynamic> _$$_MyUserInfoToJson(_$_MyUserInfo instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_FederatedInstances _$$_FederatedInstancesFromJson(
+_$FederatedInstancesImpl _$$FederatedInstancesImplFromJson(
         Map<String, dynamic> json) =>
-    _$_FederatedInstances(
+    _$FederatedInstancesImpl(
       linked:
           (json['linked'] as List<dynamic>).map((e) => e as String).toList(),
       allowed:
@@ -310,8 +315,8 @@ _$_FederatedInstances _$$_FederatedInstancesFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_FederatedInstancesToJson(
-        _$_FederatedInstances instance) =>
+Map<String, dynamic> _$$FederatedInstancesImplToJson(
+        _$FederatedInstancesImpl instance) =>
     <String, dynamic>{
       'linked': instance.linked,
       'allowed': instance.allowed,
@@ -319,21 +324,22 @@ Map<String, dynamic> _$$_FederatedInstancesToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_Captcha _$$_CaptchaFromJson(Map<String, dynamic> json) => _$_Captcha(
+_$CaptchaImpl _$$CaptchaImplFromJson(Map<String, dynamic> json) =>
+    _$CaptchaImpl(
       png: json['png'] as String,
       wav: json['wav'] as String?,
       uuid: json['uuid'] as String,
     );
 
-Map<String, dynamic> _$$_CaptchaToJson(_$_Captcha instance) =>
+Map<String, dynamic> _$$CaptchaImplToJson(_$CaptchaImpl instance) =>
     <String, dynamic>{
       'png': instance.png,
       'wav': instance.wav,
       'uuid': instance.uuid,
     };
 
-_$_FullPersonView _$$_FullPersonViewFromJson(Map<String, dynamic> json) =>
-    _$_FullPersonView(
+_$FullPersonViewImpl _$$FullPersonViewImplFromJson(Map<String, dynamic> json) =>
+    _$FullPersonViewImpl(
       personView:
           PersonViewSafe.fromJson(json['person_view'] as Map<String, dynamic>),
       moderates: (json['moderates'] as List<dynamic>)
@@ -349,7 +355,8 @@ _$_FullPersonView _$$_FullPersonViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_FullPersonViewToJson(_$_FullPersonView instance) =>
+Map<String, dynamic> _$$FullPersonViewImplToJson(
+        _$FullPersonViewImpl instance) =>
     <String, dynamic>{
       'person_view': instance.personView.toJson(),
       'moderates': instance.moderates.map((e) => e.toJson()).toList(),
@@ -358,41 +365,41 @@ Map<String, dynamic> _$$_FullPersonViewToJson(_$_FullPersonView instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_BannedCommunityUser _$$_BannedCommunityUserFromJson(
+_$BannedCommunityUserImpl _$$BannedCommunityUserImplFromJson(
         Map<String, dynamic> json) =>
-    _$_BannedCommunityUser(
+    _$BannedCommunityUserImpl(
       personView:
           PersonViewSafe.fromJson(json['person_view'] as Map<String, dynamic>),
       banned: json['banned'] as bool,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_BannedCommunityUserToJson(
-        _$_BannedCommunityUser instance) =>
+Map<String, dynamic> _$$BannedCommunityUserImplToJson(
+        _$BannedCommunityUserImpl instance) =>
     <String, dynamic>{
       'person_view': instance.personView.toJson(),
       'banned': instance.banned,
       'instance_host': instance.instanceHost,
     };
 
-_$_BannedPerson _$$_BannedPersonFromJson(Map<String, dynamic> json) =>
-    _$_BannedPerson(
+_$BannedPersonImpl _$$BannedPersonImplFromJson(Map<String, dynamic> json) =>
+    _$BannedPersonImpl(
       personView:
           PersonViewSafe.fromJson(json['person_view'] as Map<String, dynamic>),
       banned: json['banned'] as bool,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_BannedPersonToJson(_$_BannedPerson instance) =>
+Map<String, dynamic> _$$BannedPersonImplToJson(_$BannedPersonImpl instance) =>
     <String, dynamic>{
       'person_view': instance.personView.toJson(),
       'banned': instance.banned,
       'instance_host': instance.instanceHost,
     };
 
-_$_ResolveObjectResponse _$$_ResolveObjectResponseFromJson(
+_$ResolveObjectResponseImpl _$$ResolveObjectResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ResolveObjectResponse(
+    _$ResolveObjectResponseImpl(
       comment: json['comment'] == null
           ? null
           : CommentView.fromJson(json['comment'] as Map<String, dynamic>),
@@ -408,8 +415,8 @@ _$_ResolveObjectResponse _$$_ResolveObjectResponseFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ResolveObjectResponseToJson(
-        _$_ResolveObjectResponse instance) =>
+Map<String, dynamic> _$$ResolveObjectResponseImplToJson(
+        _$ResolveObjectResponseImpl instance) =>
     <String, dynamic>{
       'comment': instance.comment?.toJson(),
       'post': instance.post?.toJson(),
@@ -418,8 +425,8 @@ Map<String, dynamic> _$$_ResolveObjectResponseToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_SiteMetadata _$$_SiteMetadataFromJson(Map<String, dynamic> json) =>
-    _$_SiteMetadata(
+_$SiteMetadataImpl _$$SiteMetadataImplFromJson(Map<String, dynamic> json) =>
+    _$SiteMetadataImpl(
       title: json['title'] as String?,
       description: json['description'] as String?,
       image: json['image'] as String?,
@@ -427,7 +434,7 @@ _$_SiteMetadata _$$_SiteMetadataFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_SiteMetadataToJson(_$_SiteMetadata instance) =>
+Map<String, dynamic> _$$SiteMetadataImplToJson(_$SiteMetadataImpl instance) =>
     <String, dynamic>{
       'title': instance.title,
       'description': instance.description,
@@ -436,45 +443,47 @@ Map<String, dynamic> _$$_SiteMetadataToJson(_$_SiteMetadata instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_BlockedPerson _$$_BlockedPersonFromJson(Map<String, dynamic> json) =>
-    _$_BlockedPerson(
+_$BlockedPersonImpl _$$BlockedPersonImplFromJson(Map<String, dynamic> json) =>
+    _$BlockedPersonImpl(
       personView:
           PersonViewSafe.fromJson(json['person_view'] as Map<String, dynamic>),
       blocked: json['blocked'] as bool,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_BlockedPersonToJson(_$_BlockedPerson instance) =>
+Map<String, dynamic> _$$BlockedPersonImplToJson(_$BlockedPersonImpl instance) =>
     <String, dynamic>{
       'person_view': instance.personView.toJson(),
       'blocked': instance.blocked,
       'instance_host': instance.instanceHost,
     };
 
-_$_BlockedCommunity _$$_BlockedCommunityFromJson(Map<String, dynamic> json) =>
-    _$_BlockedCommunity(
+_$BlockedCommunityImpl _$$BlockedCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$BlockedCommunityImpl(
       communityView: CommunityView.fromJson(
           json['community_view'] as Map<String, dynamic>),
       blocked: json['blocked'] as bool,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_BlockedCommunityToJson(_$_BlockedCommunity instance) =>
+Map<String, dynamic> _$$BlockedCommunityImplToJson(
+        _$BlockedCommunityImpl instance) =>
     <String, dynamic>{
       'community_view': instance.communityView.toJson(),
       'blocked': instance.blocked,
       'instance_host': instance.instanceHost,
     };
 
-_$_ReportCount _$$_ReportCountFromJson(Map<String, dynamic> json) =>
-    _$_ReportCount(
+_$ReportCountImpl _$$ReportCountImplFromJson(Map<String, dynamic> json) =>
+    _$ReportCountImpl(
       communityId: json['community_id'] as int?,
       commentReports: json['comment_reports'] as int,
       postReports: json['post_reports'] as int,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ReportCountToJson(_$_ReportCount instance) =>
+Map<String, dynamic> _$$ReportCountImplToJson(_$ReportCountImpl instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'comment_reports': instance.commentReports,
@@ -482,15 +491,15 @@ Map<String, dynamic> _$$_ReportCountToJson(_$_ReportCount instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_UnreadCount _$$_UnreadCountFromJson(Map<String, dynamic> json) =>
-    _$_UnreadCount(
+_$UnreadCountImpl _$$UnreadCountImplFromJson(Map<String, dynamic> json) =>
+    _$UnreadCountImpl(
       replies: json['replies'] as int,
       mentions: json['mentions'] as int,
       privateMessages: json['private_messages'] as int,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_UnreadCountToJson(_$_UnreadCount instance) =>
+Map<String, dynamic> _$$UnreadCountImplToJson(_$UnreadCountImpl instance) =>
     <String, dynamic>{
       'replies': instance.replies,
       'mentions': instance.mentions,
@@ -498,15 +507,15 @@ Map<String, dynamic> _$$_UnreadCountToJson(_$_UnreadCount instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_LoginResponse _$$_LoginResponseFromJson(Map<String, dynamic> json) =>
-    _$_LoginResponse(
+_$LoginResponseImpl _$$LoginResponseImplFromJson(Map<String, dynamic> json) =>
+    _$LoginResponseImpl(
       jwt: json['jwt'] == null ? null : Jwt.fromJson(json['jwt'] as String),
       verifyEmailSent: json['verify_email_sent'] as bool,
       registrationCreated: json['registration_created'] as bool,
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_LoginResponseToJson(_$_LoginResponse instance) =>
+Map<String, dynamic> _$$LoginResponseImplToJson(_$LoginResponseImpl instance) =>
     <String, dynamic>{
       'jwt': instance.jwt?.toJson(),
       'verify_email_sent': instance.verifyEmailSent,
@@ -514,14 +523,14 @@ Map<String, dynamic> _$$_LoginResponseToJson(_$_LoginResponse instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_BlockInstanceResponse _$$_BlockInstanceResponseFromJson(
+_$BlockInstanceResponseImpl _$$BlockInstanceResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_BlockInstanceResponse(
+    _$BlockInstanceResponseImpl(
       blocked: json['blocked'] as bool,
     );
 
-Map<String, dynamic> _$$_BlockInstanceResponseToJson(
-        _$_BlockInstanceResponse instance) =>
+Map<String, dynamic> _$$BlockInstanceResponseImplToJson(
+        _$BlockInstanceResponseImpl instance) =>
     <String, dynamic>{
       'blocked': instance.blocked,
     };

--- a/lib/src/v3/models/source.dart
+++ b/lib/src/v3/models/source.dart
@@ -24,9 +24,7 @@ class PersonSafe with _$PersonSafe {
     String? banner,
     required bool deleted,
     String? matrixUserId,
-
-    /// Removed in Lemmy 0.19
-    bool? admin,
+    @deprecated bool? admin,
     required bool botAccount,
     DateTime? banExpires,
     required String instanceHost,

--- a/lib/src/v3/models/source.freezed.dart
+++ b/lib/src/v3/models/source.freezed.dart
@@ -33,8 +33,7 @@ mixin _$PersonSafe {
   String? get banner => throw _privateConstructorUsedError;
   bool get deleted => throw _privateConstructorUsedError;
   String? get matrixUserId => throw _privateConstructorUsedError;
-
-  /// Removed in Lemmy 0.19
+  @deprecated
   bool? get admin => throw _privateConstructorUsedError;
   bool get botAccount => throw _privateConstructorUsedError;
   DateTime? get banExpires => throw _privateConstructorUsedError;
@@ -66,7 +65,7 @@ abstract class $PersonSafeCopyWith<$Res> {
       String? banner,
       bool deleted,
       String? matrixUserId,
-      bool? admin,
+      @deprecated bool? admin,
       bool botAccount,
       DateTime? banExpires,
       String instanceHost});
@@ -198,7 +197,7 @@ abstract class _$$PersonSafeImplCopyWith<$Res>
       String? banner,
       bool deleted,
       String? matrixUserId,
-      bool? admin,
+      @deprecated bool? admin,
       bool botAccount,
       DateTime? banExpires,
       String instanceHost});
@@ -324,7 +323,7 @@ class _$PersonSafeImpl extends _PersonSafe {
       this.banner,
       required this.deleted,
       this.matrixUserId,
-      this.admin,
+      @deprecated this.admin,
       required this.botAccount,
       this.banExpires,
       required this.instanceHost})
@@ -359,9 +358,8 @@ class _$PersonSafeImpl extends _PersonSafe {
   final bool deleted;
   @override
   final String? matrixUserId;
-
-  /// Removed in Lemmy 0.19
   @override
+  @deprecated
   final bool? admin;
   @override
   final bool botAccount;
@@ -456,7 +454,7 @@ abstract class _PersonSafe extends PersonSafe {
       final String? banner,
       required final bool deleted,
       final String? matrixUserId,
-      final bool? admin,
+      @deprecated final bool? admin,
       required final bool botAccount,
       final DateTime? banExpires,
       required final String instanceHost}) = _$PersonSafeImpl;
@@ -492,8 +490,7 @@ abstract class _PersonSafe extends PersonSafe {
   @override
   String? get matrixUserId;
   @override
-
-  /// Removed in Lemmy 0.19
+  @deprecated
   bool? get admin;
   @override
   bool get botAccount;

--- a/lib/src/v3/models/source.freezed.dart
+++ b/lib/src/v3/models/source.freezed.dart
@@ -177,11 +177,11 @@ class _$PersonSafeCopyWithImpl<$Res, $Val extends PersonSafe>
 }
 
 /// @nodoc
-abstract class _$$_PersonSafeCopyWith<$Res>
+abstract class _$$PersonSafeImplCopyWith<$Res>
     implements $PersonSafeCopyWith<$Res> {
-  factory _$$_PersonSafeCopyWith(
-          _$_PersonSafe value, $Res Function(_$_PersonSafe) then) =
-      __$$_PersonSafeCopyWithImpl<$Res>;
+  factory _$$PersonSafeImplCopyWith(
+          _$PersonSafeImpl value, $Res Function(_$PersonSafeImpl) then) =
+      __$$PersonSafeImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -205,11 +205,11 @@ abstract class _$$_PersonSafeCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PersonSafeCopyWithImpl<$Res>
-    extends _$PersonSafeCopyWithImpl<$Res, _$_PersonSafe>
-    implements _$$_PersonSafeCopyWith<$Res> {
-  __$$_PersonSafeCopyWithImpl(
-      _$_PersonSafe _value, $Res Function(_$_PersonSafe) _then)
+class __$$PersonSafeImplCopyWithImpl<$Res>
+    extends _$PersonSafeCopyWithImpl<$Res, _$PersonSafeImpl>
+    implements _$$PersonSafeImplCopyWith<$Res> {
+  __$$PersonSafeImplCopyWithImpl(
+      _$PersonSafeImpl _value, $Res Function(_$PersonSafeImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -233,7 +233,7 @@ class __$$_PersonSafeCopyWithImpl<$Res>
     Object? banExpires = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_PersonSafe(
+    return _then(_$PersonSafeImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -309,8 +309,8 @@ class __$$_PersonSafeCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PersonSafe extends _PersonSafe {
-  const _$_PersonSafe(
+class _$PersonSafeImpl extends _PersonSafe {
+  const _$PersonSafeImpl(
       {required this.id,
       required this.name,
       this.displayName,
@@ -330,8 +330,8 @@ class _$_PersonSafe extends _PersonSafe {
       required this.instanceHost})
       : super._();
 
-  factory _$_PersonSafe.fromJson(Map<String, dynamic> json) =>
-      _$$_PersonSafeFromJson(json);
+  factory _$PersonSafeImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonSafeImplFromJson(json);
 
   @override
   final int id;
@@ -379,7 +379,7 @@ class _$_PersonSafe extends _PersonSafe {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PersonSafe &&
+            other is _$PersonSafeImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.displayName, displayName) ||
@@ -430,12 +430,12 @@ class _$_PersonSafe extends _PersonSafe {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PersonSafeCopyWith<_$_PersonSafe> get copyWith =>
-      __$$_PersonSafeCopyWithImpl<_$_PersonSafe>(this, _$identity);
+  _$$PersonSafeImplCopyWith<_$PersonSafeImpl> get copyWith =>
+      __$$PersonSafeImplCopyWithImpl<_$PersonSafeImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PersonSafeToJson(
+    return _$$PersonSafeImplToJson(
       this,
     );
   }
@@ -459,11 +459,11 @@ abstract class _PersonSafe extends PersonSafe {
       final bool? admin,
       required final bool botAccount,
       final DateTime? banExpires,
-      required final String instanceHost}) = _$_PersonSafe;
+      required final String instanceHost}) = _$PersonSafeImpl;
   const _PersonSafe._() : super._();
 
   factory _PersonSafe.fromJson(Map<String, dynamic> json) =
-      _$_PersonSafe.fromJson;
+      _$PersonSafeImpl.fromJson;
 
   @override
   int get id;
@@ -503,7 +503,7 @@ abstract class _PersonSafe extends PersonSafe {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PersonSafeCopyWith<_$_PersonSafe> get copyWith =>
+  _$$PersonSafeImplCopyWith<_$PersonSafeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -668,11 +668,11 @@ class _$LocalUserSettingsCopyWithImpl<$Res, $Val extends LocalUserSettings>
 }
 
 /// @nodoc
-abstract class _$$_LocalUserSettingsCopyWith<$Res>
+abstract class _$$LocalUserSettingsImplCopyWith<$Res>
     implements $LocalUserSettingsCopyWith<$Res> {
-  factory _$$_LocalUserSettingsCopyWith(_$_LocalUserSettings value,
-          $Res Function(_$_LocalUserSettings) then) =
-      __$$_LocalUserSettingsCopyWithImpl<$Res>;
+  factory _$$LocalUserSettingsImplCopyWith(_$LocalUserSettingsImpl value,
+          $Res Function(_$LocalUserSettingsImpl) then) =
+      __$$LocalUserSettingsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -696,11 +696,11 @@ abstract class _$$_LocalUserSettingsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_LocalUserSettingsCopyWithImpl<$Res>
-    extends _$LocalUserSettingsCopyWithImpl<$Res, _$_LocalUserSettings>
-    implements _$$_LocalUserSettingsCopyWith<$Res> {
-  __$$_LocalUserSettingsCopyWithImpl(
-      _$_LocalUserSettings _value, $Res Function(_$_LocalUserSettings) _then)
+class __$$LocalUserSettingsImplCopyWithImpl<$Res>
+    extends _$LocalUserSettingsCopyWithImpl<$Res, _$LocalUserSettingsImpl>
+    implements _$$LocalUserSettingsImplCopyWith<$Res> {
+  __$$LocalUserSettingsImplCopyWithImpl(_$LocalUserSettingsImpl _value,
+      $Res Function(_$LocalUserSettingsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -724,7 +724,7 @@ class __$$_LocalUserSettingsCopyWithImpl<$Res>
     Object? acceptedApplication = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_LocalUserSettings(
+    return _then(_$LocalUserSettingsImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -800,8 +800,8 @@ class __$$_LocalUserSettingsCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_LocalUserSettings extends _LocalUserSettings {
-  const _$_LocalUserSettings(
+class _$LocalUserSettingsImpl extends _LocalUserSettings {
+  const _$LocalUserSettingsImpl(
       {required this.id,
       required this.personId,
       this.email,
@@ -821,8 +821,8 @@ class _$_LocalUserSettings extends _LocalUserSettings {
       required this.instanceHost})
       : super._();
 
-  factory _$_LocalUserSettings.fromJson(Map<String, dynamic> json) =>
-      _$$_LocalUserSettingsFromJson(json);
+  factory _$LocalUserSettingsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LocalUserSettingsImplFromJson(json);
 
   @override
   final int id;
@@ -868,7 +868,7 @@ class _$_LocalUserSettings extends _LocalUserSettings {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LocalUserSettings &&
+            other is _$LocalUserSettingsImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
@@ -928,13 +928,13 @@ class _$_LocalUserSettings extends _LocalUserSettings {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LocalUserSettingsCopyWith<_$_LocalUserSettings> get copyWith =>
-      __$$_LocalUserSettingsCopyWithImpl<_$_LocalUserSettings>(
+  _$$LocalUserSettingsImplCopyWith<_$LocalUserSettingsImpl> get copyWith =>
+      __$$LocalUserSettingsImplCopyWithImpl<_$LocalUserSettingsImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LocalUserSettingsToJson(
+    return _$$LocalUserSettingsImplToJson(
       this,
     );
   }
@@ -958,11 +958,11 @@ abstract class _LocalUserSettings extends LocalUserSettings {
       required final bool showNewPostNotifs,
       required final bool emailVerified,
       required final bool acceptedApplication,
-      required final String instanceHost}) = _$_LocalUserSettings;
+      required final String instanceHost}) = _$LocalUserSettingsImpl;
   const _LocalUserSettings._() : super._();
 
   factory _LocalUserSettings.fromJson(Map<String, dynamic> json) =
-      _$_LocalUserSettings.fromJson;
+      _$LocalUserSettingsImpl.fromJson;
 
   @override
   int get id;
@@ -1000,7 +1000,7 @@ abstract class _LocalUserSettings extends LocalUserSettings {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_LocalUserSettingsCopyWith<_$_LocalUserSettings> get copyWith =>
+  _$$LocalUserSettingsImplCopyWith<_$LocalUserSettingsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1142,9 +1142,10 @@ class _$SiteCopyWithImpl<$Res, $Val extends Site>
 }
 
 /// @nodoc
-abstract class _$$_SiteCopyWith<$Res> implements $SiteCopyWith<$Res> {
-  factory _$$_SiteCopyWith(_$_Site value, $Res Function(_$_Site) then) =
-      __$$_SiteCopyWithImpl<$Res>;
+abstract class _$$SiteImplCopyWith<$Res> implements $SiteCopyWith<$Res> {
+  factory _$$SiteImplCopyWith(
+          _$SiteImpl value, $Res Function(_$SiteImpl) then) =
+      __$$SiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1165,9 +1166,10 @@ abstract class _$$_SiteCopyWith<$Res> implements $SiteCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_SiteCopyWithImpl<$Res> extends _$SiteCopyWithImpl<$Res, _$_Site>
-    implements _$$_SiteCopyWith<$Res> {
-  __$$_SiteCopyWithImpl(_$_Site _value, $Res Function(_$_Site) _then)
+class __$$SiteImplCopyWithImpl<$Res>
+    extends _$SiteCopyWithImpl<$Res, _$SiteImpl>
+    implements _$$SiteImplCopyWith<$Res> {
+  __$$SiteImplCopyWithImpl(_$SiteImpl _value, $Res Function(_$SiteImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1188,7 +1190,7 @@ class __$$_SiteCopyWithImpl<$Res> extends _$SiteCopyWithImpl<$Res, _$_Site>
     Object? instanceId = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_Site(
+    return _then(_$SiteImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -1252,8 +1254,8 @@ class __$$_SiteCopyWithImpl<$Res> extends _$SiteCopyWithImpl<$Res, _$_Site>
 /// @nodoc
 
 @modelSerde
-class _$_Site extends _Site {
-  const _$_Site(
+class _$SiteImpl extends _Site {
+  const _$SiteImpl(
       {required this.id,
       required this.name,
       this.sidebar,
@@ -1270,7 +1272,8 @@ class _$_Site extends _Site {
       required this.instanceHost})
       : super._();
 
-  factory _$_Site.fromJson(Map<String, dynamic> json) => _$$_SiteFromJson(json);
+  factory _$SiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SiteImplFromJson(json);
 
   @override
   final int id;
@@ -1310,7 +1313,7 @@ class _$_Site extends _Site {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Site &&
+            other is _$SiteImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.sidebar, sidebar) || other.sidebar == sidebar) &&
@@ -1356,12 +1359,12 @@ class _$_Site extends _Site {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SiteCopyWith<_$_Site> get copyWith =>
-      __$$_SiteCopyWithImpl<_$_Site>(this, _$identity);
+  _$$SiteImplCopyWith<_$SiteImpl> get copyWith =>
+      __$$SiteImplCopyWithImpl<_$SiteImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SiteToJson(
+    return _$$SiteImplToJson(
       this,
     );
   }
@@ -1382,10 +1385,10 @@ abstract class _Site extends Site {
       required final String inboxUrl,
       required final String publicKey,
       required final int instanceId,
-      required final String instanceHost}) = _$_Site;
+      required final String instanceHost}) = _$SiteImpl;
   const _Site._() : super._();
 
-  factory _Site.fromJson(Map<String, dynamic> json) = _$_Site.fromJson;
+  factory _Site.fromJson(Map<String, dynamic> json) = _$SiteImpl.fromJson;
 
   @override
   int get id;
@@ -1417,7 +1420,8 @@ abstract class _Site extends Site {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_SiteCopyWith<_$_Site> get copyWith => throw _privateConstructorUsedError;
+  _$$SiteImplCopyWith<_$SiteImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 LocalSite _$LocalSiteFromJson(Map<String, dynamic> json) {
@@ -1630,10 +1634,11 @@ class _$LocalSiteCopyWithImpl<$Res, $Val extends LocalSite>
 }
 
 /// @nodoc
-abstract class _$$_LocalSiteCopyWith<$Res> implements $LocalSiteCopyWith<$Res> {
-  factory _$$_LocalSiteCopyWith(
-          _$_LocalSite value, $Res Function(_$_LocalSite) then) =
-      __$$_LocalSiteCopyWithImpl<$Res>;
+abstract class _$$LocalSiteImplCopyWith<$Res>
+    implements $LocalSiteCopyWith<$Res> {
+  factory _$$LocalSiteImplCopyWith(
+          _$LocalSiteImpl value, $Res Function(_$LocalSiteImpl) then) =
+      __$$LocalSiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1664,11 +1669,11 @@ abstract class _$$_LocalSiteCopyWith<$Res> implements $LocalSiteCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_LocalSiteCopyWithImpl<$Res>
-    extends _$LocalSiteCopyWithImpl<$Res, _$_LocalSite>
-    implements _$$_LocalSiteCopyWith<$Res> {
-  __$$_LocalSiteCopyWithImpl(
-      _$_LocalSite _value, $Res Function(_$_LocalSite) _then)
+class __$$LocalSiteImplCopyWithImpl<$Res>
+    extends _$LocalSiteCopyWithImpl<$Res, _$LocalSiteImpl>
+    implements _$$LocalSiteImplCopyWith<$Res> {
+  __$$LocalSiteImplCopyWithImpl(
+      _$LocalSiteImpl _value, $Res Function(_$LocalSiteImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1699,7 +1704,7 @@ class __$$_LocalSiteCopyWithImpl<$Res>
     Object? registrationMode = null,
     Object? reportsEmailAdmins = null,
   }) {
-    return _then(_$_LocalSite(
+    return _then(_$LocalSiteImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -1803,8 +1808,8 @@ class __$$_LocalSiteCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_LocalSite extends _LocalSite {
-  const _$_LocalSite(
+class _$LocalSiteImpl extends _LocalSite {
+  const _$LocalSiteImpl(
       {required this.id,
       required this.siteId,
       required this.siteSetup,
@@ -1831,8 +1836,8 @@ class _$_LocalSite extends _LocalSite {
       required this.reportsEmailAdmins})
       : super._();
 
-  factory _$_LocalSite.fromJson(Map<String, dynamic> json) =>
-      _$$_LocalSiteFromJson(json);
+  factory _$LocalSiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LocalSiteImplFromJson(json);
 
   @override
   final int id;
@@ -1892,7 +1897,7 @@ class _$_LocalSite extends _LocalSite {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LocalSite &&
+            other is _$LocalSiteImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.siteId, siteId) || other.siteId == siteId) &&
             (identical(other.siteSetup, siteSetup) ||
@@ -1976,12 +1981,12 @@ class _$_LocalSite extends _LocalSite {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LocalSiteCopyWith<_$_LocalSite> get copyWith =>
-      __$$_LocalSiteCopyWithImpl<_$_LocalSite>(this, _$identity);
+  _$$LocalSiteImplCopyWith<_$LocalSiteImpl> get copyWith =>
+      __$$LocalSiteImplCopyWithImpl<_$LocalSiteImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LocalSiteToJson(
+    return _$$LocalSiteImplToJson(
       this,
     );
   }
@@ -2012,11 +2017,11 @@ abstract class _LocalSite extends LocalSite {
       required final String published,
       final DateTime? updated,
       required final String registrationMode,
-      required final bool reportsEmailAdmins}) = _$_LocalSite;
+      required final bool reportsEmailAdmins}) = _$LocalSiteImpl;
   const _LocalSite._() : super._();
 
   factory _LocalSite.fromJson(Map<String, dynamic> json) =
-      _$_LocalSite.fromJson;
+      _$LocalSiteImpl.fromJson;
 
   @override
   int get id;
@@ -2068,7 +2073,7 @@ abstract class _LocalSite extends LocalSite {
   bool get reportsEmailAdmins;
   @override
   @JsonKey(ignore: true)
-  _$$_LocalSiteCopyWith<_$_LocalSite> get copyWith =>
+  _$$LocalSiteImplCopyWith<_$LocalSiteImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2191,11 +2196,11 @@ class _$PrivateMessageCopyWithImpl<$Res, $Val extends PrivateMessage>
 }
 
 /// @nodoc
-abstract class _$$_PrivateMessageCopyWith<$Res>
+abstract class _$$PrivateMessageImplCopyWith<$Res>
     implements $PrivateMessageCopyWith<$Res> {
-  factory _$$_PrivateMessageCopyWith(
-          _$_PrivateMessage value, $Res Function(_$_PrivateMessage) then) =
-      __$$_PrivateMessageCopyWithImpl<$Res>;
+  factory _$$PrivateMessageImplCopyWith(_$PrivateMessageImpl value,
+          $Res Function(_$PrivateMessageImpl) then) =
+      __$$PrivateMessageImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2213,11 +2218,11 @@ abstract class _$$_PrivateMessageCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PrivateMessageCopyWithImpl<$Res>
-    extends _$PrivateMessageCopyWithImpl<$Res, _$_PrivateMessage>
-    implements _$$_PrivateMessageCopyWith<$Res> {
-  __$$_PrivateMessageCopyWithImpl(
-      _$_PrivateMessage _value, $Res Function(_$_PrivateMessage) _then)
+class __$$PrivateMessageImplCopyWithImpl<$Res>
+    extends _$PrivateMessageCopyWithImpl<$Res, _$PrivateMessageImpl>
+    implements _$$PrivateMessageImplCopyWith<$Res> {
+  __$$PrivateMessageImplCopyWithImpl(
+      _$PrivateMessageImpl _value, $Res Function(_$PrivateMessageImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2235,7 +2240,7 @@ class __$$_PrivateMessageCopyWithImpl<$Res>
     Object? local = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_PrivateMessage(
+    return _then(_$PrivateMessageImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -2287,8 +2292,8 @@ class __$$_PrivateMessageCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PrivateMessage extends _PrivateMessage {
-  const _$_PrivateMessage(
+class _$PrivateMessageImpl extends _PrivateMessage {
+  const _$PrivateMessageImpl(
       {required this.id,
       required this.creatorId,
       required this.recipientId,
@@ -2302,8 +2307,8 @@ class _$_PrivateMessage extends _PrivateMessage {
       required this.instanceHost})
       : super._();
 
-  factory _$_PrivateMessage.fromJson(Map<String, dynamic> json) =>
-      _$$_PrivateMessageFromJson(json);
+  factory _$PrivateMessageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PrivateMessageImplFromJson(json);
 
   @override
   final int id;
@@ -2337,7 +2342,7 @@ class _$_PrivateMessage extends _PrivateMessage {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PrivateMessage &&
+            other is _$PrivateMessageImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -2363,12 +2368,13 @@ class _$_PrivateMessage extends _PrivateMessage {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PrivateMessageCopyWith<_$_PrivateMessage> get copyWith =>
-      __$$_PrivateMessageCopyWithImpl<_$_PrivateMessage>(this, _$identity);
+  _$$PrivateMessageImplCopyWith<_$PrivateMessageImpl> get copyWith =>
+      __$$PrivateMessageImplCopyWithImpl<_$PrivateMessageImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PrivateMessageToJson(
+    return _$$PrivateMessageImplToJson(
       this,
     );
   }
@@ -2386,11 +2392,11 @@ abstract class _PrivateMessage extends PrivateMessage {
       final DateTime? updated,
       required final String apId,
       required final bool local,
-      required final String instanceHost}) = _$_PrivateMessage;
+      required final String instanceHost}) = _$PrivateMessageImpl;
   const _PrivateMessage._() : super._();
 
   factory _PrivateMessage.fromJson(Map<String, dynamic> json) =
-      _$_PrivateMessage.fromJson;
+      _$PrivateMessageImpl.fromJson;
 
   @override
   int get id;
@@ -2416,7 +2422,7 @@ abstract class _PrivateMessage extends PrivateMessage {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PrivateMessageCopyWith<_$_PrivateMessage> get copyWith =>
+  _$$PrivateMessageImplCopyWith<_$PrivateMessageImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2546,11 +2552,11 @@ class _$PostReportCopyWithImpl<$Res, $Val extends PostReport>
 }
 
 /// @nodoc
-abstract class _$$_PostReportCopyWith<$Res>
+abstract class _$$PostReportImplCopyWith<$Res>
     implements $PostReportCopyWith<$Res> {
-  factory _$$_PostReportCopyWith(
-          _$_PostReport value, $Res Function(_$_PostReport) then) =
-      __$$_PostReportCopyWithImpl<$Res>;
+  factory _$$PostReportImplCopyWith(
+          _$PostReportImpl value, $Res Function(_$PostReportImpl) then) =
+      __$$PostReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2569,11 +2575,11 @@ abstract class _$$_PostReportCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PostReportCopyWithImpl<$Res>
-    extends _$PostReportCopyWithImpl<$Res, _$_PostReport>
-    implements _$$_PostReportCopyWith<$Res> {
-  __$$_PostReportCopyWithImpl(
-      _$_PostReport _value, $Res Function(_$_PostReport) _then)
+class __$$PostReportImplCopyWithImpl<$Res>
+    extends _$PostReportCopyWithImpl<$Res, _$PostReportImpl>
+    implements _$$PostReportImplCopyWith<$Res> {
+  __$$PostReportImplCopyWithImpl(
+      _$PostReportImpl _value, $Res Function(_$PostReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2592,7 +2598,7 @@ class __$$_PostReportCopyWithImpl<$Res>
     Object? updated = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_PostReport(
+    return _then(_$PostReportImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -2648,8 +2654,8 @@ class __$$_PostReportCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PostReport extends _PostReport {
-  const _$_PostReport(
+class _$PostReportImpl extends _PostReport {
+  const _$PostReportImpl(
       {required this.id,
       required this.creatorId,
       required this.postId,
@@ -2664,8 +2670,8 @@ class _$_PostReport extends _PostReport {
       required this.instanceHost})
       : super._();
 
-  factory _$_PostReport.fromJson(Map<String, dynamic> json) =>
-      _$$_PostReportFromJson(json);
+  factory _$PostReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PostReportImplFromJson(json);
 
   @override
   final int id;
@@ -2701,7 +2707,7 @@ class _$_PostReport extends _PostReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PostReport &&
+            other is _$PostReportImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -2744,12 +2750,12 @@ class _$_PostReport extends _PostReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PostReportCopyWith<_$_PostReport> get copyWith =>
-      __$$_PostReportCopyWithImpl<_$_PostReport>(this, _$identity);
+  _$$PostReportImplCopyWith<_$PostReportImpl> get copyWith =>
+      __$$PostReportImplCopyWithImpl<_$PostReportImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PostReportToJson(
+    return _$$PostReportImplToJson(
       this,
     );
   }
@@ -2768,11 +2774,11 @@ abstract class _PostReport extends PostReport {
       final int? resolverId,
       required final DateTime published,
       final DateTime? updated,
-      required final String instanceHost}) = _$_PostReport;
+      required final String instanceHost}) = _$PostReportImpl;
   const _PostReport._() : super._();
 
   factory _PostReport.fromJson(Map<String, dynamic> json) =
-      _$_PostReport.fromJson;
+      _$PostReportImpl.fromJson;
 
   @override
   int get id;
@@ -2800,7 +2806,7 @@ abstract class _PostReport extends PostReport {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PostReportCopyWith<_$_PostReport> get copyWith =>
+  _$$PostReportImplCopyWith<_$PostReportImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2991,9 +2997,10 @@ class _$PostCopyWithImpl<$Res, $Val extends Post>
 }
 
 /// @nodoc
-abstract class _$$_PostCopyWith<$Res> implements $PostCopyWith<$Res> {
-  factory _$$_PostCopyWith(_$_Post value, $Res Function(_$_Post) then) =
-      __$$_PostCopyWithImpl<$Res>;
+abstract class _$$PostImplCopyWith<$Res> implements $PostCopyWith<$Res> {
+  factory _$$PostImplCopyWith(
+          _$PostImpl value, $Res Function(_$PostImpl) then) =
+      __$$PostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3021,9 +3028,10 @@ abstract class _$$_PostCopyWith<$Res> implements $PostCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_PostCopyWithImpl<$Res> extends _$PostCopyWithImpl<$Res, _$_Post>
-    implements _$$_PostCopyWith<$Res> {
-  __$$_PostCopyWithImpl(_$_Post _value, $Res Function(_$_Post) _then)
+class __$$PostImplCopyWithImpl<$Res>
+    extends _$PostCopyWithImpl<$Res, _$PostImpl>
+    implements _$$PostImplCopyWith<$Res> {
+  __$$PostImplCopyWithImpl(_$PostImpl _value, $Res Function(_$PostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3051,7 +3059,7 @@ class __$$_PostCopyWithImpl<$Res> extends _$PostCopyWithImpl<$Res, _$_Post>
     Object? local = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_Post(
+    return _then(_$PostImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -3143,8 +3151,8 @@ class __$$_PostCopyWithImpl<$Res> extends _$PostCopyWithImpl<$Res, _$_Post>
 /// @nodoc
 
 @modelSerde
-class _$_Post extends _Post {
-  const _$_Post(
+class _$PostImpl extends _Post {
+  const _$PostImpl(
       {required this.id,
       required this.name,
       this.url,
@@ -3168,7 +3176,8 @@ class _$_Post extends _Post {
       required this.instanceHost})
       : super._();
 
-  factory _$_Post.fromJson(Map<String, dynamic> json) => _$$_PostFromJson(json);
+  factory _$PostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PostImplFromJson(json);
 
   @override
   final int id;
@@ -3222,7 +3231,7 @@ class _$_Post extends _Post {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Post &&
+            other is _$PostImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.url, url) || other.url == url) &&
@@ -3286,12 +3295,12 @@ class _$_Post extends _Post {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PostCopyWith<_$_Post> get copyWith =>
-      __$$_PostCopyWithImpl<_$_Post>(this, _$identity);
+  _$$PostImplCopyWith<_$PostImpl> get copyWith =>
+      __$$PostImplCopyWithImpl<_$PostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PostToJson(
+    return _$$PostImplToJson(
       this,
     );
   }
@@ -3319,10 +3328,10 @@ abstract class _Post extends Post {
       final String? thumbnailUrl,
       required final String apId,
       required final bool local,
-      required final String instanceHost}) = _$_Post;
+      required final String instanceHost}) = _$PostImpl;
   const _Post._() : super._();
 
-  factory _Post.fromJson(Map<String, dynamic> json) = _$_Post.fromJson;
+  factory _Post.fromJson(Map<String, dynamic> json) = _$PostImpl.fromJson;
 
   @override
   int get id;
@@ -3368,7 +3377,8 @@ abstract class _Post extends Post {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PostCopyWith<_$_Post> get copyWith => throw _privateConstructorUsedError;
+  _$$PostImplCopyWith<_$PostImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 PasswordResetRequest _$PasswordResetRequestFromJson(Map<String, dynamic> json) {
@@ -3449,11 +3459,11 @@ class _$PasswordResetRequestCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_PasswordResetRequestCopyWith<$Res>
+abstract class _$$PasswordResetRequestImplCopyWith<$Res>
     implements $PasswordResetRequestCopyWith<$Res> {
-  factory _$$_PasswordResetRequestCopyWith(_$_PasswordResetRequest value,
-          $Res Function(_$_PasswordResetRequest) then) =
-      __$$_PasswordResetRequestCopyWithImpl<$Res>;
+  factory _$$PasswordResetRequestImplCopyWith(_$PasswordResetRequestImpl value,
+          $Res Function(_$PasswordResetRequestImpl) then) =
+      __$$PasswordResetRequestImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3465,11 +3475,11 @@ abstract class _$$_PasswordResetRequestCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PasswordResetRequestCopyWithImpl<$Res>
-    extends _$PasswordResetRequestCopyWithImpl<$Res, _$_PasswordResetRequest>
-    implements _$$_PasswordResetRequestCopyWith<$Res> {
-  __$$_PasswordResetRequestCopyWithImpl(_$_PasswordResetRequest _value,
-      $Res Function(_$_PasswordResetRequest) _then)
+class __$$PasswordResetRequestImplCopyWithImpl<$Res>
+    extends _$PasswordResetRequestCopyWithImpl<$Res, _$PasswordResetRequestImpl>
+    implements _$$PasswordResetRequestImplCopyWith<$Res> {
+  __$$PasswordResetRequestImplCopyWithImpl(_$PasswordResetRequestImpl _value,
+      $Res Function(_$PasswordResetRequestImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3481,7 +3491,7 @@ class __$$_PasswordResetRequestCopyWithImpl<$Res>
     Object? published = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_PasswordResetRequest(
+    return _then(_$PasswordResetRequestImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -3509,8 +3519,8 @@ class __$$_PasswordResetRequestCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PasswordResetRequest extends _PasswordResetRequest {
-  const _$_PasswordResetRequest(
+class _$PasswordResetRequestImpl extends _PasswordResetRequest {
+  const _$PasswordResetRequestImpl(
       {required this.id,
       required this.localUserId,
       required this.tokenEncrypted,
@@ -3518,8 +3528,8 @@ class _$_PasswordResetRequest extends _PasswordResetRequest {
       required this.instanceHost})
       : super._();
 
-  factory _$_PasswordResetRequest.fromJson(Map<String, dynamic> json) =>
-      _$$_PasswordResetRequestFromJson(json);
+  factory _$PasswordResetRequestImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PasswordResetRequestImplFromJson(json);
 
   @override
   final int id;
@@ -3541,7 +3551,7 @@ class _$_PasswordResetRequest extends _PasswordResetRequest {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PasswordResetRequest &&
+            other is _$PasswordResetRequestImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.localUserId, localUserId) ||
                 other.localUserId == localUserId) &&
@@ -3561,13 +3571,14 @@ class _$_PasswordResetRequest extends _PasswordResetRequest {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PasswordResetRequestCopyWith<_$_PasswordResetRequest> get copyWith =>
-      __$$_PasswordResetRequestCopyWithImpl<_$_PasswordResetRequest>(
-          this, _$identity);
+  _$$PasswordResetRequestImplCopyWith<_$PasswordResetRequestImpl>
+      get copyWith =>
+          __$$PasswordResetRequestImplCopyWithImpl<_$PasswordResetRequestImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PasswordResetRequestToJson(
+    return _$$PasswordResetRequestImplToJson(
       this,
     );
   }
@@ -3579,11 +3590,11 @@ abstract class _PasswordResetRequest extends PasswordResetRequest {
       required final int localUserId,
       required final String tokenEncrypted,
       required final DateTime published,
-      required final String instanceHost}) = _$_PasswordResetRequest;
+      required final String instanceHost}) = _$PasswordResetRequestImpl;
   const _PasswordResetRequest._() : super._();
 
   factory _PasswordResetRequest.fromJson(Map<String, dynamic> json) =
-      _$_PasswordResetRequest.fromJson;
+      _$PasswordResetRequestImpl.fromJson;
 
   @override
   int get id;
@@ -3597,8 +3608,8 @@ abstract class _PasswordResetRequest extends PasswordResetRequest {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PasswordResetRequestCopyWith<_$_PasswordResetRequest> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$PasswordResetRequestImplCopyWith<_$PasswordResetRequestImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 ModRemovePost _$ModRemovePostFromJson(Map<String, dynamic> json) {
@@ -3693,11 +3704,11 @@ class _$ModRemovePostCopyWithImpl<$Res, $Val extends ModRemovePost>
 }
 
 /// @nodoc
-abstract class _$$_ModRemovePostCopyWith<$Res>
+abstract class _$$ModRemovePostImplCopyWith<$Res>
     implements $ModRemovePostCopyWith<$Res> {
-  factory _$$_ModRemovePostCopyWith(
-          _$_ModRemovePost value, $Res Function(_$_ModRemovePost) then) =
-      __$$_ModRemovePostCopyWithImpl<$Res>;
+  factory _$$ModRemovePostImplCopyWith(
+          _$ModRemovePostImpl value, $Res Function(_$ModRemovePostImpl) then) =
+      __$$ModRemovePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3711,11 +3722,11 @@ abstract class _$$_ModRemovePostCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModRemovePostCopyWithImpl<$Res>
-    extends _$ModRemovePostCopyWithImpl<$Res, _$_ModRemovePost>
-    implements _$$_ModRemovePostCopyWith<$Res> {
-  __$$_ModRemovePostCopyWithImpl(
-      _$_ModRemovePost _value, $Res Function(_$_ModRemovePost) _then)
+class __$$ModRemovePostImplCopyWithImpl<$Res>
+    extends _$ModRemovePostCopyWithImpl<$Res, _$ModRemovePostImpl>
+    implements _$$ModRemovePostImplCopyWith<$Res> {
+  __$$ModRemovePostImplCopyWithImpl(
+      _$ModRemovePostImpl _value, $Res Function(_$ModRemovePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3729,7 +3740,7 @@ class __$$_ModRemovePostCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModRemovePost(
+    return _then(_$ModRemovePostImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -3765,8 +3776,8 @@ class __$$_ModRemovePostCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModRemovePost extends _ModRemovePost {
-  const _$_ModRemovePost(
+class _$ModRemovePostImpl extends _ModRemovePost {
+  const _$ModRemovePostImpl(
       {required this.id,
       required this.modPersonId,
       required this.postId,
@@ -3776,8 +3787,8 @@ class _$_ModRemovePost extends _ModRemovePost {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModRemovePost.fromJson(Map<String, dynamic> json) =>
-      _$$_ModRemovePostFromJson(json);
+  factory _$ModRemovePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModRemovePostImplFromJson(json);
 
   @override
   final int id;
@@ -3804,7 +3815,7 @@ class _$_ModRemovePost extends _ModRemovePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModRemovePost &&
+            other is _$ModRemovePostImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -3824,12 +3835,12 @@ class _$_ModRemovePost extends _ModRemovePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModRemovePostCopyWith<_$_ModRemovePost> get copyWith =>
-      __$$_ModRemovePostCopyWithImpl<_$_ModRemovePost>(this, _$identity);
+  _$$ModRemovePostImplCopyWith<_$ModRemovePostImpl> get copyWith =>
+      __$$ModRemovePostImplCopyWithImpl<_$ModRemovePostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModRemovePostToJson(
+    return _$$ModRemovePostImplToJson(
       this,
     );
   }
@@ -3843,11 +3854,11 @@ abstract class _ModRemovePost extends ModRemovePost {
       final String? reason,
       final bool? removed,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_ModRemovePost;
+      required final String instanceHost}) = _$ModRemovePostImpl;
   const _ModRemovePost._() : super._();
 
   factory _ModRemovePost.fromJson(Map<String, dynamic> json) =
-      _$_ModRemovePost.fromJson;
+      _$ModRemovePostImpl.fromJson;
 
   @override
   int get id;
@@ -3866,7 +3877,7 @@ abstract class _ModRemovePost extends ModRemovePost {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModRemovePostCopyWith<_$_ModRemovePost> get copyWith =>
+  _$$ModRemovePostImplCopyWith<_$ModRemovePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3955,11 +3966,11 @@ class _$ModLockPostCopyWithImpl<$Res, $Val extends ModLockPost>
 }
 
 /// @nodoc
-abstract class _$$_ModLockPostCopyWith<$Res>
+abstract class _$$ModLockPostImplCopyWith<$Res>
     implements $ModLockPostCopyWith<$Res> {
-  factory _$$_ModLockPostCopyWith(
-          _$_ModLockPost value, $Res Function(_$_ModLockPost) then) =
-      __$$_ModLockPostCopyWithImpl<$Res>;
+  factory _$$ModLockPostImplCopyWith(
+          _$ModLockPostImpl value, $Res Function(_$ModLockPostImpl) then) =
+      __$$ModLockPostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3972,11 +3983,11 @@ abstract class _$$_ModLockPostCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModLockPostCopyWithImpl<$Res>
-    extends _$ModLockPostCopyWithImpl<$Res, _$_ModLockPost>
-    implements _$$_ModLockPostCopyWith<$Res> {
-  __$$_ModLockPostCopyWithImpl(
-      _$_ModLockPost _value, $Res Function(_$_ModLockPost) _then)
+class __$$ModLockPostImplCopyWithImpl<$Res>
+    extends _$ModLockPostCopyWithImpl<$Res, _$ModLockPostImpl>
+    implements _$$ModLockPostImplCopyWith<$Res> {
+  __$$ModLockPostImplCopyWithImpl(
+      _$ModLockPostImpl _value, $Res Function(_$ModLockPostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3989,7 +4000,7 @@ class __$$_ModLockPostCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModLockPost(
+    return _then(_$ModLockPostImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -4021,8 +4032,8 @@ class __$$_ModLockPostCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModLockPost extends _ModLockPost {
-  const _$_ModLockPost(
+class _$ModLockPostImpl extends _ModLockPost {
+  const _$ModLockPostImpl(
       {required this.id,
       required this.modPersonId,
       required this.postId,
@@ -4031,8 +4042,8 @@ class _$_ModLockPost extends _ModLockPost {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModLockPost.fromJson(Map<String, dynamic> json) =>
-      _$$_ModLockPostFromJson(json);
+  factory _$ModLockPostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModLockPostImplFromJson(json);
 
   @override
   final int id;
@@ -4057,7 +4068,7 @@ class _$_ModLockPost extends _ModLockPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModLockPost &&
+            other is _$ModLockPostImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -4076,12 +4087,12 @@ class _$_ModLockPost extends _ModLockPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModLockPostCopyWith<_$_ModLockPost> get copyWith =>
-      __$$_ModLockPostCopyWithImpl<_$_ModLockPost>(this, _$identity);
+  _$$ModLockPostImplCopyWith<_$ModLockPostImpl> get copyWith =>
+      __$$ModLockPostImplCopyWithImpl<_$ModLockPostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModLockPostToJson(
+    return _$$ModLockPostImplToJson(
       this,
     );
   }
@@ -4094,11 +4105,11 @@ abstract class _ModLockPost extends ModLockPost {
       required final int postId,
       final bool? locked,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_ModLockPost;
+      required final String instanceHost}) = _$ModLockPostImpl;
   const _ModLockPost._() : super._();
 
   factory _ModLockPost.fromJson(Map<String, dynamic> json) =
-      _$_ModLockPost.fromJson;
+      _$ModLockPostImpl.fromJson;
 
   @override
   int get id;
@@ -4115,7 +4126,7 @@ abstract class _ModLockPost extends ModLockPost {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModLockPostCopyWith<_$_ModLockPost> get copyWith =>
+  _$$ModLockPostImplCopyWith<_$ModLockPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4204,11 +4215,11 @@ class _$ModStickyPostCopyWithImpl<$Res, $Val extends ModStickyPost>
 }
 
 /// @nodoc
-abstract class _$$_ModStickyPostCopyWith<$Res>
+abstract class _$$ModStickyPostImplCopyWith<$Res>
     implements $ModStickyPostCopyWith<$Res> {
-  factory _$$_ModStickyPostCopyWith(
-          _$_ModStickyPost value, $Res Function(_$_ModStickyPost) then) =
-      __$$_ModStickyPostCopyWithImpl<$Res>;
+  factory _$$ModStickyPostImplCopyWith(
+          _$ModStickyPostImpl value, $Res Function(_$ModStickyPostImpl) then) =
+      __$$ModStickyPostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4221,11 +4232,11 @@ abstract class _$$_ModStickyPostCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModStickyPostCopyWithImpl<$Res>
-    extends _$ModStickyPostCopyWithImpl<$Res, _$_ModStickyPost>
-    implements _$$_ModStickyPostCopyWith<$Res> {
-  __$$_ModStickyPostCopyWithImpl(
-      _$_ModStickyPost _value, $Res Function(_$_ModStickyPost) _then)
+class __$$ModStickyPostImplCopyWithImpl<$Res>
+    extends _$ModStickyPostCopyWithImpl<$Res, _$ModStickyPostImpl>
+    implements _$$ModStickyPostImplCopyWith<$Res> {
+  __$$ModStickyPostImplCopyWithImpl(
+      _$ModStickyPostImpl _value, $Res Function(_$ModStickyPostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4238,7 +4249,7 @@ class __$$_ModStickyPostCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModStickyPost(
+    return _then(_$ModStickyPostImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -4270,8 +4281,8 @@ class __$$_ModStickyPostCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModStickyPost extends _ModStickyPost {
-  const _$_ModStickyPost(
+class _$ModStickyPostImpl extends _ModStickyPost {
+  const _$ModStickyPostImpl(
       {required this.id,
       required this.modPersonId,
       required this.postId,
@@ -4280,8 +4291,8 @@ class _$_ModStickyPost extends _ModStickyPost {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModStickyPost.fromJson(Map<String, dynamic> json) =>
-      _$$_ModStickyPostFromJson(json);
+  factory _$ModStickyPostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModStickyPostImplFromJson(json);
 
   @override
   final int id;
@@ -4306,7 +4317,7 @@ class _$_ModStickyPost extends _ModStickyPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModStickyPost &&
+            other is _$ModStickyPostImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -4326,12 +4337,12 @@ class _$_ModStickyPost extends _ModStickyPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModStickyPostCopyWith<_$_ModStickyPost> get copyWith =>
-      __$$_ModStickyPostCopyWithImpl<_$_ModStickyPost>(this, _$identity);
+  _$$ModStickyPostImplCopyWith<_$ModStickyPostImpl> get copyWith =>
+      __$$ModStickyPostImplCopyWithImpl<_$ModStickyPostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModStickyPostToJson(
+    return _$$ModStickyPostImplToJson(
       this,
     );
   }
@@ -4344,11 +4355,11 @@ abstract class _ModStickyPost extends ModStickyPost {
       required final int postId,
       final bool? stickied,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_ModStickyPost;
+      required final String instanceHost}) = _$ModStickyPostImpl;
   const _ModStickyPost._() : super._();
 
   factory _ModStickyPost.fromJson(Map<String, dynamic> json) =
-      _$_ModStickyPost.fromJson;
+      _$ModStickyPostImpl.fromJson;
 
   @override
   int get id;
@@ -4365,7 +4376,7 @@ abstract class _ModStickyPost extends ModStickyPost {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModStickyPostCopyWith<_$_ModStickyPost> get copyWith =>
+  _$$ModStickyPostImplCopyWith<_$ModStickyPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4461,11 +4472,11 @@ class _$ModFeaturePostCopyWithImpl<$Res, $Val extends ModFeaturePost>
 }
 
 /// @nodoc
-abstract class _$$_ModFeaturePostCopyWith<$Res>
+abstract class _$$ModFeaturePostImplCopyWith<$Res>
     implements $ModFeaturePostCopyWith<$Res> {
-  factory _$$_ModFeaturePostCopyWith(
-          _$_ModFeaturePost value, $Res Function(_$_ModFeaturePost) then) =
-      __$$_ModFeaturePostCopyWithImpl<$Res>;
+  factory _$$ModFeaturePostImplCopyWith(_$ModFeaturePostImpl value,
+          $Res Function(_$ModFeaturePostImpl) then) =
+      __$$ModFeaturePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4479,11 +4490,11 @@ abstract class _$$_ModFeaturePostCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModFeaturePostCopyWithImpl<$Res>
-    extends _$ModFeaturePostCopyWithImpl<$Res, _$_ModFeaturePost>
-    implements _$$_ModFeaturePostCopyWith<$Res> {
-  __$$_ModFeaturePostCopyWithImpl(
-      _$_ModFeaturePost _value, $Res Function(_$_ModFeaturePost) _then)
+class __$$ModFeaturePostImplCopyWithImpl<$Res>
+    extends _$ModFeaturePostCopyWithImpl<$Res, _$ModFeaturePostImpl>
+    implements _$$ModFeaturePostImplCopyWith<$Res> {
+  __$$ModFeaturePostImplCopyWithImpl(
+      _$ModFeaturePostImpl _value, $Res Function(_$ModFeaturePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4497,7 +4508,7 @@ class __$$_ModFeaturePostCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModFeaturePost(
+    return _then(_$ModFeaturePostImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -4533,8 +4544,8 @@ class __$$_ModFeaturePostCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModFeaturePost extends _ModFeaturePost {
-  const _$_ModFeaturePost(
+class _$ModFeaturePostImpl extends _ModFeaturePost {
+  const _$ModFeaturePostImpl(
       {required this.id,
       required this.modPersonId,
       required this.postId,
@@ -4544,8 +4555,8 @@ class _$_ModFeaturePost extends _ModFeaturePost {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModFeaturePost.fromJson(Map<String, dynamic> json) =>
-      _$$_ModFeaturePostFromJson(json);
+  factory _$ModFeaturePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModFeaturePostImplFromJson(json);
 
   @override
   final int id;
@@ -4572,7 +4583,7 @@ class _$_ModFeaturePost extends _ModFeaturePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModFeaturePost &&
+            other is _$ModFeaturePostImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -4594,12 +4605,13 @@ class _$_ModFeaturePost extends _ModFeaturePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModFeaturePostCopyWith<_$_ModFeaturePost> get copyWith =>
-      __$$_ModFeaturePostCopyWithImpl<_$_ModFeaturePost>(this, _$identity);
+  _$$ModFeaturePostImplCopyWith<_$ModFeaturePostImpl> get copyWith =>
+      __$$ModFeaturePostImplCopyWithImpl<_$ModFeaturePostImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModFeaturePostToJson(
+    return _$$ModFeaturePostImplToJson(
       this,
     );
   }
@@ -4613,11 +4625,11 @@ abstract class _ModFeaturePost extends ModFeaturePost {
       required final bool featured,
       required final bool isFeaturedCommunity,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_ModFeaturePost;
+      required final String instanceHost}) = _$ModFeaturePostImpl;
   const _ModFeaturePost._() : super._();
 
   factory _ModFeaturePost.fromJson(Map<String, dynamic> json) =
-      _$_ModFeaturePost.fromJson;
+      _$ModFeaturePostImpl.fromJson;
 
   @override
   int get id;
@@ -4636,7 +4648,7 @@ abstract class _ModFeaturePost extends ModFeaturePost {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModFeaturePostCopyWith<_$_ModFeaturePost> get copyWith =>
+  _$$ModFeaturePostImplCopyWith<_$ModFeaturePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4732,11 +4744,11 @@ class _$ModRemoveCommentCopyWithImpl<$Res, $Val extends ModRemoveComment>
 }
 
 /// @nodoc
-abstract class _$$_ModRemoveCommentCopyWith<$Res>
+abstract class _$$ModRemoveCommentImplCopyWith<$Res>
     implements $ModRemoveCommentCopyWith<$Res> {
-  factory _$$_ModRemoveCommentCopyWith(
-          _$_ModRemoveComment value, $Res Function(_$_ModRemoveComment) then) =
-      __$$_ModRemoveCommentCopyWithImpl<$Res>;
+  factory _$$ModRemoveCommentImplCopyWith(_$ModRemoveCommentImpl value,
+          $Res Function(_$ModRemoveCommentImpl) then) =
+      __$$ModRemoveCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4750,11 +4762,11 @@ abstract class _$$_ModRemoveCommentCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModRemoveCommentCopyWithImpl<$Res>
-    extends _$ModRemoveCommentCopyWithImpl<$Res, _$_ModRemoveComment>
-    implements _$$_ModRemoveCommentCopyWith<$Res> {
-  __$$_ModRemoveCommentCopyWithImpl(
-      _$_ModRemoveComment _value, $Res Function(_$_ModRemoveComment) _then)
+class __$$ModRemoveCommentImplCopyWithImpl<$Res>
+    extends _$ModRemoveCommentCopyWithImpl<$Res, _$ModRemoveCommentImpl>
+    implements _$$ModRemoveCommentImplCopyWith<$Res> {
+  __$$ModRemoveCommentImplCopyWithImpl(_$ModRemoveCommentImpl _value,
+      $Res Function(_$ModRemoveCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4768,7 +4780,7 @@ class __$$_ModRemoveCommentCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModRemoveComment(
+    return _then(_$ModRemoveCommentImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -4804,8 +4816,8 @@ class __$$_ModRemoveCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModRemoveComment extends _ModRemoveComment {
-  const _$_ModRemoveComment(
+class _$ModRemoveCommentImpl extends _ModRemoveComment {
+  const _$ModRemoveCommentImpl(
       {required this.id,
       required this.modPersonId,
       required this.commentId,
@@ -4815,8 +4827,8 @@ class _$_ModRemoveComment extends _ModRemoveComment {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModRemoveComment.fromJson(Map<String, dynamic> json) =>
-      _$$_ModRemoveCommentFromJson(json);
+  factory _$ModRemoveCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModRemoveCommentImplFromJson(json);
 
   @override
   final int id;
@@ -4843,7 +4855,7 @@ class _$_ModRemoveComment extends _ModRemoveComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModRemoveComment &&
+            other is _$ModRemoveCommentImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -4864,12 +4876,13 @@ class _$_ModRemoveComment extends _ModRemoveComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModRemoveCommentCopyWith<_$_ModRemoveComment> get copyWith =>
-      __$$_ModRemoveCommentCopyWithImpl<_$_ModRemoveComment>(this, _$identity);
+  _$$ModRemoveCommentImplCopyWith<_$ModRemoveCommentImpl> get copyWith =>
+      __$$ModRemoveCommentImplCopyWithImpl<_$ModRemoveCommentImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModRemoveCommentToJson(
+    return _$$ModRemoveCommentImplToJson(
       this,
     );
   }
@@ -4883,11 +4896,11 @@ abstract class _ModRemoveComment extends ModRemoveComment {
       final String? reason,
       final bool? removed,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_ModRemoveComment;
+      required final String instanceHost}) = _$ModRemoveCommentImpl;
   const _ModRemoveComment._() : super._();
 
   factory _ModRemoveComment.fromJson(Map<String, dynamic> json) =
-      _$_ModRemoveComment.fromJson;
+      _$ModRemoveCommentImpl.fromJson;
 
   @override
   int get id;
@@ -4906,7 +4919,7 @@ abstract class _ModRemoveComment extends ModRemoveComment {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModRemoveCommentCopyWith<_$_ModRemoveComment> get copyWith =>
+  _$$ModRemoveCommentImplCopyWith<_$ModRemoveCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5009,11 +5022,11 @@ class _$ModRemoveCommunityCopyWithImpl<$Res, $Val extends ModRemoveCommunity>
 }
 
 /// @nodoc
-abstract class _$$_ModRemoveCommunityCopyWith<$Res>
+abstract class _$$ModRemoveCommunityImplCopyWith<$Res>
     implements $ModRemoveCommunityCopyWith<$Res> {
-  factory _$$_ModRemoveCommunityCopyWith(_$_ModRemoveCommunity value,
-          $Res Function(_$_ModRemoveCommunity) then) =
-      __$$_ModRemoveCommunityCopyWithImpl<$Res>;
+  factory _$$ModRemoveCommunityImplCopyWith(_$ModRemoveCommunityImpl value,
+          $Res Function(_$ModRemoveCommunityImpl) then) =
+      __$$ModRemoveCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5028,11 +5041,11 @@ abstract class _$$_ModRemoveCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModRemoveCommunityCopyWithImpl<$Res>
-    extends _$ModRemoveCommunityCopyWithImpl<$Res, _$_ModRemoveCommunity>
-    implements _$$_ModRemoveCommunityCopyWith<$Res> {
-  __$$_ModRemoveCommunityCopyWithImpl(
-      _$_ModRemoveCommunity _value, $Res Function(_$_ModRemoveCommunity) _then)
+class __$$ModRemoveCommunityImplCopyWithImpl<$Res>
+    extends _$ModRemoveCommunityCopyWithImpl<$Res, _$ModRemoveCommunityImpl>
+    implements _$$ModRemoveCommunityImplCopyWith<$Res> {
+  __$$ModRemoveCommunityImplCopyWithImpl(_$ModRemoveCommunityImpl _value,
+      $Res Function(_$ModRemoveCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5047,7 +5060,7 @@ class __$$_ModRemoveCommunityCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModRemoveCommunity(
+    return _then(_$ModRemoveCommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -5087,8 +5100,8 @@ class __$$_ModRemoveCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModRemoveCommunity extends _ModRemoveCommunity {
-  const _$_ModRemoveCommunity(
+class _$ModRemoveCommunityImpl extends _ModRemoveCommunity {
+  const _$ModRemoveCommunityImpl(
       {required this.id,
       required this.modPersonId,
       required this.communityId,
@@ -5099,8 +5112,8 @@ class _$_ModRemoveCommunity extends _ModRemoveCommunity {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModRemoveCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_ModRemoveCommunityFromJson(json);
+  factory _$ModRemoveCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModRemoveCommunityImplFromJson(json);
 
   @override
   final int id;
@@ -5129,7 +5142,7 @@ class _$_ModRemoveCommunity extends _ModRemoveCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModRemoveCommunity &&
+            other is _$ModRemoveCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -5151,13 +5164,13 @@ class _$_ModRemoveCommunity extends _ModRemoveCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModRemoveCommunityCopyWith<_$_ModRemoveCommunity> get copyWith =>
-      __$$_ModRemoveCommunityCopyWithImpl<_$_ModRemoveCommunity>(
+  _$$ModRemoveCommunityImplCopyWith<_$ModRemoveCommunityImpl> get copyWith =>
+      __$$ModRemoveCommunityImplCopyWithImpl<_$ModRemoveCommunityImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModRemoveCommunityToJson(
+    return _$$ModRemoveCommunityImplToJson(
       this,
     );
   }
@@ -5172,11 +5185,11 @@ abstract class _ModRemoveCommunity extends ModRemoveCommunity {
       final bool? removed,
       final DateTime? expires,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_ModRemoveCommunity;
+      required final String instanceHost}) = _$ModRemoveCommunityImpl;
   const _ModRemoveCommunity._() : super._();
 
   factory _ModRemoveCommunity.fromJson(Map<String, dynamic> json) =
-      _$_ModRemoveCommunity.fromJson;
+      _$ModRemoveCommunityImpl.fromJson;
 
   @override
   int get id;
@@ -5197,7 +5210,7 @@ abstract class _ModRemoveCommunity extends ModRemoveCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModRemoveCommunityCopyWith<_$_ModRemoveCommunity> get copyWith =>
+  _$$ModRemoveCommunityImplCopyWith<_$ModRemoveCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5293,11 +5306,11 @@ class _$ModHideCommunityCopyWithImpl<$Res, $Val extends ModHideCommunity>
 }
 
 /// @nodoc
-abstract class _$$_ModHideCommunityCopyWith<$Res>
+abstract class _$$ModHideCommunityImplCopyWith<$Res>
     implements $ModHideCommunityCopyWith<$Res> {
-  factory _$$_ModHideCommunityCopyWith(
-          _$_ModHideCommunity value, $Res Function(_$_ModHideCommunity) then) =
-      __$$_ModHideCommunityCopyWithImpl<$Res>;
+  factory _$$ModHideCommunityImplCopyWith(_$ModHideCommunityImpl value,
+          $Res Function(_$ModHideCommunityImpl) then) =
+      __$$ModHideCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5311,11 +5324,11 @@ abstract class _$$_ModHideCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModHideCommunityCopyWithImpl<$Res>
-    extends _$ModHideCommunityCopyWithImpl<$Res, _$_ModHideCommunity>
-    implements _$$_ModHideCommunityCopyWith<$Res> {
-  __$$_ModHideCommunityCopyWithImpl(
-      _$_ModHideCommunity _value, $Res Function(_$_ModHideCommunity) _then)
+class __$$ModHideCommunityImplCopyWithImpl<$Res>
+    extends _$ModHideCommunityCopyWithImpl<$Res, _$ModHideCommunityImpl>
+    implements _$$ModHideCommunityImplCopyWith<$Res> {
+  __$$ModHideCommunityImplCopyWithImpl(_$ModHideCommunityImpl _value,
+      $Res Function(_$ModHideCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5329,7 +5342,7 @@ class __$$_ModHideCommunityCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModHideCommunity(
+    return _then(_$ModHideCommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -5365,8 +5378,8 @@ class __$$_ModHideCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModHideCommunity extends _ModHideCommunity {
-  const _$_ModHideCommunity(
+class _$ModHideCommunityImpl extends _ModHideCommunity {
+  const _$ModHideCommunityImpl(
       {required this.id,
       required this.modPersonId,
       required this.communityId,
@@ -5376,8 +5389,8 @@ class _$_ModHideCommunity extends _ModHideCommunity {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModHideCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_ModHideCommunityFromJson(json);
+  factory _$ModHideCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModHideCommunityImplFromJson(json);
 
   @override
   final int id;
@@ -5404,7 +5417,7 @@ class _$_ModHideCommunity extends _ModHideCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModHideCommunity &&
+            other is _$ModHideCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -5425,12 +5438,13 @@ class _$_ModHideCommunity extends _ModHideCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModHideCommunityCopyWith<_$_ModHideCommunity> get copyWith =>
-      __$$_ModHideCommunityCopyWithImpl<_$_ModHideCommunity>(this, _$identity);
+  _$$ModHideCommunityImplCopyWith<_$ModHideCommunityImpl> get copyWith =>
+      __$$ModHideCommunityImplCopyWithImpl<_$ModHideCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModHideCommunityToJson(
+    return _$$ModHideCommunityImplToJson(
       this,
     );
   }
@@ -5444,11 +5458,11 @@ abstract class _ModHideCommunity extends ModHideCommunity {
       final String? reason,
       required final bool hidden,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_ModHideCommunity;
+      required final String instanceHost}) = _$ModHideCommunityImpl;
   const _ModHideCommunity._() : super._();
 
   factory _ModHideCommunity.fromJson(Map<String, dynamic> json) =
-      _$_ModHideCommunity.fromJson;
+      _$ModHideCommunityImpl.fromJson;
 
   @override
   int get id;
@@ -5467,7 +5481,7 @@ abstract class _ModHideCommunity extends ModHideCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModHideCommunityCopyWith<_$_ModHideCommunity> get copyWith =>
+  _$$ModHideCommunityImplCopyWith<_$ModHideCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5577,11 +5591,11 @@ class _$ModBanFromCommunityCopyWithImpl<$Res, $Val extends ModBanFromCommunity>
 }
 
 /// @nodoc
-abstract class _$$_ModBanFromCommunityCopyWith<$Res>
+abstract class _$$ModBanFromCommunityImplCopyWith<$Res>
     implements $ModBanFromCommunityCopyWith<$Res> {
-  factory _$$_ModBanFromCommunityCopyWith(_$_ModBanFromCommunity value,
-          $Res Function(_$_ModBanFromCommunity) then) =
-      __$$_ModBanFromCommunityCopyWithImpl<$Res>;
+  factory _$$ModBanFromCommunityImplCopyWith(_$ModBanFromCommunityImpl value,
+          $Res Function(_$ModBanFromCommunityImpl) then) =
+      __$$ModBanFromCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5597,11 +5611,11 @@ abstract class _$$_ModBanFromCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModBanFromCommunityCopyWithImpl<$Res>
-    extends _$ModBanFromCommunityCopyWithImpl<$Res, _$_ModBanFromCommunity>
-    implements _$$_ModBanFromCommunityCopyWith<$Res> {
-  __$$_ModBanFromCommunityCopyWithImpl(_$_ModBanFromCommunity _value,
-      $Res Function(_$_ModBanFromCommunity) _then)
+class __$$ModBanFromCommunityImplCopyWithImpl<$Res>
+    extends _$ModBanFromCommunityCopyWithImpl<$Res, _$ModBanFromCommunityImpl>
+    implements _$$ModBanFromCommunityImplCopyWith<$Res> {
+  __$$ModBanFromCommunityImplCopyWithImpl(_$ModBanFromCommunityImpl _value,
+      $Res Function(_$ModBanFromCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5617,7 +5631,7 @@ class __$$_ModBanFromCommunityCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModBanFromCommunity(
+    return _then(_$ModBanFromCommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -5661,8 +5675,8 @@ class __$$_ModBanFromCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModBanFromCommunity extends _ModBanFromCommunity {
-  const _$_ModBanFromCommunity(
+class _$ModBanFromCommunityImpl extends _ModBanFromCommunity {
+  const _$ModBanFromCommunityImpl(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -5674,8 +5688,8 @@ class _$_ModBanFromCommunity extends _ModBanFromCommunity {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModBanFromCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_ModBanFromCommunityFromJson(json);
+  factory _$ModBanFromCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModBanFromCommunityImplFromJson(json);
 
   @override
   final int id;
@@ -5706,7 +5720,7 @@ class _$_ModBanFromCommunity extends _ModBanFromCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModBanFromCommunity &&
+            other is _$ModBanFromCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -5730,13 +5744,13 @@ class _$_ModBanFromCommunity extends _ModBanFromCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModBanFromCommunityCopyWith<_$_ModBanFromCommunity> get copyWith =>
-      __$$_ModBanFromCommunityCopyWithImpl<_$_ModBanFromCommunity>(
+  _$$ModBanFromCommunityImplCopyWith<_$ModBanFromCommunityImpl> get copyWith =>
+      __$$ModBanFromCommunityImplCopyWithImpl<_$ModBanFromCommunityImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModBanFromCommunityToJson(
+    return _$$ModBanFromCommunityImplToJson(
       this,
     );
   }
@@ -5752,11 +5766,11 @@ abstract class _ModBanFromCommunity extends ModBanFromCommunity {
       final bool? banned,
       final DateTime? expires,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_ModBanFromCommunity;
+      required final String instanceHost}) = _$ModBanFromCommunityImpl;
   const _ModBanFromCommunity._() : super._();
 
   factory _ModBanFromCommunity.fromJson(Map<String, dynamic> json) =
-      _$_ModBanFromCommunity.fromJson;
+      _$ModBanFromCommunityImpl.fromJson;
 
   @override
   int get id;
@@ -5779,7 +5793,7 @@ abstract class _ModBanFromCommunity extends ModBanFromCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModBanFromCommunityCopyWith<_$_ModBanFromCommunity> get copyWith =>
+  _$$ModBanFromCommunityImplCopyWith<_$ModBanFromCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5880,9 +5894,10 @@ class _$ModBanCopyWithImpl<$Res, $Val extends ModBan>
 }
 
 /// @nodoc
-abstract class _$$_ModBanCopyWith<$Res> implements $ModBanCopyWith<$Res> {
-  factory _$$_ModBanCopyWith(_$_ModBan value, $Res Function(_$_ModBan) then) =
-      __$$_ModBanCopyWithImpl<$Res>;
+abstract class _$$ModBanImplCopyWith<$Res> implements $ModBanCopyWith<$Res> {
+  factory _$$ModBanImplCopyWith(
+          _$ModBanImpl value, $Res Function(_$ModBanImpl) then) =
+      __$$ModBanImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5897,10 +5912,11 @@ abstract class _$$_ModBanCopyWith<$Res> implements $ModBanCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_ModBanCopyWithImpl<$Res>
-    extends _$ModBanCopyWithImpl<$Res, _$_ModBan>
-    implements _$$_ModBanCopyWith<$Res> {
-  __$$_ModBanCopyWithImpl(_$_ModBan _value, $Res Function(_$_ModBan) _then)
+class __$$ModBanImplCopyWithImpl<$Res>
+    extends _$ModBanCopyWithImpl<$Res, _$ModBanImpl>
+    implements _$$ModBanImplCopyWith<$Res> {
+  __$$ModBanImplCopyWithImpl(
+      _$ModBanImpl _value, $Res Function(_$ModBanImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5915,7 +5931,7 @@ class __$$_ModBanCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModBan(
+    return _then(_$ModBanImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -5955,8 +5971,8 @@ class __$$_ModBanCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModBan extends _ModBan {
-  const _$_ModBan(
+class _$ModBanImpl extends _ModBan {
+  const _$ModBanImpl(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -5967,8 +5983,8 @@ class _$_ModBan extends _ModBan {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModBan.fromJson(Map<String, dynamic> json) =>
-      _$$_ModBanFromJson(json);
+  factory _$ModBanImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModBanImplFromJson(json);
 
   @override
   final int id;
@@ -5997,7 +6013,7 @@ class _$_ModBan extends _ModBan {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModBan &&
+            other is _$ModBanImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -6019,12 +6035,12 @@ class _$_ModBan extends _ModBan {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModBanCopyWith<_$_ModBan> get copyWith =>
-      __$$_ModBanCopyWithImpl<_$_ModBan>(this, _$identity);
+  _$$ModBanImplCopyWith<_$ModBanImpl> get copyWith =>
+      __$$ModBanImplCopyWithImpl<_$ModBanImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModBanToJson(
+    return _$$ModBanImplToJson(
       this,
     );
   }
@@ -6039,10 +6055,10 @@ abstract class _ModBan extends ModBan {
       final bool? banned,
       final DateTime? expires,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_ModBan;
+      required final String instanceHost}) = _$ModBanImpl;
   const _ModBan._() : super._();
 
-  factory _ModBan.fromJson(Map<String, dynamic> json) = _$_ModBan.fromJson;
+  factory _ModBan.fromJson(Map<String, dynamic> json) = _$ModBanImpl.fromJson;
 
   @override
   int get id;
@@ -6063,7 +6079,7 @@ abstract class _ModBan extends ModBan {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModBanCopyWith<_$_ModBan> get copyWith =>
+  _$$ModBanImplCopyWith<_$ModBanImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -6159,11 +6175,11 @@ class _$ModAddCommunityCopyWithImpl<$Res, $Val extends ModAddCommunity>
 }
 
 /// @nodoc
-abstract class _$$_ModAddCommunityCopyWith<$Res>
+abstract class _$$ModAddCommunityImplCopyWith<$Res>
     implements $ModAddCommunityCopyWith<$Res> {
-  factory _$$_ModAddCommunityCopyWith(
-          _$_ModAddCommunity value, $Res Function(_$_ModAddCommunity) then) =
-      __$$_ModAddCommunityCopyWithImpl<$Res>;
+  factory _$$ModAddCommunityImplCopyWith(_$ModAddCommunityImpl value,
+          $Res Function(_$ModAddCommunityImpl) then) =
+      __$$ModAddCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6177,11 +6193,11 @@ abstract class _$$_ModAddCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModAddCommunityCopyWithImpl<$Res>
-    extends _$ModAddCommunityCopyWithImpl<$Res, _$_ModAddCommunity>
-    implements _$$_ModAddCommunityCopyWith<$Res> {
-  __$$_ModAddCommunityCopyWithImpl(
-      _$_ModAddCommunity _value, $Res Function(_$_ModAddCommunity) _then)
+class __$$ModAddCommunityImplCopyWithImpl<$Res>
+    extends _$ModAddCommunityCopyWithImpl<$Res, _$ModAddCommunityImpl>
+    implements _$$ModAddCommunityImplCopyWith<$Res> {
+  __$$ModAddCommunityImplCopyWithImpl(
+      _$ModAddCommunityImpl _value, $Res Function(_$ModAddCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6195,7 +6211,7 @@ class __$$_ModAddCommunityCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModAddCommunity(
+    return _then(_$ModAddCommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -6231,8 +6247,8 @@ class __$$_ModAddCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModAddCommunity extends _ModAddCommunity {
-  const _$_ModAddCommunity(
+class _$ModAddCommunityImpl extends _ModAddCommunity {
+  const _$ModAddCommunityImpl(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -6242,8 +6258,8 @@ class _$_ModAddCommunity extends _ModAddCommunity {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModAddCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_ModAddCommunityFromJson(json);
+  factory _$ModAddCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModAddCommunityImplFromJson(json);
 
   @override
   final int id;
@@ -6270,7 +6286,7 @@ class _$_ModAddCommunity extends _ModAddCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModAddCommunity &&
+            other is _$ModAddCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -6292,12 +6308,13 @@ class _$_ModAddCommunity extends _ModAddCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModAddCommunityCopyWith<_$_ModAddCommunity> get copyWith =>
-      __$$_ModAddCommunityCopyWithImpl<_$_ModAddCommunity>(this, _$identity);
+  _$$ModAddCommunityImplCopyWith<_$ModAddCommunityImpl> get copyWith =>
+      __$$ModAddCommunityImplCopyWithImpl<_$ModAddCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModAddCommunityToJson(
+    return _$$ModAddCommunityImplToJson(
       this,
     );
   }
@@ -6311,11 +6328,11 @@ abstract class _ModAddCommunity extends ModAddCommunity {
       required final int communityId,
       final bool? removed,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_ModAddCommunity;
+      required final String instanceHost}) = _$ModAddCommunityImpl;
   const _ModAddCommunity._() : super._();
 
   factory _ModAddCommunity.fromJson(Map<String, dynamic> json) =
-      _$_ModAddCommunity.fromJson;
+      _$ModAddCommunityImpl.fromJson;
 
   @override
   int get id;
@@ -6334,7 +6351,7 @@ abstract class _ModAddCommunity extends ModAddCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModAddCommunityCopyWith<_$_ModAddCommunity> get copyWith =>
+  _$$ModAddCommunityImplCopyWith<_$ModAddCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -6431,11 +6448,11 @@ class _$ModTransferCommunityCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ModTransferCommunityCopyWith<$Res>
+abstract class _$$ModTransferCommunityImplCopyWith<$Res>
     implements $ModTransferCommunityCopyWith<$Res> {
-  factory _$$_ModTransferCommunityCopyWith(_$_ModTransferCommunity value,
-          $Res Function(_$_ModTransferCommunity) then) =
-      __$$_ModTransferCommunityCopyWithImpl<$Res>;
+  factory _$$ModTransferCommunityImplCopyWith(_$ModTransferCommunityImpl value,
+          $Res Function(_$ModTransferCommunityImpl) then) =
+      __$$ModTransferCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6449,11 +6466,11 @@ abstract class _$$_ModTransferCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModTransferCommunityCopyWithImpl<$Res>
-    extends _$ModTransferCommunityCopyWithImpl<$Res, _$_ModTransferCommunity>
-    implements _$$_ModTransferCommunityCopyWith<$Res> {
-  __$$_ModTransferCommunityCopyWithImpl(_$_ModTransferCommunity _value,
-      $Res Function(_$_ModTransferCommunity) _then)
+class __$$ModTransferCommunityImplCopyWithImpl<$Res>
+    extends _$ModTransferCommunityCopyWithImpl<$Res, _$ModTransferCommunityImpl>
+    implements _$$ModTransferCommunityImplCopyWith<$Res> {
+  __$$ModTransferCommunityImplCopyWithImpl(_$ModTransferCommunityImpl _value,
+      $Res Function(_$ModTransferCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6467,7 +6484,7 @@ class __$$_ModTransferCommunityCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModTransferCommunity(
+    return _then(_$ModTransferCommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -6503,8 +6520,8 @@ class __$$_ModTransferCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModTransferCommunity extends _ModTransferCommunity {
-  const _$_ModTransferCommunity(
+class _$ModTransferCommunityImpl extends _ModTransferCommunity {
+  const _$ModTransferCommunityImpl(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -6514,8 +6531,8 @@ class _$_ModTransferCommunity extends _ModTransferCommunity {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModTransferCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_ModTransferCommunityFromJson(json);
+  factory _$ModTransferCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModTransferCommunityImplFromJson(json);
 
   @override
   final int id;
@@ -6542,7 +6559,7 @@ class _$_ModTransferCommunity extends _ModTransferCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModTransferCommunity &&
+            other is _$ModTransferCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -6564,13 +6581,14 @@ class _$_ModTransferCommunity extends _ModTransferCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModTransferCommunityCopyWith<_$_ModTransferCommunity> get copyWith =>
-      __$$_ModTransferCommunityCopyWithImpl<_$_ModTransferCommunity>(
-          this, _$identity);
+  _$$ModTransferCommunityImplCopyWith<_$ModTransferCommunityImpl>
+      get copyWith =>
+          __$$ModTransferCommunityImplCopyWithImpl<_$ModTransferCommunityImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModTransferCommunityToJson(
+    return _$$ModTransferCommunityImplToJson(
       this,
     );
   }
@@ -6584,11 +6602,11 @@ abstract class _ModTransferCommunity extends ModTransferCommunity {
       required final int communityId,
       final bool? removed,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_ModTransferCommunity;
+      required final String instanceHost}) = _$ModTransferCommunityImpl;
   const _ModTransferCommunity._() : super._();
 
   factory _ModTransferCommunity.fromJson(Map<String, dynamic> json) =
-      _$_ModTransferCommunity.fromJson;
+      _$ModTransferCommunityImpl.fromJson;
 
   @override
   int get id;
@@ -6607,8 +6625,8 @@ abstract class _ModTransferCommunity extends ModTransferCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModTransferCommunityCopyWith<_$_ModTransferCommunity> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ModTransferCommunityImplCopyWith<_$ModTransferCommunityImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 ModAdd _$ModAddFromJson(Map<String, dynamic> json) {
@@ -6694,9 +6712,10 @@ class _$ModAddCopyWithImpl<$Res, $Val extends ModAdd>
 }
 
 /// @nodoc
-abstract class _$$_ModAddCopyWith<$Res> implements $ModAddCopyWith<$Res> {
-  factory _$$_ModAddCopyWith(_$_ModAdd value, $Res Function(_$_ModAdd) then) =
-      __$$_ModAddCopyWithImpl<$Res>;
+abstract class _$$ModAddImplCopyWith<$Res> implements $ModAddCopyWith<$Res> {
+  factory _$$ModAddImplCopyWith(
+          _$ModAddImpl value, $Res Function(_$ModAddImpl) then) =
+      __$$ModAddImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6709,10 +6728,11 @@ abstract class _$$_ModAddCopyWith<$Res> implements $ModAddCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_ModAddCopyWithImpl<$Res>
-    extends _$ModAddCopyWithImpl<$Res, _$_ModAdd>
-    implements _$$_ModAddCopyWith<$Res> {
-  __$$_ModAddCopyWithImpl(_$_ModAdd _value, $Res Function(_$_ModAdd) _then)
+class __$$ModAddImplCopyWithImpl<$Res>
+    extends _$ModAddCopyWithImpl<$Res, _$ModAddImpl>
+    implements _$$ModAddImplCopyWith<$Res> {
+  __$$ModAddImplCopyWithImpl(
+      _$ModAddImpl _value, $Res Function(_$ModAddImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6725,7 +6745,7 @@ class __$$_ModAddCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModAdd(
+    return _then(_$ModAddImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -6757,8 +6777,8 @@ class __$$_ModAddCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModAdd extends _ModAdd {
-  const _$_ModAdd(
+class _$ModAddImpl extends _ModAdd {
+  const _$ModAddImpl(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -6767,8 +6787,8 @@ class _$_ModAdd extends _ModAdd {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModAdd.fromJson(Map<String, dynamic> json) =>
-      _$$_ModAddFromJson(json);
+  factory _$ModAddImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModAddImplFromJson(json);
 
   @override
   final int id;
@@ -6793,7 +6813,7 @@ class _$_ModAdd extends _ModAdd {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModAdd &&
+            other is _$ModAddImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -6813,12 +6833,12 @@ class _$_ModAdd extends _ModAdd {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModAddCopyWith<_$_ModAdd> get copyWith =>
-      __$$_ModAddCopyWithImpl<_$_ModAdd>(this, _$identity);
+  _$$ModAddImplCopyWith<_$ModAddImpl> get copyWith =>
+      __$$ModAddImplCopyWithImpl<_$ModAddImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModAddToJson(
+    return _$$ModAddImplToJson(
       this,
     );
   }
@@ -6831,10 +6851,10 @@ abstract class _ModAdd extends ModAdd {
       required final int otherPersonId,
       final bool? removed,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_ModAdd;
+      required final String instanceHost}) = _$ModAddImpl;
   const _ModAdd._() : super._();
 
-  factory _ModAdd.fromJson(Map<String, dynamic> json) = _$_ModAdd.fromJson;
+  factory _ModAdd.fromJson(Map<String, dynamic> json) = _$ModAddImpl.fromJson;
 
   @override
   int get id;
@@ -6851,7 +6871,7 @@ abstract class _ModAdd extends ModAdd {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModAddCopyWith<_$_ModAdd> get copyWith =>
+  _$$ModAddImplCopyWith<_$ModAddImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -6940,11 +6960,11 @@ class _$AdminPurgeCommentCopyWithImpl<$Res, $Val extends AdminPurgeComment>
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgeCommentCopyWith<$Res>
+abstract class _$$AdminPurgeCommentImplCopyWith<$Res>
     implements $AdminPurgeCommentCopyWith<$Res> {
-  factory _$$_AdminPurgeCommentCopyWith(_$_AdminPurgeComment value,
-          $Res Function(_$_AdminPurgeComment) then) =
-      __$$_AdminPurgeCommentCopyWithImpl<$Res>;
+  factory _$$AdminPurgeCommentImplCopyWith(_$AdminPurgeCommentImpl value,
+          $Res Function(_$AdminPurgeCommentImpl) then) =
+      __$$AdminPurgeCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6957,11 +6977,11 @@ abstract class _$$_AdminPurgeCommentCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgeCommentCopyWithImpl<$Res>
-    extends _$AdminPurgeCommentCopyWithImpl<$Res, _$_AdminPurgeComment>
-    implements _$$_AdminPurgeCommentCopyWith<$Res> {
-  __$$_AdminPurgeCommentCopyWithImpl(
-      _$_AdminPurgeComment _value, $Res Function(_$_AdminPurgeComment) _then)
+class __$$AdminPurgeCommentImplCopyWithImpl<$Res>
+    extends _$AdminPurgeCommentCopyWithImpl<$Res, _$AdminPurgeCommentImpl>
+    implements _$$AdminPurgeCommentImplCopyWith<$Res> {
+  __$$AdminPurgeCommentImplCopyWithImpl(_$AdminPurgeCommentImpl _value,
+      $Res Function(_$AdminPurgeCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6974,7 +6994,7 @@ class __$$_AdminPurgeCommentCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_AdminPurgeComment(
+    return _then(_$AdminPurgeCommentImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -7006,8 +7026,8 @@ class __$$_AdminPurgeCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgeComment extends _AdminPurgeComment {
-  const _$_AdminPurgeComment(
+class _$AdminPurgeCommentImpl extends _AdminPurgeComment {
+  const _$AdminPurgeCommentImpl(
       {required this.id,
       required this.adminPersonId,
       required this.postId,
@@ -7016,8 +7036,8 @@ class _$_AdminPurgeComment extends _AdminPurgeComment {
       required this.instanceHost})
       : super._();
 
-  factory _$_AdminPurgeComment.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgeCommentFromJson(json);
+  factory _$AdminPurgeCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgeCommentImplFromJson(json);
 
   @override
   final int id;
@@ -7042,7 +7062,7 @@ class _$_AdminPurgeComment extends _AdminPurgeComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgeComment &&
+            other is _$AdminPurgeCommentImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.adminPersonId, adminPersonId) ||
                 other.adminPersonId == adminPersonId) &&
@@ -7061,13 +7081,13 @@ class _$_AdminPurgeComment extends _AdminPurgeComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgeCommentCopyWith<_$_AdminPurgeComment> get copyWith =>
-      __$$_AdminPurgeCommentCopyWithImpl<_$_AdminPurgeComment>(
+  _$$AdminPurgeCommentImplCopyWith<_$AdminPurgeCommentImpl> get copyWith =>
+      __$$AdminPurgeCommentImplCopyWithImpl<_$AdminPurgeCommentImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgeCommentToJson(
+    return _$$AdminPurgeCommentImplToJson(
       this,
     );
   }
@@ -7080,11 +7100,11 @@ abstract class _AdminPurgeComment extends AdminPurgeComment {
       required final int postId,
       final String? reason,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_AdminPurgeComment;
+      required final String instanceHost}) = _$AdminPurgeCommentImpl;
   const _AdminPurgeComment._() : super._();
 
   factory _AdminPurgeComment.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgeComment.fromJson;
+      _$AdminPurgeCommentImpl.fromJson;
 
   @override
   int get id;
@@ -7101,7 +7121,7 @@ abstract class _AdminPurgeComment extends AdminPurgeComment {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgeCommentCopyWith<_$_AdminPurgeComment> get copyWith =>
+  _$$AdminPurgeCommentImplCopyWith<_$AdminPurgeCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7190,11 +7210,11 @@ class _$AdminPurgePostCopyWithImpl<$Res, $Val extends AdminPurgePost>
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgePostCopyWith<$Res>
+abstract class _$$AdminPurgePostImplCopyWith<$Res>
     implements $AdminPurgePostCopyWith<$Res> {
-  factory _$$_AdminPurgePostCopyWith(
-          _$_AdminPurgePost value, $Res Function(_$_AdminPurgePost) then) =
-      __$$_AdminPurgePostCopyWithImpl<$Res>;
+  factory _$$AdminPurgePostImplCopyWith(_$AdminPurgePostImpl value,
+          $Res Function(_$AdminPurgePostImpl) then) =
+      __$$AdminPurgePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -7207,11 +7227,11 @@ abstract class _$$_AdminPurgePostCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgePostCopyWithImpl<$Res>
-    extends _$AdminPurgePostCopyWithImpl<$Res, _$_AdminPurgePost>
-    implements _$$_AdminPurgePostCopyWith<$Res> {
-  __$$_AdminPurgePostCopyWithImpl(
-      _$_AdminPurgePost _value, $Res Function(_$_AdminPurgePost) _then)
+class __$$AdminPurgePostImplCopyWithImpl<$Res>
+    extends _$AdminPurgePostCopyWithImpl<$Res, _$AdminPurgePostImpl>
+    implements _$$AdminPurgePostImplCopyWith<$Res> {
+  __$$AdminPurgePostImplCopyWithImpl(
+      _$AdminPurgePostImpl _value, $Res Function(_$AdminPurgePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7224,7 +7244,7 @@ class __$$_AdminPurgePostCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_AdminPurgePost(
+    return _then(_$AdminPurgePostImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -7256,8 +7276,8 @@ class __$$_AdminPurgePostCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgePost extends _AdminPurgePost {
-  const _$_AdminPurgePost(
+class _$AdminPurgePostImpl extends _AdminPurgePost {
+  const _$AdminPurgePostImpl(
       {required this.id,
       required this.adminPersonId,
       required this.communityId,
@@ -7266,8 +7286,8 @@ class _$_AdminPurgePost extends _AdminPurgePost {
       required this.instanceHost})
       : super._();
 
-  factory _$_AdminPurgePost.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgePostFromJson(json);
+  factory _$AdminPurgePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgePostImplFromJson(json);
 
   @override
   final int id;
@@ -7292,7 +7312,7 @@ class _$_AdminPurgePost extends _AdminPurgePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgePost &&
+            other is _$AdminPurgePostImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.adminPersonId, adminPersonId) ||
                 other.adminPersonId == adminPersonId) &&
@@ -7312,12 +7332,13 @@ class _$_AdminPurgePost extends _AdminPurgePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgePostCopyWith<_$_AdminPurgePost> get copyWith =>
-      __$$_AdminPurgePostCopyWithImpl<_$_AdminPurgePost>(this, _$identity);
+  _$$AdminPurgePostImplCopyWith<_$AdminPurgePostImpl> get copyWith =>
+      __$$AdminPurgePostImplCopyWithImpl<_$AdminPurgePostImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgePostToJson(
+    return _$$AdminPurgePostImplToJson(
       this,
     );
   }
@@ -7330,11 +7351,11 @@ abstract class _AdminPurgePost extends AdminPurgePost {
       required final int communityId,
       final String? reason,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_AdminPurgePost;
+      required final String instanceHost}) = _$AdminPurgePostImpl;
   const _AdminPurgePost._() : super._();
 
   factory _AdminPurgePost.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgePost.fromJson;
+      _$AdminPurgePostImpl.fromJson;
 
   @override
   int get id;
@@ -7351,7 +7372,7 @@ abstract class _AdminPurgePost extends AdminPurgePost {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgePostCopyWith<_$_AdminPurgePost> get copyWith =>
+  _$$AdminPurgePostImplCopyWith<_$AdminPurgePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7433,11 +7454,11 @@ class _$AdminPurgePersonCopyWithImpl<$Res, $Val extends AdminPurgePerson>
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgePersonCopyWith<$Res>
+abstract class _$$AdminPurgePersonImplCopyWith<$Res>
     implements $AdminPurgePersonCopyWith<$Res> {
-  factory _$$_AdminPurgePersonCopyWith(
-          _$_AdminPurgePerson value, $Res Function(_$_AdminPurgePerson) then) =
-      __$$_AdminPurgePersonCopyWithImpl<$Res>;
+  factory _$$AdminPurgePersonImplCopyWith(_$AdminPurgePersonImpl value,
+          $Res Function(_$AdminPurgePersonImpl) then) =
+      __$$AdminPurgePersonImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -7449,11 +7470,11 @@ abstract class _$$_AdminPurgePersonCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgePersonCopyWithImpl<$Res>
-    extends _$AdminPurgePersonCopyWithImpl<$Res, _$_AdminPurgePerson>
-    implements _$$_AdminPurgePersonCopyWith<$Res> {
-  __$$_AdminPurgePersonCopyWithImpl(
-      _$_AdminPurgePerson _value, $Res Function(_$_AdminPurgePerson) _then)
+class __$$AdminPurgePersonImplCopyWithImpl<$Res>
+    extends _$AdminPurgePersonCopyWithImpl<$Res, _$AdminPurgePersonImpl>
+    implements _$$AdminPurgePersonImplCopyWith<$Res> {
+  __$$AdminPurgePersonImplCopyWithImpl(_$AdminPurgePersonImpl _value,
+      $Res Function(_$AdminPurgePersonImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7465,7 +7486,7 @@ class __$$_AdminPurgePersonCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_AdminPurgePerson(
+    return _then(_$AdminPurgePersonImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -7493,8 +7514,8 @@ class __$$_AdminPurgePersonCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgePerson extends _AdminPurgePerson {
-  const _$_AdminPurgePerson(
+class _$AdminPurgePersonImpl extends _AdminPurgePerson {
+  const _$AdminPurgePersonImpl(
       {required this.id,
       required this.adminPersonId,
       this.reason,
@@ -7502,8 +7523,8 @@ class _$_AdminPurgePerson extends _AdminPurgePerson {
       required this.instanceHost})
       : super._();
 
-  factory _$_AdminPurgePerson.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgePersonFromJson(json);
+  factory _$AdminPurgePersonImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgePersonImplFromJson(json);
 
   @override
   final int id;
@@ -7526,7 +7547,7 @@ class _$_AdminPurgePerson extends _AdminPurgePerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgePerson &&
+            other is _$AdminPurgePersonImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.adminPersonId, adminPersonId) ||
                 other.adminPersonId == adminPersonId) &&
@@ -7544,12 +7565,13 @@ class _$_AdminPurgePerson extends _AdminPurgePerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgePersonCopyWith<_$_AdminPurgePerson> get copyWith =>
-      __$$_AdminPurgePersonCopyWithImpl<_$_AdminPurgePerson>(this, _$identity);
+  _$$AdminPurgePersonImplCopyWith<_$AdminPurgePersonImpl> get copyWith =>
+      __$$AdminPurgePersonImplCopyWithImpl<_$AdminPurgePersonImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgePersonToJson(
+    return _$$AdminPurgePersonImplToJson(
       this,
     );
   }
@@ -7561,11 +7583,11 @@ abstract class _AdminPurgePerson extends AdminPurgePerson {
       required final int adminPersonId,
       final String? reason,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_AdminPurgePerson;
+      required final String instanceHost}) = _$AdminPurgePersonImpl;
   const _AdminPurgePerson._() : super._();
 
   factory _AdminPurgePerson.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgePerson.fromJson;
+      _$AdminPurgePersonImpl.fromJson;
 
   @override
   int get id;
@@ -7580,7 +7602,7 @@ abstract class _AdminPurgePerson extends AdminPurgePerson {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgePersonCopyWith<_$_AdminPurgePerson> get copyWith =>
+  _$$AdminPurgePersonImplCopyWith<_$AdminPurgePersonImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7662,11 +7684,11 @@ class _$AdminPurgeCommunityCopyWithImpl<$Res, $Val extends AdminPurgeCommunity>
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgeCommunityCopyWith<$Res>
+abstract class _$$AdminPurgeCommunityImplCopyWith<$Res>
     implements $AdminPurgeCommunityCopyWith<$Res> {
-  factory _$$_AdminPurgeCommunityCopyWith(_$_AdminPurgeCommunity value,
-          $Res Function(_$_AdminPurgeCommunity) then) =
-      __$$_AdminPurgeCommunityCopyWithImpl<$Res>;
+  factory _$$AdminPurgeCommunityImplCopyWith(_$AdminPurgeCommunityImpl value,
+          $Res Function(_$AdminPurgeCommunityImpl) then) =
+      __$$AdminPurgeCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -7678,11 +7700,11 @@ abstract class _$$_AdminPurgeCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgeCommunityCopyWithImpl<$Res>
-    extends _$AdminPurgeCommunityCopyWithImpl<$Res, _$_AdminPurgeCommunity>
-    implements _$$_AdminPurgeCommunityCopyWith<$Res> {
-  __$$_AdminPurgeCommunityCopyWithImpl(_$_AdminPurgeCommunity _value,
-      $Res Function(_$_AdminPurgeCommunity) _then)
+class __$$AdminPurgeCommunityImplCopyWithImpl<$Res>
+    extends _$AdminPurgeCommunityCopyWithImpl<$Res, _$AdminPurgeCommunityImpl>
+    implements _$$AdminPurgeCommunityImplCopyWith<$Res> {
+  __$$AdminPurgeCommunityImplCopyWithImpl(_$AdminPurgeCommunityImpl _value,
+      $Res Function(_$AdminPurgeCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7694,7 +7716,7 @@ class __$$_AdminPurgeCommunityCopyWithImpl<$Res>
     Object? when = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_AdminPurgeCommunity(
+    return _then(_$AdminPurgeCommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -7722,8 +7744,8 @@ class __$$_AdminPurgeCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgeCommunity extends _AdminPurgeCommunity {
-  const _$_AdminPurgeCommunity(
+class _$AdminPurgeCommunityImpl extends _AdminPurgeCommunity {
+  const _$AdminPurgeCommunityImpl(
       {required this.id,
       required this.adminPersonId,
       this.reason,
@@ -7731,8 +7753,8 @@ class _$_AdminPurgeCommunity extends _AdminPurgeCommunity {
       required this.instanceHost})
       : super._();
 
-  factory _$_AdminPurgeCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgeCommunityFromJson(json);
+  factory _$AdminPurgeCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgeCommunityImplFromJson(json);
 
   @override
   final int id;
@@ -7755,7 +7777,7 @@ class _$_AdminPurgeCommunity extends _AdminPurgeCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgeCommunity &&
+            other is _$AdminPurgeCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.adminPersonId, adminPersonId) ||
                 other.adminPersonId == adminPersonId) &&
@@ -7773,13 +7795,13 @@ class _$_AdminPurgeCommunity extends _AdminPurgeCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgeCommunityCopyWith<_$_AdminPurgeCommunity> get copyWith =>
-      __$$_AdminPurgeCommunityCopyWithImpl<_$_AdminPurgeCommunity>(
+  _$$AdminPurgeCommunityImplCopyWith<_$AdminPurgeCommunityImpl> get copyWith =>
+      __$$AdminPurgeCommunityImplCopyWithImpl<_$AdminPurgeCommunityImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgeCommunityToJson(
+    return _$$AdminPurgeCommunityImplToJson(
       this,
     );
   }
@@ -7791,11 +7813,11 @@ abstract class _AdminPurgeCommunity extends AdminPurgeCommunity {
       required final int adminPersonId,
       final String? reason,
       @JsonKey(name: 'when_') required final DateTime when,
-      required final String instanceHost}) = _$_AdminPurgeCommunity;
+      required final String instanceHost}) = _$AdminPurgeCommunityImpl;
   const _AdminPurgeCommunity._() : super._();
 
   factory _AdminPurgeCommunity.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgeCommunity.fromJson;
+      _$AdminPurgeCommunityImpl.fromJson;
 
   @override
   int get id;
@@ -7810,7 +7832,7 @@ abstract class _AdminPurgeCommunity extends AdminPurgeCommunity {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgeCommunityCopyWith<_$_AdminPurgeCommunity> get copyWith =>
+  _$$AdminPurgeCommunityImplCopyWith<_$AdminPurgeCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7954,11 +7976,11 @@ class _$CommunitySafeCopyWithImpl<$Res, $Val extends CommunitySafe>
 }
 
 /// @nodoc
-abstract class _$$_CommunitySafeCopyWith<$Res>
+abstract class _$$CommunitySafeImplCopyWith<$Res>
     implements $CommunitySafeCopyWith<$Res> {
-  factory _$$_CommunitySafeCopyWith(
-          _$_CommunitySafe value, $Res Function(_$_CommunitySafe) then) =
-      __$$_CommunitySafeCopyWithImpl<$Res>;
+  factory _$$CommunitySafeImplCopyWith(
+          _$CommunitySafeImpl value, $Res Function(_$CommunitySafeImpl) then) =
+      __$$CommunitySafeImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -7979,11 +8001,11 @@ abstract class _$$_CommunitySafeCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunitySafeCopyWithImpl<$Res>
-    extends _$CommunitySafeCopyWithImpl<$Res, _$_CommunitySafe>
-    implements _$$_CommunitySafeCopyWith<$Res> {
-  __$$_CommunitySafeCopyWithImpl(
-      _$_CommunitySafe _value, $Res Function(_$_CommunitySafe) _then)
+class __$$CommunitySafeImplCopyWithImpl<$Res>
+    extends _$CommunitySafeCopyWithImpl<$Res, _$CommunitySafeImpl>
+    implements _$$CommunitySafeImplCopyWith<$Res> {
+  __$$CommunitySafeImplCopyWithImpl(
+      _$CommunitySafeImpl _value, $Res Function(_$CommunitySafeImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8004,7 +8026,7 @@ class __$$_CommunitySafeCopyWithImpl<$Res>
     Object? banner = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_CommunitySafe(
+    return _then(_$CommunitySafeImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -8068,8 +8090,8 @@ class __$$_CommunitySafeCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunitySafe extends _CommunitySafe {
-  const _$_CommunitySafe(
+class _$CommunitySafeImpl extends _CommunitySafe {
+  const _$CommunitySafeImpl(
       {required this.id,
       required this.name,
       required this.title,
@@ -8086,8 +8108,8 @@ class _$_CommunitySafe extends _CommunitySafe {
       required this.instanceHost})
       : super._();
 
-  factory _$_CommunitySafe.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunitySafeFromJson(json);
+  factory _$CommunitySafeImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunitySafeImplFromJson(json);
 
   @override
   final int id;
@@ -8127,7 +8149,7 @@ class _$_CommunitySafe extends _CommunitySafe {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunitySafe &&
+            other is _$CommunitySafeImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.title, title) || other.title == title) &&
@@ -8169,12 +8191,12 @@ class _$_CommunitySafe extends _CommunitySafe {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunitySafeCopyWith<_$_CommunitySafe> get copyWith =>
-      __$$_CommunitySafeCopyWithImpl<_$_CommunitySafe>(this, _$identity);
+  _$$CommunitySafeImplCopyWith<_$CommunitySafeImpl> get copyWith =>
+      __$$CommunitySafeImplCopyWithImpl<_$CommunitySafeImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunitySafeToJson(
+    return _$$CommunitySafeImplToJson(
       this,
     );
   }
@@ -8195,11 +8217,11 @@ abstract class _CommunitySafe extends CommunitySafe {
       required final bool local,
       final String? icon,
       final String? banner,
-      required final String instanceHost}) = _$_CommunitySafe;
+      required final String instanceHost}) = _$CommunitySafeImpl;
   const _CommunitySafe._() : super._();
 
   factory _CommunitySafe.fromJson(Map<String, dynamic> json) =
-      _$_CommunitySafe.fromJson;
+      _$CommunitySafeImpl.fromJson;
 
   @override
   int get id;
@@ -8231,7 +8253,7 @@ abstract class _CommunitySafe extends CommunitySafe {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunitySafeCopyWith<_$_CommunitySafe> get copyWith =>
+  _$$CommunitySafeImplCopyWith<_$CommunitySafeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -8347,11 +8369,11 @@ class _$CommentReportCopyWithImpl<$Res, $Val extends CommentReport>
 }
 
 /// @nodoc
-abstract class _$$_CommentReportCopyWith<$Res>
+abstract class _$$CommentReportImplCopyWith<$Res>
     implements $CommentReportCopyWith<$Res> {
-  factory _$$_CommentReportCopyWith(
-          _$_CommentReport value, $Res Function(_$_CommentReport) then) =
-      __$$_CommentReportCopyWithImpl<$Res>;
+  factory _$$CommentReportImplCopyWith(
+          _$CommentReportImpl value, $Res Function(_$CommentReportImpl) then) =
+      __$$CommentReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -8368,11 +8390,11 @@ abstract class _$$_CommentReportCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentReportCopyWithImpl<$Res>
-    extends _$CommentReportCopyWithImpl<$Res, _$_CommentReport>
-    implements _$$_CommentReportCopyWith<$Res> {
-  __$$_CommentReportCopyWithImpl(
-      _$_CommentReport _value, $Res Function(_$_CommentReport) _then)
+class __$$CommentReportImplCopyWithImpl<$Res>
+    extends _$CommentReportCopyWithImpl<$Res, _$CommentReportImpl>
+    implements _$$CommentReportImplCopyWith<$Res> {
+  __$$CommentReportImplCopyWithImpl(
+      _$CommentReportImpl _value, $Res Function(_$CommentReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8389,7 +8411,7 @@ class __$$_CommentReportCopyWithImpl<$Res>
     Object? updated = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_CommentReport(
+    return _then(_$CommentReportImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -8437,8 +8459,8 @@ class __$$_CommentReportCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentReport extends _CommentReport {
-  const _$_CommentReport(
+class _$CommentReportImpl extends _CommentReport {
+  const _$CommentReportImpl(
       {required this.id,
       required this.creatorId,
       required this.commentId,
@@ -8451,8 +8473,8 @@ class _$_CommentReport extends _CommentReport {
       required this.instanceHost})
       : super._();
 
-  factory _$_CommentReport.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentReportFromJson(json);
+  factory _$CommentReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentReportImplFromJson(json);
 
   @override
   final int id;
@@ -8484,7 +8506,7 @@ class _$_CommentReport extends _CommentReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentReport &&
+            other is _$CommentReportImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -8522,12 +8544,12 @@ class _$_CommentReport extends _CommentReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentReportCopyWith<_$_CommentReport> get copyWith =>
-      __$$_CommentReportCopyWithImpl<_$_CommentReport>(this, _$identity);
+  _$$CommentReportImplCopyWith<_$CommentReportImpl> get copyWith =>
+      __$$CommentReportImplCopyWithImpl<_$CommentReportImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentReportToJson(
+    return _$$CommentReportImplToJson(
       this,
     );
   }
@@ -8544,11 +8566,11 @@ abstract class _CommentReport extends CommentReport {
       final int? resolverId,
       required final DateTime published,
       final DateTime? updated,
-      required final String instanceHost}) = _$_CommentReport;
+      required final String instanceHost}) = _$CommentReportImpl;
   const _CommentReport._() : super._();
 
   factory _CommentReport.fromJson(Map<String, dynamic> json) =
-      _$_CommentReport.fromJson;
+      _$CommentReportImpl.fromJson;
 
   @override
   int get id;
@@ -8572,7 +8594,7 @@ abstract class _CommentReport extends CommentReport {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentReportCopyWith<_$_CommentReport> get copyWith =>
+  _$$CommentReportImplCopyWith<_$CommentReportImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -8721,10 +8743,10 @@ class _$CommentCopyWithImpl<$Res, $Val extends Comment>
 }
 
 /// @nodoc
-abstract class _$$_CommentCopyWith<$Res> implements $CommentCopyWith<$Res> {
-  factory _$$_CommentCopyWith(
-          _$_Comment value, $Res Function(_$_Comment) then) =
-      __$$_CommentCopyWithImpl<$Res>;
+abstract class _$$CommentImplCopyWith<$Res> implements $CommentCopyWith<$Res> {
+  factory _$$CommentImplCopyWith(
+          _$CommentImpl value, $Res Function(_$CommentImpl) then) =
+      __$$CommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -8746,10 +8768,11 @@ abstract class _$$_CommentCopyWith<$Res> implements $CommentCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_CommentCopyWithImpl<$Res>
-    extends _$CommentCopyWithImpl<$Res, _$_Comment>
-    implements _$$_CommentCopyWith<$Res> {
-  __$$_CommentCopyWithImpl(_$_Comment _value, $Res Function(_$_Comment) _then)
+class __$$CommentImplCopyWithImpl<$Res>
+    extends _$CommentCopyWithImpl<$Res, _$CommentImpl>
+    implements _$$CommentImplCopyWith<$Res> {
+  __$$CommentImplCopyWithImpl(
+      _$CommentImpl _value, $Res Function(_$CommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8771,7 +8794,7 @@ class __$$_CommentCopyWithImpl<$Res>
     Object? instanceHost = null,
     Object? path = null,
   }) {
-    return _then(_$_Comment(
+    return _then(_$CommentImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -8839,8 +8862,8 @@ class __$$_CommentCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_Comment extends _Comment {
-  const _$_Comment(
+class _$CommentImpl extends _Comment {
+  const _$CommentImpl(
       {required this.id,
       required this.creatorId,
       required this.postId,
@@ -8858,8 +8881,8 @@ class _$_Comment extends _Comment {
       required this.path})
       : super._();
 
-  factory _$_Comment.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentFromJson(json);
+  factory _$CommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentImplFromJson(json);
 
   @override
   final int id;
@@ -8901,7 +8924,7 @@ class _$_Comment extends _Comment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Comment &&
+            other is _$CommentImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -8948,12 +8971,12 @@ class _$_Comment extends _Comment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentCopyWith<_$_Comment> get copyWith =>
-      __$$_CommentCopyWithImpl<_$_Comment>(this, _$identity);
+  _$$CommentImplCopyWith<_$CommentImpl> get copyWith =>
+      __$$CommentImplCopyWithImpl<_$CommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentToJson(
+    return _$$CommentImplToJson(
       this,
     );
   }
@@ -8975,10 +8998,10 @@ abstract class _Comment extends Comment {
       required final bool local,
       required final int languageId,
       required final String instanceHost,
-      required final String path}) = _$_Comment;
+      required final String path}) = _$CommentImpl;
   const _Comment._() : super._();
 
-  factory _Comment.fromJson(Map<String, dynamic> json) = _$_Comment.fromJson;
+  factory _Comment.fromJson(Map<String, dynamic> json) = _$CommentImpl.fromJson;
 
   @override
   int get id;
@@ -9012,7 +9035,7 @@ abstract class _Comment extends Comment {
   String get path;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentCopyWith<_$_Comment> get copyWith =>
+  _$$CommentImplCopyWith<_$CommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -9100,11 +9123,11 @@ class _$CommentReplyCopyWithImpl<$Res, $Val extends CommentReply>
 }
 
 /// @nodoc
-abstract class _$$_CommentReplyCopyWith<$Res>
+abstract class _$$CommentReplyImplCopyWith<$Res>
     implements $CommentReplyCopyWith<$Res> {
-  factory _$$_CommentReplyCopyWith(
-          _$_CommentReply value, $Res Function(_$_CommentReply) then) =
-      __$$_CommentReplyCopyWithImpl<$Res>;
+  factory _$$CommentReplyImplCopyWith(
+          _$CommentReplyImpl value, $Res Function(_$CommentReplyImpl) then) =
+      __$$CommentReplyImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -9117,11 +9140,11 @@ abstract class _$$_CommentReplyCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentReplyCopyWithImpl<$Res>
-    extends _$CommentReplyCopyWithImpl<$Res, _$_CommentReply>
-    implements _$$_CommentReplyCopyWith<$Res> {
-  __$$_CommentReplyCopyWithImpl(
-      _$_CommentReply _value, $Res Function(_$_CommentReply) _then)
+class __$$CommentReplyImplCopyWithImpl<$Res>
+    extends _$CommentReplyCopyWithImpl<$Res, _$CommentReplyImpl>
+    implements _$$CommentReplyImplCopyWith<$Res> {
+  __$$CommentReplyImplCopyWithImpl(
+      _$CommentReplyImpl _value, $Res Function(_$CommentReplyImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -9134,7 +9157,7 @@ class __$$_CommentReplyCopyWithImpl<$Res>
     Object? published = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_CommentReply(
+    return _then(_$CommentReplyImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -9166,8 +9189,8 @@ class __$$_CommentReplyCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentReply extends _CommentReply {
-  const _$_CommentReply(
+class _$CommentReplyImpl extends _CommentReply {
+  const _$CommentReplyImpl(
       {required this.id,
       required this.recipientId,
       required this.commentId,
@@ -9176,8 +9199,8 @@ class _$_CommentReply extends _CommentReply {
       required this.instanceHost})
       : super._();
 
-  factory _$_CommentReply.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentReplyFromJson(json);
+  factory _$CommentReplyImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentReplyImplFromJson(json);
 
   @override
   final int id;
@@ -9201,7 +9224,7 @@ class _$_CommentReply extends _CommentReply {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentReply &&
+            other is _$CommentReplyImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.recipientId, recipientId) ||
                 other.recipientId == recipientId) &&
@@ -9222,12 +9245,12 @@ class _$_CommentReply extends _CommentReply {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentReplyCopyWith<_$_CommentReply> get copyWith =>
-      __$$_CommentReplyCopyWithImpl<_$_CommentReply>(this, _$identity);
+  _$$CommentReplyImplCopyWith<_$CommentReplyImpl> get copyWith =>
+      __$$CommentReplyImplCopyWithImpl<_$CommentReplyImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentReplyToJson(
+    return _$$CommentReplyImplToJson(
       this,
     );
   }
@@ -9240,11 +9263,11 @@ abstract class _CommentReply extends CommentReply {
       required final int commentId,
       required final bool read,
       required final DateTime published,
-      required final String instanceHost}) = _$_CommentReply;
+      required final String instanceHost}) = _$CommentReplyImpl;
   const _CommentReply._() : super._();
 
   factory _CommentReply.fromJson(Map<String, dynamic> json) =
-      _$_CommentReply.fromJson;
+      _$CommentReplyImpl.fromJson;
 
   @override
   int get id;
@@ -9260,7 +9283,7 @@ abstract class _CommentReply extends CommentReply {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentReplyCopyWith<_$_CommentReply> get copyWith =>
+  _$$CommentReplyImplCopyWith<_$CommentReplyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -9348,11 +9371,11 @@ class _$PersonMentionCopyWithImpl<$Res, $Val extends PersonMention>
 }
 
 /// @nodoc
-abstract class _$$_PersonMentionCopyWith<$Res>
+abstract class _$$PersonMentionImplCopyWith<$Res>
     implements $PersonMentionCopyWith<$Res> {
-  factory _$$_PersonMentionCopyWith(
-          _$_PersonMention value, $Res Function(_$_PersonMention) then) =
-      __$$_PersonMentionCopyWithImpl<$Res>;
+  factory _$$PersonMentionImplCopyWith(
+          _$PersonMentionImpl value, $Res Function(_$PersonMentionImpl) then) =
+      __$$PersonMentionImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -9365,11 +9388,11 @@ abstract class _$$_PersonMentionCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PersonMentionCopyWithImpl<$Res>
-    extends _$PersonMentionCopyWithImpl<$Res, _$_PersonMention>
-    implements _$$_PersonMentionCopyWith<$Res> {
-  __$$_PersonMentionCopyWithImpl(
-      _$_PersonMention _value, $Res Function(_$_PersonMention) _then)
+class __$$PersonMentionImplCopyWithImpl<$Res>
+    extends _$PersonMentionCopyWithImpl<$Res, _$PersonMentionImpl>
+    implements _$$PersonMentionImplCopyWith<$Res> {
+  __$$PersonMentionImplCopyWithImpl(
+      _$PersonMentionImpl _value, $Res Function(_$PersonMentionImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -9382,7 +9405,7 @@ class __$$_PersonMentionCopyWithImpl<$Res>
     Object? published = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_PersonMention(
+    return _then(_$PersonMentionImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -9414,8 +9437,8 @@ class __$$_PersonMentionCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PersonMention extends _PersonMention {
-  const _$_PersonMention(
+class _$PersonMentionImpl extends _PersonMention {
+  const _$PersonMentionImpl(
       {required this.id,
       required this.recipientId,
       required this.commentId,
@@ -9424,8 +9447,8 @@ class _$_PersonMention extends _PersonMention {
       required this.instanceHost})
       : super._();
 
-  factory _$_PersonMention.fromJson(Map<String, dynamic> json) =>
-      _$$_PersonMentionFromJson(json);
+  factory _$PersonMentionImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonMentionImplFromJson(json);
 
   @override
   final int id;
@@ -9449,7 +9472,7 @@ class _$_PersonMention extends _PersonMention {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PersonMention &&
+            other is _$PersonMentionImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.recipientId, recipientId) ||
                 other.recipientId == recipientId) &&
@@ -9470,12 +9493,12 @@ class _$_PersonMention extends _PersonMention {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PersonMentionCopyWith<_$_PersonMention> get copyWith =>
-      __$$_PersonMentionCopyWithImpl<_$_PersonMention>(this, _$identity);
+  _$$PersonMentionImplCopyWith<_$PersonMentionImpl> get copyWith =>
+      __$$PersonMentionImplCopyWithImpl<_$PersonMentionImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PersonMentionToJson(
+    return _$$PersonMentionImplToJson(
       this,
     );
   }
@@ -9488,11 +9511,11 @@ abstract class _PersonMention extends PersonMention {
       required final int commentId,
       required final bool read,
       required final DateTime published,
-      required final String instanceHost}) = _$_PersonMention;
+      required final String instanceHost}) = _$PersonMentionImpl;
   const _PersonMention._() : super._();
 
   factory _PersonMention.fromJson(Map<String, dynamic> json) =
-      _$_PersonMention.fromJson;
+      _$PersonMentionImpl.fromJson;
 
   @override
   int get id;
@@ -9508,7 +9531,7 @@ abstract class _PersonMention extends PersonMention {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PersonMentionCopyWith<_$_PersonMention> get copyWith =>
+  _$$PersonMentionImplCopyWith<_$PersonMentionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -9605,11 +9628,12 @@ class _$RegistrationApplicationCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_RegistrationApplicationCopyWith<$Res>
+abstract class _$$RegistrationApplicationImplCopyWith<$Res>
     implements $RegistrationApplicationCopyWith<$Res> {
-  factory _$$_RegistrationApplicationCopyWith(_$_RegistrationApplication value,
-          $Res Function(_$_RegistrationApplication) then) =
-      __$$_RegistrationApplicationCopyWithImpl<$Res>;
+  factory _$$RegistrationApplicationImplCopyWith(
+          _$RegistrationApplicationImpl value,
+          $Res Function(_$RegistrationApplicationImpl) then) =
+      __$$RegistrationApplicationImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -9623,12 +9647,13 @@ abstract class _$$_RegistrationApplicationCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_RegistrationApplicationCopyWithImpl<$Res>
+class __$$RegistrationApplicationImplCopyWithImpl<$Res>
     extends _$RegistrationApplicationCopyWithImpl<$Res,
-        _$_RegistrationApplication>
-    implements _$$_RegistrationApplicationCopyWith<$Res> {
-  __$$_RegistrationApplicationCopyWithImpl(_$_RegistrationApplication _value,
-      $Res Function(_$_RegistrationApplication) _then)
+        _$RegistrationApplicationImpl>
+    implements _$$RegistrationApplicationImplCopyWith<$Res> {
+  __$$RegistrationApplicationImplCopyWithImpl(
+      _$RegistrationApplicationImpl _value,
+      $Res Function(_$RegistrationApplicationImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -9642,7 +9667,7 @@ class __$$_RegistrationApplicationCopyWithImpl<$Res>
     Object? published = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_RegistrationApplication(
+    return _then(_$RegistrationApplicationImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -9678,8 +9703,8 @@ class __$$_RegistrationApplicationCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_RegistrationApplication extends _RegistrationApplication {
-  const _$_RegistrationApplication(
+class _$RegistrationApplicationImpl extends _RegistrationApplication {
+  const _$RegistrationApplicationImpl(
       {required this.id,
       required this.localUserId,
       required this.answer,
@@ -9689,8 +9714,8 @@ class _$_RegistrationApplication extends _RegistrationApplication {
       required this.instanceHost})
       : super._();
 
-  factory _$_RegistrationApplication.fromJson(Map<String, dynamic> json) =>
-      _$$_RegistrationApplicationFromJson(json);
+  factory _$RegistrationApplicationImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RegistrationApplicationImplFromJson(json);
 
   @override
   final int id;
@@ -9716,7 +9741,7 @@ class _$_RegistrationApplication extends _RegistrationApplication {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_RegistrationApplication &&
+            other is _$RegistrationApplicationImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.localUserId, localUserId) ||
                 other.localUserId == localUserId) &&
@@ -9738,14 +9763,13 @@ class _$_RegistrationApplication extends _RegistrationApplication {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RegistrationApplicationCopyWith<_$_RegistrationApplication>
-      get copyWith =>
-          __$$_RegistrationApplicationCopyWithImpl<_$_RegistrationApplication>(
-              this, _$identity);
+  _$$RegistrationApplicationImplCopyWith<_$RegistrationApplicationImpl>
+      get copyWith => __$$RegistrationApplicationImplCopyWithImpl<
+          _$RegistrationApplicationImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RegistrationApplicationToJson(
+    return _$$RegistrationApplicationImplToJson(
       this,
     );
   }
@@ -9759,11 +9783,11 @@ abstract class _RegistrationApplication extends RegistrationApplication {
       final int? adminId,
       final String? denyReason,
       required final DateTime published,
-      required final String instanceHost}) = _$_RegistrationApplication;
+      required final String instanceHost}) = _$RegistrationApplicationImpl;
   const _RegistrationApplication._() : super._();
 
   factory _RegistrationApplication.fromJson(Map<String, dynamic> json) =
-      _$_RegistrationApplication.fromJson;
+      _$RegistrationApplicationImpl.fromJson;
 
   @override
   int get id;
@@ -9781,6 +9805,6 @@ abstract class _RegistrationApplication extends RegistrationApplication {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_RegistrationApplicationCopyWith<_$_RegistrationApplication>
+  _$$RegistrationApplicationImplCopyWith<_$RegistrationApplicationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/source.g.dart
+++ b/lib/src/v3/models/source.g.dart
@@ -6,8 +6,8 @@ part of 'source.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PersonSafe _$$_PersonSafeFromJson(Map<String, dynamic> json) =>
-    _$_PersonSafe(
+_$PersonSafeImpl _$$PersonSafeImplFromJson(Map<String, dynamic> json) =>
+    _$PersonSafeImpl(
       id: json['id'] as int,
       name: json['name'] as String,
       displayName: json['display_name'] as String?,
@@ -29,7 +29,7 @@ _$_PersonSafe _$$_PersonSafeFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PersonSafeToJson(_$_PersonSafe instance) =>
+Map<String, dynamic> _$$PersonSafeImplToJson(_$PersonSafeImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
@@ -64,8 +64,9 @@ Json? _$JsonConverterToJson<Json, Value>(
 ) =>
     value == null ? null : toJson(value);
 
-_$_LocalUserSettings _$$_LocalUserSettingsFromJson(Map<String, dynamic> json) =>
-    _$_LocalUserSettings(
+_$LocalUserSettingsImpl _$$LocalUserSettingsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$LocalUserSettingsImpl(
       id: json['id'] as int,
       personId: json['person_id'] as int,
       email: json['email'] as String?,
@@ -89,8 +90,8 @@ _$_LocalUserSettings _$$_LocalUserSettingsFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_LocalUserSettingsToJson(
-        _$_LocalUserSettings instance) =>
+Map<String, dynamic> _$$LocalUserSettingsImplToJson(
+        _$LocalUserSettingsImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'person_id': instance.personId,
@@ -111,7 +112,7 @@ Map<String, dynamic> _$$_LocalUserSettingsToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_Site _$$_SiteFromJson(Map<String, dynamic> json) => _$_Site(
+_$SiteImpl _$$SiteImplFromJson(Map<String, dynamic> json) => _$SiteImpl(
       id: json['id'] as int,
       name: json['name'] as String,
       sidebar: json['sidebar'] as String?,
@@ -129,7 +130,8 @@ _$_Site _$$_SiteFromJson(Map<String, dynamic> json) => _$_Site(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_SiteToJson(_$_Site instance) => <String, dynamic>{
+Map<String, dynamic> _$$SiteImplToJson(_$SiteImpl instance) =>
+    <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
       'sidebar': instance.sidebar,
@@ -147,7 +149,8 @@ Map<String, dynamic> _$$_SiteToJson(_$_Site instance) => <String, dynamic>{
       'instance_host': instance.instanceHost,
     };
 
-_$_LocalSite _$$_LocalSiteFromJson(Map<String, dynamic> json) => _$_LocalSite(
+_$LocalSiteImpl _$$LocalSiteImplFromJson(Map<String, dynamic> json) =>
+    _$LocalSiteImpl(
       id: json['id'] as int,
       siteId: json['site_id'] as int,
       siteSetup: json['site_setup'] as bool,
@@ -176,7 +179,7 @@ _$_LocalSite _$$_LocalSiteFromJson(Map<String, dynamic> json) => _$_LocalSite(
       reportsEmailAdmins: json['reports_email_admins'] as bool,
     );
 
-Map<String, dynamic> _$$_LocalSiteToJson(_$_LocalSite instance) =>
+Map<String, dynamic> _$$LocalSiteImplToJson(_$LocalSiteImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'site_id': instance.siteId,
@@ -205,8 +208,8 @@ Map<String, dynamic> _$$_LocalSiteToJson(_$_LocalSite instance) =>
       'reports_email_admins': instance.reportsEmailAdmins,
     };
 
-_$_PrivateMessage _$$_PrivateMessageFromJson(Map<String, dynamic> json) =>
-    _$_PrivateMessage(
+_$PrivateMessageImpl _$$PrivateMessageImplFromJson(Map<String, dynamic> json) =>
+    _$PrivateMessageImpl(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       recipientId: json['recipient_id'] as int,
@@ -221,7 +224,8 @@ _$_PrivateMessage _$$_PrivateMessageFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PrivateMessageToJson(_$_PrivateMessage instance) =>
+Map<String, dynamic> _$$PrivateMessageImplToJson(
+        _$PrivateMessageImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,
@@ -237,8 +241,8 @@ Map<String, dynamic> _$$_PrivateMessageToJson(_$_PrivateMessage instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_PostReport _$$_PostReportFromJson(Map<String, dynamic> json) =>
-    _$_PostReport(
+_$PostReportImpl _$$PostReportImplFromJson(Map<String, dynamic> json) =>
+    _$PostReportImpl(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       postId: json['post_id'] as int,
@@ -254,7 +258,7 @@ _$_PostReport _$$_PostReportFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PostReportToJson(_$_PostReport instance) =>
+Map<String, dynamic> _$$PostReportImplToJson(_$PostReportImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,
@@ -271,7 +275,7 @@ Map<String, dynamic> _$$_PostReportToJson(_$_PostReport instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_Post _$$_PostFromJson(Map<String, dynamic> json) => _$_Post(
+_$PostImpl _$$PostImplFromJson(Map<String, dynamic> json) => _$PostImpl(
       id: json['id'] as int,
       name: json['name'] as String,
       url: json['url'] as String?,
@@ -296,7 +300,8 @@ _$_Post _$$_PostFromJson(Map<String, dynamic> json) => _$_Post(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PostToJson(_$_Post instance) => <String, dynamic>{
+Map<String, dynamic> _$$PostImplToJson(_$PostImpl instance) =>
+    <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
       'url': instance.url,
@@ -321,9 +326,9 @@ Map<String, dynamic> _$$_PostToJson(_$_Post instance) => <String, dynamic>{
       'instance_host': instance.instanceHost,
     };
 
-_$_PasswordResetRequest _$$_PasswordResetRequestFromJson(
+_$PasswordResetRequestImpl _$$PasswordResetRequestImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PasswordResetRequest(
+    _$PasswordResetRequestImpl(
       id: json['id'] as int,
       localUserId: json['local_user_id'] as int,
       tokenEncrypted: json['token_encrypted'] as String,
@@ -331,8 +336,8 @@ _$_PasswordResetRequest _$$_PasswordResetRequestFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PasswordResetRequestToJson(
-        _$_PasswordResetRequest instance) =>
+Map<String, dynamic> _$$PasswordResetRequestImplToJson(
+        _$PasswordResetRequestImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'local_user_id': instance.localUserId,
@@ -341,8 +346,8 @@ Map<String, dynamic> _$$_PasswordResetRequestToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModRemovePost _$$_ModRemovePostFromJson(Map<String, dynamic> json) =>
-    _$_ModRemovePost(
+_$ModRemovePostImpl _$$ModRemovePostImplFromJson(Map<String, dynamic> json) =>
+    _$ModRemovePostImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       postId: json['post_id'] as int,
@@ -352,7 +357,7 @@ _$_ModRemovePost _$$_ModRemovePostFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModRemovePostToJson(_$_ModRemovePost instance) =>
+Map<String, dynamic> _$$ModRemovePostImplToJson(_$ModRemovePostImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -363,8 +368,8 @@ Map<String, dynamic> _$$_ModRemovePostToJson(_$_ModRemovePost instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_ModLockPost _$$_ModLockPostFromJson(Map<String, dynamic> json) =>
-    _$_ModLockPost(
+_$ModLockPostImpl _$$ModLockPostImplFromJson(Map<String, dynamic> json) =>
+    _$ModLockPostImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       postId: json['post_id'] as int,
@@ -373,7 +378,7 @@ _$_ModLockPost _$$_ModLockPostFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModLockPostToJson(_$_ModLockPost instance) =>
+Map<String, dynamic> _$$ModLockPostImplToJson(_$ModLockPostImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -383,8 +388,8 @@ Map<String, dynamic> _$$_ModLockPostToJson(_$_ModLockPost instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_ModStickyPost _$$_ModStickyPostFromJson(Map<String, dynamic> json) =>
-    _$_ModStickyPost(
+_$ModStickyPostImpl _$$ModStickyPostImplFromJson(Map<String, dynamic> json) =>
+    _$ModStickyPostImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       postId: json['post_id'] as int,
@@ -393,7 +398,7 @@ _$_ModStickyPost _$$_ModStickyPostFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModStickyPostToJson(_$_ModStickyPost instance) =>
+Map<String, dynamic> _$$ModStickyPostImplToJson(_$ModStickyPostImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -403,8 +408,8 @@ Map<String, dynamic> _$$_ModStickyPostToJson(_$_ModStickyPost instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_ModFeaturePost _$$_ModFeaturePostFromJson(Map<String, dynamic> json) =>
-    _$_ModFeaturePost(
+_$ModFeaturePostImpl _$$ModFeaturePostImplFromJson(Map<String, dynamic> json) =>
+    _$ModFeaturePostImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       postId: json['post_id'] as int,
@@ -414,7 +419,8 @@ _$_ModFeaturePost _$$_ModFeaturePostFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModFeaturePostToJson(_$_ModFeaturePost instance) =>
+Map<String, dynamic> _$$ModFeaturePostImplToJson(
+        _$ModFeaturePostImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -425,8 +431,9 @@ Map<String, dynamic> _$$_ModFeaturePostToJson(_$_ModFeaturePost instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_ModRemoveComment _$$_ModRemoveCommentFromJson(Map<String, dynamic> json) =>
-    _$_ModRemoveComment(
+_$ModRemoveCommentImpl _$$ModRemoveCommentImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ModRemoveCommentImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       commentId: json['comment_id'] as int,
@@ -436,7 +443,8 @@ _$_ModRemoveComment _$$_ModRemoveCommentFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModRemoveCommentToJson(_$_ModRemoveComment instance) =>
+Map<String, dynamic> _$$ModRemoveCommentImplToJson(
+        _$ModRemoveCommentImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -447,9 +455,9 @@ Map<String, dynamic> _$$_ModRemoveCommentToJson(_$_ModRemoveComment instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_ModRemoveCommunity _$$_ModRemoveCommunityFromJson(
+_$ModRemoveCommunityImpl _$$ModRemoveCommunityImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModRemoveCommunity(
+    _$ModRemoveCommunityImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       communityId: json['community_id'] as int,
@@ -461,8 +469,8 @@ _$_ModRemoveCommunity _$$_ModRemoveCommunityFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModRemoveCommunityToJson(
-        _$_ModRemoveCommunity instance) =>
+Map<String, dynamic> _$$ModRemoveCommunityImplToJson(
+        _$ModRemoveCommunityImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -475,8 +483,9 @@ Map<String, dynamic> _$$_ModRemoveCommunityToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModHideCommunity _$$_ModHideCommunityFromJson(Map<String, dynamic> json) =>
-    _$_ModHideCommunity(
+_$ModHideCommunityImpl _$$ModHideCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ModHideCommunityImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       communityId: json['community_id'] as int,
@@ -486,7 +495,8 @@ _$_ModHideCommunity _$$_ModHideCommunityFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModHideCommunityToJson(_$_ModHideCommunity instance) =>
+Map<String, dynamic> _$$ModHideCommunityImplToJson(
+        _$ModHideCommunityImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -497,9 +507,9 @@ Map<String, dynamic> _$$_ModHideCommunityToJson(_$_ModHideCommunity instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_ModBanFromCommunity _$$_ModBanFromCommunityFromJson(
+_$ModBanFromCommunityImpl _$$ModBanFromCommunityImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModBanFromCommunity(
+    _$ModBanFromCommunityImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       otherPersonId: json['other_person_id'] as int,
@@ -512,8 +522,8 @@ _$_ModBanFromCommunity _$$_ModBanFromCommunityFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModBanFromCommunityToJson(
-        _$_ModBanFromCommunity instance) =>
+Map<String, dynamic> _$$ModBanFromCommunityImplToJson(
+        _$ModBanFromCommunityImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -527,7 +537,7 @@ Map<String, dynamic> _$$_ModBanFromCommunityToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModBan _$$_ModBanFromJson(Map<String, dynamic> json) => _$_ModBan(
+_$ModBanImpl _$$ModBanImplFromJson(Map<String, dynamic> json) => _$ModBanImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       otherPersonId: json['other_person_id'] as int,
@@ -539,7 +549,8 @@ _$_ModBan _$$_ModBanFromJson(Map<String, dynamic> json) => _$_ModBan(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModBanToJson(_$_ModBan instance) => <String, dynamic>{
+Map<String, dynamic> _$$ModBanImplToJson(_$ModBanImpl instance) =>
+    <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
       'other_person_id': instance.otherPersonId,
@@ -551,31 +562,9 @@ Map<String, dynamic> _$$_ModBanToJson(_$_ModBan instance) => <String, dynamic>{
       'instance_host': instance.instanceHost,
     };
 
-_$_ModAddCommunity _$$_ModAddCommunityFromJson(Map<String, dynamic> json) =>
-    _$_ModAddCommunity(
-      id: json['id'] as int,
-      modPersonId: json['mod_person_id'] as int,
-      otherPersonId: json['other_person_id'] as int,
-      communityId: json['community_id'] as int,
-      removed: json['removed'] as bool?,
-      when: const ForceUtcDateTime().fromJson(json['when_'] as String),
-      instanceHost: json['instance_host'] as String,
-    );
-
-Map<String, dynamic> _$$_ModAddCommunityToJson(_$_ModAddCommunity instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'mod_person_id': instance.modPersonId,
-      'other_person_id': instance.otherPersonId,
-      'community_id': instance.communityId,
-      'removed': instance.removed,
-      'when_': const ForceUtcDateTime().toJson(instance.when),
-      'instance_host': instance.instanceHost,
-    };
-
-_$_ModTransferCommunity _$$_ModTransferCommunityFromJson(
+_$ModAddCommunityImpl _$$ModAddCommunityImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModTransferCommunity(
+    _$ModAddCommunityImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       otherPersonId: json['other_person_id'] as int,
@@ -585,8 +574,8 @@ _$_ModTransferCommunity _$$_ModTransferCommunityFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModTransferCommunityToJson(
-        _$_ModTransferCommunity instance) =>
+Map<String, dynamic> _$$ModAddCommunityImplToJson(
+        _$ModAddCommunityImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
@@ -597,7 +586,31 @@ Map<String, dynamic> _$$_ModTransferCommunityToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModAdd _$$_ModAddFromJson(Map<String, dynamic> json) => _$_ModAdd(
+_$ModTransferCommunityImpl _$$ModTransferCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ModTransferCommunityImpl(
+      id: json['id'] as int,
+      modPersonId: json['mod_person_id'] as int,
+      otherPersonId: json['other_person_id'] as int,
+      communityId: json['community_id'] as int,
+      removed: json['removed'] as bool?,
+      when: const ForceUtcDateTime().fromJson(json['when_'] as String),
+      instanceHost: json['instance_host'] as String,
+    );
+
+Map<String, dynamic> _$$ModTransferCommunityImplToJson(
+        _$ModTransferCommunityImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'mod_person_id': instance.modPersonId,
+      'other_person_id': instance.otherPersonId,
+      'community_id': instance.communityId,
+      'removed': instance.removed,
+      'when_': const ForceUtcDateTime().toJson(instance.when),
+      'instance_host': instance.instanceHost,
+    };
+
+_$ModAddImpl _$$ModAddImplFromJson(Map<String, dynamic> json) => _$ModAddImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       otherPersonId: json['other_person_id'] as int,
@@ -606,7 +619,8 @@ _$_ModAdd _$$_ModAddFromJson(Map<String, dynamic> json) => _$_ModAdd(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModAddToJson(_$_ModAdd instance) => <String, dynamic>{
+Map<String, dynamic> _$$ModAddImplToJson(_$ModAddImpl instance) =>
+    <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,
       'other_person_id': instance.otherPersonId,
@@ -615,8 +629,9 @@ Map<String, dynamic> _$$_ModAddToJson(_$_ModAdd instance) => <String, dynamic>{
       'instance_host': instance.instanceHost,
     };
 
-_$_AdminPurgeComment _$$_AdminPurgeCommentFromJson(Map<String, dynamic> json) =>
-    _$_AdminPurgeComment(
+_$AdminPurgeCommentImpl _$$AdminPurgeCommentImplFromJson(
+        Map<String, dynamic> json) =>
+    _$AdminPurgeCommentImpl(
       id: json['id'] as int,
       adminPersonId: json['admin_person_id'] as int,
       postId: json['post_id'] as int,
@@ -625,8 +640,8 @@ _$_AdminPurgeComment _$$_AdminPurgeCommentFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_AdminPurgeCommentToJson(
-        _$_AdminPurgeComment instance) =>
+Map<String, dynamic> _$$AdminPurgeCommentImplToJson(
+        _$AdminPurgeCommentImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'admin_person_id': instance.adminPersonId,
@@ -636,8 +651,8 @@ Map<String, dynamic> _$$_AdminPurgeCommentToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_AdminPurgePost _$$_AdminPurgePostFromJson(Map<String, dynamic> json) =>
-    _$_AdminPurgePost(
+_$AdminPurgePostImpl _$$AdminPurgePostImplFromJson(Map<String, dynamic> json) =>
+    _$AdminPurgePostImpl(
       id: json['id'] as int,
       adminPersonId: json['admin_person_id'] as int,
       communityId: json['community_id'] as int,
@@ -646,7 +661,8 @@ _$_AdminPurgePost _$$_AdminPurgePostFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_AdminPurgePostToJson(_$_AdminPurgePost instance) =>
+Map<String, dynamic> _$$AdminPurgePostImplToJson(
+        _$AdminPurgePostImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'admin_person_id': instance.adminPersonId,
@@ -656,27 +672,9 @@ Map<String, dynamic> _$$_AdminPurgePostToJson(_$_AdminPurgePost instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_AdminPurgePerson _$$_AdminPurgePersonFromJson(Map<String, dynamic> json) =>
-    _$_AdminPurgePerson(
-      id: json['id'] as int,
-      adminPersonId: json['admin_person_id'] as int,
-      reason: json['reason'] as String?,
-      when: const ForceUtcDateTime().fromJson(json['when_'] as String),
-      instanceHost: json['instance_host'] as String,
-    );
-
-Map<String, dynamic> _$$_AdminPurgePersonToJson(_$_AdminPurgePerson instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'admin_person_id': instance.adminPersonId,
-      'reason': instance.reason,
-      'when_': const ForceUtcDateTime().toJson(instance.when),
-      'instance_host': instance.instanceHost,
-    };
-
-_$_AdminPurgeCommunity _$$_AdminPurgeCommunityFromJson(
+_$AdminPurgePersonImpl _$$AdminPurgePersonImplFromJson(
         Map<String, dynamic> json) =>
-    _$_AdminPurgeCommunity(
+    _$AdminPurgePersonImpl(
       id: json['id'] as int,
       adminPersonId: json['admin_person_id'] as int,
       reason: json['reason'] as String?,
@@ -684,8 +682,8 @@ _$_AdminPurgeCommunity _$$_AdminPurgeCommunityFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_AdminPurgeCommunityToJson(
-        _$_AdminPurgeCommunity instance) =>
+Map<String, dynamic> _$$AdminPurgePersonImplToJson(
+        _$AdminPurgePersonImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'admin_person_id': instance.adminPersonId,
@@ -694,8 +692,28 @@ Map<String, dynamic> _$$_AdminPurgeCommunityToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_CommunitySafe _$$_CommunitySafeFromJson(Map<String, dynamic> json) =>
-    _$_CommunitySafe(
+_$AdminPurgeCommunityImpl _$$AdminPurgeCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$AdminPurgeCommunityImpl(
+      id: json['id'] as int,
+      adminPersonId: json['admin_person_id'] as int,
+      reason: json['reason'] as String?,
+      when: const ForceUtcDateTime().fromJson(json['when_'] as String),
+      instanceHost: json['instance_host'] as String,
+    );
+
+Map<String, dynamic> _$$AdminPurgeCommunityImplToJson(
+        _$AdminPurgeCommunityImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'admin_person_id': instance.adminPersonId,
+      'reason': instance.reason,
+      'when_': const ForceUtcDateTime().toJson(instance.when),
+      'instance_host': instance.instanceHost,
+    };
+
+_$CommunitySafeImpl _$$CommunitySafeImplFromJson(Map<String, dynamic> json) =>
+    _$CommunitySafeImpl(
       id: json['id'] as int,
       name: json['name'] as String,
       title: json['title'] as String,
@@ -713,7 +731,7 @@ _$_CommunitySafe _$$_CommunitySafeFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_CommunitySafeToJson(_$_CommunitySafe instance) =>
+Map<String, dynamic> _$$CommunitySafeImplToJson(_$CommunitySafeImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
@@ -732,8 +750,8 @@ Map<String, dynamic> _$$_CommunitySafeToJson(_$_CommunitySafe instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_CommentReport _$$_CommentReportFromJson(Map<String, dynamic> json) =>
-    _$_CommentReport(
+_$CommentReportImpl _$$CommentReportImplFromJson(Map<String, dynamic> json) =>
+    _$CommentReportImpl(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       commentId: json['comment_id'] as int,
@@ -747,7 +765,7 @@ _$_CommentReport _$$_CommentReportFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_CommentReportToJson(_$_CommentReport instance) =>
+Map<String, dynamic> _$$CommentReportImplToJson(_$CommentReportImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,
@@ -762,7 +780,8 @@ Map<String, dynamic> _$$_CommentReportToJson(_$_CommentReport instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_Comment _$$_CommentFromJson(Map<String, dynamic> json) => _$_Comment(
+_$CommentImpl _$$CommentImplFromJson(Map<String, dynamic> json) =>
+    _$CommentImpl(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       postId: json['post_id'] as int,
@@ -781,7 +800,7 @@ _$_Comment _$$_CommentFromJson(Map<String, dynamic> json) => _$_Comment(
       path: json['path'] as String,
     );
 
-Map<String, dynamic> _$$_CommentToJson(_$_Comment instance) =>
+Map<String, dynamic> _$$CommentImplToJson(_$CommentImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,
@@ -801,8 +820,8 @@ Map<String, dynamic> _$$_CommentToJson(_$_Comment instance) =>
       'path': instance.path,
     };
 
-_$_CommentReply _$$_CommentReplyFromJson(Map<String, dynamic> json) =>
-    _$_CommentReply(
+_$CommentReplyImpl _$$CommentReplyImplFromJson(Map<String, dynamic> json) =>
+    _$CommentReplyImpl(
       id: json['id'] as int,
       recipientId: json['recipient_id'] as int,
       commentId: json['comment_id'] as int,
@@ -811,7 +830,7 @@ _$_CommentReply _$$_CommentReplyFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_CommentReplyToJson(_$_CommentReply instance) =>
+Map<String, dynamic> _$$CommentReplyImplToJson(_$CommentReplyImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'recipient_id': instance.recipientId,
@@ -821,8 +840,8 @@ Map<String, dynamic> _$$_CommentReplyToJson(_$_CommentReply instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_PersonMention _$$_PersonMentionFromJson(Map<String, dynamic> json) =>
-    _$_PersonMention(
+_$PersonMentionImpl _$$PersonMentionImplFromJson(Map<String, dynamic> json) =>
+    _$PersonMentionImpl(
       id: json['id'] as int,
       recipientId: json['recipient_id'] as int,
       commentId: json['comment_id'] as int,
@@ -831,7 +850,7 @@ _$_PersonMention _$$_PersonMentionFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PersonMentionToJson(_$_PersonMention instance) =>
+Map<String, dynamic> _$$PersonMentionImplToJson(_$PersonMentionImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'recipient_id': instance.recipientId,
@@ -841,9 +860,9 @@ Map<String, dynamic> _$$_PersonMentionToJson(_$_PersonMention instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_RegistrationApplication _$$_RegistrationApplicationFromJson(
+_$RegistrationApplicationImpl _$$RegistrationApplicationImplFromJson(
         Map<String, dynamic> json) =>
-    _$_RegistrationApplication(
+    _$RegistrationApplicationImpl(
       id: json['id'] as int,
       localUserId: json['local_user_id'] as int,
       answer: json['answer'] as String,
@@ -853,8 +872,8 @@ _$_RegistrationApplication _$$_RegistrationApplicationFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_RegistrationApplicationToJson(
-        _$_RegistrationApplication instance) =>
+Map<String, dynamic> _$$RegistrationApplicationImplToJson(
+        _$RegistrationApplicationImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'local_user_id': instance.localUserId,

--- a/lib/src/v3/models/views.freezed.dart
+++ b/lib/src/v3/models/views.freezed.dart
@@ -93,11 +93,11 @@ class _$PersonViewSafeCopyWithImpl<$Res, $Val extends PersonViewSafe>
 }
 
 /// @nodoc
-abstract class _$$_PersonViewSafeCopyWith<$Res>
+abstract class _$$PersonViewSafeImplCopyWith<$Res>
     implements $PersonViewSafeCopyWith<$Res> {
-  factory _$$_PersonViewSafeCopyWith(
-          _$_PersonViewSafe value, $Res Function(_$_PersonViewSafe) then) =
-      __$$_PersonViewSafeCopyWithImpl<$Res>;
+  factory _$$PersonViewSafeImplCopyWith(_$PersonViewSafeImpl value,
+          $Res Function(_$PersonViewSafeImpl) then) =
+      __$$PersonViewSafeImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonSafe person, PersonAggregates counts, String instanceHost});
@@ -109,11 +109,11 @@ abstract class _$$_PersonViewSafeCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PersonViewSafeCopyWithImpl<$Res>
-    extends _$PersonViewSafeCopyWithImpl<$Res, _$_PersonViewSafe>
-    implements _$$_PersonViewSafeCopyWith<$Res> {
-  __$$_PersonViewSafeCopyWithImpl(
-      _$_PersonViewSafe _value, $Res Function(_$_PersonViewSafe) _then)
+class __$$PersonViewSafeImplCopyWithImpl<$Res>
+    extends _$PersonViewSafeCopyWithImpl<$Res, _$PersonViewSafeImpl>
+    implements _$$PersonViewSafeImplCopyWith<$Res> {
+  __$$PersonViewSafeImplCopyWithImpl(
+      _$PersonViewSafeImpl _value, $Res Function(_$PersonViewSafeImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -123,7 +123,7 @@ class __$$_PersonViewSafeCopyWithImpl<$Res>
     Object? counts = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_PersonViewSafe(
+    return _then(_$PersonViewSafeImpl(
       person: null == person
           ? _value.person
           : person // ignore: cast_nullable_to_non_nullable
@@ -143,13 +143,13 @@ class __$$_PersonViewSafeCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PersonViewSafe extends _PersonViewSafe {
-  const _$_PersonViewSafe(
+class _$PersonViewSafeImpl extends _PersonViewSafe {
+  const _$PersonViewSafeImpl(
       {required this.person, required this.counts, required this.instanceHost})
       : super._();
 
-  factory _$_PersonViewSafe.fromJson(Map<String, dynamic> json) =>
-      _$$_PersonViewSafeFromJson(json);
+  factory _$PersonViewSafeImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonViewSafeImplFromJson(json);
 
   @override
   final PersonSafe person;
@@ -167,7 +167,7 @@ class _$_PersonViewSafe extends _PersonViewSafe {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PersonViewSafe &&
+            other is _$PersonViewSafeImpl &&
             (identical(other.person, person) || other.person == person) &&
             (identical(other.counts, counts) || other.counts == counts) &&
             (identical(other.instanceHost, instanceHost) ||
@@ -181,12 +181,13 @@ class _$_PersonViewSafe extends _PersonViewSafe {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PersonViewSafeCopyWith<_$_PersonViewSafe> get copyWith =>
-      __$$_PersonViewSafeCopyWithImpl<_$_PersonViewSafe>(this, _$identity);
+  _$$PersonViewSafeImplCopyWith<_$PersonViewSafeImpl> get copyWith =>
+      __$$PersonViewSafeImplCopyWithImpl<_$PersonViewSafeImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PersonViewSafeToJson(
+    return _$$PersonViewSafeImplToJson(
       this,
     );
   }
@@ -196,11 +197,11 @@ abstract class _PersonViewSafe extends PersonViewSafe {
   const factory _PersonViewSafe(
       {required final PersonSafe person,
       required final PersonAggregates counts,
-      required final String instanceHost}) = _$_PersonViewSafe;
+      required final String instanceHost}) = _$PersonViewSafeImpl;
   const _PersonViewSafe._() : super._();
 
   factory _PersonViewSafe.fromJson(Map<String, dynamic> json) =
-      _$_PersonViewSafe.fromJson;
+      _$PersonViewSafeImpl.fromJson;
 
   @override
   PersonSafe get person;
@@ -210,7 +211,7 @@ abstract class _PersonViewSafe extends PersonViewSafe {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PersonViewSafeCopyWith<_$_PersonViewSafe> get copyWith =>
+  _$$PersonViewSafeImplCopyWith<_$PersonViewSafeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -411,11 +412,11 @@ class _$PersonMentionViewCopyWithImpl<$Res, $Val extends PersonMentionView>
 }
 
 /// @nodoc
-abstract class _$$_PersonMentionViewCopyWith<$Res>
+abstract class _$$PersonMentionViewImplCopyWith<$Res>
     implements $PersonMentionViewCopyWith<$Res> {
-  factory _$$_PersonMentionViewCopyWith(_$_PersonMentionView value,
-          $Res Function(_$_PersonMentionView) then) =
-      __$$_PersonMentionViewCopyWithImpl<$Res>;
+  factory _$$PersonMentionViewImplCopyWith(_$PersonMentionViewImpl value,
+          $Res Function(_$PersonMentionViewImpl) then) =
+      __$$PersonMentionViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -450,11 +451,11 @@ abstract class _$$_PersonMentionViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PersonMentionViewCopyWithImpl<$Res>
-    extends _$PersonMentionViewCopyWithImpl<$Res, _$_PersonMentionView>
-    implements _$$_PersonMentionViewCopyWith<$Res> {
-  __$$_PersonMentionViewCopyWithImpl(
-      _$_PersonMentionView _value, $Res Function(_$_PersonMentionView) _then)
+class __$$PersonMentionViewImplCopyWithImpl<$Res>
+    extends _$PersonMentionViewCopyWithImpl<$Res, _$PersonMentionViewImpl>
+    implements _$$PersonMentionViewImplCopyWith<$Res> {
+  __$$PersonMentionViewImplCopyWithImpl(_$PersonMentionViewImpl _value,
+      $Res Function(_$PersonMentionViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -474,7 +475,7 @@ class __$$_PersonMentionViewCopyWithImpl<$Res>
     Object? myVote = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_PersonMentionView(
+    return _then(_$PersonMentionViewImpl(
       personMention: null == personMention
           ? _value.personMention
           : personMention // ignore: cast_nullable_to_non_nullable
@@ -534,8 +535,8 @@ class __$$_PersonMentionViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PersonMentionView extends _PersonMentionView {
-  const _$_PersonMentionView(
+class _$PersonMentionViewImpl extends _PersonMentionView {
+  const _$PersonMentionViewImpl(
       {required this.personMention,
       required this.comment,
       required this.creator,
@@ -551,8 +552,8 @@ class _$_PersonMentionView extends _PersonMentionView {
       required this.instanceHost})
       : super._();
 
-  factory _$_PersonMentionView.fromJson(Map<String, dynamic> json) =>
-      _$$_PersonMentionViewFromJson(json);
+  factory _$PersonMentionViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonMentionViewImplFromJson(json);
 
   @override
   final PersonMention personMention;
@@ -591,7 +592,7 @@ class _$_PersonMentionView extends _PersonMentionView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PersonMentionView &&
+            other is _$PersonMentionViewImpl &&
             (identical(other.personMention, personMention) ||
                 other.personMention == personMention) &&
             (identical(other.comment, comment) || other.comment == comment) &&
@@ -637,13 +638,13 @@ class _$_PersonMentionView extends _PersonMentionView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PersonMentionViewCopyWith<_$_PersonMentionView> get copyWith =>
-      __$$_PersonMentionViewCopyWithImpl<_$_PersonMentionView>(
+  _$$PersonMentionViewImplCopyWith<_$PersonMentionViewImpl> get copyWith =>
+      __$$PersonMentionViewImplCopyWithImpl<_$PersonMentionViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PersonMentionViewToJson(
+    return _$$PersonMentionViewImplToJson(
       this,
     );
   }
@@ -663,11 +664,11 @@ abstract class _PersonMentionView extends PersonMentionView {
       required final bool saved,
       required final bool creatorBlocked,
       final VoteType? myVote,
-      required final String instanceHost}) = _$_PersonMentionView;
+      required final String instanceHost}) = _$PersonMentionViewImpl;
   const _PersonMentionView._() : super._();
 
   factory _PersonMentionView.fromJson(Map<String, dynamic> json) =
-      _$_PersonMentionView.fromJson;
+      _$PersonMentionViewImpl.fromJson;
 
   @override
   PersonMention get personMention;
@@ -697,7 +698,7 @@ abstract class _PersonMentionView extends PersonMentionView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PersonMentionViewCopyWith<_$_PersonMentionView> get copyWith =>
+  _$$PersonMentionViewImplCopyWith<_$PersonMentionViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -801,11 +802,12 @@ class _$LocalUserSettingsViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_LocalUserSettingsViewCopyWith<$Res>
+abstract class _$$LocalUserSettingsViewImplCopyWith<$Res>
     implements $LocalUserSettingsViewCopyWith<$Res> {
-  factory _$$_LocalUserSettingsViewCopyWith(_$_LocalUserSettingsView value,
-          $Res Function(_$_LocalUserSettingsView) then) =
-      __$$_LocalUserSettingsViewCopyWithImpl<$Res>;
+  factory _$$LocalUserSettingsViewImplCopyWith(
+          _$LocalUserSettingsViewImpl value,
+          $Res Function(_$LocalUserSettingsViewImpl) then) =
+      __$$LocalUserSettingsViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -823,11 +825,12 @@ abstract class _$$_LocalUserSettingsViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_LocalUserSettingsViewCopyWithImpl<$Res>
-    extends _$LocalUserSettingsViewCopyWithImpl<$Res, _$_LocalUserSettingsView>
-    implements _$$_LocalUserSettingsViewCopyWith<$Res> {
-  __$$_LocalUserSettingsViewCopyWithImpl(_$_LocalUserSettingsView _value,
-      $Res Function(_$_LocalUserSettingsView) _then)
+class __$$LocalUserSettingsViewImplCopyWithImpl<$Res>
+    extends _$LocalUserSettingsViewCopyWithImpl<$Res,
+        _$LocalUserSettingsViewImpl>
+    implements _$$LocalUserSettingsViewImplCopyWith<$Res> {
+  __$$LocalUserSettingsViewImplCopyWithImpl(_$LocalUserSettingsViewImpl _value,
+      $Res Function(_$LocalUserSettingsViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -838,7 +841,7 @@ class __$$_LocalUserSettingsViewCopyWithImpl<$Res>
     Object? counts = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_LocalUserSettingsView(
+    return _then(_$LocalUserSettingsViewImpl(
       localUser: null == localUser
           ? _value.localUser
           : localUser // ignore: cast_nullable_to_non_nullable
@@ -862,16 +865,16 @@ class __$$_LocalUserSettingsViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_LocalUserSettingsView extends _LocalUserSettingsView {
-  const _$_LocalUserSettingsView(
+class _$LocalUserSettingsViewImpl extends _LocalUserSettingsView {
+  const _$LocalUserSettingsViewImpl(
       {required this.localUser,
       required this.person,
       required this.counts,
       required this.instanceHost})
       : super._();
 
-  factory _$_LocalUserSettingsView.fromJson(Map<String, dynamic> json) =>
-      _$$_LocalUserSettingsViewFromJson(json);
+  factory _$LocalUserSettingsViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LocalUserSettingsViewImplFromJson(json);
 
   @override
   final LocalUserSettings localUser;
@@ -891,7 +894,7 @@ class _$_LocalUserSettingsView extends _LocalUserSettingsView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LocalUserSettingsView &&
+            other is _$LocalUserSettingsViewImpl &&
             (identical(other.localUser, localUser) ||
                 other.localUser == localUser) &&
             (identical(other.person, person) || other.person == person) &&
@@ -908,13 +911,13 @@ class _$_LocalUserSettingsView extends _LocalUserSettingsView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LocalUserSettingsViewCopyWith<_$_LocalUserSettingsView> get copyWith =>
-      __$$_LocalUserSettingsViewCopyWithImpl<_$_LocalUserSettingsView>(
-          this, _$identity);
+  _$$LocalUserSettingsViewImplCopyWith<_$LocalUserSettingsViewImpl>
+      get copyWith => __$$LocalUserSettingsViewImplCopyWithImpl<
+          _$LocalUserSettingsViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LocalUserSettingsViewToJson(
+    return _$$LocalUserSettingsViewImplToJson(
       this,
     );
   }
@@ -925,11 +928,11 @@ abstract class _LocalUserSettingsView extends LocalUserSettingsView {
       {required final LocalUserSettings localUser,
       required final PersonSafe person,
       required final PersonAggregates counts,
-      required final String instanceHost}) = _$_LocalUserSettingsView;
+      required final String instanceHost}) = _$LocalUserSettingsViewImpl;
   const _LocalUserSettingsView._() : super._();
 
   factory _LocalUserSettingsView.fromJson(Map<String, dynamic> json) =
-      _$_LocalUserSettingsView.fromJson;
+      _$LocalUserSettingsViewImpl.fromJson;
 
   @override
   LocalUserSettings get localUser;
@@ -941,8 +944,8 @@ abstract class _LocalUserSettingsView extends LocalUserSettingsView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_LocalUserSettingsViewCopyWith<_$_LocalUserSettingsView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$LocalUserSettingsViewImplCopyWith<_$LocalUserSettingsViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 SiteView _$SiteViewFromJson(Map<String, dynamic> json) {
@@ -1042,10 +1045,11 @@ class _$SiteViewCopyWithImpl<$Res, $Val extends SiteView>
 }
 
 /// @nodoc
-abstract class _$$_SiteViewCopyWith<$Res> implements $SiteViewCopyWith<$Res> {
-  factory _$$_SiteViewCopyWith(
-          _$_SiteView value, $Res Function(_$_SiteView) then) =
-      __$$_SiteViewCopyWithImpl<$Res>;
+abstract class _$$SiteViewImplCopyWith<$Res>
+    implements $SiteViewCopyWith<$Res> {
+  factory _$$SiteViewImplCopyWith(
+          _$SiteViewImpl value, $Res Function(_$SiteViewImpl) then) =
+      __$$SiteViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1063,11 +1067,11 @@ abstract class _$$_SiteViewCopyWith<$Res> implements $SiteViewCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_SiteViewCopyWithImpl<$Res>
-    extends _$SiteViewCopyWithImpl<$Res, _$_SiteView>
-    implements _$$_SiteViewCopyWith<$Res> {
-  __$$_SiteViewCopyWithImpl(
-      _$_SiteView _value, $Res Function(_$_SiteView) _then)
+class __$$SiteViewImplCopyWithImpl<$Res>
+    extends _$SiteViewCopyWithImpl<$Res, _$SiteViewImpl>
+    implements _$$SiteViewImplCopyWith<$Res> {
+  __$$SiteViewImplCopyWithImpl(
+      _$SiteViewImpl _value, $Res Function(_$SiteViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1078,7 +1082,7 @@ class __$$_SiteViewCopyWithImpl<$Res>
     Object? counts = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_SiteView(
+    return _then(_$SiteViewImpl(
       site: null == site
           ? _value.site
           : site // ignore: cast_nullable_to_non_nullable
@@ -1102,16 +1106,16 @@ class __$$_SiteViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_SiteView extends _SiteView {
-  const _$_SiteView(
+class _$SiteViewImpl extends _SiteView {
+  const _$SiteViewImpl(
       {required this.site,
       required this.localSite,
       required this.counts,
       required this.instanceHost})
       : super._();
 
-  factory _$_SiteView.fromJson(Map<String, dynamic> json) =>
-      _$$_SiteViewFromJson(json);
+  factory _$SiteViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SiteViewImplFromJson(json);
 
   @override
   final Site site;
@@ -1131,7 +1135,7 @@ class _$_SiteView extends _SiteView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SiteView &&
+            other is _$SiteViewImpl &&
             (identical(other.site, site) || other.site == site) &&
             (identical(other.localSite, localSite) ||
                 other.localSite == localSite) &&
@@ -1148,12 +1152,12 @@ class _$_SiteView extends _SiteView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SiteViewCopyWith<_$_SiteView> get copyWith =>
-      __$$_SiteViewCopyWithImpl<_$_SiteView>(this, _$identity);
+  _$$SiteViewImplCopyWith<_$SiteViewImpl> get copyWith =>
+      __$$SiteViewImplCopyWithImpl<_$SiteViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SiteViewToJson(
+    return _$$SiteViewImplToJson(
       this,
     );
   }
@@ -1164,10 +1168,11 @@ abstract class _SiteView extends SiteView {
       {required final Site site,
       required final LocalSite localSite,
       required final SiteAggregates counts,
-      required final String instanceHost}) = _$_SiteView;
+      required final String instanceHost}) = _$SiteViewImpl;
   const _SiteView._() : super._();
 
-  factory _SiteView.fromJson(Map<String, dynamic> json) = _$_SiteView.fromJson;
+  factory _SiteView.fromJson(Map<String, dynamic> json) =
+      _$SiteViewImpl.fromJson;
 
   @override
   Site get site;
@@ -1179,7 +1184,7 @@ abstract class _SiteView extends SiteView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_SiteViewCopyWith<_$_SiteView> get copyWith =>
+  _$$SiteViewImplCopyWith<_$SiteViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1281,11 +1286,11 @@ class _$PrivateMessageViewCopyWithImpl<$Res, $Val extends PrivateMessageView>
 }
 
 /// @nodoc
-abstract class _$$_PrivateMessageViewCopyWith<$Res>
+abstract class _$$PrivateMessageViewImplCopyWith<$Res>
     implements $PrivateMessageViewCopyWith<$Res> {
-  factory _$$_PrivateMessageViewCopyWith(_$_PrivateMessageView value,
-          $Res Function(_$_PrivateMessageView) then) =
-      __$$_PrivateMessageViewCopyWithImpl<$Res>;
+  factory _$$PrivateMessageViewImplCopyWith(_$PrivateMessageViewImpl value,
+          $Res Function(_$PrivateMessageViewImpl) then) =
+      __$$PrivateMessageViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1303,11 +1308,11 @@ abstract class _$$_PrivateMessageViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PrivateMessageViewCopyWithImpl<$Res>
-    extends _$PrivateMessageViewCopyWithImpl<$Res, _$_PrivateMessageView>
-    implements _$$_PrivateMessageViewCopyWith<$Res> {
-  __$$_PrivateMessageViewCopyWithImpl(
-      _$_PrivateMessageView _value, $Res Function(_$_PrivateMessageView) _then)
+class __$$PrivateMessageViewImplCopyWithImpl<$Res>
+    extends _$PrivateMessageViewCopyWithImpl<$Res, _$PrivateMessageViewImpl>
+    implements _$$PrivateMessageViewImplCopyWith<$Res> {
+  __$$PrivateMessageViewImplCopyWithImpl(_$PrivateMessageViewImpl _value,
+      $Res Function(_$PrivateMessageViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1318,7 +1323,7 @@ class __$$_PrivateMessageViewCopyWithImpl<$Res>
     Object? recipient = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_PrivateMessageView(
+    return _then(_$PrivateMessageViewImpl(
       privateMessage: null == privateMessage
           ? _value.privateMessage
           : privateMessage // ignore: cast_nullable_to_non_nullable
@@ -1342,16 +1347,16 @@ class __$$_PrivateMessageViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PrivateMessageView extends _PrivateMessageView {
-  const _$_PrivateMessageView(
+class _$PrivateMessageViewImpl extends _PrivateMessageView {
+  const _$PrivateMessageViewImpl(
       {required this.privateMessage,
       required this.creator,
       required this.recipient,
       required this.instanceHost})
       : super._();
 
-  factory _$_PrivateMessageView.fromJson(Map<String, dynamic> json) =>
-      _$$_PrivateMessageViewFromJson(json);
+  factory _$PrivateMessageViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PrivateMessageViewImplFromJson(json);
 
   @override
   final PrivateMessage privateMessage;
@@ -1371,7 +1376,7 @@ class _$_PrivateMessageView extends _PrivateMessageView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PrivateMessageView &&
+            other is _$PrivateMessageViewImpl &&
             (identical(other.privateMessage, privateMessage) ||
                 other.privateMessage == privateMessage) &&
             (identical(other.creator, creator) || other.creator == creator) &&
@@ -1389,13 +1394,13 @@ class _$_PrivateMessageView extends _PrivateMessageView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PrivateMessageViewCopyWith<_$_PrivateMessageView> get copyWith =>
-      __$$_PrivateMessageViewCopyWithImpl<_$_PrivateMessageView>(
+  _$$PrivateMessageViewImplCopyWith<_$PrivateMessageViewImpl> get copyWith =>
+      __$$PrivateMessageViewImplCopyWithImpl<_$PrivateMessageViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PrivateMessageViewToJson(
+    return _$$PrivateMessageViewImplToJson(
       this,
     );
   }
@@ -1406,11 +1411,11 @@ abstract class _PrivateMessageView extends PrivateMessageView {
       {required final PrivateMessage privateMessage,
       required final PersonSafe creator,
       required final PersonSafe recipient,
-      required final String instanceHost}) = _$_PrivateMessageView;
+      required final String instanceHost}) = _$PrivateMessageViewImpl;
   const _PrivateMessageView._() : super._();
 
   factory _PrivateMessageView.fromJson(Map<String, dynamic> json) =
-      _$_PrivateMessageView.fromJson;
+      _$PrivateMessageViewImpl.fromJson;
 
   @override
   PrivateMessage get privateMessage;
@@ -1422,7 +1427,7 @@ abstract class _PrivateMessageView extends PrivateMessageView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PrivateMessageViewCopyWith<_$_PrivateMessageView> get copyWith =>
+  _$$PrivateMessageViewImplCopyWith<_$PrivateMessageViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1588,10 +1593,11 @@ class _$PostViewCopyWithImpl<$Res, $Val extends PostView>
 }
 
 /// @nodoc
-abstract class _$$_PostViewCopyWith<$Res> implements $PostViewCopyWith<$Res> {
-  factory _$$_PostViewCopyWith(
-          _$_PostView value, $Res Function(_$_PostView) then) =
-      __$$_PostViewCopyWithImpl<$Res>;
+abstract class _$$PostViewImplCopyWith<$Res>
+    implements $PostViewCopyWith<$Res> {
+  factory _$$PostViewImplCopyWith(
+          _$PostViewImpl value, $Res Function(_$PostViewImpl) then) =
+      __$$PostViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1619,11 +1625,11 @@ abstract class _$$_PostViewCopyWith<$Res> implements $PostViewCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_PostViewCopyWithImpl<$Res>
-    extends _$PostViewCopyWithImpl<$Res, _$_PostView>
-    implements _$$_PostViewCopyWith<$Res> {
-  __$$_PostViewCopyWithImpl(
-      _$_PostView _value, $Res Function(_$_PostView) _then)
+class __$$PostViewImplCopyWithImpl<$Res>
+    extends _$PostViewCopyWithImpl<$Res, _$PostViewImpl>
+    implements _$$PostViewImplCopyWith<$Res> {
+  __$$PostViewImplCopyWithImpl(
+      _$PostViewImpl _value, $Res Function(_$PostViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1642,7 +1648,7 @@ class __$$_PostViewCopyWithImpl<$Res>
     Object? myVote = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_PostView(
+    return _then(_$PostViewImpl(
       post: null == post
           ? _value.post
           : post // ignore: cast_nullable_to_non_nullable
@@ -1698,8 +1704,8 @@ class __$$_PostViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PostView extends _PostView {
-  const _$_PostView(
+class _$PostViewImpl extends _PostView {
+  const _$PostViewImpl(
       {required this.post,
       required this.creator,
       required this.community,
@@ -1714,8 +1720,8 @@ class _$_PostView extends _PostView {
       required this.instanceHost})
       : super._();
 
-  factory _$_PostView.fromJson(Map<String, dynamic> json) =>
-      _$$_PostViewFromJson(json);
+  factory _$PostViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PostViewImplFromJson(json);
 
   @override
   final Post post;
@@ -1752,7 +1758,7 @@ class _$_PostView extends _PostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PostView &&
+            other is _$PostViewImpl &&
             (identical(other.post, post) || other.post == post) &&
             (identical(other.creator, creator) || other.creator == creator) &&
             (identical(other.community, community) ||
@@ -1795,12 +1801,12 @@ class _$_PostView extends _PostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PostViewCopyWith<_$_PostView> get copyWith =>
-      __$$_PostViewCopyWithImpl<_$_PostView>(this, _$identity);
+  _$$PostViewImplCopyWith<_$PostViewImpl> get copyWith =>
+      __$$PostViewImplCopyWithImpl<_$PostViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PostViewToJson(
+    return _$$PostViewImplToJson(
       this,
     );
   }
@@ -1819,10 +1825,11 @@ abstract class _PostView extends PostView {
       required final bool creatorBlocked,
       required final int unreadComments,
       final VoteType? myVote,
-      required final String instanceHost}) = _$_PostView;
+      required final String instanceHost}) = _$PostViewImpl;
   const _PostView._() : super._();
 
-  factory _PostView.fromJson(Map<String, dynamic> json) = _$_PostView.fromJson;
+  factory _PostView.fromJson(Map<String, dynamic> json) =
+      _$PostViewImpl.fromJson;
 
   @override
   Post get post;
@@ -1850,7 +1857,7 @@ abstract class _PostView extends PostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PostViewCopyWith<_$_PostView> get copyWith =>
+  _$$PostViewImplCopyWith<_$PostViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2034,11 +2041,11 @@ class _$PostReportViewCopyWithImpl<$Res, $Val extends PostReportView>
 }
 
 /// @nodoc
-abstract class _$$_PostReportViewCopyWith<$Res>
+abstract class _$$PostReportViewImplCopyWith<$Res>
     implements $PostReportViewCopyWith<$Res> {
-  factory _$$_PostReportViewCopyWith(
-          _$_PostReportView value, $Res Function(_$_PostReportView) then) =
-      __$$_PostReportViewCopyWithImpl<$Res>;
+  factory _$$PostReportViewImplCopyWith(_$PostReportViewImpl value,
+          $Res Function(_$PostReportViewImpl) then) =
+      __$$PostReportViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2070,11 +2077,11 @@ abstract class _$$_PostReportViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PostReportViewCopyWithImpl<$Res>
-    extends _$PostReportViewCopyWithImpl<$Res, _$_PostReportView>
-    implements _$$_PostReportViewCopyWith<$Res> {
-  __$$_PostReportViewCopyWithImpl(
-      _$_PostReportView _value, $Res Function(_$_PostReportView) _then)
+class __$$PostReportViewImplCopyWithImpl<$Res>
+    extends _$PostReportViewCopyWithImpl<$Res, _$PostReportViewImpl>
+    implements _$$PostReportViewImplCopyWith<$Res> {
+  __$$PostReportViewImplCopyWithImpl(
+      _$PostReportViewImpl _value, $Res Function(_$PostReportViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2091,7 +2098,7 @@ class __$$_PostReportViewCopyWithImpl<$Res>
     Object? resolver = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_PostReportView(
+    return _then(_$PostReportViewImpl(
       postReport: null == postReport
           ? _value.postReport
           : postReport // ignore: cast_nullable_to_non_nullable
@@ -2139,8 +2146,8 @@ class __$$_PostReportViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PostReportView extends _PostReportView {
-  const _$_PostReportView(
+class _$PostReportViewImpl extends _PostReportView {
+  const _$PostReportViewImpl(
       {required this.postReport,
       required this.post,
       required this.community,
@@ -2153,8 +2160,8 @@ class _$_PostReportView extends _PostReportView {
       required this.instanceHost})
       : super._();
 
-  factory _$_PostReportView.fromJson(Map<String, dynamic> json) =>
-      _$$_PostReportViewFromJson(json);
+  factory _$PostReportViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PostReportViewImplFromJson(json);
 
   @override
   final PostReport postReport;
@@ -2186,7 +2193,7 @@ class _$_PostReportView extends _PostReportView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PostReportView &&
+            other is _$PostReportViewImpl &&
             (identical(other.postReport, postReport) ||
                 other.postReport == postReport) &&
             (identical(other.post, post) || other.post == post) &&
@@ -2225,12 +2232,13 @@ class _$_PostReportView extends _PostReportView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PostReportViewCopyWith<_$_PostReportView> get copyWith =>
-      __$$_PostReportViewCopyWithImpl<_$_PostReportView>(this, _$identity);
+  _$$PostReportViewImplCopyWith<_$PostReportViewImpl> get copyWith =>
+      __$$PostReportViewImplCopyWithImpl<_$PostReportViewImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PostReportViewToJson(
+    return _$$PostReportViewImplToJson(
       this,
     );
   }
@@ -2247,11 +2255,11 @@ abstract class _PostReportView extends PostReportView {
       final VoteType? myVote,
       required final PostAggregates counts,
       final PersonSafe? resolver,
-      required final String instanceHost}) = _$_PostReportView;
+      required final String instanceHost}) = _$PostReportViewImpl;
   const _PostReportView._() : super._();
 
   factory _PostReportView.fromJson(Map<String, dynamic> json) =
-      _$_PostReportView.fromJson;
+      _$PostReportViewImpl.fromJson;
 
   @override
   PostReport get postReport;
@@ -2275,7 +2283,7 @@ abstract class _PostReportView extends PostReportView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PostReportViewCopyWith<_$_PostReportView> get copyWith =>
+  _$$PostReportViewImplCopyWith<_$PostReportViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2484,11 +2492,11 @@ class _$CommentViewCopyWithImpl<$Res, $Val extends CommentView>
 }
 
 /// @nodoc
-abstract class _$$_CommentViewCopyWith<$Res>
+abstract class _$$CommentViewImplCopyWith<$Res>
     implements $CommentViewCopyWith<$Res> {
-  factory _$$_CommentViewCopyWith(
-          _$_CommentView value, $Res Function(_$_CommentView) then) =
-      __$$_CommentViewCopyWithImpl<$Res>;
+  factory _$$CommentViewImplCopyWith(
+          _$CommentViewImpl value, $Res Function(_$CommentViewImpl) then) =
+      __$$CommentViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2523,11 +2531,11 @@ abstract class _$$_CommentViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentViewCopyWithImpl<$Res>
-    extends _$CommentViewCopyWithImpl<$Res, _$_CommentView>
-    implements _$$_CommentViewCopyWith<$Res> {
-  __$$_CommentViewCopyWithImpl(
-      _$_CommentView _value, $Res Function(_$_CommentView) _then)
+class __$$CommentViewImplCopyWithImpl<$Res>
+    extends _$CommentViewCopyWithImpl<$Res, _$CommentViewImpl>
+    implements _$$CommentViewImplCopyWith<$Res> {
+  __$$CommentViewImplCopyWithImpl(
+      _$CommentViewImpl _value, $Res Function(_$CommentViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2547,7 +2555,7 @@ class __$$_CommentViewCopyWithImpl<$Res>
     Object? myVote = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_CommentView(
+    return _then(_$CommentViewImpl(
       comment: null == comment
           ? _value.comment
           : comment // ignore: cast_nullable_to_non_nullable
@@ -2607,8 +2615,8 @@ class __$$_CommentViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentView extends _CommentView {
-  const _$_CommentView(
+class _$CommentViewImpl extends _CommentView {
+  const _$CommentViewImpl(
       {required this.comment,
       required this.creator,
       this.commentReply,
@@ -2624,8 +2632,8 @@ class _$_CommentView extends _CommentView {
       required this.instanceHost})
       : super._();
 
-  factory _$_CommentView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentViewFromJson(json);
+  factory _$CommentViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentViewImplFromJson(json);
 
   @override
   final Comment comment;
@@ -2664,7 +2672,7 @@ class _$_CommentView extends _CommentView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentView &&
+            other is _$CommentViewImpl &&
             (identical(other.comment, comment) || other.comment == comment) &&
             (identical(other.creator, creator) || other.creator == creator) &&
             (identical(other.commentReply, commentReply) ||
@@ -2710,12 +2718,12 @@ class _$_CommentView extends _CommentView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentViewCopyWith<_$_CommentView> get copyWith =>
-      __$$_CommentViewCopyWithImpl<_$_CommentView>(this, _$identity);
+  _$$CommentViewImplCopyWith<_$CommentViewImpl> get copyWith =>
+      __$$CommentViewImplCopyWithImpl<_$CommentViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentViewToJson(
+    return _$$CommentViewImplToJson(
       this,
     );
   }
@@ -2735,11 +2743,11 @@ abstract class _CommentView extends CommentView {
       required final bool saved,
       required final bool creatorBlocked,
       final VoteType? myVote,
-      required final String instanceHost}) = _$_CommentView;
+      required final String instanceHost}) = _$CommentViewImpl;
   const _CommentView._() : super._();
 
   factory _CommentView.fromJson(Map<String, dynamic> json) =
-      _$_CommentView.fromJson;
+      _$CommentViewImpl.fromJson;
 
   @override
   Comment get comment;
@@ -2769,7 +2777,7 @@ abstract class _CommentView extends CommentView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentViewCopyWith<_$_CommentView> get copyWith =>
+  _$$CommentViewImplCopyWith<_$CommentViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2974,11 +2982,11 @@ class _$CommentReplyViewCopyWithImpl<$Res, $Val extends CommentReplyView>
 }
 
 /// @nodoc
-abstract class _$$_CommentReplyViewCopyWith<$Res>
+abstract class _$$CommentReplyViewImplCopyWith<$Res>
     implements $CommentReplyViewCopyWith<$Res> {
-  factory _$$_CommentReplyViewCopyWith(
-          _$_CommentReplyView value, $Res Function(_$_CommentReplyView) then) =
-      __$$_CommentReplyViewCopyWithImpl<$Res>;
+  factory _$$CommentReplyViewImplCopyWith(_$CommentReplyViewImpl value,
+          $Res Function(_$CommentReplyViewImpl) then) =
+      __$$CommentReplyViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3013,11 +3021,11 @@ abstract class _$$_CommentReplyViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentReplyViewCopyWithImpl<$Res>
-    extends _$CommentReplyViewCopyWithImpl<$Res, _$_CommentReplyView>
-    implements _$$_CommentReplyViewCopyWith<$Res> {
-  __$$_CommentReplyViewCopyWithImpl(
-      _$_CommentReplyView _value, $Res Function(_$_CommentReplyView) _then)
+class __$$CommentReplyViewImplCopyWithImpl<$Res>
+    extends _$CommentReplyViewCopyWithImpl<$Res, _$CommentReplyViewImpl>
+    implements _$$CommentReplyViewImplCopyWith<$Res> {
+  __$$CommentReplyViewImplCopyWithImpl(_$CommentReplyViewImpl _value,
+      $Res Function(_$CommentReplyViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3037,7 +3045,7 @@ class __$$_CommentReplyViewCopyWithImpl<$Res>
     Object? myVote = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_CommentReplyView(
+    return _then(_$CommentReplyViewImpl(
       commentReply: null == commentReply
           ? _value.commentReply
           : commentReply // ignore: cast_nullable_to_non_nullable
@@ -3097,8 +3105,8 @@ class __$$_CommentReplyViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentReplyView extends _CommentReplyView {
-  const _$_CommentReplyView(
+class _$CommentReplyViewImpl extends _CommentReplyView {
+  const _$CommentReplyViewImpl(
       {required this.commentReply,
       required this.comment,
       required this.creator,
@@ -3114,8 +3122,8 @@ class _$_CommentReplyView extends _CommentReplyView {
       required this.instanceHost})
       : super._();
 
-  factory _$_CommentReplyView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentReplyViewFromJson(json);
+  factory _$CommentReplyViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentReplyViewImplFromJson(json);
 
   @override
   final CommentReply commentReply;
@@ -3154,7 +3162,7 @@ class _$_CommentReplyView extends _CommentReplyView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentReplyView &&
+            other is _$CommentReplyViewImpl &&
             (identical(other.commentReply, commentReply) ||
                 other.commentReply == commentReply) &&
             (identical(other.comment, comment) || other.comment == comment) &&
@@ -3200,12 +3208,13 @@ class _$_CommentReplyView extends _CommentReplyView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentReplyViewCopyWith<_$_CommentReplyView> get copyWith =>
-      __$$_CommentReplyViewCopyWithImpl<_$_CommentReplyView>(this, _$identity);
+  _$$CommentReplyViewImplCopyWith<_$CommentReplyViewImpl> get copyWith =>
+      __$$CommentReplyViewImplCopyWithImpl<_$CommentReplyViewImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentReplyViewToJson(
+    return _$$CommentReplyViewImplToJson(
       this,
     );
   }
@@ -3225,11 +3234,11 @@ abstract class _CommentReplyView extends CommentReplyView {
       required final bool saved,
       required final bool creatorBlocked,
       final VoteType? myVote,
-      required final String instanceHost}) = _$_CommentReplyView;
+      required final String instanceHost}) = _$CommentReplyViewImpl;
   const _CommentReplyView._() : super._();
 
   factory _CommentReplyView.fromJson(Map<String, dynamic> json) =
-      _$_CommentReplyView.fromJson;
+      _$CommentReplyViewImpl.fromJson;
 
   @override
   CommentReply get commentReply;
@@ -3259,7 +3268,7 @@ abstract class _CommentReplyView extends CommentReplyView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentReplyViewCopyWith<_$_CommentReplyView> get copyWith =>
+  _$$CommentReplyViewImplCopyWith<_$CommentReplyViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3459,11 +3468,11 @@ class _$CommentReportViewCopyWithImpl<$Res, $Val extends CommentReportView>
 }
 
 /// @nodoc
-abstract class _$$_CommentReportViewCopyWith<$Res>
+abstract class _$$CommentReportViewImplCopyWith<$Res>
     implements $CommentReportViewCopyWith<$Res> {
-  factory _$$_CommentReportViewCopyWith(_$_CommentReportView value,
-          $Res Function(_$_CommentReportView) then) =
-      __$$_CommentReportViewCopyWithImpl<$Res>;
+  factory _$$CommentReportViewImplCopyWith(_$CommentReportViewImpl value,
+          $Res Function(_$CommentReportViewImpl) then) =
+      __$$CommentReportViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3498,11 +3507,11 @@ abstract class _$$_CommentReportViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentReportViewCopyWithImpl<$Res>
-    extends _$CommentReportViewCopyWithImpl<$Res, _$_CommentReportView>
-    implements _$$_CommentReportViewCopyWith<$Res> {
-  __$$_CommentReportViewCopyWithImpl(
-      _$_CommentReportView _value, $Res Function(_$_CommentReportView) _then)
+class __$$CommentReportViewImplCopyWithImpl<$Res>
+    extends _$CommentReportViewCopyWithImpl<$Res, _$CommentReportViewImpl>
+    implements _$$CommentReportViewImplCopyWith<$Res> {
+  __$$CommentReportViewImplCopyWithImpl(_$CommentReportViewImpl _value,
+      $Res Function(_$CommentReportViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3520,7 +3529,7 @@ class __$$_CommentReportViewCopyWithImpl<$Res>
     Object? resolver = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_CommentReportView(
+    return _then(_$CommentReportViewImpl(
       commentReport: null == commentReport
           ? _value.commentReport
           : commentReport // ignore: cast_nullable_to_non_nullable
@@ -3572,8 +3581,8 @@ class __$$_CommentReportViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentReportView extends _CommentReportView {
-  const _$_CommentReportView(
+class _$CommentReportViewImpl extends _CommentReportView {
+  const _$CommentReportViewImpl(
       {required this.commentReport,
       required this.comment,
       required this.post,
@@ -3587,8 +3596,8 @@ class _$_CommentReportView extends _CommentReportView {
       required this.instanceHost})
       : super._();
 
-  factory _$_CommentReportView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentReportViewFromJson(json);
+  factory _$CommentReportViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentReportViewImplFromJson(json);
 
   @override
   final CommentReport commentReport;
@@ -3622,7 +3631,7 @@ class _$_CommentReportView extends _CommentReportView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentReportView &&
+            other is _$CommentReportViewImpl &&
             (identical(other.commentReport, commentReport) ||
                 other.commentReport == commentReport) &&
             (identical(other.comment, comment) || other.comment == comment) &&
@@ -3663,13 +3672,13 @@ class _$_CommentReportView extends _CommentReportView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentReportViewCopyWith<_$_CommentReportView> get copyWith =>
-      __$$_CommentReportViewCopyWithImpl<_$_CommentReportView>(
+  _$$CommentReportViewImplCopyWith<_$CommentReportViewImpl> get copyWith =>
+      __$$CommentReportViewImplCopyWithImpl<_$CommentReportViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentReportViewToJson(
+    return _$$CommentReportViewImplToJson(
       this,
     );
   }
@@ -3687,11 +3696,11 @@ abstract class _CommentReportView extends CommentReportView {
       final VoteType? myVote,
       required final CommentAggregates counts,
       final PersonSafe? resolver,
-      required final String instanceHost}) = _$_CommentReportView;
+      required final String instanceHost}) = _$CommentReportViewImpl;
   const _CommentReportView._() : super._();
 
   factory _CommentReportView.fromJson(Map<String, dynamic> json) =
-      _$_CommentReportView.fromJson;
+      _$CommentReportViewImpl.fromJson;
 
   @override
   CommentReport get commentReport;
@@ -3717,7 +3726,7 @@ abstract class _CommentReportView extends CommentReportView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentReportViewCopyWith<_$_CommentReportView> get copyWith =>
+  _$$CommentReportViewImplCopyWith<_$CommentReportViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3839,11 +3848,11 @@ class _$ModAddCommunityViewCopyWithImpl<$Res, $Val extends ModAddCommunityView>
 }
 
 /// @nodoc
-abstract class _$$_ModAddCommunityViewCopyWith<$Res>
+abstract class _$$ModAddCommunityViewImplCopyWith<$Res>
     implements $ModAddCommunityViewCopyWith<$Res> {
-  factory _$$_ModAddCommunityViewCopyWith(_$_ModAddCommunityView value,
-          $Res Function(_$_ModAddCommunityView) then) =
-      __$$_ModAddCommunityViewCopyWithImpl<$Res>;
+  factory _$$ModAddCommunityViewImplCopyWith(_$ModAddCommunityViewImpl value,
+          $Res Function(_$ModAddCommunityViewImpl) then) =
+      __$$ModAddCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3864,11 +3873,11 @@ abstract class _$$_ModAddCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModAddCommunityViewCopyWithImpl<$Res>
-    extends _$ModAddCommunityViewCopyWithImpl<$Res, _$_ModAddCommunityView>
-    implements _$$_ModAddCommunityViewCopyWith<$Res> {
-  __$$_ModAddCommunityViewCopyWithImpl(_$_ModAddCommunityView _value,
-      $Res Function(_$_ModAddCommunityView) _then)
+class __$$ModAddCommunityViewImplCopyWithImpl<$Res>
+    extends _$ModAddCommunityViewCopyWithImpl<$Res, _$ModAddCommunityViewImpl>
+    implements _$$ModAddCommunityViewImplCopyWith<$Res> {
+  __$$ModAddCommunityViewImplCopyWithImpl(_$ModAddCommunityViewImpl _value,
+      $Res Function(_$ModAddCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3880,7 +3889,7 @@ class __$$_ModAddCommunityViewCopyWithImpl<$Res>
     Object? moddedPerson = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModAddCommunityView(
+    return _then(_$ModAddCommunityViewImpl(
       modAddCommunity: null == modAddCommunity
           ? _value.modAddCommunity
           : modAddCommunity // ignore: cast_nullable_to_non_nullable
@@ -3908,8 +3917,8 @@ class __$$_ModAddCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModAddCommunityView extends _ModAddCommunityView {
-  const _$_ModAddCommunityView(
+class _$ModAddCommunityViewImpl extends _ModAddCommunityView {
+  const _$ModAddCommunityViewImpl(
       {required this.modAddCommunity,
       this.moderator,
       required this.community,
@@ -3917,8 +3926,8 @@ class _$_ModAddCommunityView extends _ModAddCommunityView {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModAddCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModAddCommunityViewFromJson(json);
+  factory _$ModAddCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModAddCommunityViewImplFromJson(json);
 
   @override
   final ModAddCommunity modAddCommunity;
@@ -3940,7 +3949,7 @@ class _$_ModAddCommunityView extends _ModAddCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModAddCommunityView &&
+            other is _$ModAddCommunityViewImpl &&
             (identical(other.modAddCommunity, modAddCommunity) ||
                 other.modAddCommunity == modAddCommunity) &&
             (identical(other.moderator, moderator) ||
@@ -3961,13 +3970,13 @@ class _$_ModAddCommunityView extends _ModAddCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModAddCommunityViewCopyWith<_$_ModAddCommunityView> get copyWith =>
-      __$$_ModAddCommunityViewCopyWithImpl<_$_ModAddCommunityView>(
+  _$$ModAddCommunityViewImplCopyWith<_$ModAddCommunityViewImpl> get copyWith =>
+      __$$ModAddCommunityViewImplCopyWithImpl<_$ModAddCommunityViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModAddCommunityViewToJson(
+    return _$$ModAddCommunityViewImplToJson(
       this,
     );
   }
@@ -3979,11 +3988,11 @@ abstract class _ModAddCommunityView extends ModAddCommunityView {
       final PersonSafe? moderator,
       required final CommunitySafe community,
       required final PersonSafe moddedPerson,
-      required final String instanceHost}) = _$_ModAddCommunityView;
+      required final String instanceHost}) = _$ModAddCommunityViewImpl;
   const _ModAddCommunityView._() : super._();
 
   factory _ModAddCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_ModAddCommunityView.fromJson;
+      _$ModAddCommunityViewImpl.fromJson;
 
   @override
   ModAddCommunity get modAddCommunity;
@@ -3997,7 +4006,7 @@ abstract class _ModAddCommunityView extends ModAddCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModAddCommunityViewCopyWith<_$_ModAddCommunityView> get copyWith =>
+  _$$ModAddCommunityViewImplCopyWith<_$ModAddCommunityViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4123,12 +4132,12 @@ class _$ModTransferCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ModTransferCommunityViewCopyWith<$Res>
+abstract class _$$ModTransferCommunityViewImplCopyWith<$Res>
     implements $ModTransferCommunityViewCopyWith<$Res> {
-  factory _$$_ModTransferCommunityViewCopyWith(
-          _$_ModTransferCommunityView value,
-          $Res Function(_$_ModTransferCommunityView) then) =
-      __$$_ModTransferCommunityViewCopyWithImpl<$Res>;
+  factory _$$ModTransferCommunityViewImplCopyWith(
+          _$ModTransferCommunityViewImpl value,
+          $Res Function(_$ModTransferCommunityViewImpl) then) =
+      __$$ModTransferCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4149,12 +4158,13 @@ abstract class _$$_ModTransferCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModTransferCommunityViewCopyWithImpl<$Res>
+class __$$ModTransferCommunityViewImplCopyWithImpl<$Res>
     extends _$ModTransferCommunityViewCopyWithImpl<$Res,
-        _$_ModTransferCommunityView>
-    implements _$$_ModTransferCommunityViewCopyWith<$Res> {
-  __$$_ModTransferCommunityViewCopyWithImpl(_$_ModTransferCommunityView _value,
-      $Res Function(_$_ModTransferCommunityView) _then)
+        _$ModTransferCommunityViewImpl>
+    implements _$$ModTransferCommunityViewImplCopyWith<$Res> {
+  __$$ModTransferCommunityViewImplCopyWithImpl(
+      _$ModTransferCommunityViewImpl _value,
+      $Res Function(_$ModTransferCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4166,7 +4176,7 @@ class __$$_ModTransferCommunityViewCopyWithImpl<$Res>
     Object? moddedPerson = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModTransferCommunityView(
+    return _then(_$ModTransferCommunityViewImpl(
       modTransferCommunity: null == modTransferCommunity
           ? _value.modTransferCommunity
           : modTransferCommunity // ignore: cast_nullable_to_non_nullable
@@ -4194,8 +4204,8 @@ class __$$_ModTransferCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModTransferCommunityView extends _ModTransferCommunityView {
-  const _$_ModTransferCommunityView(
+class _$ModTransferCommunityViewImpl extends _ModTransferCommunityView {
+  const _$ModTransferCommunityViewImpl(
       {required this.modTransferCommunity,
       required this.moderator,
       required this.community,
@@ -4203,8 +4213,8 @@ class _$_ModTransferCommunityView extends _ModTransferCommunityView {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModTransferCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModTransferCommunityViewFromJson(json);
+  factory _$ModTransferCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModTransferCommunityViewImplFromJson(json);
 
   @override
   final ModTransferCommunity modTransferCommunity;
@@ -4226,7 +4236,7 @@ class _$_ModTransferCommunityView extends _ModTransferCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModTransferCommunityView &&
+            other is _$ModTransferCommunityViewImpl &&
             (identical(other.modTransferCommunity, modTransferCommunity) ||
                 other.modTransferCommunity == modTransferCommunity) &&
             (identical(other.moderator, moderator) ||
@@ -4247,13 +4257,13 @@ class _$_ModTransferCommunityView extends _ModTransferCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModTransferCommunityViewCopyWith<_$_ModTransferCommunityView>
-      get copyWith => __$$_ModTransferCommunityViewCopyWithImpl<
-          _$_ModTransferCommunityView>(this, _$identity);
+  _$$ModTransferCommunityViewImplCopyWith<_$ModTransferCommunityViewImpl>
+      get copyWith => __$$ModTransferCommunityViewImplCopyWithImpl<
+          _$ModTransferCommunityViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModTransferCommunityViewToJson(
+    return _$$ModTransferCommunityViewImplToJson(
       this,
     );
   }
@@ -4265,11 +4275,11 @@ abstract class _ModTransferCommunityView extends ModTransferCommunityView {
       required final PersonSafe? moderator,
       required final CommunitySafe community,
       required final PersonSafe moddedPerson,
-      required final String instanceHost}) = _$_ModTransferCommunityView;
+      required final String instanceHost}) = _$ModTransferCommunityViewImpl;
   const _ModTransferCommunityView._() : super._();
 
   factory _ModTransferCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_ModTransferCommunityView.fromJson;
+      _$ModTransferCommunityViewImpl.fromJson;
 
   @override
   ModTransferCommunity get modTransferCommunity;
@@ -4283,7 +4293,7 @@ abstract class _ModTransferCommunityView extends ModTransferCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModTransferCommunityViewCopyWith<_$_ModTransferCommunityView>
+  _$$ModTransferCommunityViewImplCopyWith<_$ModTransferCommunityViewImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -4389,11 +4399,11 @@ class _$ModAddViewCopyWithImpl<$Res, $Val extends ModAddView>
 }
 
 /// @nodoc
-abstract class _$$_ModAddViewCopyWith<$Res>
+abstract class _$$ModAddViewImplCopyWith<$Res>
     implements $ModAddViewCopyWith<$Res> {
-  factory _$$_ModAddViewCopyWith(
-          _$_ModAddView value, $Res Function(_$_ModAddView) then) =
-      __$$_ModAddViewCopyWithImpl<$Res>;
+  factory _$$ModAddViewImplCopyWith(
+          _$ModAddViewImpl value, $Res Function(_$ModAddViewImpl) then) =
+      __$$ModAddViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4411,11 +4421,11 @@ abstract class _$$_ModAddViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModAddViewCopyWithImpl<$Res>
-    extends _$ModAddViewCopyWithImpl<$Res, _$_ModAddView>
-    implements _$$_ModAddViewCopyWith<$Res> {
-  __$$_ModAddViewCopyWithImpl(
-      _$_ModAddView _value, $Res Function(_$_ModAddView) _then)
+class __$$ModAddViewImplCopyWithImpl<$Res>
+    extends _$ModAddViewCopyWithImpl<$Res, _$ModAddViewImpl>
+    implements _$$ModAddViewImplCopyWith<$Res> {
+  __$$ModAddViewImplCopyWithImpl(
+      _$ModAddViewImpl _value, $Res Function(_$ModAddViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4426,7 +4436,7 @@ class __$$_ModAddViewCopyWithImpl<$Res>
     Object? moddedPerson = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModAddView(
+    return _then(_$ModAddViewImpl(
       modAdd: null == modAdd
           ? _value.modAdd
           : modAdd // ignore: cast_nullable_to_non_nullable
@@ -4450,16 +4460,16 @@ class __$$_ModAddViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModAddView extends _ModAddView {
-  const _$_ModAddView(
+class _$ModAddViewImpl extends _ModAddView {
+  const _$ModAddViewImpl(
       {required this.modAdd,
       required this.moderator,
       required this.moddedPerson,
       required this.instanceHost})
       : super._();
 
-  factory _$_ModAddView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModAddViewFromJson(json);
+  factory _$ModAddViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModAddViewImplFromJson(json);
 
   @override
   final ModAdd modAdd;
@@ -4479,7 +4489,7 @@ class _$_ModAddView extends _ModAddView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModAddView &&
+            other is _$ModAddViewImpl &&
             (identical(other.modAdd, modAdd) || other.modAdd == modAdd) &&
             (identical(other.moderator, moderator) ||
                 other.moderator == moderator) &&
@@ -4497,12 +4507,12 @@ class _$_ModAddView extends _ModAddView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModAddViewCopyWith<_$_ModAddView> get copyWith =>
-      __$$_ModAddViewCopyWithImpl<_$_ModAddView>(this, _$identity);
+  _$$ModAddViewImplCopyWith<_$ModAddViewImpl> get copyWith =>
+      __$$ModAddViewImplCopyWithImpl<_$ModAddViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModAddViewToJson(
+    return _$$ModAddViewImplToJson(
       this,
     );
   }
@@ -4513,11 +4523,11 @@ abstract class _ModAddView extends ModAddView {
       {required final ModAdd modAdd,
       required final PersonSafe? moderator,
       required final PersonSafe moddedPerson,
-      required final String instanceHost}) = _$_ModAddView;
+      required final String instanceHost}) = _$ModAddViewImpl;
   const _ModAddView._() : super._();
 
   factory _ModAddView.fromJson(Map<String, dynamic> json) =
-      _$_ModAddView.fromJson;
+      _$ModAddViewImpl.fromJson;
 
   @override
   ModAdd get modAdd;
@@ -4529,7 +4539,7 @@ abstract class _ModAddView extends ModAddView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModAddViewCopyWith<_$_ModAddView> get copyWith =>
+  _$$ModAddViewImplCopyWith<_$ModAddViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4655,11 +4665,12 @@ class _$ModBanFromCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ModBanFromCommunityViewCopyWith<$Res>
+abstract class _$$ModBanFromCommunityViewImplCopyWith<$Res>
     implements $ModBanFromCommunityViewCopyWith<$Res> {
-  factory _$$_ModBanFromCommunityViewCopyWith(_$_ModBanFromCommunityView value,
-          $Res Function(_$_ModBanFromCommunityView) then) =
-      __$$_ModBanFromCommunityViewCopyWithImpl<$Res>;
+  factory _$$ModBanFromCommunityViewImplCopyWith(
+          _$ModBanFromCommunityViewImpl value,
+          $Res Function(_$ModBanFromCommunityViewImpl) then) =
+      __$$ModBanFromCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4680,12 +4691,13 @@ abstract class _$$_ModBanFromCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModBanFromCommunityViewCopyWithImpl<$Res>
+class __$$ModBanFromCommunityViewImplCopyWithImpl<$Res>
     extends _$ModBanFromCommunityViewCopyWithImpl<$Res,
-        _$_ModBanFromCommunityView>
-    implements _$$_ModBanFromCommunityViewCopyWith<$Res> {
-  __$$_ModBanFromCommunityViewCopyWithImpl(_$_ModBanFromCommunityView _value,
-      $Res Function(_$_ModBanFromCommunityView) _then)
+        _$ModBanFromCommunityViewImpl>
+    implements _$$ModBanFromCommunityViewImplCopyWith<$Res> {
+  __$$ModBanFromCommunityViewImplCopyWithImpl(
+      _$ModBanFromCommunityViewImpl _value,
+      $Res Function(_$ModBanFromCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4697,7 +4709,7 @@ class __$$_ModBanFromCommunityViewCopyWithImpl<$Res>
     Object? bannedPerson = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModBanFromCommunityView(
+    return _then(_$ModBanFromCommunityViewImpl(
       modBanFromCommunity: null == modBanFromCommunity
           ? _value.modBanFromCommunity
           : modBanFromCommunity // ignore: cast_nullable_to_non_nullable
@@ -4725,8 +4737,8 @@ class __$$_ModBanFromCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModBanFromCommunityView extends _ModBanFromCommunityView {
-  const _$_ModBanFromCommunityView(
+class _$ModBanFromCommunityViewImpl extends _ModBanFromCommunityView {
+  const _$ModBanFromCommunityViewImpl(
       {required this.modBanFromCommunity,
       required this.moderator,
       required this.community,
@@ -4734,8 +4746,8 @@ class _$_ModBanFromCommunityView extends _ModBanFromCommunityView {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModBanFromCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModBanFromCommunityViewFromJson(json);
+  factory _$ModBanFromCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModBanFromCommunityViewImplFromJson(json);
 
   @override
   final ModBanFromCommunity modBanFromCommunity;
@@ -4757,7 +4769,7 @@ class _$_ModBanFromCommunityView extends _ModBanFromCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModBanFromCommunityView &&
+            other is _$ModBanFromCommunityViewImpl &&
             (identical(other.modBanFromCommunity, modBanFromCommunity) ||
                 other.modBanFromCommunity == modBanFromCommunity) &&
             (identical(other.moderator, moderator) ||
@@ -4778,14 +4790,13 @@ class _$_ModBanFromCommunityView extends _ModBanFromCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModBanFromCommunityViewCopyWith<_$_ModBanFromCommunityView>
-      get copyWith =>
-          __$$_ModBanFromCommunityViewCopyWithImpl<_$_ModBanFromCommunityView>(
-              this, _$identity);
+  _$$ModBanFromCommunityViewImplCopyWith<_$ModBanFromCommunityViewImpl>
+      get copyWith => __$$ModBanFromCommunityViewImplCopyWithImpl<
+          _$ModBanFromCommunityViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModBanFromCommunityViewToJson(
+    return _$$ModBanFromCommunityViewImplToJson(
       this,
     );
   }
@@ -4797,11 +4808,11 @@ abstract class _ModBanFromCommunityView extends ModBanFromCommunityView {
       required final PersonSafe? moderator,
       required final CommunitySafe community,
       required final PersonSafe bannedPerson,
-      required final String instanceHost}) = _$_ModBanFromCommunityView;
+      required final String instanceHost}) = _$ModBanFromCommunityViewImpl;
   const _ModBanFromCommunityView._() : super._();
 
   factory _ModBanFromCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_ModBanFromCommunityView.fromJson;
+      _$ModBanFromCommunityViewImpl.fromJson;
 
   @override
   ModBanFromCommunity get modBanFromCommunity;
@@ -4815,7 +4826,7 @@ abstract class _ModBanFromCommunityView extends ModBanFromCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModBanFromCommunityViewCopyWith<_$_ModBanFromCommunityView>
+  _$$ModBanFromCommunityViewImplCopyWith<_$ModBanFromCommunityViewImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -4921,11 +4932,11 @@ class _$ModBanViewCopyWithImpl<$Res, $Val extends ModBanView>
 }
 
 /// @nodoc
-abstract class _$$_ModBanViewCopyWith<$Res>
+abstract class _$$ModBanViewImplCopyWith<$Res>
     implements $ModBanViewCopyWith<$Res> {
-  factory _$$_ModBanViewCopyWith(
-          _$_ModBanView value, $Res Function(_$_ModBanView) then) =
-      __$$_ModBanViewCopyWithImpl<$Res>;
+  factory _$$ModBanViewImplCopyWith(
+          _$ModBanViewImpl value, $Res Function(_$ModBanViewImpl) then) =
+      __$$ModBanViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4943,11 +4954,11 @@ abstract class _$$_ModBanViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModBanViewCopyWithImpl<$Res>
-    extends _$ModBanViewCopyWithImpl<$Res, _$_ModBanView>
-    implements _$$_ModBanViewCopyWith<$Res> {
-  __$$_ModBanViewCopyWithImpl(
-      _$_ModBanView _value, $Res Function(_$_ModBanView) _then)
+class __$$ModBanViewImplCopyWithImpl<$Res>
+    extends _$ModBanViewCopyWithImpl<$Res, _$ModBanViewImpl>
+    implements _$$ModBanViewImplCopyWith<$Res> {
+  __$$ModBanViewImplCopyWithImpl(
+      _$ModBanViewImpl _value, $Res Function(_$ModBanViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4958,7 +4969,7 @@ class __$$_ModBanViewCopyWithImpl<$Res>
     Object? bannedPerson = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModBanView(
+    return _then(_$ModBanViewImpl(
       modBan: null == modBan
           ? _value.modBan
           : modBan // ignore: cast_nullable_to_non_nullable
@@ -4982,16 +4993,16 @@ class __$$_ModBanViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModBanView extends _ModBanView {
-  const _$_ModBanView(
+class _$ModBanViewImpl extends _ModBanView {
+  const _$ModBanViewImpl(
       {required this.modBan,
       required this.moderator,
       required this.bannedPerson,
       required this.instanceHost})
       : super._();
 
-  factory _$_ModBanView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModBanViewFromJson(json);
+  factory _$ModBanViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModBanViewImplFromJson(json);
 
   @override
   final ModBan modBan;
@@ -5011,7 +5022,7 @@ class _$_ModBanView extends _ModBanView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModBanView &&
+            other is _$ModBanViewImpl &&
             (identical(other.modBan, modBan) || other.modBan == modBan) &&
             (identical(other.moderator, moderator) ||
                 other.moderator == moderator) &&
@@ -5029,12 +5040,12 @@ class _$_ModBanView extends _ModBanView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModBanViewCopyWith<_$_ModBanView> get copyWith =>
-      __$$_ModBanViewCopyWithImpl<_$_ModBanView>(this, _$identity);
+  _$$ModBanViewImplCopyWith<_$ModBanViewImpl> get copyWith =>
+      __$$ModBanViewImplCopyWithImpl<_$ModBanViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModBanViewToJson(
+    return _$$ModBanViewImplToJson(
       this,
     );
   }
@@ -5045,11 +5056,11 @@ abstract class _ModBanView extends ModBanView {
       {required final ModBan modBan,
       required final PersonSafe? moderator,
       required final PersonSafe bannedPerson,
-      required final String instanceHost}) = _$_ModBanView;
+      required final String instanceHost}) = _$ModBanViewImpl;
   const _ModBanView._() : super._();
 
   factory _ModBanView.fromJson(Map<String, dynamic> json) =
-      _$_ModBanView.fromJson;
+      _$ModBanViewImpl.fromJson;
 
   @override
   ModBan get modBan;
@@ -5061,7 +5072,7 @@ abstract class _ModBanView extends ModBanView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModBanViewCopyWith<_$_ModBanView> get copyWith =>
+  _$$ModBanViewImplCopyWith<_$ModBanViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5183,11 +5194,11 @@ class _$ModLockPostViewCopyWithImpl<$Res, $Val extends ModLockPostView>
 }
 
 /// @nodoc
-abstract class _$$_ModLockPostViewCopyWith<$Res>
+abstract class _$$ModLockPostViewImplCopyWith<$Res>
     implements $ModLockPostViewCopyWith<$Res> {
-  factory _$$_ModLockPostViewCopyWith(
-          _$_ModLockPostView value, $Res Function(_$_ModLockPostView) then) =
-      __$$_ModLockPostViewCopyWithImpl<$Res>;
+  factory _$$ModLockPostViewImplCopyWith(_$ModLockPostViewImpl value,
+          $Res Function(_$ModLockPostViewImpl) then) =
+      __$$ModLockPostViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5208,11 +5219,11 @@ abstract class _$$_ModLockPostViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModLockPostViewCopyWithImpl<$Res>
-    extends _$ModLockPostViewCopyWithImpl<$Res, _$_ModLockPostView>
-    implements _$$_ModLockPostViewCopyWith<$Res> {
-  __$$_ModLockPostViewCopyWithImpl(
-      _$_ModLockPostView _value, $Res Function(_$_ModLockPostView) _then)
+class __$$ModLockPostViewImplCopyWithImpl<$Res>
+    extends _$ModLockPostViewCopyWithImpl<$Res, _$ModLockPostViewImpl>
+    implements _$$ModLockPostViewImplCopyWith<$Res> {
+  __$$ModLockPostViewImplCopyWithImpl(
+      _$ModLockPostViewImpl _value, $Res Function(_$ModLockPostViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5224,7 +5235,7 @@ class __$$_ModLockPostViewCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModLockPostView(
+    return _then(_$ModLockPostViewImpl(
       modLockPost: null == modLockPost
           ? _value.modLockPost
           : modLockPost // ignore: cast_nullable_to_non_nullable
@@ -5252,8 +5263,8 @@ class __$$_ModLockPostViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModLockPostView extends _ModLockPostView {
-  const _$_ModLockPostView(
+class _$ModLockPostViewImpl extends _ModLockPostView {
+  const _$ModLockPostViewImpl(
       {required this.modLockPost,
       required this.moderator,
       required this.post,
@@ -5261,8 +5272,8 @@ class _$_ModLockPostView extends _ModLockPostView {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModLockPostView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModLockPostViewFromJson(json);
+  factory _$ModLockPostViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModLockPostViewImplFromJson(json);
 
   @override
   final ModLockPost modLockPost;
@@ -5284,7 +5295,7 @@ class _$_ModLockPostView extends _ModLockPostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModLockPostView &&
+            other is _$ModLockPostViewImpl &&
             (identical(other.modLockPost, modLockPost) ||
                 other.modLockPost == modLockPost) &&
             (identical(other.moderator, moderator) ||
@@ -5304,12 +5315,13 @@ class _$_ModLockPostView extends _ModLockPostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModLockPostViewCopyWith<_$_ModLockPostView> get copyWith =>
-      __$$_ModLockPostViewCopyWithImpl<_$_ModLockPostView>(this, _$identity);
+  _$$ModLockPostViewImplCopyWith<_$ModLockPostViewImpl> get copyWith =>
+      __$$ModLockPostViewImplCopyWithImpl<_$ModLockPostViewImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModLockPostViewToJson(
+    return _$$ModLockPostViewImplToJson(
       this,
     );
   }
@@ -5321,11 +5333,11 @@ abstract class _ModLockPostView extends ModLockPostView {
       required final PersonSafe? moderator,
       required final Post post,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$_ModLockPostView;
+      required final String instanceHost}) = _$ModLockPostViewImpl;
   const _ModLockPostView._() : super._();
 
   factory _ModLockPostView.fromJson(Map<String, dynamic> json) =
-      _$_ModLockPostView.fromJson;
+      _$ModLockPostViewImpl.fromJson;
 
   @override
   ModLockPost get modLockPost;
@@ -5339,7 +5351,7 @@ abstract class _ModLockPostView extends ModLockPostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModLockPostViewCopyWith<_$_ModLockPostView> get copyWith =>
+  _$$ModLockPostViewImplCopyWith<_$ModLockPostViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5494,11 +5506,11 @@ class _$ModRemoveCommentViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ModRemoveCommentViewCopyWith<$Res>
+abstract class _$$ModRemoveCommentViewImplCopyWith<$Res>
     implements $ModRemoveCommentViewCopyWith<$Res> {
-  factory _$$_ModRemoveCommentViewCopyWith(_$_ModRemoveCommentView value,
-          $Res Function(_$_ModRemoveCommentView) then) =
-      __$$_ModRemoveCommentViewCopyWithImpl<$Res>;
+  factory _$$ModRemoveCommentViewImplCopyWith(_$ModRemoveCommentViewImpl value,
+          $Res Function(_$ModRemoveCommentViewImpl) then) =
+      __$$ModRemoveCommentViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5525,11 +5537,11 @@ abstract class _$$_ModRemoveCommentViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModRemoveCommentViewCopyWithImpl<$Res>
-    extends _$ModRemoveCommentViewCopyWithImpl<$Res, _$_ModRemoveCommentView>
-    implements _$$_ModRemoveCommentViewCopyWith<$Res> {
-  __$$_ModRemoveCommentViewCopyWithImpl(_$_ModRemoveCommentView _value,
-      $Res Function(_$_ModRemoveCommentView) _then)
+class __$$ModRemoveCommentViewImplCopyWithImpl<$Res>
+    extends _$ModRemoveCommentViewCopyWithImpl<$Res, _$ModRemoveCommentViewImpl>
+    implements _$$ModRemoveCommentViewImplCopyWith<$Res> {
+  __$$ModRemoveCommentViewImplCopyWithImpl(_$ModRemoveCommentViewImpl _value,
+      $Res Function(_$ModRemoveCommentViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5543,7 +5555,7 @@ class __$$_ModRemoveCommentViewCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModRemoveCommentView(
+    return _then(_$ModRemoveCommentViewImpl(
       modRemoveComment: null == modRemoveComment
           ? _value.modRemoveComment
           : modRemoveComment // ignore: cast_nullable_to_non_nullable
@@ -5579,8 +5591,8 @@ class __$$_ModRemoveCommentViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModRemoveCommentView extends _ModRemoveCommentView {
-  const _$_ModRemoveCommentView(
+class _$ModRemoveCommentViewImpl extends _ModRemoveCommentView {
+  const _$ModRemoveCommentViewImpl(
       {required this.modRemoveComment,
       required this.moderator,
       required this.comment,
@@ -5590,8 +5602,8 @@ class _$_ModRemoveCommentView extends _ModRemoveCommentView {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModRemoveCommentView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModRemoveCommentViewFromJson(json);
+  factory _$ModRemoveCommentViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModRemoveCommentViewImplFromJson(json);
 
   @override
   final ModRemoveComment modRemoveComment;
@@ -5617,7 +5629,7 @@ class _$_ModRemoveCommentView extends _ModRemoveCommentView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModRemoveCommentView &&
+            other is _$ModRemoveCommentViewImpl &&
             (identical(other.modRemoveComment, modRemoveComment) ||
                 other.modRemoveComment == modRemoveComment) &&
             (identical(other.moderator, moderator) ||
@@ -5640,13 +5652,14 @@ class _$_ModRemoveCommentView extends _ModRemoveCommentView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModRemoveCommentViewCopyWith<_$_ModRemoveCommentView> get copyWith =>
-      __$$_ModRemoveCommentViewCopyWithImpl<_$_ModRemoveCommentView>(
-          this, _$identity);
+  _$$ModRemoveCommentViewImplCopyWith<_$ModRemoveCommentViewImpl>
+      get copyWith =>
+          __$$ModRemoveCommentViewImplCopyWithImpl<_$ModRemoveCommentViewImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModRemoveCommentViewToJson(
+    return _$$ModRemoveCommentViewImplToJson(
       this,
     );
   }
@@ -5660,11 +5673,11 @@ abstract class _ModRemoveCommentView extends ModRemoveCommentView {
       required final PersonSafe commenter,
       required final Post post,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$_ModRemoveCommentView;
+      required final String instanceHost}) = _$ModRemoveCommentViewImpl;
   const _ModRemoveCommentView._() : super._();
 
   factory _ModRemoveCommentView.fromJson(Map<String, dynamic> json) =
-      _$_ModRemoveCommentView.fromJson;
+      _$ModRemoveCommentViewImpl.fromJson;
 
   @override
   ModRemoveComment get modRemoveComment;
@@ -5682,8 +5695,8 @@ abstract class _ModRemoveCommentView extends ModRemoveCommentView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModRemoveCommentViewCopyWith<_$_ModRemoveCommentView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ModRemoveCommentViewImplCopyWith<_$ModRemoveCommentViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 ModRemoveCommunityView _$ModRemoveCommunityViewFromJson(
@@ -5792,11 +5805,12 @@ class _$ModRemoveCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ModRemoveCommunityViewCopyWith<$Res>
+abstract class _$$ModRemoveCommunityViewImplCopyWith<$Res>
     implements $ModRemoveCommunityViewCopyWith<$Res> {
-  factory _$$_ModRemoveCommunityViewCopyWith(_$_ModRemoveCommunityView value,
-          $Res Function(_$_ModRemoveCommunityView) then) =
-      __$$_ModRemoveCommunityViewCopyWithImpl<$Res>;
+  factory _$$ModRemoveCommunityViewImplCopyWith(
+          _$ModRemoveCommunityViewImpl value,
+          $Res Function(_$ModRemoveCommunityViewImpl) then) =
+      __$$ModRemoveCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -5814,12 +5828,13 @@ abstract class _$$_ModRemoveCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModRemoveCommunityViewCopyWithImpl<$Res>
+class __$$ModRemoveCommunityViewImplCopyWithImpl<$Res>
     extends _$ModRemoveCommunityViewCopyWithImpl<$Res,
-        _$_ModRemoveCommunityView>
-    implements _$$_ModRemoveCommunityViewCopyWith<$Res> {
-  __$$_ModRemoveCommunityViewCopyWithImpl(_$_ModRemoveCommunityView _value,
-      $Res Function(_$_ModRemoveCommunityView) _then)
+        _$ModRemoveCommunityViewImpl>
+    implements _$$ModRemoveCommunityViewImplCopyWith<$Res> {
+  __$$ModRemoveCommunityViewImplCopyWithImpl(
+      _$ModRemoveCommunityViewImpl _value,
+      $Res Function(_$ModRemoveCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5830,7 +5845,7 @@ class __$$_ModRemoveCommunityViewCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModRemoveCommunityView(
+    return _then(_$ModRemoveCommunityViewImpl(
       modRemoveCommunity: null == modRemoveCommunity
           ? _value.modRemoveCommunity
           : modRemoveCommunity // ignore: cast_nullable_to_non_nullable
@@ -5854,16 +5869,16 @@ class __$$_ModRemoveCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModRemoveCommunityView extends _ModRemoveCommunityView {
-  const _$_ModRemoveCommunityView(
+class _$ModRemoveCommunityViewImpl extends _ModRemoveCommunityView {
+  const _$ModRemoveCommunityViewImpl(
       {required this.modRemoveCommunity,
       required this.moderator,
       required this.community,
       required this.instanceHost})
       : super._();
 
-  factory _$_ModRemoveCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModRemoveCommunityViewFromJson(json);
+  factory _$ModRemoveCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModRemoveCommunityViewImplFromJson(json);
 
   @override
   final ModRemoveCommunity modRemoveCommunity;
@@ -5883,7 +5898,7 @@ class _$_ModRemoveCommunityView extends _ModRemoveCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModRemoveCommunityView &&
+            other is _$ModRemoveCommunityViewImpl &&
             (identical(other.modRemoveCommunity, modRemoveCommunity) ||
                 other.modRemoveCommunity == modRemoveCommunity) &&
             (identical(other.moderator, moderator) ||
@@ -5902,13 +5917,13 @@ class _$_ModRemoveCommunityView extends _ModRemoveCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModRemoveCommunityViewCopyWith<_$_ModRemoveCommunityView> get copyWith =>
-      __$$_ModRemoveCommunityViewCopyWithImpl<_$_ModRemoveCommunityView>(
-          this, _$identity);
+  _$$ModRemoveCommunityViewImplCopyWith<_$ModRemoveCommunityViewImpl>
+      get copyWith => __$$ModRemoveCommunityViewImplCopyWithImpl<
+          _$ModRemoveCommunityViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModRemoveCommunityViewToJson(
+    return _$$ModRemoveCommunityViewImplToJson(
       this,
     );
   }
@@ -5919,11 +5934,11 @@ abstract class _ModRemoveCommunityView extends ModRemoveCommunityView {
       {required final ModRemoveCommunity modRemoveCommunity,
       required final PersonSafe? moderator,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$_ModRemoveCommunityView;
+      required final String instanceHost}) = _$ModRemoveCommunityViewImpl;
   const _ModRemoveCommunityView._() : super._();
 
   factory _ModRemoveCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_ModRemoveCommunityView.fromJson;
+      _$ModRemoveCommunityViewImpl.fromJson;
 
   @override
   ModRemoveCommunity get modRemoveCommunity;
@@ -5935,8 +5950,8 @@ abstract class _ModRemoveCommunityView extends ModRemoveCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModRemoveCommunityViewCopyWith<_$_ModRemoveCommunityView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ModRemoveCommunityViewImplCopyWith<_$ModRemoveCommunityViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 ModHideCommunityView _$ModHideCommunityViewFromJson(Map<String, dynamic> json) {
@@ -6042,11 +6057,11 @@ class _$ModHideCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ModHideCommunityViewCopyWith<$Res>
+abstract class _$$ModHideCommunityViewImplCopyWith<$Res>
     implements $ModHideCommunityViewCopyWith<$Res> {
-  factory _$$_ModHideCommunityViewCopyWith(_$_ModHideCommunityView value,
-          $Res Function(_$_ModHideCommunityView) then) =
-      __$$_ModHideCommunityViewCopyWithImpl<$Res>;
+  factory _$$ModHideCommunityViewImplCopyWith(_$ModHideCommunityViewImpl value,
+          $Res Function(_$ModHideCommunityViewImpl) then) =
+      __$$ModHideCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6064,11 +6079,11 @@ abstract class _$$_ModHideCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModHideCommunityViewCopyWithImpl<$Res>
-    extends _$ModHideCommunityViewCopyWithImpl<$Res, _$_ModHideCommunityView>
-    implements _$$_ModHideCommunityViewCopyWith<$Res> {
-  __$$_ModHideCommunityViewCopyWithImpl(_$_ModHideCommunityView _value,
-      $Res Function(_$_ModHideCommunityView) _then)
+class __$$ModHideCommunityViewImplCopyWithImpl<$Res>
+    extends _$ModHideCommunityViewCopyWithImpl<$Res, _$ModHideCommunityViewImpl>
+    implements _$$ModHideCommunityViewImplCopyWith<$Res> {
+  __$$ModHideCommunityViewImplCopyWithImpl(_$ModHideCommunityViewImpl _value,
+      $Res Function(_$ModHideCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6079,7 +6094,7 @@ class __$$_ModHideCommunityViewCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModHideCommunityView(
+    return _then(_$ModHideCommunityViewImpl(
       modHideCommunity: null == modHideCommunity
           ? _value.modHideCommunity
           : modHideCommunity // ignore: cast_nullable_to_non_nullable
@@ -6103,16 +6118,16 @@ class __$$_ModHideCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModHideCommunityView extends _ModHideCommunityView {
-  const _$_ModHideCommunityView(
+class _$ModHideCommunityViewImpl extends _ModHideCommunityView {
+  const _$ModHideCommunityViewImpl(
       {required this.modHideCommunity,
       this.admin,
       required this.community,
       required this.instanceHost})
       : super._();
 
-  factory _$_ModHideCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModHideCommunityViewFromJson(json);
+  factory _$ModHideCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModHideCommunityViewImplFromJson(json);
 
   @override
   final ModHideCommunity modHideCommunity;
@@ -6132,7 +6147,7 @@ class _$_ModHideCommunityView extends _ModHideCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModHideCommunityView &&
+            other is _$ModHideCommunityViewImpl &&
             (identical(other.modHideCommunity, modHideCommunity) ||
                 other.modHideCommunity == modHideCommunity) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -6150,13 +6165,14 @@ class _$_ModHideCommunityView extends _ModHideCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModHideCommunityViewCopyWith<_$_ModHideCommunityView> get copyWith =>
-      __$$_ModHideCommunityViewCopyWithImpl<_$_ModHideCommunityView>(
-          this, _$identity);
+  _$$ModHideCommunityViewImplCopyWith<_$ModHideCommunityViewImpl>
+      get copyWith =>
+          __$$ModHideCommunityViewImplCopyWithImpl<_$ModHideCommunityViewImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModHideCommunityViewToJson(
+    return _$$ModHideCommunityViewImplToJson(
       this,
     );
   }
@@ -6167,11 +6183,11 @@ abstract class _ModHideCommunityView extends ModHideCommunityView {
       {required final ModHideCommunity modHideCommunity,
       final PersonSafe? admin,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$_ModHideCommunityView;
+      required final String instanceHost}) = _$ModHideCommunityViewImpl;
   const _ModHideCommunityView._() : super._();
 
   factory _ModHideCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_ModHideCommunityView.fromJson;
+      _$ModHideCommunityViewImpl.fromJson;
 
   @override
   ModHideCommunity get modHideCommunity;
@@ -6183,8 +6199,8 @@ abstract class _ModHideCommunityView extends ModHideCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModHideCommunityViewCopyWith<_$_ModHideCommunityView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ModHideCommunityViewImplCopyWith<_$ModHideCommunityViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 ModRemovePostView _$ModRemovePostViewFromJson(Map<String, dynamic> json) {
@@ -6305,11 +6321,11 @@ class _$ModRemovePostViewCopyWithImpl<$Res, $Val extends ModRemovePostView>
 }
 
 /// @nodoc
-abstract class _$$_ModRemovePostViewCopyWith<$Res>
+abstract class _$$ModRemovePostViewImplCopyWith<$Res>
     implements $ModRemovePostViewCopyWith<$Res> {
-  factory _$$_ModRemovePostViewCopyWith(_$_ModRemovePostView value,
-          $Res Function(_$_ModRemovePostView) then) =
-      __$$_ModRemovePostViewCopyWithImpl<$Res>;
+  factory _$$ModRemovePostViewImplCopyWith(_$ModRemovePostViewImpl value,
+          $Res Function(_$ModRemovePostViewImpl) then) =
+      __$$ModRemovePostViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6330,11 +6346,11 @@ abstract class _$$_ModRemovePostViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModRemovePostViewCopyWithImpl<$Res>
-    extends _$ModRemovePostViewCopyWithImpl<$Res, _$_ModRemovePostView>
-    implements _$$_ModRemovePostViewCopyWith<$Res> {
-  __$$_ModRemovePostViewCopyWithImpl(
-      _$_ModRemovePostView _value, $Res Function(_$_ModRemovePostView) _then)
+class __$$ModRemovePostViewImplCopyWithImpl<$Res>
+    extends _$ModRemovePostViewCopyWithImpl<$Res, _$ModRemovePostViewImpl>
+    implements _$$ModRemovePostViewImplCopyWith<$Res> {
+  __$$ModRemovePostViewImplCopyWithImpl(_$ModRemovePostViewImpl _value,
+      $Res Function(_$ModRemovePostViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6346,7 +6362,7 @@ class __$$_ModRemovePostViewCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModRemovePostView(
+    return _then(_$ModRemovePostViewImpl(
       modRemovePost: null == modRemovePost
           ? _value.modRemovePost
           : modRemovePost // ignore: cast_nullable_to_non_nullable
@@ -6374,8 +6390,8 @@ class __$$_ModRemovePostViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModRemovePostView extends _ModRemovePostView {
-  const _$_ModRemovePostView(
+class _$ModRemovePostViewImpl extends _ModRemovePostView {
+  const _$ModRemovePostViewImpl(
       {required this.modRemovePost,
       required this.moderator,
       required this.post,
@@ -6383,8 +6399,8 @@ class _$_ModRemovePostView extends _ModRemovePostView {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModRemovePostView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModRemovePostViewFromJson(json);
+  factory _$ModRemovePostViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModRemovePostViewImplFromJson(json);
 
   @override
   final ModRemovePost modRemovePost;
@@ -6406,7 +6422,7 @@ class _$_ModRemovePostView extends _ModRemovePostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModRemovePostView &&
+            other is _$ModRemovePostViewImpl &&
             (identical(other.modRemovePost, modRemovePost) ||
                 other.modRemovePost == modRemovePost) &&
             (identical(other.moderator, moderator) ||
@@ -6426,13 +6442,13 @@ class _$_ModRemovePostView extends _ModRemovePostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModRemovePostViewCopyWith<_$_ModRemovePostView> get copyWith =>
-      __$$_ModRemovePostViewCopyWithImpl<_$_ModRemovePostView>(
+  _$$ModRemovePostViewImplCopyWith<_$ModRemovePostViewImpl> get copyWith =>
+      __$$ModRemovePostViewImplCopyWithImpl<_$ModRemovePostViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModRemovePostViewToJson(
+    return _$$ModRemovePostViewImplToJson(
       this,
     );
   }
@@ -6444,11 +6460,11 @@ abstract class _ModRemovePostView extends ModRemovePostView {
       required final PersonSafe? moderator,
       required final Post post,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$_ModRemovePostView;
+      required final String instanceHost}) = _$ModRemovePostViewImpl;
   const _ModRemovePostView._() : super._();
 
   factory _ModRemovePostView.fromJson(Map<String, dynamic> json) =
-      _$_ModRemovePostView.fromJson;
+      _$ModRemovePostViewImpl.fromJson;
 
   @override
   ModRemovePost get modRemovePost;
@@ -6462,7 +6478,7 @@ abstract class _ModRemovePostView extends ModRemovePostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModRemovePostViewCopyWith<_$_ModRemovePostView> get copyWith =>
+  _$$ModRemovePostViewImplCopyWith<_$ModRemovePostViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -6584,11 +6600,11 @@ class _$ModStickyPostViewCopyWithImpl<$Res, $Val extends ModStickyPostView>
 }
 
 /// @nodoc
-abstract class _$$_ModStickyPostViewCopyWith<$Res>
+abstract class _$$ModStickyPostViewImplCopyWith<$Res>
     implements $ModStickyPostViewCopyWith<$Res> {
-  factory _$$_ModStickyPostViewCopyWith(_$_ModStickyPostView value,
-          $Res Function(_$_ModStickyPostView) then) =
-      __$$_ModStickyPostViewCopyWithImpl<$Res>;
+  factory _$$ModStickyPostViewImplCopyWith(_$ModStickyPostViewImpl value,
+          $Res Function(_$ModStickyPostViewImpl) then) =
+      __$$ModStickyPostViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6609,11 +6625,11 @@ abstract class _$$_ModStickyPostViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModStickyPostViewCopyWithImpl<$Res>
-    extends _$ModStickyPostViewCopyWithImpl<$Res, _$_ModStickyPostView>
-    implements _$$_ModStickyPostViewCopyWith<$Res> {
-  __$$_ModStickyPostViewCopyWithImpl(
-      _$_ModStickyPostView _value, $Res Function(_$_ModStickyPostView) _then)
+class __$$ModStickyPostViewImplCopyWithImpl<$Res>
+    extends _$ModStickyPostViewCopyWithImpl<$Res, _$ModStickyPostViewImpl>
+    implements _$$ModStickyPostViewImplCopyWith<$Res> {
+  __$$ModStickyPostViewImplCopyWithImpl(_$ModStickyPostViewImpl _value,
+      $Res Function(_$ModStickyPostViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6625,7 +6641,7 @@ class __$$_ModStickyPostViewCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModStickyPostView(
+    return _then(_$ModStickyPostViewImpl(
       modStickyPost: null == modStickyPost
           ? _value.modStickyPost
           : modStickyPost // ignore: cast_nullable_to_non_nullable
@@ -6653,8 +6669,8 @@ class __$$_ModStickyPostViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModStickyPostView extends _ModStickyPostView {
-  const _$_ModStickyPostView(
+class _$ModStickyPostViewImpl extends _ModStickyPostView {
+  const _$ModStickyPostViewImpl(
       {required this.modStickyPost,
       required this.moderator,
       required this.post,
@@ -6662,8 +6678,8 @@ class _$_ModStickyPostView extends _ModStickyPostView {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModStickyPostView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModStickyPostViewFromJson(json);
+  factory _$ModStickyPostViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModStickyPostViewImplFromJson(json);
 
   @override
   final ModStickyPost modStickyPost;
@@ -6685,7 +6701,7 @@ class _$_ModStickyPostView extends _ModStickyPostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModStickyPostView &&
+            other is _$ModStickyPostViewImpl &&
             (identical(other.modStickyPost, modStickyPost) ||
                 other.modStickyPost == modStickyPost) &&
             (identical(other.moderator, moderator) ||
@@ -6705,13 +6721,13 @@ class _$_ModStickyPostView extends _ModStickyPostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModStickyPostViewCopyWith<_$_ModStickyPostView> get copyWith =>
-      __$$_ModStickyPostViewCopyWithImpl<_$_ModStickyPostView>(
+  _$$ModStickyPostViewImplCopyWith<_$ModStickyPostViewImpl> get copyWith =>
+      __$$ModStickyPostViewImplCopyWithImpl<_$ModStickyPostViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModStickyPostViewToJson(
+    return _$$ModStickyPostViewImplToJson(
       this,
     );
   }
@@ -6723,11 +6739,11 @@ abstract class _ModStickyPostView extends ModStickyPostView {
       required final PersonSafe? moderator,
       required final Post post,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$_ModStickyPostView;
+      required final String instanceHost}) = _$ModStickyPostViewImpl;
   const _ModStickyPostView._() : super._();
 
   factory _ModStickyPostView.fromJson(Map<String, dynamic> json) =
-      _$_ModStickyPostView.fromJson;
+      _$ModStickyPostViewImpl.fromJson;
 
   @override
   ModStickyPost get modStickyPost;
@@ -6741,7 +6757,7 @@ abstract class _ModStickyPostView extends ModStickyPostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModStickyPostViewCopyWith<_$_ModStickyPostView> get copyWith =>
+  _$$ModStickyPostViewImplCopyWith<_$ModStickyPostViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -6863,11 +6879,11 @@ class _$ModFeaturePostViewCopyWithImpl<$Res, $Val extends ModFeaturePostView>
 }
 
 /// @nodoc
-abstract class _$$_ModFeaturePostViewCopyWith<$Res>
+abstract class _$$ModFeaturePostViewImplCopyWith<$Res>
     implements $ModFeaturePostViewCopyWith<$Res> {
-  factory _$$_ModFeaturePostViewCopyWith(_$_ModFeaturePostView value,
-          $Res Function(_$_ModFeaturePostView) then) =
-      __$$_ModFeaturePostViewCopyWithImpl<$Res>;
+  factory _$$ModFeaturePostViewImplCopyWith(_$ModFeaturePostViewImpl value,
+          $Res Function(_$ModFeaturePostViewImpl) then) =
+      __$$ModFeaturePostViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -6888,11 +6904,11 @@ abstract class _$$_ModFeaturePostViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModFeaturePostViewCopyWithImpl<$Res>
-    extends _$ModFeaturePostViewCopyWithImpl<$Res, _$_ModFeaturePostView>
-    implements _$$_ModFeaturePostViewCopyWith<$Res> {
-  __$$_ModFeaturePostViewCopyWithImpl(
-      _$_ModFeaturePostView _value, $Res Function(_$_ModFeaturePostView) _then)
+class __$$ModFeaturePostViewImplCopyWithImpl<$Res>
+    extends _$ModFeaturePostViewCopyWithImpl<$Res, _$ModFeaturePostViewImpl>
+    implements _$$ModFeaturePostViewImplCopyWith<$Res> {
+  __$$ModFeaturePostViewImplCopyWithImpl(_$ModFeaturePostViewImpl _value,
+      $Res Function(_$ModFeaturePostViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -6904,7 +6920,7 @@ class __$$_ModFeaturePostViewCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_ModFeaturePostView(
+    return _then(_$ModFeaturePostViewImpl(
       modFeaturePost: null == modFeaturePost
           ? _value.modFeaturePost
           : modFeaturePost // ignore: cast_nullable_to_non_nullable
@@ -6932,8 +6948,8 @@ class __$$_ModFeaturePostViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModFeaturePostView extends _ModFeaturePostView {
-  const _$_ModFeaturePostView(
+class _$ModFeaturePostViewImpl extends _ModFeaturePostView {
+  const _$ModFeaturePostViewImpl(
       {required this.modFeaturePost,
       this.moderator,
       required this.post,
@@ -6941,8 +6957,8 @@ class _$_ModFeaturePostView extends _ModFeaturePostView {
       required this.instanceHost})
       : super._();
 
-  factory _$_ModFeaturePostView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModFeaturePostViewFromJson(json);
+  factory _$ModFeaturePostViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModFeaturePostViewImplFromJson(json);
 
   @override
   final ModFeaturePost modFeaturePost;
@@ -6964,7 +6980,7 @@ class _$_ModFeaturePostView extends _ModFeaturePostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModFeaturePostView &&
+            other is _$ModFeaturePostViewImpl &&
             (identical(other.modFeaturePost, modFeaturePost) ||
                 other.modFeaturePost == modFeaturePost) &&
             (identical(other.moderator, moderator) ||
@@ -6984,13 +7000,13 @@ class _$_ModFeaturePostView extends _ModFeaturePostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModFeaturePostViewCopyWith<_$_ModFeaturePostView> get copyWith =>
-      __$$_ModFeaturePostViewCopyWithImpl<_$_ModFeaturePostView>(
+  _$$ModFeaturePostViewImplCopyWith<_$ModFeaturePostViewImpl> get copyWith =>
+      __$$ModFeaturePostViewImplCopyWithImpl<_$ModFeaturePostViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModFeaturePostViewToJson(
+    return _$$ModFeaturePostViewImplToJson(
       this,
     );
   }
@@ -7002,11 +7018,11 @@ abstract class _ModFeaturePostView extends ModFeaturePostView {
       final PersonSafe? moderator,
       required final Post post,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$_ModFeaturePostView;
+      required final String instanceHost}) = _$ModFeaturePostViewImpl;
   const _ModFeaturePostView._() : super._();
 
   factory _ModFeaturePostView.fromJson(Map<String, dynamic> json) =
-      _$_ModFeaturePostView.fromJson;
+      _$ModFeaturePostViewImpl.fromJson;
 
   @override
   ModFeaturePost get modFeaturePost;
@@ -7020,7 +7036,7 @@ abstract class _ModFeaturePostView extends ModFeaturePostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_ModFeaturePostViewCopyWith<_$_ModFeaturePostView> get copyWith =>
+  _$$ModFeaturePostViewImplCopyWith<_$ModFeaturePostViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7106,11 +7122,12 @@ class _$CommunityFollowerViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_CommunityFollowerViewCopyWith<$Res>
+abstract class _$$CommunityFollowerViewImplCopyWith<$Res>
     implements $CommunityFollowerViewCopyWith<$Res> {
-  factory _$$_CommunityFollowerViewCopyWith(_$_CommunityFollowerView value,
-          $Res Function(_$_CommunityFollowerView) then) =
-      __$$_CommunityFollowerViewCopyWithImpl<$Res>;
+  factory _$$CommunityFollowerViewImplCopyWith(
+          _$CommunityFollowerViewImpl value,
+          $Res Function(_$CommunityFollowerViewImpl) then) =
+      __$$CommunityFollowerViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -7123,11 +7140,12 @@ abstract class _$$_CommunityFollowerViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunityFollowerViewCopyWithImpl<$Res>
-    extends _$CommunityFollowerViewCopyWithImpl<$Res, _$_CommunityFollowerView>
-    implements _$$_CommunityFollowerViewCopyWith<$Res> {
-  __$$_CommunityFollowerViewCopyWithImpl(_$_CommunityFollowerView _value,
-      $Res Function(_$_CommunityFollowerView) _then)
+class __$$CommunityFollowerViewImplCopyWithImpl<$Res>
+    extends _$CommunityFollowerViewCopyWithImpl<$Res,
+        _$CommunityFollowerViewImpl>
+    implements _$$CommunityFollowerViewImplCopyWith<$Res> {
+  __$$CommunityFollowerViewImplCopyWithImpl(_$CommunityFollowerViewImpl _value,
+      $Res Function(_$CommunityFollowerViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7137,7 +7155,7 @@ class __$$_CommunityFollowerViewCopyWithImpl<$Res>
     Object? follower = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_CommunityFollowerView(
+    return _then(_$CommunityFollowerViewImpl(
       community: null == community
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
@@ -7157,15 +7175,15 @@ class __$$_CommunityFollowerViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunityFollowerView extends _CommunityFollowerView {
-  const _$_CommunityFollowerView(
+class _$CommunityFollowerViewImpl extends _CommunityFollowerView {
+  const _$CommunityFollowerViewImpl(
       {required this.community,
       required this.follower,
       required this.instanceHost})
       : super._();
 
-  factory _$_CommunityFollowerView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityFollowerViewFromJson(json);
+  factory _$CommunityFollowerViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityFollowerViewImplFromJson(json);
 
   @override
   final CommunitySafe community;
@@ -7183,7 +7201,7 @@ class _$_CommunityFollowerView extends _CommunityFollowerView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunityFollowerView &&
+            other is _$CommunityFollowerViewImpl &&
             (identical(other.community, community) ||
                 other.community == community) &&
             (identical(other.follower, follower) ||
@@ -7200,13 +7218,13 @@ class _$_CommunityFollowerView extends _CommunityFollowerView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityFollowerViewCopyWith<_$_CommunityFollowerView> get copyWith =>
-      __$$_CommunityFollowerViewCopyWithImpl<_$_CommunityFollowerView>(
-          this, _$identity);
+  _$$CommunityFollowerViewImplCopyWith<_$CommunityFollowerViewImpl>
+      get copyWith => __$$CommunityFollowerViewImplCopyWithImpl<
+          _$CommunityFollowerViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityFollowerViewToJson(
+    return _$$CommunityFollowerViewImplToJson(
       this,
     );
   }
@@ -7216,11 +7234,11 @@ abstract class _CommunityFollowerView extends CommunityFollowerView {
   const factory _CommunityFollowerView(
       {required final CommunitySafe community,
       required final PersonSafe follower,
-      required final String instanceHost}) = _$_CommunityFollowerView;
+      required final String instanceHost}) = _$CommunityFollowerViewImpl;
   const _CommunityFollowerView._() : super._();
 
   factory _CommunityFollowerView.fromJson(Map<String, dynamic> json) =
-      _$_CommunityFollowerView.fromJson;
+      _$CommunityFollowerViewImpl.fromJson;
 
   @override
   CommunitySafe get community;
@@ -7230,8 +7248,8 @@ abstract class _CommunityFollowerView extends CommunityFollowerView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityFollowerViewCopyWith<_$_CommunityFollowerView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$CommunityFollowerViewImplCopyWith<_$CommunityFollowerViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 CommunityModeratorView _$CommunityModeratorViewFromJson(
@@ -7320,11 +7338,12 @@ class _$CommunityModeratorViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_CommunityModeratorViewCopyWith<$Res>
+abstract class _$$CommunityModeratorViewImplCopyWith<$Res>
     implements $CommunityModeratorViewCopyWith<$Res> {
-  factory _$$_CommunityModeratorViewCopyWith(_$_CommunityModeratorView value,
-          $Res Function(_$_CommunityModeratorView) then) =
-      __$$_CommunityModeratorViewCopyWithImpl<$Res>;
+  factory _$$CommunityModeratorViewImplCopyWith(
+          _$CommunityModeratorViewImpl value,
+          $Res Function(_$CommunityModeratorViewImpl) then) =
+      __$$CommunityModeratorViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -7337,12 +7356,13 @@ abstract class _$$_CommunityModeratorViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunityModeratorViewCopyWithImpl<$Res>
+class __$$CommunityModeratorViewImplCopyWithImpl<$Res>
     extends _$CommunityModeratorViewCopyWithImpl<$Res,
-        _$_CommunityModeratorView>
-    implements _$$_CommunityModeratorViewCopyWith<$Res> {
-  __$$_CommunityModeratorViewCopyWithImpl(_$_CommunityModeratorView _value,
-      $Res Function(_$_CommunityModeratorView) _then)
+        _$CommunityModeratorViewImpl>
+    implements _$$CommunityModeratorViewImplCopyWith<$Res> {
+  __$$CommunityModeratorViewImplCopyWithImpl(
+      _$CommunityModeratorViewImpl _value,
+      $Res Function(_$CommunityModeratorViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7352,7 +7372,7 @@ class __$$_CommunityModeratorViewCopyWithImpl<$Res>
     Object? moderator = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_CommunityModeratorView(
+    return _then(_$CommunityModeratorViewImpl(
       community: null == community
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
@@ -7372,15 +7392,15 @@ class __$$_CommunityModeratorViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunityModeratorView extends _CommunityModeratorView {
-  const _$_CommunityModeratorView(
+class _$CommunityModeratorViewImpl extends _CommunityModeratorView {
+  const _$CommunityModeratorViewImpl(
       {required this.community,
       required this.moderator,
       required this.instanceHost})
       : super._();
 
-  factory _$_CommunityModeratorView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityModeratorViewFromJson(json);
+  factory _$CommunityModeratorViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityModeratorViewImplFromJson(json);
 
   @override
   final CommunitySafe community;
@@ -7398,7 +7418,7 @@ class _$_CommunityModeratorView extends _CommunityModeratorView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunityModeratorView &&
+            other is _$CommunityModeratorViewImpl &&
             (identical(other.community, community) ||
                 other.community == community) &&
             (identical(other.moderator, moderator) ||
@@ -7415,13 +7435,13 @@ class _$_CommunityModeratorView extends _CommunityModeratorView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityModeratorViewCopyWith<_$_CommunityModeratorView> get copyWith =>
-      __$$_CommunityModeratorViewCopyWithImpl<_$_CommunityModeratorView>(
-          this, _$identity);
+  _$$CommunityModeratorViewImplCopyWith<_$CommunityModeratorViewImpl>
+      get copyWith => __$$CommunityModeratorViewImplCopyWithImpl<
+          _$CommunityModeratorViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityModeratorViewToJson(
+    return _$$CommunityModeratorViewImplToJson(
       this,
     );
   }
@@ -7431,11 +7451,11 @@ abstract class _CommunityModeratorView extends CommunityModeratorView {
   const factory _CommunityModeratorView(
       {required final CommunitySafe community,
       required final PersonSafe? moderator,
-      required final String instanceHost}) = _$_CommunityModeratorView;
+      required final String instanceHost}) = _$CommunityModeratorViewImpl;
   const _CommunityModeratorView._() : super._();
 
   factory _CommunityModeratorView.fromJson(Map<String, dynamic> json) =
-      _$_CommunityModeratorView.fromJson;
+      _$CommunityModeratorViewImpl.fromJson;
 
   @override
   CommunitySafe get community;
@@ -7445,8 +7465,8 @@ abstract class _CommunityModeratorView extends CommunityModeratorView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityModeratorViewCopyWith<_$_CommunityModeratorView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$CommunityModeratorViewImplCopyWith<_$CommunityModeratorViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 PersonBlockView _$PersonBlockViewFromJson(Map<String, dynamic> json) {
@@ -7528,11 +7548,11 @@ class _$PersonBlockViewCopyWithImpl<$Res, $Val extends PersonBlockView>
 }
 
 /// @nodoc
-abstract class _$$_PersonBlockViewCopyWith<$Res>
+abstract class _$$PersonBlockViewImplCopyWith<$Res>
     implements $PersonBlockViewCopyWith<$Res> {
-  factory _$$_PersonBlockViewCopyWith(
-          _$_PersonBlockView value, $Res Function(_$_PersonBlockView) then) =
-      __$$_PersonBlockViewCopyWithImpl<$Res>;
+  factory _$$PersonBlockViewImplCopyWith(_$PersonBlockViewImpl value,
+          $Res Function(_$PersonBlockViewImpl) then) =
+      __$$PersonBlockViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonSafe person, PersonSafe target, String instanceHost});
@@ -7544,11 +7564,11 @@ abstract class _$$_PersonBlockViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PersonBlockViewCopyWithImpl<$Res>
-    extends _$PersonBlockViewCopyWithImpl<$Res, _$_PersonBlockView>
-    implements _$$_PersonBlockViewCopyWith<$Res> {
-  __$$_PersonBlockViewCopyWithImpl(
-      _$_PersonBlockView _value, $Res Function(_$_PersonBlockView) _then)
+class __$$PersonBlockViewImplCopyWithImpl<$Res>
+    extends _$PersonBlockViewCopyWithImpl<$Res, _$PersonBlockViewImpl>
+    implements _$$PersonBlockViewImplCopyWith<$Res> {
+  __$$PersonBlockViewImplCopyWithImpl(
+      _$PersonBlockViewImpl _value, $Res Function(_$PersonBlockViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7558,7 +7578,7 @@ class __$$_PersonBlockViewCopyWithImpl<$Res>
     Object? target = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_PersonBlockView(
+    return _then(_$PersonBlockViewImpl(
       person: null == person
           ? _value.person
           : person // ignore: cast_nullable_to_non_nullable
@@ -7578,13 +7598,13 @@ class __$$_PersonBlockViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PersonBlockView extends _PersonBlockView {
-  const _$_PersonBlockView(
+class _$PersonBlockViewImpl extends _PersonBlockView {
+  const _$PersonBlockViewImpl(
       {required this.person, required this.target, required this.instanceHost})
       : super._();
 
-  factory _$_PersonBlockView.fromJson(Map<String, dynamic> json) =>
-      _$$_PersonBlockViewFromJson(json);
+  factory _$PersonBlockViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonBlockViewImplFromJson(json);
 
   @override
   final PersonSafe person;
@@ -7602,7 +7622,7 @@ class _$_PersonBlockView extends _PersonBlockView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PersonBlockView &&
+            other is _$PersonBlockViewImpl &&
             (identical(other.person, person) || other.person == person) &&
             (identical(other.target, target) || other.target == target) &&
             (identical(other.instanceHost, instanceHost) ||
@@ -7616,12 +7636,13 @@ class _$_PersonBlockView extends _PersonBlockView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PersonBlockViewCopyWith<_$_PersonBlockView> get copyWith =>
-      __$$_PersonBlockViewCopyWithImpl<_$_PersonBlockView>(this, _$identity);
+  _$$PersonBlockViewImplCopyWith<_$PersonBlockViewImpl> get copyWith =>
+      __$$PersonBlockViewImplCopyWithImpl<_$PersonBlockViewImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PersonBlockViewToJson(
+    return _$$PersonBlockViewImplToJson(
       this,
     );
   }
@@ -7631,11 +7652,11 @@ abstract class _PersonBlockView extends PersonBlockView {
   const factory _PersonBlockView(
       {required final PersonSafe person,
       required final PersonSafe target,
-      required final String instanceHost}) = _$_PersonBlockView;
+      required final String instanceHost}) = _$PersonBlockViewImpl;
   const _PersonBlockView._() : super._();
 
   factory _PersonBlockView.fromJson(Map<String, dynamic> json) =
-      _$_PersonBlockView.fromJson;
+      _$PersonBlockViewImpl.fromJson;
 
   @override
   PersonSafe get person;
@@ -7645,7 +7666,7 @@ abstract class _PersonBlockView extends PersonBlockView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PersonBlockViewCopyWith<_$_PersonBlockView> get copyWith =>
+  _$$PersonBlockViewImplCopyWith<_$PersonBlockViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7728,11 +7749,11 @@ class _$CommunityBlockViewCopyWithImpl<$Res, $Val extends CommunityBlockView>
 }
 
 /// @nodoc
-abstract class _$$_CommunityBlockViewCopyWith<$Res>
+abstract class _$$CommunityBlockViewImplCopyWith<$Res>
     implements $CommunityBlockViewCopyWith<$Res> {
-  factory _$$_CommunityBlockViewCopyWith(_$_CommunityBlockView value,
-          $Res Function(_$_CommunityBlockView) then) =
-      __$$_CommunityBlockViewCopyWithImpl<$Res>;
+  factory _$$CommunityBlockViewImplCopyWith(_$CommunityBlockViewImpl value,
+          $Res Function(_$CommunityBlockViewImpl) then) =
+      __$$CommunityBlockViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonSafe person, CommunitySafe community, String instanceHost});
@@ -7744,11 +7765,11 @@ abstract class _$$_CommunityBlockViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunityBlockViewCopyWithImpl<$Res>
-    extends _$CommunityBlockViewCopyWithImpl<$Res, _$_CommunityBlockView>
-    implements _$$_CommunityBlockViewCopyWith<$Res> {
-  __$$_CommunityBlockViewCopyWithImpl(
-      _$_CommunityBlockView _value, $Res Function(_$_CommunityBlockView) _then)
+class __$$CommunityBlockViewImplCopyWithImpl<$Res>
+    extends _$CommunityBlockViewCopyWithImpl<$Res, _$CommunityBlockViewImpl>
+    implements _$$CommunityBlockViewImplCopyWith<$Res> {
+  __$$CommunityBlockViewImplCopyWithImpl(_$CommunityBlockViewImpl _value,
+      $Res Function(_$CommunityBlockViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7758,7 +7779,7 @@ class __$$_CommunityBlockViewCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_CommunityBlockView(
+    return _then(_$CommunityBlockViewImpl(
       person: null == person
           ? _value.person
           : person // ignore: cast_nullable_to_non_nullable
@@ -7778,15 +7799,15 @@ class __$$_CommunityBlockViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunityBlockView extends _CommunityBlockView {
-  const _$_CommunityBlockView(
+class _$CommunityBlockViewImpl extends _CommunityBlockView {
+  const _$CommunityBlockViewImpl(
       {required this.person,
       required this.community,
       required this.instanceHost})
       : super._();
 
-  factory _$_CommunityBlockView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityBlockViewFromJson(json);
+  factory _$CommunityBlockViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityBlockViewImplFromJson(json);
 
   @override
   final PersonSafe person;
@@ -7804,7 +7825,7 @@ class _$_CommunityBlockView extends _CommunityBlockView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunityBlockView &&
+            other is _$CommunityBlockViewImpl &&
             (identical(other.person, person) || other.person == person) &&
             (identical(other.community, community) ||
                 other.community == community) &&
@@ -7819,13 +7840,13 @@ class _$_CommunityBlockView extends _CommunityBlockView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityBlockViewCopyWith<_$_CommunityBlockView> get copyWith =>
-      __$$_CommunityBlockViewCopyWithImpl<_$_CommunityBlockView>(
+  _$$CommunityBlockViewImplCopyWith<_$CommunityBlockViewImpl> get copyWith =>
+      __$$CommunityBlockViewImplCopyWithImpl<_$CommunityBlockViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityBlockViewToJson(
+    return _$$CommunityBlockViewImplToJson(
       this,
     );
   }
@@ -7835,11 +7856,11 @@ abstract class _CommunityBlockView extends CommunityBlockView {
   const factory _CommunityBlockView(
       {required final PersonSafe person,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$_CommunityBlockView;
+      required final String instanceHost}) = _$CommunityBlockViewImpl;
   const _CommunityBlockView._() : super._();
 
   factory _CommunityBlockView.fromJson(Map<String, dynamic> json) =
-      _$_CommunityBlockView.fromJson;
+      _$CommunityBlockViewImpl.fromJson;
 
   @override
   PersonSafe get person;
@@ -7849,7 +7870,7 @@ abstract class _CommunityBlockView extends CommunityBlockView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityBlockViewCopyWith<_$_CommunityBlockView> get copyWith =>
+  _$$CommunityBlockViewImplCopyWith<_$CommunityBlockViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -7934,11 +7955,12 @@ class _$CommunityPersonBanViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_CommunityPersonBanViewCopyWith<$Res>
+abstract class _$$CommunityPersonBanViewImplCopyWith<$Res>
     implements $CommunityPersonBanViewCopyWith<$Res> {
-  factory _$$_CommunityPersonBanViewCopyWith(_$_CommunityPersonBanView value,
-          $Res Function(_$_CommunityPersonBanView) then) =
-      __$$_CommunityPersonBanViewCopyWithImpl<$Res>;
+  factory _$$CommunityPersonBanViewImplCopyWith(
+          _$CommunityPersonBanViewImpl value,
+          $Res Function(_$CommunityPersonBanViewImpl) then) =
+      __$$CommunityPersonBanViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CommunitySafe community, PersonSafe person, String instanceHost});
@@ -7950,12 +7972,13 @@ abstract class _$$_CommunityPersonBanViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunityPersonBanViewCopyWithImpl<$Res>
+class __$$CommunityPersonBanViewImplCopyWithImpl<$Res>
     extends _$CommunityPersonBanViewCopyWithImpl<$Res,
-        _$_CommunityPersonBanView>
-    implements _$$_CommunityPersonBanViewCopyWith<$Res> {
-  __$$_CommunityPersonBanViewCopyWithImpl(_$_CommunityPersonBanView _value,
-      $Res Function(_$_CommunityPersonBanView) _then)
+        _$CommunityPersonBanViewImpl>
+    implements _$$CommunityPersonBanViewImplCopyWith<$Res> {
+  __$$CommunityPersonBanViewImplCopyWithImpl(
+      _$CommunityPersonBanViewImpl _value,
+      $Res Function(_$CommunityPersonBanViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -7965,7 +7988,7 @@ class __$$_CommunityPersonBanViewCopyWithImpl<$Res>
     Object? person = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_CommunityPersonBanView(
+    return _then(_$CommunityPersonBanViewImpl(
       community: null == community
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
@@ -7985,15 +8008,15 @@ class __$$_CommunityPersonBanViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunityPersonBanView extends _CommunityPersonBanView {
-  const _$_CommunityPersonBanView(
+class _$CommunityPersonBanViewImpl extends _CommunityPersonBanView {
+  const _$CommunityPersonBanViewImpl(
       {required this.community,
       required this.person,
       required this.instanceHost})
       : super._();
 
-  factory _$_CommunityPersonBanView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityPersonBanViewFromJson(json);
+  factory _$CommunityPersonBanViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityPersonBanViewImplFromJson(json);
 
   @override
   final CommunitySafe community;
@@ -8011,7 +8034,7 @@ class _$_CommunityPersonBanView extends _CommunityPersonBanView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunityPersonBanView &&
+            other is _$CommunityPersonBanViewImpl &&
             (identical(other.community, community) ||
                 other.community == community) &&
             (identical(other.person, person) || other.person == person) &&
@@ -8026,13 +8049,13 @@ class _$_CommunityPersonBanView extends _CommunityPersonBanView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityPersonBanViewCopyWith<_$_CommunityPersonBanView> get copyWith =>
-      __$$_CommunityPersonBanViewCopyWithImpl<_$_CommunityPersonBanView>(
-          this, _$identity);
+  _$$CommunityPersonBanViewImplCopyWith<_$CommunityPersonBanViewImpl>
+      get copyWith => __$$CommunityPersonBanViewImplCopyWithImpl<
+          _$CommunityPersonBanViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityPersonBanViewToJson(
+    return _$$CommunityPersonBanViewImplToJson(
       this,
     );
   }
@@ -8042,11 +8065,11 @@ abstract class _CommunityPersonBanView extends CommunityPersonBanView {
   const factory _CommunityPersonBanView(
       {required final CommunitySafe community,
       required final PersonSafe person,
-      required final String instanceHost}) = _$_CommunityPersonBanView;
+      required final String instanceHost}) = _$CommunityPersonBanViewImpl;
   const _CommunityPersonBanView._() : super._();
 
   factory _CommunityPersonBanView.fromJson(Map<String, dynamic> json) =
-      _$_CommunityPersonBanView.fromJson;
+      _$CommunityPersonBanViewImpl.fromJson;
 
   @override
   CommunitySafe get community;
@@ -8056,8 +8079,8 @@ abstract class _CommunityPersonBanView extends CommunityPersonBanView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityPersonBanViewCopyWith<_$_CommunityPersonBanView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$CommunityPersonBanViewImplCopyWith<_$CommunityPersonBanViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 CommunityView _$CommunityViewFromJson(Map<String, dynamic> json) {
@@ -8156,11 +8179,11 @@ class _$CommunityViewCopyWithImpl<$Res, $Val extends CommunityView>
 }
 
 /// @nodoc
-abstract class _$$_CommunityViewCopyWith<$Res>
+abstract class _$$CommunityViewImplCopyWith<$Res>
     implements $CommunityViewCopyWith<$Res> {
-  factory _$$_CommunityViewCopyWith(
-          _$_CommunityView value, $Res Function(_$_CommunityView) then) =
-      __$$_CommunityViewCopyWithImpl<$Res>;
+  factory _$$CommunityViewImplCopyWith(
+          _$CommunityViewImpl value, $Res Function(_$CommunityViewImpl) then) =
+      __$$CommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -8177,11 +8200,11 @@ abstract class _$$_CommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunityViewCopyWithImpl<$Res>
-    extends _$CommunityViewCopyWithImpl<$Res, _$_CommunityView>
-    implements _$$_CommunityViewCopyWith<$Res> {
-  __$$_CommunityViewCopyWithImpl(
-      _$_CommunityView _value, $Res Function(_$_CommunityView) _then)
+class __$$CommunityViewImplCopyWithImpl<$Res>
+    extends _$CommunityViewCopyWithImpl<$Res, _$CommunityViewImpl>
+    implements _$$CommunityViewImplCopyWith<$Res> {
+  __$$CommunityViewImplCopyWithImpl(
+      _$CommunityViewImpl _value, $Res Function(_$CommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8193,7 +8216,7 @@ class __$$_CommunityViewCopyWithImpl<$Res>
     Object? counts = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_CommunityView(
+    return _then(_$CommunityViewImpl(
       community: null == community
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
@@ -8221,8 +8244,8 @@ class __$$_CommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunityView extends _CommunityView {
-  const _$_CommunityView(
+class _$CommunityViewImpl extends _CommunityView {
+  const _$CommunityViewImpl(
       {required this.community,
       this.subscribed = SubscribedType.notSubscribed,
       required this.blocked,
@@ -8230,8 +8253,8 @@ class _$_CommunityView extends _CommunityView {
       required this.instanceHost})
       : super._();
 
-  factory _$_CommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityViewFromJson(json);
+  factory _$CommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityViewImplFromJson(json);
 
   @override
   final CommunitySafe community;
@@ -8254,7 +8277,7 @@ class _$_CommunityView extends _CommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunityView &&
+            other is _$CommunityViewImpl &&
             (identical(other.community, community) ||
                 other.community == community) &&
             (identical(other.subscribed, subscribed) ||
@@ -8273,12 +8296,12 @@ class _$_CommunityView extends _CommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityViewCopyWith<_$_CommunityView> get copyWith =>
-      __$$_CommunityViewCopyWithImpl<_$_CommunityView>(this, _$identity);
+  _$$CommunityViewImplCopyWith<_$CommunityViewImpl> get copyWith =>
+      __$$CommunityViewImplCopyWithImpl<_$CommunityViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityViewToJson(
+    return _$$CommunityViewImplToJson(
       this,
     );
   }
@@ -8290,11 +8313,11 @@ abstract class _CommunityView extends CommunityView {
       final SubscribedType subscribed,
       required final bool blocked,
       required final CommunityAggregates counts,
-      required final String instanceHost}) = _$_CommunityView;
+      required final String instanceHost}) = _$CommunityViewImpl;
   const _CommunityView._() : super._();
 
   factory _CommunityView.fromJson(Map<String, dynamic> json) =
-      _$_CommunityView.fromJson;
+      _$CommunityViewImpl.fromJson;
 
   @override
   CommunitySafe get community;
@@ -8308,7 +8331,7 @@ abstract class _CommunityView extends CommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityViewCopyWith<_$_CommunityView> get copyWith =>
+  _$$CommunityViewImplCopyWith<_$CommunityViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -8436,12 +8459,12 @@ class _$RegistrationApplicationViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_RegistrationApplicationViewCopyWith<$Res>
+abstract class _$$RegistrationApplicationViewImplCopyWith<$Res>
     implements $RegistrationApplicationViewCopyWith<$Res> {
-  factory _$$_RegistrationApplicationViewCopyWith(
-          _$_RegistrationApplicationView value,
-          $Res Function(_$_RegistrationApplicationView) then) =
-      __$$_RegistrationApplicationViewCopyWithImpl<$Res>;
+  factory _$$RegistrationApplicationViewImplCopyWith(
+          _$RegistrationApplicationViewImpl value,
+          $Res Function(_$RegistrationApplicationViewImpl) then) =
+      __$$RegistrationApplicationViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -8462,13 +8485,13 @@ abstract class _$$_RegistrationApplicationViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_RegistrationApplicationViewCopyWithImpl<$Res>
+class __$$RegistrationApplicationViewImplCopyWithImpl<$Res>
     extends _$RegistrationApplicationViewCopyWithImpl<$Res,
-        _$_RegistrationApplicationView>
-    implements _$$_RegistrationApplicationViewCopyWith<$Res> {
-  __$$_RegistrationApplicationViewCopyWithImpl(
-      _$_RegistrationApplicationView _value,
-      $Res Function(_$_RegistrationApplicationView) _then)
+        _$RegistrationApplicationViewImpl>
+    implements _$$RegistrationApplicationViewImplCopyWith<$Res> {
+  __$$RegistrationApplicationViewImplCopyWithImpl(
+      _$RegistrationApplicationViewImpl _value,
+      $Res Function(_$RegistrationApplicationViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8480,7 +8503,7 @@ class __$$_RegistrationApplicationViewCopyWithImpl<$Res>
     Object? admin = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_RegistrationApplicationView(
+    return _then(_$RegistrationApplicationViewImpl(
       registrationApplication: null == registrationApplication
           ? _value.registrationApplication
           : registrationApplication // ignore: cast_nullable_to_non_nullable
@@ -8508,8 +8531,8 @@ class __$$_RegistrationApplicationViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_RegistrationApplicationView extends _RegistrationApplicationView {
-  const _$_RegistrationApplicationView(
+class _$RegistrationApplicationViewImpl extends _RegistrationApplicationView {
+  const _$RegistrationApplicationViewImpl(
       {required this.registrationApplication,
       required this.creatorLocalUser,
       required this.creator,
@@ -8517,8 +8540,9 @@ class _$_RegistrationApplicationView extends _RegistrationApplicationView {
       required this.instanceHost})
       : super._();
 
-  factory _$_RegistrationApplicationView.fromJson(Map<String, dynamic> json) =>
-      _$$_RegistrationApplicationViewFromJson(json);
+  factory _$RegistrationApplicationViewImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$RegistrationApplicationViewImplFromJson(json);
 
   @override
   final RegistrationApplication registrationApplication;
@@ -8540,7 +8564,7 @@ class _$_RegistrationApplicationView extends _RegistrationApplicationView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_RegistrationApplicationView &&
+            other is _$RegistrationApplicationViewImpl &&
             (identical(
                     other.registrationApplication, registrationApplication) ||
                 other.registrationApplication == registrationApplication) &&
@@ -8560,13 +8584,13 @@ class _$_RegistrationApplicationView extends _RegistrationApplicationView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RegistrationApplicationViewCopyWith<_$_RegistrationApplicationView>
-      get copyWith => __$$_RegistrationApplicationViewCopyWithImpl<
-          _$_RegistrationApplicationView>(this, _$identity);
+  _$$RegistrationApplicationViewImplCopyWith<_$RegistrationApplicationViewImpl>
+      get copyWith => __$$RegistrationApplicationViewImplCopyWithImpl<
+          _$RegistrationApplicationViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RegistrationApplicationViewToJson(
+    return _$$RegistrationApplicationViewImplToJson(
       this,
     );
   }
@@ -8579,11 +8603,11 @@ abstract class _RegistrationApplicationView
       required final LocalUserSettings creatorLocalUser,
       required final PersonSafe creator,
       final PersonSafe? admin,
-      required final String instanceHost}) = _$_RegistrationApplicationView;
+      required final String instanceHost}) = _$RegistrationApplicationViewImpl;
   const _RegistrationApplicationView._() : super._();
 
   factory _RegistrationApplicationView.fromJson(Map<String, dynamic> json) =
-      _$_RegistrationApplicationView.fromJson;
+      _$RegistrationApplicationViewImpl.fromJson;
 
   @override
   RegistrationApplication get registrationApplication;
@@ -8597,7 +8621,7 @@ abstract class _RegistrationApplicationView
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_RegistrationApplicationViewCopyWith<_$_RegistrationApplicationView>
+  _$$RegistrationApplicationViewImplCopyWith<_$RegistrationApplicationViewImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -8705,11 +8729,12 @@ class _$AdminPurgeCommentViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgeCommentViewCopyWith<$Res>
+abstract class _$$AdminPurgeCommentViewImplCopyWith<$Res>
     implements $AdminPurgeCommentViewCopyWith<$Res> {
-  factory _$$_AdminPurgeCommentViewCopyWith(_$_AdminPurgeCommentView value,
-          $Res Function(_$_AdminPurgeCommentView) then) =
-      __$$_AdminPurgeCommentViewCopyWithImpl<$Res>;
+  factory _$$AdminPurgeCommentViewImplCopyWith(
+          _$AdminPurgeCommentViewImpl value,
+          $Res Function(_$AdminPurgeCommentViewImpl) then) =
+      __$$AdminPurgeCommentViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -8727,11 +8752,12 @@ abstract class _$$_AdminPurgeCommentViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgeCommentViewCopyWithImpl<$Res>
-    extends _$AdminPurgeCommentViewCopyWithImpl<$Res, _$_AdminPurgeCommentView>
-    implements _$$_AdminPurgeCommentViewCopyWith<$Res> {
-  __$$_AdminPurgeCommentViewCopyWithImpl(_$_AdminPurgeCommentView _value,
-      $Res Function(_$_AdminPurgeCommentView) _then)
+class __$$AdminPurgeCommentViewImplCopyWithImpl<$Res>
+    extends _$AdminPurgeCommentViewCopyWithImpl<$Res,
+        _$AdminPurgeCommentViewImpl>
+    implements _$$AdminPurgeCommentViewImplCopyWith<$Res> {
+  __$$AdminPurgeCommentViewImplCopyWithImpl(_$AdminPurgeCommentViewImpl _value,
+      $Res Function(_$AdminPurgeCommentViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8742,7 +8768,7 @@ class __$$_AdminPurgeCommentViewCopyWithImpl<$Res>
     Object? post = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_AdminPurgeCommentView(
+    return _then(_$AdminPurgeCommentViewImpl(
       adminPurgeComment: null == adminPurgeComment
           ? _value.adminPurgeComment
           : adminPurgeComment // ignore: cast_nullable_to_non_nullable
@@ -8766,16 +8792,16 @@ class __$$_AdminPurgeCommentViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgeCommentView extends _AdminPurgeCommentView {
-  const _$_AdminPurgeCommentView(
+class _$AdminPurgeCommentViewImpl extends _AdminPurgeCommentView {
+  const _$AdminPurgeCommentViewImpl(
       {required this.adminPurgeComment,
       this.admin,
       required this.post,
       required this.instanceHost})
       : super._();
 
-  factory _$_AdminPurgeCommentView.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgeCommentViewFromJson(json);
+  factory _$AdminPurgeCommentViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgeCommentViewImplFromJson(json);
 
   @override
   final AdminPurgeComment adminPurgeComment;
@@ -8795,7 +8821,7 @@ class _$_AdminPurgeCommentView extends _AdminPurgeCommentView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgeCommentView &&
+            other is _$AdminPurgeCommentViewImpl &&
             (identical(other.adminPurgeComment, adminPurgeComment) ||
                 other.adminPurgeComment == adminPurgeComment) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -8812,13 +8838,13 @@ class _$_AdminPurgeCommentView extends _AdminPurgeCommentView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgeCommentViewCopyWith<_$_AdminPurgeCommentView> get copyWith =>
-      __$$_AdminPurgeCommentViewCopyWithImpl<_$_AdminPurgeCommentView>(
-          this, _$identity);
+  _$$AdminPurgeCommentViewImplCopyWith<_$AdminPurgeCommentViewImpl>
+      get copyWith => __$$AdminPurgeCommentViewImplCopyWithImpl<
+          _$AdminPurgeCommentViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgeCommentViewToJson(
+    return _$$AdminPurgeCommentViewImplToJson(
       this,
     );
   }
@@ -8829,11 +8855,11 @@ abstract class _AdminPurgeCommentView extends AdminPurgeCommentView {
       {required final AdminPurgeComment adminPurgeComment,
       final PersonSafe? admin,
       required final Post post,
-      required final String instanceHost}) = _$_AdminPurgeCommentView;
+      required final String instanceHost}) = _$AdminPurgeCommentViewImpl;
   const _AdminPurgeCommentView._() : super._();
 
   factory _AdminPurgeCommentView.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgeCommentView.fromJson;
+      _$AdminPurgeCommentViewImpl.fromJson;
 
   @override
   AdminPurgeComment get adminPurgeComment;
@@ -8845,8 +8871,8 @@ abstract class _AdminPurgeCommentView extends AdminPurgeCommentView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgeCommentViewCopyWith<_$_AdminPurgeCommentView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$AdminPurgeCommentViewImplCopyWith<_$AdminPurgeCommentViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 AdminPurgePostView _$AdminPurgePostViewFromJson(Map<String, dynamic> json) {
@@ -8951,11 +8977,11 @@ class _$AdminPurgePostViewCopyWithImpl<$Res, $Val extends AdminPurgePostView>
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgePostViewCopyWith<$Res>
+abstract class _$$AdminPurgePostViewImplCopyWith<$Res>
     implements $AdminPurgePostViewCopyWith<$Res> {
-  factory _$$_AdminPurgePostViewCopyWith(_$_AdminPurgePostView value,
-          $Res Function(_$_AdminPurgePostView) then) =
-      __$$_AdminPurgePostViewCopyWithImpl<$Res>;
+  factory _$$AdminPurgePostViewImplCopyWith(_$AdminPurgePostViewImpl value,
+          $Res Function(_$AdminPurgePostViewImpl) then) =
+      __$$AdminPurgePostViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -8973,11 +8999,11 @@ abstract class _$$_AdminPurgePostViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgePostViewCopyWithImpl<$Res>
-    extends _$AdminPurgePostViewCopyWithImpl<$Res, _$_AdminPurgePostView>
-    implements _$$_AdminPurgePostViewCopyWith<$Res> {
-  __$$_AdminPurgePostViewCopyWithImpl(
-      _$_AdminPurgePostView _value, $Res Function(_$_AdminPurgePostView) _then)
+class __$$AdminPurgePostViewImplCopyWithImpl<$Res>
+    extends _$AdminPurgePostViewCopyWithImpl<$Res, _$AdminPurgePostViewImpl>
+    implements _$$AdminPurgePostViewImplCopyWith<$Res> {
+  __$$AdminPurgePostViewImplCopyWithImpl(_$AdminPurgePostViewImpl _value,
+      $Res Function(_$AdminPurgePostViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -8988,7 +9014,7 @@ class __$$_AdminPurgePostViewCopyWithImpl<$Res>
     Object? community = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_AdminPurgePostView(
+    return _then(_$AdminPurgePostViewImpl(
       adminPurgePost: null == adminPurgePost
           ? _value.adminPurgePost
           : adminPurgePost // ignore: cast_nullable_to_non_nullable
@@ -9012,16 +9038,16 @@ class __$$_AdminPurgePostViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgePostView extends _AdminPurgePostView {
-  const _$_AdminPurgePostView(
+class _$AdminPurgePostViewImpl extends _AdminPurgePostView {
+  const _$AdminPurgePostViewImpl(
       {required this.adminPurgePost,
       this.admin,
       required this.community,
       required this.instanceHost})
       : super._();
 
-  factory _$_AdminPurgePostView.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgePostViewFromJson(json);
+  factory _$AdminPurgePostViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgePostViewImplFromJson(json);
 
   @override
   final AdminPurgePost adminPurgePost;
@@ -9041,7 +9067,7 @@ class _$_AdminPurgePostView extends _AdminPurgePostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgePostView &&
+            other is _$AdminPurgePostViewImpl &&
             (identical(other.adminPurgePost, adminPurgePost) ||
                 other.adminPurgePost == adminPurgePost) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -9059,13 +9085,13 @@ class _$_AdminPurgePostView extends _AdminPurgePostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgePostViewCopyWith<_$_AdminPurgePostView> get copyWith =>
-      __$$_AdminPurgePostViewCopyWithImpl<_$_AdminPurgePostView>(
+  _$$AdminPurgePostViewImplCopyWith<_$AdminPurgePostViewImpl> get copyWith =>
+      __$$AdminPurgePostViewImplCopyWithImpl<_$AdminPurgePostViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgePostViewToJson(
+    return _$$AdminPurgePostViewImplToJson(
       this,
     );
   }
@@ -9076,11 +9102,11 @@ abstract class _AdminPurgePostView extends AdminPurgePostView {
       {required final AdminPurgePost adminPurgePost,
       final PersonSafe? admin,
       required final CommunitySafe community,
-      required final String instanceHost}) = _$_AdminPurgePostView;
+      required final String instanceHost}) = _$AdminPurgePostViewImpl;
   const _AdminPurgePostView._() : super._();
 
   factory _AdminPurgePostView.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgePostView.fromJson;
+      _$AdminPurgePostViewImpl.fromJson;
 
   @override
   AdminPurgePost get adminPurgePost;
@@ -9092,7 +9118,7 @@ abstract class _AdminPurgePostView extends AdminPurgePostView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgePostViewCopyWith<_$_AdminPurgePostView> get copyWith =>
+  _$$AdminPurgePostViewImplCopyWith<_$AdminPurgePostViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -9183,11 +9209,11 @@ class _$AdminPurgePersonViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgePersonViewCopyWith<$Res>
+abstract class _$$AdminPurgePersonViewImplCopyWith<$Res>
     implements $AdminPurgePersonViewCopyWith<$Res> {
-  factory _$$_AdminPurgePersonViewCopyWith(_$_AdminPurgePersonView value,
-          $Res Function(_$_AdminPurgePersonView) then) =
-      __$$_AdminPurgePersonViewCopyWithImpl<$Res>;
+  factory _$$AdminPurgePersonViewImplCopyWith(_$AdminPurgePersonViewImpl value,
+          $Res Function(_$AdminPurgePersonViewImpl) then) =
+      __$$AdminPurgePersonViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -9202,11 +9228,11 @@ abstract class _$$_AdminPurgePersonViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgePersonViewCopyWithImpl<$Res>
-    extends _$AdminPurgePersonViewCopyWithImpl<$Res, _$_AdminPurgePersonView>
-    implements _$$_AdminPurgePersonViewCopyWith<$Res> {
-  __$$_AdminPurgePersonViewCopyWithImpl(_$_AdminPurgePersonView _value,
-      $Res Function(_$_AdminPurgePersonView) _then)
+class __$$AdminPurgePersonViewImplCopyWithImpl<$Res>
+    extends _$AdminPurgePersonViewCopyWithImpl<$Res, _$AdminPurgePersonViewImpl>
+    implements _$$AdminPurgePersonViewImplCopyWith<$Res> {
+  __$$AdminPurgePersonViewImplCopyWithImpl(_$AdminPurgePersonViewImpl _value,
+      $Res Function(_$AdminPurgePersonViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -9216,7 +9242,7 @@ class __$$_AdminPurgePersonViewCopyWithImpl<$Res>
     Object? admin = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_AdminPurgePersonView(
+    return _then(_$AdminPurgePersonViewImpl(
       adminPurgePerson: null == adminPurgePerson
           ? _value.adminPurgePerson
           : adminPurgePerson // ignore: cast_nullable_to_non_nullable
@@ -9236,13 +9262,13 @@ class __$$_AdminPurgePersonViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgePersonView extends _AdminPurgePersonView {
-  const _$_AdminPurgePersonView(
+class _$AdminPurgePersonViewImpl extends _AdminPurgePersonView {
+  const _$AdminPurgePersonViewImpl(
       {required this.adminPurgePerson, this.admin, required this.instanceHost})
       : super._();
 
-  factory _$_AdminPurgePersonView.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgePersonViewFromJson(json);
+  factory _$AdminPurgePersonViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgePersonViewImplFromJson(json);
 
   @override
   final AdminPurgePerson adminPurgePerson;
@@ -9260,7 +9286,7 @@ class _$_AdminPurgePersonView extends _AdminPurgePersonView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgePersonView &&
+            other is _$AdminPurgePersonViewImpl &&
             (identical(other.adminPurgePerson, adminPurgePerson) ||
                 other.adminPurgePerson == adminPurgePerson) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -9276,13 +9302,14 @@ class _$_AdminPurgePersonView extends _AdminPurgePersonView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgePersonViewCopyWith<_$_AdminPurgePersonView> get copyWith =>
-      __$$_AdminPurgePersonViewCopyWithImpl<_$_AdminPurgePersonView>(
-          this, _$identity);
+  _$$AdminPurgePersonViewImplCopyWith<_$AdminPurgePersonViewImpl>
+      get copyWith =>
+          __$$AdminPurgePersonViewImplCopyWithImpl<_$AdminPurgePersonViewImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgePersonViewToJson(
+    return _$$AdminPurgePersonViewImplToJson(
       this,
     );
   }
@@ -9292,11 +9319,11 @@ abstract class _AdminPurgePersonView extends AdminPurgePersonView {
   const factory _AdminPurgePersonView(
       {required final AdminPurgePerson adminPurgePerson,
       final PersonSafe? admin,
-      required final String instanceHost}) = _$_AdminPurgePersonView;
+      required final String instanceHost}) = _$AdminPurgePersonViewImpl;
   const _AdminPurgePersonView._() : super._();
 
   factory _AdminPurgePersonView.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgePersonView.fromJson;
+      _$AdminPurgePersonViewImpl.fromJson;
 
   @override
   AdminPurgePerson get adminPurgePerson;
@@ -9306,8 +9333,8 @@ abstract class _AdminPurgePersonView extends AdminPurgePersonView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgePersonViewCopyWith<_$_AdminPurgePersonView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$AdminPurgePersonViewImplCopyWith<_$AdminPurgePersonViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 AdminPurgeCommunityView _$AdminPurgeCommunityViewFromJson(
@@ -9400,11 +9427,12 @@ class _$AdminPurgeCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgeCommunityViewCopyWith<$Res>
+abstract class _$$AdminPurgeCommunityViewImplCopyWith<$Res>
     implements $AdminPurgeCommunityViewCopyWith<$Res> {
-  factory _$$_AdminPurgeCommunityViewCopyWith(_$_AdminPurgeCommunityView value,
-          $Res Function(_$_AdminPurgeCommunityView) then) =
-      __$$_AdminPurgeCommunityViewCopyWithImpl<$Res>;
+  factory _$$AdminPurgeCommunityViewImplCopyWith(
+          _$AdminPurgeCommunityViewImpl value,
+          $Res Function(_$AdminPurgeCommunityViewImpl) then) =
+      __$$AdminPurgeCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -9419,12 +9447,13 @@ abstract class _$$_AdminPurgeCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgeCommunityViewCopyWithImpl<$Res>
+class __$$AdminPurgeCommunityViewImplCopyWithImpl<$Res>
     extends _$AdminPurgeCommunityViewCopyWithImpl<$Res,
-        _$_AdminPurgeCommunityView>
-    implements _$$_AdminPurgeCommunityViewCopyWith<$Res> {
-  __$$_AdminPurgeCommunityViewCopyWithImpl(_$_AdminPurgeCommunityView _value,
-      $Res Function(_$_AdminPurgeCommunityView) _then)
+        _$AdminPurgeCommunityViewImpl>
+    implements _$$AdminPurgeCommunityViewImplCopyWith<$Res> {
+  __$$AdminPurgeCommunityViewImplCopyWithImpl(
+      _$AdminPurgeCommunityViewImpl _value,
+      $Res Function(_$AdminPurgeCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -9434,7 +9463,7 @@ class __$$_AdminPurgeCommunityViewCopyWithImpl<$Res>
     Object? admin = freezed,
     Object? instanceHost = null,
   }) {
-    return _then(_$_AdminPurgeCommunityView(
+    return _then(_$AdminPurgeCommunityViewImpl(
       adminPurgeCommunity: null == adminPurgeCommunity
           ? _value.adminPurgeCommunity
           : adminPurgeCommunity // ignore: cast_nullable_to_non_nullable
@@ -9454,15 +9483,15 @@ class __$$_AdminPurgeCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgeCommunityView extends _AdminPurgeCommunityView {
-  const _$_AdminPurgeCommunityView(
+class _$AdminPurgeCommunityViewImpl extends _AdminPurgeCommunityView {
+  const _$AdminPurgeCommunityViewImpl(
       {required this.adminPurgeCommunity,
       this.admin,
       required this.instanceHost})
       : super._();
 
-  factory _$_AdminPurgeCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgeCommunityViewFromJson(json);
+  factory _$AdminPurgeCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgeCommunityViewImplFromJson(json);
 
   @override
   final AdminPurgeCommunity adminPurgeCommunity;
@@ -9480,7 +9509,7 @@ class _$_AdminPurgeCommunityView extends _AdminPurgeCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgeCommunityView &&
+            other is _$AdminPurgeCommunityViewImpl &&
             (identical(other.adminPurgeCommunity, adminPurgeCommunity) ||
                 other.adminPurgeCommunity == adminPurgeCommunity) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -9496,14 +9525,13 @@ class _$_AdminPurgeCommunityView extends _AdminPurgeCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgeCommunityViewCopyWith<_$_AdminPurgeCommunityView>
-      get copyWith =>
-          __$$_AdminPurgeCommunityViewCopyWithImpl<_$_AdminPurgeCommunityView>(
-              this, _$identity);
+  _$$AdminPurgeCommunityViewImplCopyWith<_$AdminPurgeCommunityViewImpl>
+      get copyWith => __$$AdminPurgeCommunityViewImplCopyWithImpl<
+          _$AdminPurgeCommunityViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgeCommunityViewToJson(
+    return _$$AdminPurgeCommunityViewImplToJson(
       this,
     );
   }
@@ -9513,11 +9541,11 @@ abstract class _AdminPurgeCommunityView extends AdminPurgeCommunityView {
   const factory _AdminPurgeCommunityView(
       {required final AdminPurgeCommunity adminPurgeCommunity,
       final PersonSafe? admin,
-      required final String instanceHost}) = _$_AdminPurgeCommunityView;
+      required final String instanceHost}) = _$AdminPurgeCommunityViewImpl;
   const _AdminPurgeCommunityView._() : super._();
 
   factory _AdminPurgeCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgeCommunityView.fromJson;
+      _$AdminPurgeCommunityViewImpl.fromJson;
 
   @override
   AdminPurgeCommunity get adminPurgeCommunity;
@@ -9527,6 +9555,6 @@ abstract class _AdminPurgeCommunityView extends AdminPurgeCommunityView {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgeCommunityViewCopyWith<_$_AdminPurgeCommunityView>
+  _$$AdminPurgeCommunityViewImplCopyWith<_$AdminPurgeCommunityViewImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/views.g.dart
+++ b/lib/src/v3/models/views.g.dart
@@ -6,22 +6,24 @@ part of 'views.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PersonViewSafe _$$_PersonViewSafeFromJson(Map<String, dynamic> json) =>
-    _$_PersonViewSafe(
+_$PersonViewSafeImpl _$$PersonViewSafeImplFromJson(Map<String, dynamic> json) =>
+    _$PersonViewSafeImpl(
       person: PersonSafe.fromJson(json['person'] as Map<String, dynamic>),
       counts: PersonAggregates.fromJson(json['counts'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PersonViewSafeToJson(_$_PersonViewSafe instance) =>
+Map<String, dynamic> _$$PersonViewSafeImplToJson(
+        _$PersonViewSafeImpl instance) =>
     <String, dynamic>{
       'person': instance.person.toJson(),
       'counts': instance.counts.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$_PersonMentionView _$$_PersonMentionViewFromJson(Map<String, dynamic> json) =>
-    _$_PersonMentionView(
+_$PersonMentionViewImpl _$$PersonMentionViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$PersonMentionViewImpl(
       personMention: PersonMention.fromJson(
           json['person_mention'] as Map<String, dynamic>),
       comment: Comment.fromJson(json['comment'] as Map<String, dynamic>),
@@ -44,8 +46,8 @@ _$_PersonMentionView _$$_PersonMentionViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PersonMentionViewToJson(
-        _$_PersonMentionView instance) =>
+Map<String, dynamic> _$$PersonMentionViewImplToJson(
+        _$PersonMentionViewImpl instance) =>
     <String, dynamic>{
       'person_mention': instance.personMention.toJson(),
       'comment': instance.comment.toJson(),
@@ -62,9 +64,9 @@ Map<String, dynamic> _$$_PersonMentionViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_LocalUserSettingsView _$$_LocalUserSettingsViewFromJson(
+_$LocalUserSettingsViewImpl _$$LocalUserSettingsViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_LocalUserSettingsView(
+    _$LocalUserSettingsViewImpl(
       localUser: LocalUserSettings.fromJson(
           json['local_user'] as Map<String, dynamic>),
       person: PersonSafe.fromJson(json['person'] as Map<String, dynamic>),
@@ -72,8 +74,8 @@ _$_LocalUserSettingsView _$$_LocalUserSettingsViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_LocalUserSettingsViewToJson(
-        _$_LocalUserSettingsView instance) =>
+Map<String, dynamic> _$$LocalUserSettingsViewImplToJson(
+        _$LocalUserSettingsViewImpl instance) =>
     <String, dynamic>{
       'local_user': instance.localUser.toJson(),
       'person': instance.person.toJson(),
@@ -81,14 +83,15 @@ Map<String, dynamic> _$$_LocalUserSettingsViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_SiteView _$$_SiteViewFromJson(Map<String, dynamic> json) => _$_SiteView(
+_$SiteViewImpl _$$SiteViewImplFromJson(Map<String, dynamic> json) =>
+    _$SiteViewImpl(
       site: Site.fromJson(json['site'] as Map<String, dynamic>),
       localSite: LocalSite.fromJson(json['local_site'] as Map<String, dynamic>),
       counts: SiteAggregates.fromJson(json['counts'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_SiteViewToJson(_$_SiteView instance) =>
+Map<String, dynamic> _$$SiteViewImplToJson(_$SiteViewImpl instance) =>
     <String, dynamic>{
       'site': instance.site.toJson(),
       'local_site': instance.localSite.toJson(),
@@ -96,9 +99,9 @@ Map<String, dynamic> _$$_SiteViewToJson(_$_SiteView instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_PrivateMessageView _$$_PrivateMessageViewFromJson(
+_$PrivateMessageViewImpl _$$PrivateMessageViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PrivateMessageView(
+    _$PrivateMessageViewImpl(
       privateMessage: PrivateMessage.fromJson(
           json['private_message'] as Map<String, dynamic>),
       creator: PersonSafe.fromJson(json['creator'] as Map<String, dynamic>),
@@ -106,8 +109,8 @@ _$_PrivateMessageView _$$_PrivateMessageViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PrivateMessageViewToJson(
-        _$_PrivateMessageView instance) =>
+Map<String, dynamic> _$$PrivateMessageViewImplToJson(
+        _$PrivateMessageViewImpl instance) =>
     <String, dynamic>{
       'private_message': instance.privateMessage.toJson(),
       'creator': instance.creator.toJson(),
@@ -115,7 +118,8 @@ Map<String, dynamic> _$$_PrivateMessageViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_PostView _$$_PostViewFromJson(Map<String, dynamic> json) => _$_PostView(
+_$PostViewImpl _$$PostViewImplFromJson(Map<String, dynamic> json) =>
+    _$PostViewImpl(
       post: Post.fromJson(json['post'] as Map<String, dynamic>),
       creator: PersonSafe.fromJson(json['creator'] as Map<String, dynamic>),
       community:
@@ -135,7 +139,7 @@ _$_PostView _$$_PostViewFromJson(Map<String, dynamic> json) => _$_PostView(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PostViewToJson(_$_PostView instance) =>
+Map<String, dynamic> _$$PostViewImplToJson(_$PostViewImpl instance) =>
     <String, dynamic>{
       'post': instance.post.toJson(),
       'creator': instance.creator.toJson(),
@@ -151,8 +155,8 @@ Map<String, dynamic> _$$_PostViewToJson(_$_PostView instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_PostReportView _$$_PostReportViewFromJson(Map<String, dynamic> json) =>
-    _$_PostReportView(
+_$PostReportViewImpl _$$PostReportViewImplFromJson(Map<String, dynamic> json) =>
+    _$PostReportViewImpl(
       postReport:
           PostReport.fromJson(json['post_report'] as Map<String, dynamic>),
       post: Post.fromJson(json['post'] as Map<String, dynamic>),
@@ -172,7 +176,8 @@ _$_PostReportView _$$_PostReportViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PostReportViewToJson(_$_PostReportView instance) =>
+Map<String, dynamic> _$$PostReportViewImplToJson(
+        _$PostReportViewImpl instance) =>
     <String, dynamic>{
       'post_report': instance.postReport.toJson(),
       'post': instance.post.toJson(),
@@ -186,8 +191,8 @@ Map<String, dynamic> _$$_PostReportViewToJson(_$_PostReportView instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_CommentView _$$_CommentViewFromJson(Map<String, dynamic> json) =>
-    _$_CommentView(
+_$CommentViewImpl _$$CommentViewImplFromJson(Map<String, dynamic> json) =>
+    _$CommentViewImpl(
       comment: Comment.fromJson(json['comment'] as Map<String, dynamic>),
       creator: PersonSafe.fromJson(json['creator'] as Map<String, dynamic>),
       commentReply: json['comment_reply'] == null
@@ -214,7 +219,7 @@ _$_CommentView _$$_CommentViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_CommentViewToJson(_$_CommentView instance) =>
+Map<String, dynamic> _$$CommentViewImplToJson(_$CommentViewImpl instance) =>
     <String, dynamic>{
       'comment': instance.comment.toJson(),
       'creator': instance.creator.toJson(),
@@ -231,8 +236,9 @@ Map<String, dynamic> _$$_CommentViewToJson(_$_CommentView instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_CommentReplyView _$$_CommentReplyViewFromJson(Map<String, dynamic> json) =>
-    _$_CommentReplyView(
+_$CommentReplyViewImpl _$$CommentReplyViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CommentReplyViewImpl(
       commentReply:
           CommentReply.fromJson(json['comment_reply'] as Map<String, dynamic>),
       comment: Comment.fromJson(json['comment'] as Map<String, dynamic>),
@@ -257,7 +263,8 @@ _$_CommentReplyView _$$_CommentReplyViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_CommentReplyViewToJson(_$_CommentReplyView instance) =>
+Map<String, dynamic> _$$CommentReplyViewImplToJson(
+        _$CommentReplyViewImpl instance) =>
     <String, dynamic>{
       'comment_reply': instance.commentReply.toJson(),
       'comment': instance.comment.toJson(),
@@ -274,8 +281,9 @@ Map<String, dynamic> _$$_CommentReplyViewToJson(_$_CommentReplyView instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_CommentReportView _$$_CommentReportViewFromJson(Map<String, dynamic> json) =>
-    _$_CommentReportView(
+_$CommentReportViewImpl _$$CommentReportViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CommentReportViewImpl(
       commentReport: CommentReport.fromJson(
           json['comment_report'] as Map<String, dynamic>),
       comment: Comment.fromJson(json['comment'] as Map<String, dynamic>),
@@ -297,8 +305,8 @@ _$_CommentReportView _$$_CommentReportViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_CommentReportViewToJson(
-        _$_CommentReportView instance) =>
+Map<String, dynamic> _$$CommentReportViewImplToJson(
+        _$CommentReportViewImpl instance) =>
     <String, dynamic>{
       'comment_report': instance.commentReport.toJson(),
       'comment': instance.comment.toJson(),
@@ -313,9 +321,9 @@ Map<String, dynamic> _$$_CommentReportViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModAddCommunityView _$$_ModAddCommunityViewFromJson(
+_$ModAddCommunityViewImpl _$$ModAddCommunityViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModAddCommunityView(
+    _$ModAddCommunityViewImpl(
       modAddCommunity: ModAddCommunity.fromJson(
           json['mod_add_community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -328,8 +336,8 @@ _$_ModAddCommunityView _$$_ModAddCommunityViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModAddCommunityViewToJson(
-        _$_ModAddCommunityView instance) =>
+Map<String, dynamic> _$$ModAddCommunityViewImplToJson(
+        _$ModAddCommunityViewImpl instance) =>
     <String, dynamic>{
       'mod_add_community': instance.modAddCommunity.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -338,9 +346,9 @@ Map<String, dynamic> _$$_ModAddCommunityViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModTransferCommunityView _$$_ModTransferCommunityViewFromJson(
+_$ModTransferCommunityViewImpl _$$ModTransferCommunityViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModTransferCommunityView(
+    _$ModTransferCommunityViewImpl(
       modTransferCommunity: ModTransferCommunity.fromJson(
           json['mod_transfer_community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -353,8 +361,8 @@ _$_ModTransferCommunityView _$$_ModTransferCommunityViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModTransferCommunityViewToJson(
-        _$_ModTransferCommunityView instance) =>
+Map<String, dynamic> _$$ModTransferCommunityViewImplToJson(
+        _$ModTransferCommunityViewImpl instance) =>
     <String, dynamic>{
       'mod_transfer_community': instance.modTransferCommunity.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -363,8 +371,8 @@ Map<String, dynamic> _$$_ModTransferCommunityViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModAddView _$$_ModAddViewFromJson(Map<String, dynamic> json) =>
-    _$_ModAddView(
+_$ModAddViewImpl _$$ModAddViewImplFromJson(Map<String, dynamic> json) =>
+    _$ModAddViewImpl(
       modAdd: ModAdd.fromJson(json['mod_add'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
           ? null
@@ -374,7 +382,7 @@ _$_ModAddView _$$_ModAddViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModAddViewToJson(_$_ModAddView instance) =>
+Map<String, dynamic> _$$ModAddViewImplToJson(_$ModAddViewImpl instance) =>
     <String, dynamic>{
       'mod_add': instance.modAdd.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -382,9 +390,9 @@ Map<String, dynamic> _$$_ModAddViewToJson(_$_ModAddView instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_ModBanFromCommunityView _$$_ModBanFromCommunityViewFromJson(
+_$ModBanFromCommunityViewImpl _$$ModBanFromCommunityViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModBanFromCommunityView(
+    _$ModBanFromCommunityViewImpl(
       modBanFromCommunity: ModBanFromCommunity.fromJson(
           json['mod_ban_from_community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -397,8 +405,8 @@ _$_ModBanFromCommunityView _$$_ModBanFromCommunityViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModBanFromCommunityViewToJson(
-        _$_ModBanFromCommunityView instance) =>
+Map<String, dynamic> _$$ModBanFromCommunityViewImplToJson(
+        _$ModBanFromCommunityViewImpl instance) =>
     <String, dynamic>{
       'mod_ban_from_community': instance.modBanFromCommunity.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -407,8 +415,8 @@ Map<String, dynamic> _$$_ModBanFromCommunityViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModBanView _$$_ModBanViewFromJson(Map<String, dynamic> json) =>
-    _$_ModBanView(
+_$ModBanViewImpl _$$ModBanViewImplFromJson(Map<String, dynamic> json) =>
+    _$ModBanViewImpl(
       modBan: ModBan.fromJson(json['mod_ban'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
           ? null
@@ -418,7 +426,7 @@ _$_ModBanView _$$_ModBanViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModBanViewToJson(_$_ModBanView instance) =>
+Map<String, dynamic> _$$ModBanViewImplToJson(_$ModBanViewImpl instance) =>
     <String, dynamic>{
       'mod_ban': instance.modBan.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -426,8 +434,9 @@ Map<String, dynamic> _$$_ModBanViewToJson(_$_ModBanView instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_ModLockPostView _$$_ModLockPostViewFromJson(Map<String, dynamic> json) =>
-    _$_ModLockPostView(
+_$ModLockPostViewImpl _$$ModLockPostViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ModLockPostViewImpl(
       modLockPost:
           ModLockPost.fromJson(json['mod_lock_post'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -439,7 +448,8 @@ _$_ModLockPostView _$$_ModLockPostViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModLockPostViewToJson(_$_ModLockPostView instance) =>
+Map<String, dynamic> _$$ModLockPostViewImplToJson(
+        _$ModLockPostViewImpl instance) =>
     <String, dynamic>{
       'mod_lock_post': instance.modLockPost.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -448,9 +458,9 @@ Map<String, dynamic> _$$_ModLockPostViewToJson(_$_ModLockPostView instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_ModRemoveCommentView _$$_ModRemoveCommentViewFromJson(
+_$ModRemoveCommentViewImpl _$$ModRemoveCommentViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModRemoveCommentView(
+    _$ModRemoveCommentViewImpl(
       modRemoveComment: ModRemoveComment.fromJson(
           json['mod_remove_comment'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -464,8 +474,8 @@ _$_ModRemoveCommentView _$$_ModRemoveCommentViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModRemoveCommentViewToJson(
-        _$_ModRemoveCommentView instance) =>
+Map<String, dynamic> _$$ModRemoveCommentViewImplToJson(
+        _$ModRemoveCommentViewImpl instance) =>
     <String, dynamic>{
       'mod_remove_comment': instance.modRemoveComment.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -476,9 +486,9 @@ Map<String, dynamic> _$$_ModRemoveCommentViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModRemoveCommunityView _$$_ModRemoveCommunityViewFromJson(
+_$ModRemoveCommunityViewImpl _$$ModRemoveCommunityViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModRemoveCommunityView(
+    _$ModRemoveCommunityViewImpl(
       modRemoveCommunity: ModRemoveCommunity.fromJson(
           json['mod_remove_community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -489,8 +499,8 @@ _$_ModRemoveCommunityView _$$_ModRemoveCommunityViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModRemoveCommunityViewToJson(
-        _$_ModRemoveCommunityView instance) =>
+Map<String, dynamic> _$$ModRemoveCommunityViewImplToJson(
+        _$ModRemoveCommunityViewImpl instance) =>
     <String, dynamic>{
       'mod_remove_community': instance.modRemoveCommunity.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -498,9 +508,9 @@ Map<String, dynamic> _$$_ModRemoveCommunityViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModHideCommunityView _$$_ModHideCommunityViewFromJson(
+_$ModHideCommunityViewImpl _$$ModHideCommunityViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModHideCommunityView(
+    _$ModHideCommunityViewImpl(
       modHideCommunity: ModHideCommunity.fromJson(
           json['mod_hide_community'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -511,8 +521,8 @@ _$_ModHideCommunityView _$$_ModHideCommunityViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModHideCommunityViewToJson(
-        _$_ModHideCommunityView instance) =>
+Map<String, dynamic> _$$ModHideCommunityViewImplToJson(
+        _$ModHideCommunityViewImpl instance) =>
     <String, dynamic>{
       'mod_hide_community': instance.modHideCommunity.toJson(),
       'admin': instance.admin?.toJson(),
@@ -520,8 +530,9 @@ Map<String, dynamic> _$$_ModHideCommunityViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModRemovePostView _$$_ModRemovePostViewFromJson(Map<String, dynamic> json) =>
-    _$_ModRemovePostView(
+_$ModRemovePostViewImpl _$$ModRemovePostViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ModRemovePostViewImpl(
       modRemovePost: ModRemovePost.fromJson(
           json['mod_remove_post'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -533,8 +544,8 @@ _$_ModRemovePostView _$$_ModRemovePostViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModRemovePostViewToJson(
-        _$_ModRemovePostView instance) =>
+Map<String, dynamic> _$$ModRemovePostViewImplToJson(
+        _$ModRemovePostViewImpl instance) =>
     <String, dynamic>{
       'mod_remove_post': instance.modRemovePost.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -543,8 +554,9 @@ Map<String, dynamic> _$$_ModRemovePostViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModStickyPostView _$$_ModStickyPostViewFromJson(Map<String, dynamic> json) =>
-    _$_ModStickyPostView(
+_$ModStickyPostViewImpl _$$ModStickyPostViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ModStickyPostViewImpl(
       modStickyPost: ModStickyPost.fromJson(
           json['mod_sticky_post'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -556,8 +568,8 @@ _$_ModStickyPostView _$$_ModStickyPostViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModStickyPostViewToJson(
-        _$_ModStickyPostView instance) =>
+Map<String, dynamic> _$$ModStickyPostViewImplToJson(
+        _$ModStickyPostViewImpl instance) =>
     <String, dynamic>{
       'mod_sticky_post': instance.modStickyPost.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -566,9 +578,9 @@ Map<String, dynamic> _$$_ModStickyPostViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_ModFeaturePostView _$$_ModFeaturePostViewFromJson(
+_$ModFeaturePostViewImpl _$$ModFeaturePostViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModFeaturePostView(
+    _$ModFeaturePostViewImpl(
       modFeaturePost: ModFeaturePost.fromJson(
           json['mod_feature_post'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -580,8 +592,8 @@ _$_ModFeaturePostView _$$_ModFeaturePostViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_ModFeaturePostViewToJson(
-        _$_ModFeaturePostView instance) =>
+Map<String, dynamic> _$$ModFeaturePostViewImplToJson(
+        _$ModFeaturePostViewImpl instance) =>
     <String, dynamic>{
       'mod_feature_post': instance.modFeaturePost.toJson(),
       'moderator': instance.moderator?.toJson(),
@@ -590,26 +602,26 @@ Map<String, dynamic> _$$_ModFeaturePostViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_CommunityFollowerView _$$_CommunityFollowerViewFromJson(
+_$CommunityFollowerViewImpl _$$CommunityFollowerViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CommunityFollowerView(
+    _$CommunityFollowerViewImpl(
       community:
           CommunitySafe.fromJson(json['community'] as Map<String, dynamic>),
       follower: PersonSafe.fromJson(json['follower'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_CommunityFollowerViewToJson(
-        _$_CommunityFollowerView instance) =>
+Map<String, dynamic> _$$CommunityFollowerViewImplToJson(
+        _$CommunityFollowerViewImpl instance) =>
     <String, dynamic>{
       'community': instance.community.toJson(),
       'follower': instance.follower.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$_CommunityModeratorView _$$_CommunityModeratorViewFromJson(
+_$CommunityModeratorViewImpl _$$CommunityModeratorViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CommunityModeratorView(
+    _$CommunityModeratorViewImpl(
       community:
           CommunitySafe.fromJson(json['community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -618,64 +630,66 @@ _$_CommunityModeratorView _$$_CommunityModeratorViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_CommunityModeratorViewToJson(
-        _$_CommunityModeratorView instance) =>
+Map<String, dynamic> _$$CommunityModeratorViewImplToJson(
+        _$CommunityModeratorViewImpl instance) =>
     <String, dynamic>{
       'community': instance.community.toJson(),
       'moderator': instance.moderator?.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$_PersonBlockView _$$_PersonBlockViewFromJson(Map<String, dynamic> json) =>
-    _$_PersonBlockView(
+_$PersonBlockViewImpl _$$PersonBlockViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$PersonBlockViewImpl(
       person: PersonSafe.fromJson(json['person'] as Map<String, dynamic>),
       target: PersonSafe.fromJson(json['target'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PersonBlockViewToJson(_$_PersonBlockView instance) =>
+Map<String, dynamic> _$$PersonBlockViewImplToJson(
+        _$PersonBlockViewImpl instance) =>
     <String, dynamic>{
       'person': instance.person.toJson(),
       'target': instance.target.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$_CommunityBlockView _$$_CommunityBlockViewFromJson(
+_$CommunityBlockViewImpl _$$CommunityBlockViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CommunityBlockView(
+    _$CommunityBlockViewImpl(
       person: PersonSafe.fromJson(json['person'] as Map<String, dynamic>),
       community:
           CommunitySafe.fromJson(json['community'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_CommunityBlockViewToJson(
-        _$_CommunityBlockView instance) =>
+Map<String, dynamic> _$$CommunityBlockViewImplToJson(
+        _$CommunityBlockViewImpl instance) =>
     <String, dynamic>{
       'person': instance.person.toJson(),
       'community': instance.community.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$_CommunityPersonBanView _$$_CommunityPersonBanViewFromJson(
+_$CommunityPersonBanViewImpl _$$CommunityPersonBanViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CommunityPersonBanView(
+    _$CommunityPersonBanViewImpl(
       community:
           CommunitySafe.fromJson(json['community'] as Map<String, dynamic>),
       person: PersonSafe.fromJson(json['person'] as Map<String, dynamic>),
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_CommunityPersonBanViewToJson(
-        _$_CommunityPersonBanView instance) =>
+Map<String, dynamic> _$$CommunityPersonBanViewImplToJson(
+        _$CommunityPersonBanViewImpl instance) =>
     <String, dynamic>{
       'community': instance.community.toJson(),
       'person': instance.person.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$_CommunityView _$$_CommunityViewFromJson(Map<String, dynamic> json) =>
-    _$_CommunityView(
+_$CommunityViewImpl _$$CommunityViewImplFromJson(Map<String, dynamic> json) =>
+    _$CommunityViewImpl(
       community:
           CommunitySafe.fromJson(json['community'] as Map<String, dynamic>),
       subscribed: json['subscribed'] == null
@@ -687,7 +701,7 @@ _$_CommunityView _$$_CommunityViewFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_CommunityViewToJson(_$_CommunityView instance) =>
+Map<String, dynamic> _$$CommunityViewImplToJson(_$CommunityViewImpl instance) =>
     <String, dynamic>{
       'community': instance.community.toJson(),
       'subscribed': instance.subscribed.toJson(),
@@ -696,9 +710,9 @@ Map<String, dynamic> _$$_CommunityViewToJson(_$_CommunityView instance) =>
       'instance_host': instance.instanceHost,
     };
 
-_$_RegistrationApplicationView _$$_RegistrationApplicationViewFromJson(
+_$RegistrationApplicationViewImpl _$$RegistrationApplicationViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_RegistrationApplicationView(
+    _$RegistrationApplicationViewImpl(
       registrationApplication: RegistrationApplication.fromJson(
           json['registration_application'] as Map<String, dynamic>),
       creatorLocalUser: LocalUserSettings.fromJson(
@@ -710,8 +724,8 @@ _$_RegistrationApplicationView _$$_RegistrationApplicationViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_RegistrationApplicationViewToJson(
-        _$_RegistrationApplicationView instance) =>
+Map<String, dynamic> _$$RegistrationApplicationViewImplToJson(
+        _$RegistrationApplicationViewImpl instance) =>
     <String, dynamic>{
       'registration_application': instance.registrationApplication.toJson(),
       'creator_local_user': instance.creatorLocalUser.toJson(),
@@ -720,9 +734,9 @@ Map<String, dynamic> _$$_RegistrationApplicationViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_AdminPurgeCommentView _$$_AdminPurgeCommentViewFromJson(
+_$AdminPurgeCommentViewImpl _$$AdminPurgeCommentViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_AdminPurgeCommentView(
+    _$AdminPurgeCommentViewImpl(
       adminPurgeComment: AdminPurgeComment.fromJson(
           json['admin_purge_comment'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -732,8 +746,8 @@ _$_AdminPurgeCommentView _$$_AdminPurgeCommentViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_AdminPurgeCommentViewToJson(
-        _$_AdminPurgeCommentView instance) =>
+Map<String, dynamic> _$$AdminPurgeCommentViewImplToJson(
+        _$AdminPurgeCommentViewImpl instance) =>
     <String, dynamic>{
       'admin_purge_comment': instance.adminPurgeComment.toJson(),
       'admin': instance.admin?.toJson(),
@@ -741,9 +755,9 @@ Map<String, dynamic> _$$_AdminPurgeCommentViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_AdminPurgePostView _$$_AdminPurgePostViewFromJson(
+_$AdminPurgePostViewImpl _$$AdminPurgePostViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_AdminPurgePostView(
+    _$AdminPurgePostViewImpl(
       adminPurgePost: AdminPurgePost.fromJson(
           json['admin_purge_post'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -754,8 +768,8 @@ _$_AdminPurgePostView _$$_AdminPurgePostViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_AdminPurgePostViewToJson(
-        _$_AdminPurgePostView instance) =>
+Map<String, dynamic> _$$AdminPurgePostViewImplToJson(
+        _$AdminPurgePostViewImpl instance) =>
     <String, dynamic>{
       'admin_purge_post': instance.adminPurgePost.toJson(),
       'admin': instance.admin?.toJson(),
@@ -763,9 +777,9 @@ Map<String, dynamic> _$$_AdminPurgePostViewToJson(
       'instance_host': instance.instanceHost,
     };
 
-_$_AdminPurgePersonView _$$_AdminPurgePersonViewFromJson(
+_$AdminPurgePersonViewImpl _$$AdminPurgePersonViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_AdminPurgePersonView(
+    _$AdminPurgePersonViewImpl(
       adminPurgePerson: AdminPurgePerson.fromJson(
           json['admin_purge_person'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -774,17 +788,17 @@ _$_AdminPurgePersonView _$$_AdminPurgePersonViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_AdminPurgePersonViewToJson(
-        _$_AdminPurgePersonView instance) =>
+Map<String, dynamic> _$$AdminPurgePersonViewImplToJson(
+        _$AdminPurgePersonViewImpl instance) =>
     <String, dynamic>{
       'admin_purge_person': instance.adminPurgePerson.toJson(),
       'admin': instance.admin?.toJson(),
       'instance_host': instance.instanceHost,
     };
 
-_$_AdminPurgeCommunityView _$$_AdminPurgeCommunityViewFromJson(
+_$AdminPurgeCommunityViewImpl _$$AdminPurgeCommunityViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_AdminPurgeCommunityView(
+    _$AdminPurgeCommunityViewImpl(
       adminPurgeCommunity: AdminPurgeCommunity.fromJson(
           json['admin_purge_community'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -793,8 +807,8 @@ _$_AdminPurgeCommunityView _$$_AdminPurgeCommunityViewFromJson(
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_AdminPurgeCommunityViewToJson(
-        _$_AdminPurgeCommunityView instance) =>
+Map<String, dynamic> _$$AdminPurgeCommunityViewImplToJson(
+        _$AdminPurgeCommunityViewImpl instance) =>
     <String, dynamic>{
       'admin_purge_community': instance.adminPurgeCommunity.toJson(),
       'admin': instance.admin?.toJson(),


### PR DESCRIPTION
I've been getting nulls in the `newestCommentTime` field. I couldn't find anything in the changelog saying it was removed, but I figured it couldn't hurt to make it nullable to play it safe. Now voyager.lemmy.ml loads for me again.

![image](https://github.com/thunder-app/lemmy_api_client/assets/7417301/0432274e-4af4-47a9-8f54-55d5b98ce915)
