### PR TITLE
Match API parity with 0.19.0-alpha.18

### DIFF
--- a/lib/src/pictrs.freezed.dart
+++ b/lib/src/pictrs.freezed.dart
@@ -68,22 +68,22 @@ class _$PictrsUploadFileCopyWithImpl<$Res, $Val extends PictrsUploadFile>
 }
 
 /// @nodoc
-abstract class _$$_PictrsUploadFileCopyWith<$Res>
+abstract class _$$PictrsUploadFileImplCopyWith<$Res>
     implements $PictrsUploadFileCopyWith<$Res> {
-  factory _$$_PictrsUploadFileCopyWith(
-          _$_PictrsUploadFile value, $Res Function(_$_PictrsUploadFile) then) =
-      __$$_PictrsUploadFileCopyWithImpl<$Res>;
+  factory _$$PictrsUploadFileImplCopyWith(_$PictrsUploadFileImpl value,
+          $Res Function(_$PictrsUploadFileImpl) then) =
+      __$$PictrsUploadFileImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String deleteToken, String file});
 }
 
 /// @nodoc
-class __$$_PictrsUploadFileCopyWithImpl<$Res>
-    extends _$PictrsUploadFileCopyWithImpl<$Res, _$_PictrsUploadFile>
-    implements _$$_PictrsUploadFileCopyWith<$Res> {
-  __$$_PictrsUploadFileCopyWithImpl(
-      _$_PictrsUploadFile _value, $Res Function(_$_PictrsUploadFile) _then)
+class __$$PictrsUploadFileImplCopyWithImpl<$Res>
+    extends _$PictrsUploadFileCopyWithImpl<$Res, _$PictrsUploadFileImpl>
+    implements _$$PictrsUploadFileImplCopyWith<$Res> {
+  __$$PictrsUploadFileImplCopyWithImpl(_$PictrsUploadFileImpl _value,
+      $Res Function(_$PictrsUploadFileImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -92,7 +92,7 @@ class __$$_PictrsUploadFileCopyWithImpl<$Res>
     Object? deleteToken = null,
     Object? file = null,
   }) {
-    return _then(_$_PictrsUploadFile(
+    return _then(_$PictrsUploadFileImpl(
       deleteToken: null == deleteToken
           ? _value.deleteToken
           : deleteToken // ignore: cast_nullable_to_non_nullable
@@ -108,12 +108,12 @@ class __$$_PictrsUploadFileCopyWithImpl<$Res>
 /// @nodoc
 
 @JsonSerializable(fieldRename: FieldRename.snake)
-class _$_PictrsUploadFile extends _PictrsUploadFile {
-  const _$_PictrsUploadFile({required this.deleteToken, required this.file})
+class _$PictrsUploadFileImpl extends _PictrsUploadFile {
+  const _$PictrsUploadFileImpl({required this.deleteToken, required this.file})
       : super._();
 
-  factory _$_PictrsUploadFile.fromJson(Map<String, dynamic> json) =>
-      _$$_PictrsUploadFileFromJson(json);
+  factory _$PictrsUploadFileImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PictrsUploadFileImplFromJson(json);
 
   @override
   final String deleteToken;
@@ -129,7 +129,7 @@ class _$_PictrsUploadFile extends _PictrsUploadFile {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PictrsUploadFile &&
+            other is _$PictrsUploadFileImpl &&
             (identical(other.deleteToken, deleteToken) ||
                 other.deleteToken == deleteToken) &&
             (identical(other.file, file) || other.file == file));
@@ -142,12 +142,13 @@ class _$_PictrsUploadFile extends _PictrsUploadFile {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PictrsUploadFileCopyWith<_$_PictrsUploadFile> get copyWith =>
-      __$$_PictrsUploadFileCopyWithImpl<_$_PictrsUploadFile>(this, _$identity);
+  _$$PictrsUploadFileImplCopyWith<_$PictrsUploadFileImpl> get copyWith =>
+      __$$PictrsUploadFileImplCopyWithImpl<_$PictrsUploadFileImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PictrsUploadFileToJson(
+    return _$$PictrsUploadFileImplToJson(
       this,
     );
   }
@@ -156,11 +157,11 @@ class _$_PictrsUploadFile extends _PictrsUploadFile {
 abstract class _PictrsUploadFile extends PictrsUploadFile {
   const factory _PictrsUploadFile(
       {required final String deleteToken,
-      required final String file}) = _$_PictrsUploadFile;
+      required final String file}) = _$PictrsUploadFileImpl;
   const _PictrsUploadFile._() : super._();
 
   factory _PictrsUploadFile.fromJson(Map<String, dynamic> json) =
-      _$_PictrsUploadFile.fromJson;
+      _$PictrsUploadFileImpl.fromJson;
 
   @override
   String get deleteToken;
@@ -168,7 +169,7 @@ abstract class _PictrsUploadFile extends PictrsUploadFile {
   String get file;
   @override
   @JsonKey(ignore: true)
-  _$$_PictrsUploadFileCopyWith<_$_PictrsUploadFile> get copyWith =>
+  _$$PictrsUploadFileImplCopyWith<_$PictrsUploadFileImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -232,22 +233,22 @@ class _$PictrsUploadCopyWithImpl<$Res, $Val extends PictrsUpload>
 }
 
 /// @nodoc
-abstract class _$$_PictrsUploadCopyWith<$Res>
+abstract class _$$PictrsUploadImplCopyWith<$Res>
     implements $PictrsUploadCopyWith<$Res> {
-  factory _$$_PictrsUploadCopyWith(
-          _$_PictrsUpload value, $Res Function(_$_PictrsUpload) then) =
-      __$$_PictrsUploadCopyWithImpl<$Res>;
+  factory _$$PictrsUploadImplCopyWith(
+          _$PictrsUploadImpl value, $Res Function(_$PictrsUploadImpl) then) =
+      __$$PictrsUploadImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String msg, List<PictrsUploadFile> files, String instanceHost});
 }
 
 /// @nodoc
-class __$$_PictrsUploadCopyWithImpl<$Res>
-    extends _$PictrsUploadCopyWithImpl<$Res, _$_PictrsUpload>
-    implements _$$_PictrsUploadCopyWith<$Res> {
-  __$$_PictrsUploadCopyWithImpl(
-      _$_PictrsUpload _value, $Res Function(_$_PictrsUpload) _then)
+class __$$PictrsUploadImplCopyWithImpl<$Res>
+    extends _$PictrsUploadCopyWithImpl<$Res, _$PictrsUploadImpl>
+    implements _$$PictrsUploadImplCopyWith<$Res> {
+  __$$PictrsUploadImplCopyWithImpl(
+      _$PictrsUploadImpl _value, $Res Function(_$PictrsUploadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -257,7 +258,7 @@ class __$$_PictrsUploadCopyWithImpl<$Res>
     Object? files = null,
     Object? instanceHost = null,
   }) {
-    return _then(_$_PictrsUpload(
+    return _then(_$PictrsUploadImpl(
       msg: null == msg
           ? _value.msg
           : msg // ignore: cast_nullable_to_non_nullable
@@ -277,16 +278,16 @@ class __$$_PictrsUploadCopyWithImpl<$Res>
 /// @nodoc
 
 @JsonSerializable(fieldRename: FieldRename.snake)
-class _$_PictrsUpload extends _PictrsUpload {
-  const _$_PictrsUpload(
+class _$PictrsUploadImpl extends _PictrsUpload {
+  const _$PictrsUploadImpl(
       {required this.msg,
       required final List<PictrsUploadFile> files,
       required this.instanceHost})
       : _files = files,
         super._();
 
-  factory _$_PictrsUpload.fromJson(Map<String, dynamic> json) =>
-      _$$_PictrsUploadFromJson(json);
+  factory _$PictrsUploadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PictrsUploadImplFromJson(json);
 
   @override
   final String msg;
@@ -310,7 +311,7 @@ class _$_PictrsUpload extends _PictrsUpload {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PictrsUpload &&
+            other is _$PictrsUploadImpl &&
             (identical(other.msg, msg) || other.msg == msg) &&
             const DeepCollectionEquality().equals(other._files, _files) &&
             (identical(other.instanceHost, instanceHost) ||
@@ -325,12 +326,12 @@ class _$_PictrsUpload extends _PictrsUpload {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PictrsUploadCopyWith<_$_PictrsUpload> get copyWith =>
-      __$$_PictrsUploadCopyWithImpl<_$_PictrsUpload>(this, _$identity);
+  _$$PictrsUploadImplCopyWith<_$PictrsUploadImpl> get copyWith =>
+      __$$PictrsUploadImplCopyWithImpl<_$PictrsUploadImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PictrsUploadToJson(
+    return _$$PictrsUploadImplToJson(
       this,
     );
   }
@@ -340,11 +341,11 @@ abstract class _PictrsUpload extends PictrsUpload {
   const factory _PictrsUpload(
       {required final String msg,
       required final List<PictrsUploadFile> files,
-      required final String instanceHost}) = _$_PictrsUpload;
+      required final String instanceHost}) = _$PictrsUploadImpl;
   const _PictrsUpload._() : super._();
 
   factory _PictrsUpload.fromJson(Map<String, dynamic> json) =
-      _$_PictrsUpload.fromJson;
+      _$PictrsUploadImpl.fromJson;
 
   @override
   String get msg;
@@ -354,6 +355,6 @@ abstract class _PictrsUpload extends PictrsUpload {
   String get instanceHost;
   @override
   @JsonKey(ignore: true)
-  _$$_PictrsUploadCopyWith<_$_PictrsUpload> get copyWith =>
+  _$$PictrsUploadImplCopyWith<_$PictrsUploadImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/pictrs.g.dart
+++ b/lib/src/pictrs.g.dart
@@ -6,20 +6,22 @@ part of 'pictrs.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PictrsUploadFile _$$_PictrsUploadFileFromJson(Map<String, dynamic> json) =>
-    _$_PictrsUploadFile(
+_$PictrsUploadFileImpl _$$PictrsUploadFileImplFromJson(
+        Map<String, dynamic> json) =>
+    _$PictrsUploadFileImpl(
       deleteToken: json['delete_token'] as String,
       file: json['file'] as String,
     );
 
-Map<String, dynamic> _$$_PictrsUploadFileToJson(_$_PictrsUploadFile instance) =>
+Map<String, dynamic> _$$PictrsUploadFileImplToJson(
+        _$PictrsUploadFileImpl instance) =>
     <String, dynamic>{
       'delete_token': instance.deleteToken,
       'file': instance.file,
     };
 
-_$_PictrsUpload _$$_PictrsUploadFromJson(Map<String, dynamic> json) =>
-    _$_PictrsUpload(
+_$PictrsUploadImpl _$$PictrsUploadImplFromJson(Map<String, dynamic> json) =>
+    _$PictrsUploadImpl(
       msg: json['msg'] as String,
       files: (json['files'] as List<dynamic>)
           .map((e) => PictrsUploadFile.fromJson(e as Map<String, dynamic>))
@@ -27,7 +29,7 @@ _$_PictrsUpload _$$_PictrsUploadFromJson(Map<String, dynamic> json) =>
       instanceHost: json['instance_host'] as String,
     );
 
-Map<String, dynamic> _$$_PictrsUploadToJson(_$_PictrsUpload instance) =>
+Map<String, dynamic> _$$PictrsUploadImplToJson(_$PictrsUploadImpl instance) =>
     <String, dynamic>{
       'msg': instance.msg,
       'files': instance.files.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/api/admin/admin.freezed.dart
+++ b/lib/src/v3/api/admin/admin.freezed.dart
@@ -73,21 +73,22 @@ class _$AddAdminCopyWithImpl<$Res, $Val extends AddAdmin>
 }
 
 /// @nodoc
-abstract class _$$_AddAdminCopyWith<$Res> implements $AddAdminCopyWith<$Res> {
-  factory _$$_AddAdminCopyWith(
-          _$_AddAdmin value, $Res Function(_$_AddAdmin) then) =
-      __$$_AddAdminCopyWithImpl<$Res>;
+abstract class _$$AddAdminImplCopyWith<$Res>
+    implements $AddAdminCopyWith<$Res> {
+  factory _$$AddAdminImplCopyWith(
+          _$AddAdminImpl value, $Res Function(_$AddAdminImpl) then) =
+      __$$AddAdminImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int personId, bool added, String? auth});
 }
 
 /// @nodoc
-class __$$_AddAdminCopyWithImpl<$Res>
-    extends _$AddAdminCopyWithImpl<$Res, _$_AddAdmin>
-    implements _$$_AddAdminCopyWith<$Res> {
-  __$$_AddAdminCopyWithImpl(
-      _$_AddAdmin _value, $Res Function(_$_AddAdmin) _then)
+class __$$AddAdminImplCopyWithImpl<$Res>
+    extends _$AddAdminCopyWithImpl<$Res, _$AddAdminImpl>
+    implements _$$AddAdminImplCopyWith<$Res> {
+  __$$AddAdminImplCopyWithImpl(
+      _$AddAdminImpl _value, $Res Function(_$AddAdminImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -97,7 +98,7 @@ class __$$_AddAdminCopyWithImpl<$Res>
     Object? added = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_AddAdmin(
+    return _then(_$AddAdminImpl(
       personId: null == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -117,12 +118,12 @@ class __$$_AddAdminCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_AddAdmin extends _AddAdmin {
-  const _$_AddAdmin({required this.personId, required this.added, this.auth})
+class _$AddAdminImpl extends _AddAdmin {
+  const _$AddAdminImpl({required this.personId, required this.added, this.auth})
       : super._();
 
-  factory _$_AddAdmin.fromJson(Map<String, dynamic> json) =>
-      _$$_AddAdminFromJson(json);
+  factory _$AddAdminImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AddAdminImplFromJson(json);
 
   @override
   final int personId;
@@ -140,7 +141,7 @@ class _$_AddAdmin extends _AddAdmin {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AddAdmin &&
+            other is _$AddAdminImpl &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.added, added) || other.added == added) &&
@@ -154,12 +155,12 @@ class _$_AddAdmin extends _AddAdmin {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AddAdminCopyWith<_$_AddAdmin> get copyWith =>
-      __$$_AddAdminCopyWithImpl<_$_AddAdmin>(this, _$identity);
+  _$$AddAdminImplCopyWith<_$AddAdminImpl> get copyWith =>
+      __$$AddAdminImplCopyWithImpl<_$AddAdminImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AddAdminToJson(
+    return _$$AddAdminImplToJson(
       this,
     );
   }
@@ -169,10 +170,11 @@ abstract class _AddAdmin extends AddAdmin {
   const factory _AddAdmin(
       {required final int personId,
       required final bool added,
-      final String? auth}) = _$_AddAdmin;
+      final String? auth}) = _$AddAdminImpl;
   const _AddAdmin._() : super._();
 
-  factory _AddAdmin.fromJson(Map<String, dynamic> json) = _$_AddAdmin.fromJson;
+  factory _AddAdmin.fromJson(Map<String, dynamic> json) =
+      _$AddAdminImpl.fromJson;
 
   @override
   int get personId;
@@ -182,7 +184,7 @@ abstract class _AddAdmin extends AddAdmin {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_AddAdminCopyWith<_$_AddAdmin> get copyWith =>
+  _$$AddAdminImplCopyWith<_$AddAdminImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -239,25 +241,25 @@ class _$GetUnreadRegistrationApplicationCountCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_GetUnreadRegistrationApplicationCountCopyWith<$Res>
+abstract class _$$GetUnreadRegistrationApplicationCountImplCopyWith<$Res>
     implements $GetUnreadRegistrationApplicationCountCopyWith<$Res> {
-  factory _$$_GetUnreadRegistrationApplicationCountCopyWith(
-          _$_GetUnreadRegistrationApplicationCount value,
-          $Res Function(_$_GetUnreadRegistrationApplicationCount) then) =
-      __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<$Res>;
+  factory _$$GetUnreadRegistrationApplicationCountImplCopyWith(
+          _$GetUnreadRegistrationApplicationCountImpl value,
+          $Res Function(_$GetUnreadRegistrationApplicationCountImpl) then) =
+      __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<$Res>
+class __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl<$Res>
     extends _$GetUnreadRegistrationApplicationCountCopyWithImpl<$Res,
-        _$_GetUnreadRegistrationApplicationCount>
-    implements _$$_GetUnreadRegistrationApplicationCountCopyWith<$Res> {
-  __$$_GetUnreadRegistrationApplicationCountCopyWithImpl(
-      _$_GetUnreadRegistrationApplicationCount _value,
-      $Res Function(_$_GetUnreadRegistrationApplicationCount) _then)
+        _$GetUnreadRegistrationApplicationCountImpl>
+    implements _$$GetUnreadRegistrationApplicationCountImplCopyWith<$Res> {
+  __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl(
+      _$GetUnreadRegistrationApplicationCountImpl _value,
+      $Res Function(_$GetUnreadRegistrationApplicationCountImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -265,7 +267,7 @@ class __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$_GetUnreadRegistrationApplicationCount(
+    return _then(_$GetUnreadRegistrationApplicationCountImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -277,13 +279,13 @@ class __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetUnreadRegistrationApplicationCount
+class _$GetUnreadRegistrationApplicationCountImpl
     extends _GetUnreadRegistrationApplicationCount {
-  const _$_GetUnreadRegistrationApplicationCount({this.auth}) : super._();
+  const _$GetUnreadRegistrationApplicationCountImpl({this.auth}) : super._();
 
-  factory _$_GetUnreadRegistrationApplicationCount.fromJson(
+  factory _$GetUnreadRegistrationApplicationCountImpl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_GetUnreadRegistrationApplicationCountFromJson(json);
+      _$$GetUnreadRegistrationApplicationCountImplFromJson(json);
 
   @override
   final String? auth;
@@ -297,7 +299,7 @@ class _$_GetUnreadRegistrationApplicationCount
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetUnreadRegistrationApplicationCount &&
+            other is _$GetUnreadRegistrationApplicationCountImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -308,14 +310,14 @@ class _$_GetUnreadRegistrationApplicationCount
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetUnreadRegistrationApplicationCountCopyWith<
-          _$_GetUnreadRegistrationApplicationCount>
-      get copyWith => __$$_GetUnreadRegistrationApplicationCountCopyWithImpl<
-          _$_GetUnreadRegistrationApplicationCount>(this, _$identity);
+  _$$GetUnreadRegistrationApplicationCountImplCopyWith<
+          _$GetUnreadRegistrationApplicationCountImpl>
+      get copyWith => __$$GetUnreadRegistrationApplicationCountImplCopyWithImpl<
+          _$GetUnreadRegistrationApplicationCountImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetUnreadRegistrationApplicationCountToJson(
+    return _$$GetUnreadRegistrationApplicationCountImplToJson(
       this,
     );
   }
@@ -324,19 +326,19 @@ class _$_GetUnreadRegistrationApplicationCount
 abstract class _GetUnreadRegistrationApplicationCount
     extends GetUnreadRegistrationApplicationCount {
   const factory _GetUnreadRegistrationApplicationCount({final String? auth}) =
-      _$_GetUnreadRegistrationApplicationCount;
+      _$GetUnreadRegistrationApplicationCountImpl;
   const _GetUnreadRegistrationApplicationCount._() : super._();
 
   factory _GetUnreadRegistrationApplicationCount.fromJson(
           Map<String, dynamic> json) =
-      _$_GetUnreadRegistrationApplicationCount.fromJson;
+      _$GetUnreadRegistrationApplicationCountImpl.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetUnreadRegistrationApplicationCountCopyWith<
-          _$_GetUnreadRegistrationApplicationCount>
+  _$$GetUnreadRegistrationApplicationCountImplCopyWith<
+          _$GetUnreadRegistrationApplicationCountImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -410,25 +412,25 @@ class _$ListRegistrationApplicationsCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ListRegistrationApplicationsCopyWith<$Res>
+abstract class _$$ListRegistrationApplicationsImplCopyWith<$Res>
     implements $ListRegistrationApplicationsCopyWith<$Res> {
-  factory _$$_ListRegistrationApplicationsCopyWith(
-          _$_ListRegistrationApplications value,
-          $Res Function(_$_ListRegistrationApplications) then) =
-      __$$_ListRegistrationApplicationsCopyWithImpl<$Res>;
+  factory _$$ListRegistrationApplicationsImplCopyWith(
+          _$ListRegistrationApplicationsImpl value,
+          $Res Function(_$ListRegistrationApplicationsImpl) then) =
+      __$$ListRegistrationApplicationsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool? unreadOnly, int? page, int? limit, String? auth});
 }
 
 /// @nodoc
-class __$$_ListRegistrationApplicationsCopyWithImpl<$Res>
+class __$$ListRegistrationApplicationsImplCopyWithImpl<$Res>
     extends _$ListRegistrationApplicationsCopyWithImpl<$Res,
-        _$_ListRegistrationApplications>
-    implements _$$_ListRegistrationApplicationsCopyWith<$Res> {
-  __$$_ListRegistrationApplicationsCopyWithImpl(
-      _$_ListRegistrationApplications _value,
-      $Res Function(_$_ListRegistrationApplications) _then)
+        _$ListRegistrationApplicationsImpl>
+    implements _$$ListRegistrationApplicationsImplCopyWith<$Res> {
+  __$$ListRegistrationApplicationsImplCopyWithImpl(
+      _$ListRegistrationApplicationsImpl _value,
+      $Res Function(_$ListRegistrationApplicationsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -439,7 +441,7 @@ class __$$_ListRegistrationApplicationsCopyWithImpl<$Res>
     Object? limit = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_ListRegistrationApplications(
+    return _then(_$ListRegistrationApplicationsImpl(
       unreadOnly: freezed == unreadOnly
           ? _value.unreadOnly
           : unreadOnly // ignore: cast_nullable_to_non_nullable
@@ -463,13 +465,14 @@ class __$$_ListRegistrationApplicationsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ListRegistrationApplications extends _ListRegistrationApplications {
-  const _$_ListRegistrationApplications(
+class _$ListRegistrationApplicationsImpl extends _ListRegistrationApplications {
+  const _$ListRegistrationApplicationsImpl(
       {this.unreadOnly, this.page, this.limit, this.auth})
       : super._();
 
-  factory _$_ListRegistrationApplications.fromJson(Map<String, dynamic> json) =>
-      _$$_ListRegistrationApplicationsFromJson(json);
+  factory _$ListRegistrationApplicationsImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$ListRegistrationApplicationsImplFromJson(json);
 
   @override
   final bool? unreadOnly;
@@ -489,7 +492,7 @@ class _$_ListRegistrationApplications extends _ListRegistrationApplications {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListRegistrationApplications &&
+            other is _$ListRegistrationApplicationsImpl &&
             (identical(other.unreadOnly, unreadOnly) ||
                 other.unreadOnly == unreadOnly) &&
             (identical(other.page, page) || other.page == page) &&
@@ -504,13 +507,14 @@ class _$_ListRegistrationApplications extends _ListRegistrationApplications {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListRegistrationApplicationsCopyWith<_$_ListRegistrationApplications>
-      get copyWith => __$$_ListRegistrationApplicationsCopyWithImpl<
-          _$_ListRegistrationApplications>(this, _$identity);
+  _$$ListRegistrationApplicationsImplCopyWith<
+          _$ListRegistrationApplicationsImpl>
+      get copyWith => __$$ListRegistrationApplicationsImplCopyWithImpl<
+          _$ListRegistrationApplicationsImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListRegistrationApplicationsToJson(
+    return _$$ListRegistrationApplicationsImplToJson(
       this,
     );
   }
@@ -522,11 +526,11 @@ abstract class _ListRegistrationApplications
       {final bool? unreadOnly,
       final int? page,
       final int? limit,
-      final String? auth}) = _$_ListRegistrationApplications;
+      final String? auth}) = _$ListRegistrationApplicationsImpl;
   const _ListRegistrationApplications._() : super._();
 
   factory _ListRegistrationApplications.fromJson(Map<String, dynamic> json) =
-      _$_ListRegistrationApplications.fromJson;
+      _$ListRegistrationApplicationsImpl.fromJson;
 
   @override
   bool? get unreadOnly;
@@ -538,7 +542,8 @@ abstract class _ListRegistrationApplications
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ListRegistrationApplicationsCopyWith<_$_ListRegistrationApplications>
+  _$$ListRegistrationApplicationsImplCopyWith<
+          _$ListRegistrationApplicationsImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -612,25 +617,25 @@ class _$ApproveRegistrationApplicationCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ApproveRegistrationApplicationCopyWith<$Res>
+abstract class _$$ApproveRegistrationApplicationImplCopyWith<$Res>
     implements $ApproveRegistrationApplicationCopyWith<$Res> {
-  factory _$$_ApproveRegistrationApplicationCopyWith(
-          _$_ApproveRegistrationApplication value,
-          $Res Function(_$_ApproveRegistrationApplication) then) =
-      __$$_ApproveRegistrationApplicationCopyWithImpl<$Res>;
+  factory _$$ApproveRegistrationApplicationImplCopyWith(
+          _$ApproveRegistrationApplicationImpl value,
+          $Res Function(_$ApproveRegistrationApplicationImpl) then) =
+      __$$ApproveRegistrationApplicationImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int id, bool approve, String? denyReason, String? auth});
 }
 
 /// @nodoc
-class __$$_ApproveRegistrationApplicationCopyWithImpl<$Res>
+class __$$ApproveRegistrationApplicationImplCopyWithImpl<$Res>
     extends _$ApproveRegistrationApplicationCopyWithImpl<$Res,
-        _$_ApproveRegistrationApplication>
-    implements _$$_ApproveRegistrationApplicationCopyWith<$Res> {
-  __$$_ApproveRegistrationApplicationCopyWithImpl(
-      _$_ApproveRegistrationApplication _value,
-      $Res Function(_$_ApproveRegistrationApplication) _then)
+        _$ApproveRegistrationApplicationImpl>
+    implements _$$ApproveRegistrationApplicationImplCopyWith<$Res> {
+  __$$ApproveRegistrationApplicationImplCopyWithImpl(
+      _$ApproveRegistrationApplicationImpl _value,
+      $Res Function(_$ApproveRegistrationApplicationImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -641,7 +646,7 @@ class __$$_ApproveRegistrationApplicationCopyWithImpl<$Res>
     Object? denyReason = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_ApproveRegistrationApplication(
+    return _then(_$ApproveRegistrationApplicationImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -665,15 +670,15 @@ class __$$_ApproveRegistrationApplicationCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ApproveRegistrationApplication
+class _$ApproveRegistrationApplicationImpl
     extends _ApproveRegistrationApplication {
-  const _$_ApproveRegistrationApplication(
+  const _$ApproveRegistrationApplicationImpl(
       {required this.id, required this.approve, this.denyReason, this.auth})
       : super._();
 
-  factory _$_ApproveRegistrationApplication.fromJson(
+  factory _$ApproveRegistrationApplicationImpl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_ApproveRegistrationApplicationFromJson(json);
+      _$$ApproveRegistrationApplicationImplFromJson(json);
 
   @override
   final int id;
@@ -693,7 +698,7 @@ class _$_ApproveRegistrationApplication
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ApproveRegistrationApplication &&
+            other is _$ApproveRegistrationApplicationImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.approve, approve) || other.approve == approve) &&
             (identical(other.denyReason, denyReason) ||
@@ -708,13 +713,14 @@ class _$_ApproveRegistrationApplication
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ApproveRegistrationApplicationCopyWith<_$_ApproveRegistrationApplication>
-      get copyWith => __$$_ApproveRegistrationApplicationCopyWithImpl<
-          _$_ApproveRegistrationApplication>(this, _$identity);
+  _$$ApproveRegistrationApplicationImplCopyWith<
+          _$ApproveRegistrationApplicationImpl>
+      get copyWith => __$$ApproveRegistrationApplicationImplCopyWithImpl<
+          _$ApproveRegistrationApplicationImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ApproveRegistrationApplicationToJson(
+    return _$$ApproveRegistrationApplicationImplToJson(
       this,
     );
   }
@@ -726,11 +732,11 @@ abstract class _ApproveRegistrationApplication
       {required final int id,
       required final bool approve,
       final String? denyReason,
-      final String? auth}) = _$_ApproveRegistrationApplication;
+      final String? auth}) = _$ApproveRegistrationApplicationImpl;
   const _ApproveRegistrationApplication._() : super._();
 
   factory _ApproveRegistrationApplication.fromJson(Map<String, dynamic> json) =
-      _$_ApproveRegistrationApplication.fromJson;
+      _$ApproveRegistrationApplicationImpl.fromJson;
 
   @override
   int get id;
@@ -742,7 +748,8 @@ abstract class _ApproveRegistrationApplication
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ApproveRegistrationApplicationCopyWith<_$_ApproveRegistrationApplication>
+  _$$ApproveRegistrationApplicationImplCopyWith<
+          _$ApproveRegistrationApplicationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -806,22 +813,22 @@ class _$PurgePersonCopyWithImpl<$Res, $Val extends PurgePerson>
 }
 
 /// @nodoc
-abstract class _$$_PurgePersonCopyWith<$Res>
+abstract class _$$PurgePersonImplCopyWith<$Res>
     implements $PurgePersonCopyWith<$Res> {
-  factory _$$_PurgePersonCopyWith(
-          _$_PurgePerson value, $Res Function(_$_PurgePerson) then) =
-      __$$_PurgePersonCopyWithImpl<$Res>;
+  factory _$$PurgePersonImplCopyWith(
+          _$PurgePersonImpl value, $Res Function(_$PurgePersonImpl) then) =
+      __$$PurgePersonImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int personId, String? reason, String? auth});
 }
 
 /// @nodoc
-class __$$_PurgePersonCopyWithImpl<$Res>
-    extends _$PurgePersonCopyWithImpl<$Res, _$_PurgePerson>
-    implements _$$_PurgePersonCopyWith<$Res> {
-  __$$_PurgePersonCopyWithImpl(
-      _$_PurgePerson _value, $Res Function(_$_PurgePerson) _then)
+class __$$PurgePersonImplCopyWithImpl<$Res>
+    extends _$PurgePersonCopyWithImpl<$Res, _$PurgePersonImpl>
+    implements _$$PurgePersonImplCopyWith<$Res> {
+  __$$PurgePersonImplCopyWithImpl(
+      _$PurgePersonImpl _value, $Res Function(_$PurgePersonImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -831,7 +838,7 @@ class __$$_PurgePersonCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_PurgePerson(
+    return _then(_$PurgePersonImpl(
       personId: null == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -851,12 +858,12 @@ class __$$_PurgePersonCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_PurgePerson extends _PurgePerson {
-  const _$_PurgePerson({required this.personId, this.reason, this.auth})
+class _$PurgePersonImpl extends _PurgePerson {
+  const _$PurgePersonImpl({required this.personId, this.reason, this.auth})
       : super._();
 
-  factory _$_PurgePerson.fromJson(Map<String, dynamic> json) =>
-      _$$_PurgePersonFromJson(json);
+  factory _$PurgePersonImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PurgePersonImplFromJson(json);
 
   @override
   final int personId;
@@ -874,7 +881,7 @@ class _$_PurgePerson extends _PurgePerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PurgePerson &&
+            other is _$PurgePersonImpl &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.reason, reason) || other.reason == reason) &&
@@ -888,12 +895,12 @@ class _$_PurgePerson extends _PurgePerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PurgePersonCopyWith<_$_PurgePerson> get copyWith =>
-      __$$_PurgePersonCopyWithImpl<_$_PurgePerson>(this, _$identity);
+  _$$PurgePersonImplCopyWith<_$PurgePersonImpl> get copyWith =>
+      __$$PurgePersonImplCopyWithImpl<_$PurgePersonImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PurgePersonToJson(
+    return _$$PurgePersonImplToJson(
       this,
     );
   }
@@ -903,11 +910,11 @@ abstract class _PurgePerson extends PurgePerson {
   const factory _PurgePerson(
       {required final int personId,
       final String? reason,
-      final String? auth}) = _$_PurgePerson;
+      final String? auth}) = _$PurgePersonImpl;
   const _PurgePerson._() : super._();
 
   factory _PurgePerson.fromJson(Map<String, dynamic> json) =
-      _$_PurgePerson.fromJson;
+      _$PurgePersonImpl.fromJson;
 
   @override
   int get personId;
@@ -917,7 +924,7 @@ abstract class _PurgePerson extends PurgePerson {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_PurgePersonCopyWith<_$_PurgePerson> get copyWith =>
+  _$$PurgePersonImplCopyWith<_$PurgePersonImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -981,22 +988,22 @@ class _$PurgeCommunityCopyWithImpl<$Res, $Val extends PurgeCommunity>
 }
 
 /// @nodoc
-abstract class _$$_PurgeCommunityCopyWith<$Res>
+abstract class _$$PurgeCommunityImplCopyWith<$Res>
     implements $PurgeCommunityCopyWith<$Res> {
-  factory _$$_PurgeCommunityCopyWith(
-          _$_PurgeCommunity value, $Res Function(_$_PurgeCommunity) then) =
-      __$$_PurgeCommunityCopyWithImpl<$Res>;
+  factory _$$PurgeCommunityImplCopyWith(_$PurgeCommunityImpl value,
+          $Res Function(_$PurgeCommunityImpl) then) =
+      __$$PurgeCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, String? reason, String? auth});
 }
 
 /// @nodoc
-class __$$_PurgeCommunityCopyWithImpl<$Res>
-    extends _$PurgeCommunityCopyWithImpl<$Res, _$_PurgeCommunity>
-    implements _$$_PurgeCommunityCopyWith<$Res> {
-  __$$_PurgeCommunityCopyWithImpl(
-      _$_PurgeCommunity _value, $Res Function(_$_PurgeCommunity) _then)
+class __$$PurgeCommunityImplCopyWithImpl<$Res>
+    extends _$PurgeCommunityCopyWithImpl<$Res, _$PurgeCommunityImpl>
+    implements _$$PurgeCommunityImplCopyWith<$Res> {
+  __$$PurgeCommunityImplCopyWithImpl(
+      _$PurgeCommunityImpl _value, $Res Function(_$PurgeCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1006,7 +1013,7 @@ class __$$_PurgeCommunityCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_PurgeCommunity(
+    return _then(_$PurgeCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1026,12 +1033,13 @@ class __$$_PurgeCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_PurgeCommunity extends _PurgeCommunity {
-  const _$_PurgeCommunity({required this.communityId, this.reason, this.auth})
+class _$PurgeCommunityImpl extends _PurgeCommunity {
+  const _$PurgeCommunityImpl(
+      {required this.communityId, this.reason, this.auth})
       : super._();
 
-  factory _$_PurgeCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_PurgeCommunityFromJson(json);
+  factory _$PurgeCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PurgeCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -1049,7 +1057,7 @@ class _$_PurgeCommunity extends _PurgeCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PurgeCommunity &&
+            other is _$PurgeCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.reason, reason) || other.reason == reason) &&
@@ -1063,12 +1071,13 @@ class _$_PurgeCommunity extends _PurgeCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PurgeCommunityCopyWith<_$_PurgeCommunity> get copyWith =>
-      __$$_PurgeCommunityCopyWithImpl<_$_PurgeCommunity>(this, _$identity);
+  _$$PurgeCommunityImplCopyWith<_$PurgeCommunityImpl> get copyWith =>
+      __$$PurgeCommunityImplCopyWithImpl<_$PurgeCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PurgeCommunityToJson(
+    return _$$PurgeCommunityImplToJson(
       this,
     );
   }
@@ -1078,11 +1087,11 @@ abstract class _PurgeCommunity extends PurgeCommunity {
   const factory _PurgeCommunity(
       {required final int communityId,
       final String? reason,
-      final String? auth}) = _$_PurgeCommunity;
+      final String? auth}) = _$PurgeCommunityImpl;
   const _PurgeCommunity._() : super._();
 
   factory _PurgeCommunity.fromJson(Map<String, dynamic> json) =
-      _$_PurgeCommunity.fromJson;
+      _$PurgeCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -1092,7 +1101,7 @@ abstract class _PurgeCommunity extends PurgeCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_PurgeCommunityCopyWith<_$_PurgeCommunity> get copyWith =>
+  _$$PurgeCommunityImplCopyWith<_$PurgeCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1155,21 +1164,22 @@ class _$PurgePostCopyWithImpl<$Res, $Val extends PurgePost>
 }
 
 /// @nodoc
-abstract class _$$_PurgePostCopyWith<$Res> implements $PurgePostCopyWith<$Res> {
-  factory _$$_PurgePostCopyWith(
-          _$_PurgePost value, $Res Function(_$_PurgePost) then) =
-      __$$_PurgePostCopyWithImpl<$Res>;
+abstract class _$$PurgePostImplCopyWith<$Res>
+    implements $PurgePostCopyWith<$Res> {
+  factory _$$PurgePostImplCopyWith(
+          _$PurgePostImpl value, $Res Function(_$PurgePostImpl) then) =
+      __$$PurgePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, String? reason, String? auth});
 }
 
 /// @nodoc
-class __$$_PurgePostCopyWithImpl<$Res>
-    extends _$PurgePostCopyWithImpl<$Res, _$_PurgePost>
-    implements _$$_PurgePostCopyWith<$Res> {
-  __$$_PurgePostCopyWithImpl(
-      _$_PurgePost _value, $Res Function(_$_PurgePost) _then)
+class __$$PurgePostImplCopyWithImpl<$Res>
+    extends _$PurgePostCopyWithImpl<$Res, _$PurgePostImpl>
+    implements _$$PurgePostImplCopyWith<$Res> {
+  __$$PurgePostImplCopyWithImpl(
+      _$PurgePostImpl _value, $Res Function(_$PurgePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1179,7 +1189,7 @@ class __$$_PurgePostCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_PurgePost(
+    return _then(_$PurgePostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1199,12 +1209,12 @@ class __$$_PurgePostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_PurgePost extends _PurgePost {
-  const _$_PurgePost({required this.postId, this.reason, this.auth})
+class _$PurgePostImpl extends _PurgePost {
+  const _$PurgePostImpl({required this.postId, this.reason, this.auth})
       : super._();
 
-  factory _$_PurgePost.fromJson(Map<String, dynamic> json) =>
-      _$$_PurgePostFromJson(json);
+  factory _$PurgePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PurgePostImplFromJson(json);
 
   @override
   final int postId;
@@ -1222,7 +1232,7 @@ class _$_PurgePost extends _PurgePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PurgePost &&
+            other is _$PurgePostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.reason, reason) || other.reason == reason) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -1235,12 +1245,12 @@ class _$_PurgePost extends _PurgePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PurgePostCopyWith<_$_PurgePost> get copyWith =>
-      __$$_PurgePostCopyWithImpl<_$_PurgePost>(this, _$identity);
+  _$$PurgePostImplCopyWith<_$PurgePostImpl> get copyWith =>
+      __$$PurgePostImplCopyWithImpl<_$PurgePostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PurgePostToJson(
+    return _$$PurgePostImplToJson(
       this,
     );
   }
@@ -1250,11 +1260,11 @@ abstract class _PurgePost extends PurgePost {
   const factory _PurgePost(
       {required final int postId,
       final String? reason,
-      final String? auth}) = _$_PurgePost;
+      final String? auth}) = _$PurgePostImpl;
   const _PurgePost._() : super._();
 
   factory _PurgePost.fromJson(Map<String, dynamic> json) =
-      _$_PurgePost.fromJson;
+      _$PurgePostImpl.fromJson;
 
   @override
   int get postId;
@@ -1264,7 +1274,7 @@ abstract class _PurgePost extends PurgePost {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_PurgePostCopyWith<_$_PurgePost> get copyWith =>
+  _$$PurgePostImplCopyWith<_$PurgePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1328,22 +1338,22 @@ class _$PurgeCommentCopyWithImpl<$Res, $Val extends PurgeComment>
 }
 
 /// @nodoc
-abstract class _$$_PurgeCommentCopyWith<$Res>
+abstract class _$$PurgeCommentImplCopyWith<$Res>
     implements $PurgeCommentCopyWith<$Res> {
-  factory _$$_PurgeCommentCopyWith(
-          _$_PurgeComment value, $Res Function(_$_PurgeComment) then) =
-      __$$_PurgeCommentCopyWithImpl<$Res>;
+  factory _$$PurgeCommentImplCopyWith(
+          _$PurgeCommentImpl value, $Res Function(_$PurgeCommentImpl) then) =
+      __$$PurgeCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, String? reason, String? auth});
 }
 
 /// @nodoc
-class __$$_PurgeCommentCopyWithImpl<$Res>
-    extends _$PurgeCommentCopyWithImpl<$Res, _$_PurgeComment>
-    implements _$$_PurgeCommentCopyWith<$Res> {
-  __$$_PurgeCommentCopyWithImpl(
-      _$_PurgeComment _value, $Res Function(_$_PurgeComment) _then)
+class __$$PurgeCommentImplCopyWithImpl<$Res>
+    extends _$PurgeCommentCopyWithImpl<$Res, _$PurgeCommentImpl>
+    implements _$$PurgeCommentImplCopyWith<$Res> {
+  __$$PurgeCommentImplCopyWithImpl(
+      _$PurgeCommentImpl _value, $Res Function(_$PurgeCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1353,7 +1363,7 @@ class __$$_PurgeCommentCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_PurgeComment(
+    return _then(_$PurgeCommentImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -1373,12 +1383,12 @@ class __$$_PurgeCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_PurgeComment extends _PurgeComment {
-  const _$_PurgeComment({required this.commentId, this.reason, this.auth})
+class _$PurgeCommentImpl extends _PurgeComment {
+  const _$PurgeCommentImpl({required this.commentId, this.reason, this.auth})
       : super._();
 
-  factory _$_PurgeComment.fromJson(Map<String, dynamic> json) =>
-      _$$_PurgeCommentFromJson(json);
+  factory _$PurgeCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PurgeCommentImplFromJson(json);
 
   @override
   final int commentId;
@@ -1396,7 +1406,7 @@ class _$_PurgeComment extends _PurgeComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PurgeComment &&
+            other is _$PurgeCommentImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.reason, reason) || other.reason == reason) &&
@@ -1410,12 +1420,12 @@ class _$_PurgeComment extends _PurgeComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PurgeCommentCopyWith<_$_PurgeComment> get copyWith =>
-      __$$_PurgeCommentCopyWithImpl<_$_PurgeComment>(this, _$identity);
+  _$$PurgeCommentImplCopyWith<_$PurgeCommentImpl> get copyWith =>
+      __$$PurgeCommentImplCopyWithImpl<_$PurgeCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PurgeCommentToJson(
+    return _$$PurgeCommentImplToJson(
       this,
     );
   }
@@ -1425,11 +1435,11 @@ abstract class _PurgeComment extends PurgeComment {
   const factory _PurgeComment(
       {required final int commentId,
       final String? reason,
-      final String? auth}) = _$_PurgeComment;
+      final String? auth}) = _$PurgeCommentImpl;
   const _PurgeComment._() : super._();
 
   factory _PurgeComment.fromJson(Map<String, dynamic> json) =
-      _$_PurgeComment.fromJson;
+      _$PurgeCommentImpl.fromJson;
 
   @override
   int get commentId;
@@ -1439,6 +1449,6 @@ abstract class _PurgeComment extends PurgeComment {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_PurgeCommentCopyWith<_$_PurgeComment> get copyWith =>
+  _$$PurgeCommentImplCopyWith<_$PurgeCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/admin/admin.g.dart
+++ b/lib/src/v3/api/admin/admin.g.dart
@@ -6,13 +6,14 @@ part of 'admin.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_AddAdmin _$$_AddAdminFromJson(Map<String, dynamic> json) => _$_AddAdmin(
+_$AddAdminImpl _$$AddAdminImplFromJson(Map<String, dynamic> json) =>
+    _$AddAdminImpl(
       personId: json['person_id'] as int,
       added: json['added'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_AddAdminToJson(_$_AddAdmin instance) {
+Map<String, dynamic> _$$AddAdminImplToJson(_$AddAdminImpl instance) {
   final val = <String, dynamic>{
     'person_id': instance.personId,
     'added': instance.added,
@@ -28,15 +29,15 @@ Map<String, dynamic> _$$_AddAdminToJson(_$_AddAdmin instance) {
   return val;
 }
 
-_$_GetUnreadRegistrationApplicationCount
-    _$$_GetUnreadRegistrationApplicationCountFromJson(
+_$GetUnreadRegistrationApplicationCountImpl
+    _$$GetUnreadRegistrationApplicationCountImplFromJson(
             Map<String, dynamic> json) =>
-        _$_GetUnreadRegistrationApplicationCount(
+        _$GetUnreadRegistrationApplicationCountImpl(
           auth: json['auth'] as String?,
         );
 
-Map<String, dynamic> _$$_GetUnreadRegistrationApplicationCountToJson(
-    _$_GetUnreadRegistrationApplicationCount instance) {
+Map<String, dynamic> _$$GetUnreadRegistrationApplicationCountImplToJson(
+    _$GetUnreadRegistrationApplicationCountImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -49,17 +50,17 @@ Map<String, dynamic> _$$_GetUnreadRegistrationApplicationCountToJson(
   return val;
 }
 
-_$_ListRegistrationApplications _$$_ListRegistrationApplicationsFromJson(
+_$ListRegistrationApplicationsImpl _$$ListRegistrationApplicationsImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ListRegistrationApplications(
+    _$ListRegistrationApplicationsImpl(
       unreadOnly: json['unread_only'] as bool?,
       page: json['page'] as int?,
       limit: json['limit'] as int?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ListRegistrationApplicationsToJson(
-    _$_ListRegistrationApplications instance) {
+Map<String, dynamic> _$$ListRegistrationApplicationsImplToJson(
+    _$ListRegistrationApplicationsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -75,17 +76,17 @@ Map<String, dynamic> _$$_ListRegistrationApplicationsToJson(
   return val;
 }
 
-_$_ApproveRegistrationApplication _$$_ApproveRegistrationApplicationFromJson(
-        Map<String, dynamic> json) =>
-    _$_ApproveRegistrationApplication(
-      id: json['id'] as int,
-      approve: json['approve'] as bool,
-      denyReason: json['deny_reason'] as String?,
-      auth: json['auth'] as String?,
-    );
+_$ApproveRegistrationApplicationImpl
+    _$$ApproveRegistrationApplicationImplFromJson(Map<String, dynamic> json) =>
+        _$ApproveRegistrationApplicationImpl(
+          id: json['id'] as int,
+          approve: json['approve'] as bool,
+          denyReason: json['deny_reason'] as String?,
+          auth: json['auth'] as String?,
+        );
 
-Map<String, dynamic> _$$_ApproveRegistrationApplicationToJson(
-    _$_ApproveRegistrationApplication instance) {
+Map<String, dynamic> _$$ApproveRegistrationApplicationImplToJson(
+    _$ApproveRegistrationApplicationImpl instance) {
   final val = <String, dynamic>{
     'id': instance.id,
     'approve': instance.approve,
@@ -102,14 +103,14 @@ Map<String, dynamic> _$$_ApproveRegistrationApplicationToJson(
   return val;
 }
 
-_$_PurgePerson _$$_PurgePersonFromJson(Map<String, dynamic> json) =>
-    _$_PurgePerson(
+_$PurgePersonImpl _$$PurgePersonImplFromJson(Map<String, dynamic> json) =>
+    _$PurgePersonImpl(
       personId: json['person_id'] as int,
       reason: json['reason'] as String?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_PurgePersonToJson(_$_PurgePerson instance) {
+Map<String, dynamic> _$$PurgePersonImplToJson(_$PurgePersonImpl instance) {
   final val = <String, dynamic>{
     'person_id': instance.personId,
   };
@@ -125,14 +126,15 @@ Map<String, dynamic> _$$_PurgePersonToJson(_$_PurgePerson instance) {
   return val;
 }
 
-_$_PurgeCommunity _$$_PurgeCommunityFromJson(Map<String, dynamic> json) =>
-    _$_PurgeCommunity(
+_$PurgeCommunityImpl _$$PurgeCommunityImplFromJson(Map<String, dynamic> json) =>
+    _$PurgeCommunityImpl(
       communityId: json['community_id'] as int,
       reason: json['reason'] as String?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_PurgeCommunityToJson(_$_PurgeCommunity instance) {
+Map<String, dynamic> _$$PurgeCommunityImplToJson(
+    _$PurgeCommunityImpl instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
   };
@@ -148,13 +150,14 @@ Map<String, dynamic> _$$_PurgeCommunityToJson(_$_PurgeCommunity instance) {
   return val;
 }
 
-_$_PurgePost _$$_PurgePostFromJson(Map<String, dynamic> json) => _$_PurgePost(
+_$PurgePostImpl _$$PurgePostImplFromJson(Map<String, dynamic> json) =>
+    _$PurgePostImpl(
       postId: json['post_id'] as int,
       reason: json['reason'] as String?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_PurgePostToJson(_$_PurgePost instance) {
+Map<String, dynamic> _$$PurgePostImplToJson(_$PurgePostImpl instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
   };
@@ -170,14 +173,14 @@ Map<String, dynamic> _$$_PurgePostToJson(_$_PurgePost instance) {
   return val;
 }
 
-_$_PurgeComment _$$_PurgeCommentFromJson(Map<String, dynamic> json) =>
-    _$_PurgeComment(
+_$PurgeCommentImpl _$$PurgeCommentImplFromJson(Map<String, dynamic> json) =>
+    _$PurgeCommentImpl(
       commentId: json['comment_id'] as int,
       reason: json['reason'] as String?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_PurgeCommentToJson(_$_PurgeComment instance) {
+Map<String, dynamic> _$$PurgeCommentImplToJson(_$PurgeCommentImpl instance) {
   final val = <String, dynamic>{
     'comment_id': instance.commentId,
   };

--- a/lib/src/v3/api/comment/comment.freezed.dart
+++ b/lib/src/v3/api/comment/comment.freezed.dart
@@ -99,11 +99,11 @@ class _$CreateCommentCopyWithImpl<$Res, $Val extends CreateComment>
 }
 
 /// @nodoc
-abstract class _$$_CreateCommentCopyWith<$Res>
+abstract class _$$CreateCommentImplCopyWith<$Res>
     implements $CreateCommentCopyWith<$Res> {
-  factory _$$_CreateCommentCopyWith(
-          _$_CreateComment value, $Res Function(_$_CreateComment) then) =
-      __$$_CreateCommentCopyWithImpl<$Res>;
+  factory _$$CreateCommentImplCopyWith(
+          _$CreateCommentImpl value, $Res Function(_$CreateCommentImpl) then) =
+      __$$CreateCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -116,11 +116,11 @@ abstract class _$$_CreateCommentCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CreateCommentCopyWithImpl<$Res>
-    extends _$CreateCommentCopyWithImpl<$Res, _$_CreateComment>
-    implements _$$_CreateCommentCopyWith<$Res> {
-  __$$_CreateCommentCopyWithImpl(
-      _$_CreateComment _value, $Res Function(_$_CreateComment) _then)
+class __$$CreateCommentImplCopyWithImpl<$Res>
+    extends _$CreateCommentCopyWithImpl<$Res, _$CreateCommentImpl>
+    implements _$$CreateCommentImplCopyWith<$Res> {
+  __$$CreateCommentImplCopyWithImpl(
+      _$CreateCommentImpl _value, $Res Function(_$CreateCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -133,7 +133,7 @@ class __$$_CreateCommentCopyWithImpl<$Res>
     Object? formId = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_CreateComment(
+    return _then(_$CreateCommentImpl(
       content: null == content
           ? _value.content
           : content // ignore: cast_nullable_to_non_nullable
@@ -165,8 +165,8 @@ class __$$_CreateCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreateComment extends _CreateComment {
-  const _$_CreateComment(
+class _$CreateCommentImpl extends _CreateComment {
+  const _$CreateCommentImpl(
       {required this.content,
       required this.postId,
       this.parentId,
@@ -175,8 +175,8 @@ class _$_CreateComment extends _CreateComment {
       this.auth})
       : super._();
 
-  factory _$_CreateComment.fromJson(Map<String, dynamic> json) =>
-      _$$_CreateCommentFromJson(json);
+  factory _$CreateCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreateCommentImplFromJson(json);
 
   @override
   final String content;
@@ -201,7 +201,7 @@ class _$_CreateComment extends _CreateComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreateComment &&
+            other is _$CreateCommentImpl &&
             (identical(other.content, content) || other.content == content) &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.parentId, parentId) ||
@@ -220,12 +220,12 @@ class _$_CreateComment extends _CreateComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreateCommentCopyWith<_$_CreateComment> get copyWith =>
-      __$$_CreateCommentCopyWithImpl<_$_CreateComment>(this, _$identity);
+  _$$CreateCommentImplCopyWith<_$CreateCommentImpl> get copyWith =>
+      __$$CreateCommentImplCopyWithImpl<_$CreateCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreateCommentToJson(
+    return _$$CreateCommentImplToJson(
       this,
     );
   }
@@ -238,11 +238,11 @@ abstract class _CreateComment extends CreateComment {
       final int? parentId,
       final int? languageId,
       @deprecated final String? formId,
-      final String? auth}) = _$_CreateComment;
+      final String? auth}) = _$CreateCommentImpl;
   const _CreateComment._() : super._();
 
   factory _CreateComment.fromJson(Map<String, dynamic> json) =
-      _$_CreateComment.fromJson;
+      _$CreateCommentImpl.fromJson;
 
   @override
   String get content;
@@ -259,7 +259,7 @@ abstract class _CreateComment extends CreateComment {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreateCommentCopyWith<_$_CreateComment> get copyWith =>
+  _$$CreateCommentImplCopyWith<_$CreateCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -341,11 +341,11 @@ class _$EditCommentCopyWithImpl<$Res, $Val extends EditComment>
 }
 
 /// @nodoc
-abstract class _$$_EditCommentCopyWith<$Res>
+abstract class _$$EditCommentImplCopyWith<$Res>
     implements $EditCommentCopyWith<$Res> {
-  factory _$$_EditCommentCopyWith(
-          _$_EditComment value, $Res Function(_$_EditComment) then) =
-      __$$_EditCommentCopyWithImpl<$Res>;
+  factory _$$EditCommentImplCopyWith(
+          _$EditCommentImpl value, $Res Function(_$EditCommentImpl) then) =
+      __$$EditCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -357,11 +357,11 @@ abstract class _$$_EditCommentCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_EditCommentCopyWithImpl<$Res>
-    extends _$EditCommentCopyWithImpl<$Res, _$_EditComment>
-    implements _$$_EditCommentCopyWith<$Res> {
-  __$$_EditCommentCopyWithImpl(
-      _$_EditComment _value, $Res Function(_$_EditComment) _then)
+class __$$EditCommentImplCopyWithImpl<$Res>
+    extends _$EditCommentCopyWithImpl<$Res, _$EditCommentImpl>
+    implements _$$EditCommentImplCopyWith<$Res> {
+  __$$EditCommentImplCopyWithImpl(
+      _$EditCommentImpl _value, $Res Function(_$EditCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -373,7 +373,7 @@ class __$$_EditCommentCopyWithImpl<$Res>
     Object? formId = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_EditComment(
+    return _then(_$EditCommentImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -401,8 +401,8 @@ class __$$_EditCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_EditComment extends _EditComment {
-  const _$_EditComment(
+class _$EditCommentImpl extends _EditComment {
+  const _$EditCommentImpl(
       {required this.commentId,
       this.content,
       this.languageId,
@@ -410,8 +410,8 @@ class _$_EditComment extends _EditComment {
       this.auth})
       : super._();
 
-  factory _$_EditComment.fromJson(Map<String, dynamic> json) =>
-      _$$_EditCommentFromJson(json);
+  factory _$EditCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EditCommentImplFromJson(json);
 
   @override
   final int commentId;
@@ -434,7 +434,7 @@ class _$_EditComment extends _EditComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_EditComment &&
+            other is _$EditCommentImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.content, content) || other.content == content) &&
@@ -452,12 +452,12 @@ class _$_EditComment extends _EditComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_EditCommentCopyWith<_$_EditComment> get copyWith =>
-      __$$_EditCommentCopyWithImpl<_$_EditComment>(this, _$identity);
+  _$$EditCommentImplCopyWith<_$EditCommentImpl> get copyWith =>
+      __$$EditCommentImplCopyWithImpl<_$EditCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_EditCommentToJson(
+    return _$$EditCommentImplToJson(
       this,
     );
   }
@@ -469,11 +469,11 @@ abstract class _EditComment extends EditComment {
       final String? content,
       final int? languageId,
       @deprecated final String? formId,
-      final String? auth}) = _$_EditComment;
+      final String? auth}) = _$EditCommentImpl;
   const _EditComment._() : super._();
 
   factory _EditComment.fromJson(Map<String, dynamic> json) =
-      _$_EditComment.fromJson;
+      _$EditCommentImpl.fromJson;
 
   @override
   int get commentId;
@@ -488,7 +488,7 @@ abstract class _EditComment extends EditComment {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_EditCommentCopyWith<_$_EditComment> get copyWith =>
+  _$$EditCommentImplCopyWith<_$EditCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -552,22 +552,22 @@ class _$DeleteCommentCopyWithImpl<$Res, $Val extends DeleteComment>
 }
 
 /// @nodoc
-abstract class _$$_DeleteCommentCopyWith<$Res>
+abstract class _$$DeleteCommentImplCopyWith<$Res>
     implements $DeleteCommentCopyWith<$Res> {
-  factory _$$_DeleteCommentCopyWith(
-          _$_DeleteComment value, $Res Function(_$_DeleteComment) then) =
-      __$$_DeleteCommentCopyWithImpl<$Res>;
+  factory _$$DeleteCommentImplCopyWith(
+          _$DeleteCommentImpl value, $Res Function(_$DeleteCommentImpl) then) =
+      __$$DeleteCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, bool deleted, String? auth});
 }
 
 /// @nodoc
-class __$$_DeleteCommentCopyWithImpl<$Res>
-    extends _$DeleteCommentCopyWithImpl<$Res, _$_DeleteComment>
-    implements _$$_DeleteCommentCopyWith<$Res> {
-  __$$_DeleteCommentCopyWithImpl(
-      _$_DeleteComment _value, $Res Function(_$_DeleteComment) _then)
+class __$$DeleteCommentImplCopyWithImpl<$Res>
+    extends _$DeleteCommentCopyWithImpl<$Res, _$DeleteCommentImpl>
+    implements _$$DeleteCommentImplCopyWith<$Res> {
+  __$$DeleteCommentImplCopyWithImpl(
+      _$DeleteCommentImpl _value, $Res Function(_$DeleteCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -577,7 +577,7 @@ class __$$_DeleteCommentCopyWithImpl<$Res>
     Object? deleted = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_DeleteComment(
+    return _then(_$DeleteCommentImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -597,13 +597,13 @@ class __$$_DeleteCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_DeleteComment extends _DeleteComment {
-  const _$_DeleteComment(
+class _$DeleteCommentImpl extends _DeleteComment {
+  const _$DeleteCommentImpl(
       {required this.commentId, required this.deleted, this.auth})
       : super._();
 
-  factory _$_DeleteComment.fromJson(Map<String, dynamic> json) =>
-      _$$_DeleteCommentFromJson(json);
+  factory _$DeleteCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeleteCommentImplFromJson(json);
 
   @override
   final int commentId;
@@ -621,7 +621,7 @@ class _$_DeleteComment extends _DeleteComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeleteComment &&
+            other is _$DeleteCommentImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.deleted, deleted) || other.deleted == deleted) &&
@@ -635,12 +635,12 @@ class _$_DeleteComment extends _DeleteComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeleteCommentCopyWith<_$_DeleteComment> get copyWith =>
-      __$$_DeleteCommentCopyWithImpl<_$_DeleteComment>(this, _$identity);
+  _$$DeleteCommentImplCopyWith<_$DeleteCommentImpl> get copyWith =>
+      __$$DeleteCommentImplCopyWithImpl<_$DeleteCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeleteCommentToJson(
+    return _$$DeleteCommentImplToJson(
       this,
     );
   }
@@ -650,11 +650,11 @@ abstract class _DeleteComment extends DeleteComment {
   const factory _DeleteComment(
       {required final int commentId,
       required final bool deleted,
-      final String? auth}) = _$_DeleteComment;
+      final String? auth}) = _$DeleteCommentImpl;
   const _DeleteComment._() : super._();
 
   factory _DeleteComment.fromJson(Map<String, dynamic> json) =
-      _$_DeleteComment.fromJson;
+      _$DeleteCommentImpl.fromJson;
 
   @override
   int get commentId;
@@ -664,7 +664,7 @@ abstract class _DeleteComment extends DeleteComment {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_DeleteCommentCopyWith<_$_DeleteComment> get copyWith =>
+  _$$DeleteCommentImplCopyWith<_$DeleteCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -734,22 +734,22 @@ class _$RemoveCommentCopyWithImpl<$Res, $Val extends RemoveComment>
 }
 
 /// @nodoc
-abstract class _$$_RemoveCommentCopyWith<$Res>
+abstract class _$$RemoveCommentImplCopyWith<$Res>
     implements $RemoveCommentCopyWith<$Res> {
-  factory _$$_RemoveCommentCopyWith(
-          _$_RemoveComment value, $Res Function(_$_RemoveComment) then) =
-      __$$_RemoveCommentCopyWithImpl<$Res>;
+  factory _$$RemoveCommentImplCopyWith(
+          _$RemoveCommentImpl value, $Res Function(_$RemoveCommentImpl) then) =
+      __$$RemoveCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, bool removed, String? reason, String? auth});
 }
 
 /// @nodoc
-class __$$_RemoveCommentCopyWithImpl<$Res>
-    extends _$RemoveCommentCopyWithImpl<$Res, _$_RemoveComment>
-    implements _$$_RemoveCommentCopyWith<$Res> {
-  __$$_RemoveCommentCopyWithImpl(
-      _$_RemoveComment _value, $Res Function(_$_RemoveComment) _then)
+class __$$RemoveCommentImplCopyWithImpl<$Res>
+    extends _$RemoveCommentCopyWithImpl<$Res, _$RemoveCommentImpl>
+    implements _$$RemoveCommentImplCopyWith<$Res> {
+  __$$RemoveCommentImplCopyWithImpl(
+      _$RemoveCommentImpl _value, $Res Function(_$RemoveCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -760,7 +760,7 @@ class __$$_RemoveCommentCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_RemoveComment(
+    return _then(_$RemoveCommentImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -784,13 +784,13 @@ class __$$_RemoveCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_RemoveComment extends _RemoveComment {
-  const _$_RemoveComment(
+class _$RemoveCommentImpl extends _RemoveComment {
+  const _$RemoveCommentImpl(
       {required this.commentId, required this.removed, this.reason, this.auth})
       : super._();
 
-  factory _$_RemoveComment.fromJson(Map<String, dynamic> json) =>
-      _$$_RemoveCommentFromJson(json);
+  factory _$RemoveCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RemoveCommentImplFromJson(json);
 
   @override
   final int commentId;
@@ -810,7 +810,7 @@ class _$_RemoveComment extends _RemoveComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_RemoveComment &&
+            other is _$RemoveCommentImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.removed, removed) || other.removed == removed) &&
@@ -826,12 +826,12 @@ class _$_RemoveComment extends _RemoveComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RemoveCommentCopyWith<_$_RemoveComment> get copyWith =>
-      __$$_RemoveCommentCopyWithImpl<_$_RemoveComment>(this, _$identity);
+  _$$RemoveCommentImplCopyWith<_$RemoveCommentImpl> get copyWith =>
+      __$$RemoveCommentImplCopyWithImpl<_$RemoveCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RemoveCommentToJson(
+    return _$$RemoveCommentImplToJson(
       this,
     );
   }
@@ -842,11 +842,11 @@ abstract class _RemoveComment extends RemoveComment {
       {required final int commentId,
       required final bool removed,
       final String? reason,
-      final String? auth}) = _$_RemoveComment;
+      final String? auth}) = _$RemoveCommentImpl;
   const _RemoveComment._() : super._();
 
   factory _RemoveComment.fromJson(Map<String, dynamic> json) =
-      _$_RemoveComment.fromJson;
+      _$RemoveCommentImpl.fromJson;
 
   @override
   int get commentId;
@@ -858,7 +858,7 @@ abstract class _RemoveComment extends RemoveComment {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_RemoveCommentCopyWith<_$_RemoveComment> get copyWith =>
+  _$$RemoveCommentImplCopyWith<_$RemoveCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -924,23 +924,25 @@ class _$MarkCommentReplyAsReadCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_MarkCommentReplyAsReadCopyWith<$Res>
+abstract class _$$MarkCommentReplyAsReadImplCopyWith<$Res>
     implements $MarkCommentReplyAsReadCopyWith<$Res> {
-  factory _$$_MarkCommentReplyAsReadCopyWith(_$_MarkCommentReplyAsRead value,
-          $Res Function(_$_MarkCommentReplyAsRead) then) =
-      __$$_MarkCommentReplyAsReadCopyWithImpl<$Res>;
+  factory _$$MarkCommentReplyAsReadImplCopyWith(
+          _$MarkCommentReplyAsReadImpl value,
+          $Res Function(_$MarkCommentReplyAsReadImpl) then) =
+      __$$MarkCommentReplyAsReadImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentReplyId, bool read, String? auth});
 }
 
 /// @nodoc
-class __$$_MarkCommentReplyAsReadCopyWithImpl<$Res>
+class __$$MarkCommentReplyAsReadImplCopyWithImpl<$Res>
     extends _$MarkCommentReplyAsReadCopyWithImpl<$Res,
-        _$_MarkCommentReplyAsRead>
-    implements _$$_MarkCommentReplyAsReadCopyWith<$Res> {
-  __$$_MarkCommentReplyAsReadCopyWithImpl(_$_MarkCommentReplyAsRead _value,
-      $Res Function(_$_MarkCommentReplyAsRead) _then)
+        _$MarkCommentReplyAsReadImpl>
+    implements _$$MarkCommentReplyAsReadImplCopyWith<$Res> {
+  __$$MarkCommentReplyAsReadImplCopyWithImpl(
+      _$MarkCommentReplyAsReadImpl _value,
+      $Res Function(_$MarkCommentReplyAsReadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -950,7 +952,7 @@ class __$$_MarkCommentReplyAsReadCopyWithImpl<$Res>
     Object? read = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_MarkCommentReplyAsRead(
+    return _then(_$MarkCommentReplyAsReadImpl(
       commentReplyId: null == commentReplyId
           ? _value.commentReplyId
           : commentReplyId // ignore: cast_nullable_to_non_nullable
@@ -970,13 +972,13 @@ class __$$_MarkCommentReplyAsReadCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_MarkCommentReplyAsRead extends _MarkCommentReplyAsRead {
-  const _$_MarkCommentReplyAsRead(
+class _$MarkCommentReplyAsReadImpl extends _MarkCommentReplyAsRead {
+  const _$MarkCommentReplyAsReadImpl(
       {required this.commentReplyId, required this.read, this.auth})
       : super._();
 
-  factory _$_MarkCommentReplyAsRead.fromJson(Map<String, dynamic> json) =>
-      _$$_MarkCommentReplyAsReadFromJson(json);
+  factory _$MarkCommentReplyAsReadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MarkCommentReplyAsReadImplFromJson(json);
 
   @override
   final int commentReplyId;
@@ -994,7 +996,7 @@ class _$_MarkCommentReplyAsRead extends _MarkCommentReplyAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MarkCommentReplyAsRead &&
+            other is _$MarkCommentReplyAsReadImpl &&
             (identical(other.commentReplyId, commentReplyId) ||
                 other.commentReplyId == commentReplyId) &&
             (identical(other.read, read) || other.read == read) &&
@@ -1008,13 +1010,13 @@ class _$_MarkCommentReplyAsRead extends _MarkCommentReplyAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MarkCommentReplyAsReadCopyWith<_$_MarkCommentReplyAsRead> get copyWith =>
-      __$$_MarkCommentReplyAsReadCopyWithImpl<_$_MarkCommentReplyAsRead>(
-          this, _$identity);
+  _$$MarkCommentReplyAsReadImplCopyWith<_$MarkCommentReplyAsReadImpl>
+      get copyWith => __$$MarkCommentReplyAsReadImplCopyWithImpl<
+          _$MarkCommentReplyAsReadImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MarkCommentReplyAsReadToJson(
+    return _$$MarkCommentReplyAsReadImplToJson(
       this,
     );
   }
@@ -1024,11 +1026,11 @@ abstract class _MarkCommentReplyAsRead extends MarkCommentReplyAsRead {
   const factory _MarkCommentReplyAsRead(
       {required final int commentReplyId,
       required final bool read,
-      final String? auth}) = _$_MarkCommentReplyAsRead;
+      final String? auth}) = _$MarkCommentReplyAsReadImpl;
   const _MarkCommentReplyAsRead._() : super._();
 
   factory _MarkCommentReplyAsRead.fromJson(Map<String, dynamic> json) =
-      _$_MarkCommentReplyAsRead.fromJson;
+      _$MarkCommentReplyAsReadImpl.fromJson;
 
   @override
   int get commentReplyId;
@@ -1038,8 +1040,8 @@ abstract class _MarkCommentReplyAsRead extends MarkCommentReplyAsRead {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_MarkCommentReplyAsReadCopyWith<_$_MarkCommentReplyAsRead> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$MarkCommentReplyAsReadImplCopyWith<_$MarkCommentReplyAsReadImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 CreateCommentLike _$CreateCommentLikeFromJson(Map<String, dynamic> json) {
@@ -1102,22 +1104,22 @@ class _$CreateCommentLikeCopyWithImpl<$Res, $Val extends CreateCommentLike>
 }
 
 /// @nodoc
-abstract class _$$_CreateCommentLikeCopyWith<$Res>
+abstract class _$$CreateCommentLikeImplCopyWith<$Res>
     implements $CreateCommentLikeCopyWith<$Res> {
-  factory _$$_CreateCommentLikeCopyWith(_$_CreateCommentLike value,
-          $Res Function(_$_CreateCommentLike) then) =
-      __$$_CreateCommentLikeCopyWithImpl<$Res>;
+  factory _$$CreateCommentLikeImplCopyWith(_$CreateCommentLikeImpl value,
+          $Res Function(_$CreateCommentLikeImpl) then) =
+      __$$CreateCommentLikeImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, num score, String? auth});
 }
 
 /// @nodoc
-class __$$_CreateCommentLikeCopyWithImpl<$Res>
-    extends _$CreateCommentLikeCopyWithImpl<$Res, _$_CreateCommentLike>
-    implements _$$_CreateCommentLikeCopyWith<$Res> {
-  __$$_CreateCommentLikeCopyWithImpl(
-      _$_CreateCommentLike _value, $Res Function(_$_CreateCommentLike) _then)
+class __$$CreateCommentLikeImplCopyWithImpl<$Res>
+    extends _$CreateCommentLikeCopyWithImpl<$Res, _$CreateCommentLikeImpl>
+    implements _$$CreateCommentLikeImplCopyWith<$Res> {
+  __$$CreateCommentLikeImplCopyWithImpl(_$CreateCommentLikeImpl _value,
+      $Res Function(_$CreateCommentLikeImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1127,7 +1129,7 @@ class __$$_CreateCommentLikeCopyWithImpl<$Res>
     Object? score = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_CreateCommentLike(
+    return _then(_$CreateCommentLikeImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -1147,13 +1149,13 @@ class __$$_CreateCommentLikeCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreateCommentLike extends _CreateCommentLike {
-  const _$_CreateCommentLike(
+class _$CreateCommentLikeImpl extends _CreateCommentLike {
+  const _$CreateCommentLikeImpl(
       {required this.commentId, required this.score, this.auth})
       : super._();
 
-  factory _$_CreateCommentLike.fromJson(Map<String, dynamic> json) =>
-      _$$_CreateCommentLikeFromJson(json);
+  factory _$CreateCommentLikeImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreateCommentLikeImplFromJson(json);
 
   @override
   final int commentId;
@@ -1171,7 +1173,7 @@ class _$_CreateCommentLike extends _CreateCommentLike {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreateCommentLike &&
+            other is _$CreateCommentLikeImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.score, score) || other.score == score) &&
@@ -1185,13 +1187,13 @@ class _$_CreateCommentLike extends _CreateCommentLike {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreateCommentLikeCopyWith<_$_CreateCommentLike> get copyWith =>
-      __$$_CreateCommentLikeCopyWithImpl<_$_CreateCommentLike>(
+  _$$CreateCommentLikeImplCopyWith<_$CreateCommentLikeImpl> get copyWith =>
+      __$$CreateCommentLikeImplCopyWithImpl<_$CreateCommentLikeImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreateCommentLikeToJson(
+    return _$$CreateCommentLikeImplToJson(
       this,
     );
   }
@@ -1201,11 +1203,11 @@ abstract class _CreateCommentLike extends CreateCommentLike {
   const factory _CreateCommentLike(
       {required final int commentId,
       required final num score,
-      final String? auth}) = _$_CreateCommentLike;
+      final String? auth}) = _$CreateCommentLikeImpl;
   const _CreateCommentLike._() : super._();
 
   factory _CreateCommentLike.fromJson(Map<String, dynamic> json) =
-      _$_CreateCommentLike.fromJson;
+      _$CreateCommentLikeImpl.fromJson;
 
   @override
   int get commentId;
@@ -1215,7 +1217,7 @@ abstract class _CreateCommentLike extends CreateCommentLike {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreateCommentLikeCopyWith<_$_CreateCommentLike> get copyWith =>
+  _$$CreateCommentLikeImplCopyWith<_$CreateCommentLikeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1279,22 +1281,22 @@ class _$SaveCommentCopyWithImpl<$Res, $Val extends SaveComment>
 }
 
 /// @nodoc
-abstract class _$$_SaveCommentCopyWith<$Res>
+abstract class _$$SaveCommentImplCopyWith<$Res>
     implements $SaveCommentCopyWith<$Res> {
-  factory _$$_SaveCommentCopyWith(
-          _$_SaveComment value, $Res Function(_$_SaveComment) then) =
-      __$$_SaveCommentCopyWithImpl<$Res>;
+  factory _$$SaveCommentImplCopyWith(
+          _$SaveCommentImpl value, $Res Function(_$SaveCommentImpl) then) =
+      __$$SaveCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, bool save, String? auth});
 }
 
 /// @nodoc
-class __$$_SaveCommentCopyWithImpl<$Res>
-    extends _$SaveCommentCopyWithImpl<$Res, _$_SaveComment>
-    implements _$$_SaveCommentCopyWith<$Res> {
-  __$$_SaveCommentCopyWithImpl(
-      _$_SaveComment _value, $Res Function(_$_SaveComment) _then)
+class __$$SaveCommentImplCopyWithImpl<$Res>
+    extends _$SaveCommentCopyWithImpl<$Res, _$SaveCommentImpl>
+    implements _$$SaveCommentImplCopyWith<$Res> {
+  __$$SaveCommentImplCopyWithImpl(
+      _$SaveCommentImpl _value, $Res Function(_$SaveCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1304,7 +1306,7 @@ class __$$_SaveCommentCopyWithImpl<$Res>
     Object? save = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_SaveComment(
+    return _then(_$SaveCommentImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -1324,12 +1326,13 @@ class __$$_SaveCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_SaveComment extends _SaveComment {
-  const _$_SaveComment({required this.commentId, required this.save, this.auth})
+class _$SaveCommentImpl extends _SaveComment {
+  const _$SaveCommentImpl(
+      {required this.commentId, required this.save, this.auth})
       : super._();
 
-  factory _$_SaveComment.fromJson(Map<String, dynamic> json) =>
-      _$$_SaveCommentFromJson(json);
+  factory _$SaveCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SaveCommentImplFromJson(json);
 
   @override
   final int commentId;
@@ -1347,7 +1350,7 @@ class _$_SaveComment extends _SaveComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SaveComment &&
+            other is _$SaveCommentImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.save, save) || other.save == save) &&
@@ -1361,12 +1364,12 @@ class _$_SaveComment extends _SaveComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SaveCommentCopyWith<_$_SaveComment> get copyWith =>
-      __$$_SaveCommentCopyWithImpl<_$_SaveComment>(this, _$identity);
+  _$$SaveCommentImplCopyWith<_$SaveCommentImpl> get copyWith =>
+      __$$SaveCommentImplCopyWithImpl<_$SaveCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SaveCommentToJson(
+    return _$$SaveCommentImplToJson(
       this,
     );
   }
@@ -1376,11 +1379,11 @@ abstract class _SaveComment extends SaveComment {
   const factory _SaveComment(
       {required final int commentId,
       required final bool save,
-      final String? auth}) = _$_SaveComment;
+      final String? auth}) = _$SaveCommentImpl;
   const _SaveComment._() : super._();
 
   factory _SaveComment.fromJson(Map<String, dynamic> json) =
-      _$_SaveComment.fromJson;
+      _$SaveCommentImpl.fromJson;
 
   @override
   int get commentId;
@@ -1390,7 +1393,7 @@ abstract class _SaveComment extends SaveComment {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_SaveCommentCopyWith<_$_SaveComment> get copyWith =>
+  _$$SaveCommentImplCopyWith<_$SaveCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1454,22 +1457,22 @@ class _$DistinguishCommentCopyWithImpl<$Res, $Val extends DistinguishComment>
 }
 
 /// @nodoc
-abstract class _$$_DistinguishCommentCopyWith<$Res>
+abstract class _$$DistinguishCommentImplCopyWith<$Res>
     implements $DistinguishCommentCopyWith<$Res> {
-  factory _$$_DistinguishCommentCopyWith(_$_DistinguishComment value,
-          $Res Function(_$_DistinguishComment) then) =
-      __$$_DistinguishCommentCopyWithImpl<$Res>;
+  factory _$$DistinguishCommentImplCopyWith(_$DistinguishCommentImpl value,
+          $Res Function(_$DistinguishCommentImpl) then) =
+      __$$DistinguishCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, bool distinguished, String? auth});
 }
 
 /// @nodoc
-class __$$_DistinguishCommentCopyWithImpl<$Res>
-    extends _$DistinguishCommentCopyWithImpl<$Res, _$_DistinguishComment>
-    implements _$$_DistinguishCommentCopyWith<$Res> {
-  __$$_DistinguishCommentCopyWithImpl(
-      _$_DistinguishComment _value, $Res Function(_$_DistinguishComment) _then)
+class __$$DistinguishCommentImplCopyWithImpl<$Res>
+    extends _$DistinguishCommentCopyWithImpl<$Res, _$DistinguishCommentImpl>
+    implements _$$DistinguishCommentImplCopyWith<$Res> {
+  __$$DistinguishCommentImplCopyWithImpl(_$DistinguishCommentImpl _value,
+      $Res Function(_$DistinguishCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1479,7 +1482,7 @@ class __$$_DistinguishCommentCopyWithImpl<$Res>
     Object? distinguished = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_DistinguishComment(
+    return _then(_$DistinguishCommentImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -1499,13 +1502,13 @@ class __$$_DistinguishCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_DistinguishComment extends _DistinguishComment {
-  const _$_DistinguishComment(
+class _$DistinguishCommentImpl extends _DistinguishComment {
+  const _$DistinguishCommentImpl(
       {required this.commentId, required this.distinguished, this.auth})
       : super._();
 
-  factory _$_DistinguishComment.fromJson(Map<String, dynamic> json) =>
-      _$$_DistinguishCommentFromJson(json);
+  factory _$DistinguishCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DistinguishCommentImplFromJson(json);
 
   @override
   final int commentId;
@@ -1523,7 +1526,7 @@ class _$_DistinguishComment extends _DistinguishComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DistinguishComment &&
+            other is _$DistinguishCommentImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.distinguished, distinguished) ||
@@ -1538,13 +1541,13 @@ class _$_DistinguishComment extends _DistinguishComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DistinguishCommentCopyWith<_$_DistinguishComment> get copyWith =>
-      __$$_DistinguishCommentCopyWithImpl<_$_DistinguishComment>(
+  _$$DistinguishCommentImplCopyWith<_$DistinguishCommentImpl> get copyWith =>
+      __$$DistinguishCommentImplCopyWithImpl<_$DistinguishCommentImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DistinguishCommentToJson(
+    return _$$DistinguishCommentImplToJson(
       this,
     );
   }
@@ -1554,11 +1557,11 @@ abstract class _DistinguishComment extends DistinguishComment {
   const factory _DistinguishComment(
       {required final int commentId,
       required final bool distinguished,
-      final String? auth}) = _$_DistinguishComment;
+      final String? auth}) = _$DistinguishCommentImpl;
   const _DistinguishComment._() : super._();
 
   factory _DistinguishComment.fromJson(Map<String, dynamic> json) =
-      _$_DistinguishComment.fromJson;
+      _$DistinguishCommentImpl.fromJson;
 
   @override
   int get commentId;
@@ -1568,7 +1571,7 @@ abstract class _DistinguishComment extends DistinguishComment {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_DistinguishCommentCopyWith<_$_DistinguishComment> get copyWith =>
+  _$$DistinguishCommentImplCopyWith<_$DistinguishCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1707,11 +1710,11 @@ class _$GetCommentsCopyWithImpl<$Res, $Val extends GetComments>
 }
 
 /// @nodoc
-abstract class _$$_GetCommentsCopyWith<$Res>
+abstract class _$$GetCommentsImplCopyWith<$Res>
     implements $GetCommentsCopyWith<$Res> {
-  factory _$$_GetCommentsCopyWith(
-          _$_GetComments value, $Res Function(_$_GetComments) then) =
-      __$$_GetCommentsCopyWithImpl<$Res>;
+  factory _$$GetCommentsImplCopyWith(
+          _$GetCommentsImpl value, $Res Function(_$GetCommentsImpl) then) =
+      __$$GetCommentsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1731,11 +1734,11 @@ abstract class _$$_GetCommentsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetCommentsCopyWithImpl<$Res>
-    extends _$GetCommentsCopyWithImpl<$Res, _$_GetComments>
-    implements _$$_GetCommentsCopyWith<$Res> {
-  __$$_GetCommentsCopyWithImpl(
-      _$_GetComments _value, $Res Function(_$_GetComments) _then)
+class __$$GetCommentsImplCopyWithImpl<$Res>
+    extends _$GetCommentsCopyWithImpl<$Res, _$GetCommentsImpl>
+    implements _$$GetCommentsImplCopyWith<$Res> {
+  __$$GetCommentsImplCopyWithImpl(
+      _$GetCommentsImpl _value, $Res Function(_$GetCommentsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1755,7 +1758,7 @@ class __$$_GetCommentsCopyWithImpl<$Res>
     Object? likedOnly = freezed,
     Object? dislikedOnly = freezed,
   }) {
-    return _then(_$_GetComments(
+    return _then(_$GetCommentsImpl(
       type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -1815,8 +1818,8 @@ class __$$_GetCommentsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetComments extends _GetComments {
-  const _$_GetComments(
+class _$GetCommentsImpl extends _GetComments {
+  const _$GetCommentsImpl(
       {@JsonKey(name: 'type_') this.type,
       this.sort,
       this.maxDepth,
@@ -1832,8 +1835,8 @@ class _$_GetComments extends _GetComments {
       this.dislikedOnly})
       : super._();
 
-  factory _$_GetComments.fromJson(Map<String, dynamic> json) =>
-      _$$_GetCommentsFromJson(json);
+  factory _$GetCommentsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetCommentsImplFromJson(json);
 
   @override
   @JsonKey(name: 'type_')
@@ -1873,7 +1876,7 @@ class _$_GetComments extends _GetComments {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetComments &&
+            other is _$GetCommentsImpl &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.maxDepth, maxDepth) ||
@@ -1917,12 +1920,12 @@ class _$_GetComments extends _GetComments {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetCommentsCopyWith<_$_GetComments> get copyWith =>
-      __$$_GetCommentsCopyWithImpl<_$_GetComments>(this, _$identity);
+  _$$GetCommentsImplCopyWith<_$GetCommentsImpl> get copyWith =>
+      __$$GetCommentsImplCopyWithImpl<_$GetCommentsImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetCommentsToJson(
+    return _$$GetCommentsImplToJson(
       this,
     );
   }
@@ -1942,11 +1945,11 @@ abstract class _GetComments extends GetComments {
       final bool? savedOnly,
       final String? auth,
       final bool? likedOnly,
-      final bool? dislikedOnly}) = _$_GetComments;
+      final bool? dislikedOnly}) = _$GetCommentsImpl;
   const _GetComments._() : super._();
 
   factory _GetComments.fromJson(Map<String, dynamic> json) =
-      _$_GetComments.fromJson;
+      _$GetCommentsImpl.fromJson;
 
   @override
   @JsonKey(name: 'type_')
@@ -1977,7 +1980,7 @@ abstract class _GetComments extends GetComments {
   bool? get dislikedOnly;
   @override
   @JsonKey(ignore: true)
-  _$$_GetCommentsCopyWith<_$_GetComments> get copyWith =>
+  _$$GetCommentsImplCopyWith<_$GetCommentsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2035,22 +2038,22 @@ class _$GetCommentCopyWithImpl<$Res, $Val extends GetComment>
 }
 
 /// @nodoc
-abstract class _$$_GetCommentCopyWith<$Res>
+abstract class _$$GetCommentImplCopyWith<$Res>
     implements $GetCommentCopyWith<$Res> {
-  factory _$$_GetCommentCopyWith(
-          _$_GetComment value, $Res Function(_$_GetComment) then) =
-      __$$_GetCommentCopyWithImpl<$Res>;
+  factory _$$GetCommentImplCopyWith(
+          _$GetCommentImpl value, $Res Function(_$GetCommentImpl) then) =
+      __$$GetCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int id, String? auth});
 }
 
 /// @nodoc
-class __$$_GetCommentCopyWithImpl<$Res>
-    extends _$GetCommentCopyWithImpl<$Res, _$_GetComment>
-    implements _$$_GetCommentCopyWith<$Res> {
-  __$$_GetCommentCopyWithImpl(
-      _$_GetComment _value, $Res Function(_$_GetComment) _then)
+class __$$GetCommentImplCopyWithImpl<$Res>
+    extends _$GetCommentCopyWithImpl<$Res, _$GetCommentImpl>
+    implements _$$GetCommentImplCopyWith<$Res> {
+  __$$GetCommentImplCopyWithImpl(
+      _$GetCommentImpl _value, $Res Function(_$GetCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2059,7 +2062,7 @@ class __$$_GetCommentCopyWithImpl<$Res>
     Object? id = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetComment(
+    return _then(_$GetCommentImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -2075,11 +2078,11 @@ class __$$_GetCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetComment extends _GetComment {
-  const _$_GetComment({required this.id, this.auth}) : super._();
+class _$GetCommentImpl extends _GetComment {
+  const _$GetCommentImpl({required this.id, this.auth}) : super._();
 
-  factory _$_GetComment.fromJson(Map<String, dynamic> json) =>
-      _$$_GetCommentFromJson(json);
+  factory _$GetCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetCommentImplFromJson(json);
 
   @override
   final int id;
@@ -2095,7 +2098,7 @@ class _$_GetComment extends _GetComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetComment &&
+            other is _$GetCommentImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.auth, auth) || other.auth == auth));
   }
@@ -2107,12 +2110,12 @@ class _$_GetComment extends _GetComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetCommentCopyWith<_$_GetComment> get copyWith =>
-      __$$_GetCommentCopyWithImpl<_$_GetComment>(this, _$identity);
+  _$$GetCommentImplCopyWith<_$GetCommentImpl> get copyWith =>
+      __$$GetCommentImplCopyWithImpl<_$GetCommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetCommentToJson(
+    return _$$GetCommentImplToJson(
       this,
     );
   }
@@ -2120,11 +2123,11 @@ class _$_GetComment extends _GetComment {
 
 abstract class _GetComment extends GetComment {
   const factory _GetComment({required final int id, final String? auth}) =
-      _$_GetComment;
+      _$GetCommentImpl;
   const _GetComment._() : super._();
 
   factory _GetComment.fromJson(Map<String, dynamic> json) =
-      _$_GetComment.fromJson;
+      _$GetCommentImpl.fromJson;
 
   @override
   int get id;
@@ -2132,7 +2135,7 @@ abstract class _GetComment extends GetComment {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetCommentCopyWith<_$_GetComment> get copyWith =>
+  _$$GetCommentImplCopyWith<_$GetCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2196,22 +2199,22 @@ class _$CreateCommentReportCopyWithImpl<$Res, $Val extends CreateCommentReport>
 }
 
 /// @nodoc
-abstract class _$$_CreateCommentReportCopyWith<$Res>
+abstract class _$$CreateCommentReportImplCopyWith<$Res>
     implements $CreateCommentReportCopyWith<$Res> {
-  factory _$$_CreateCommentReportCopyWith(_$_CreateCommentReport value,
-          $Res Function(_$_CreateCommentReport) then) =
-      __$$_CreateCommentReportCopyWithImpl<$Res>;
+  factory _$$CreateCommentReportImplCopyWith(_$CreateCommentReportImpl value,
+          $Res Function(_$CreateCommentReportImpl) then) =
+      __$$CreateCommentReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int commentId, String reason, String? auth});
 }
 
 /// @nodoc
-class __$$_CreateCommentReportCopyWithImpl<$Res>
-    extends _$CreateCommentReportCopyWithImpl<$Res, _$_CreateCommentReport>
-    implements _$$_CreateCommentReportCopyWith<$Res> {
-  __$$_CreateCommentReportCopyWithImpl(_$_CreateCommentReport _value,
-      $Res Function(_$_CreateCommentReport) _then)
+class __$$CreateCommentReportImplCopyWithImpl<$Res>
+    extends _$CreateCommentReportCopyWithImpl<$Res, _$CreateCommentReportImpl>
+    implements _$$CreateCommentReportImplCopyWith<$Res> {
+  __$$CreateCommentReportImplCopyWithImpl(_$CreateCommentReportImpl _value,
+      $Res Function(_$CreateCommentReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2221,7 +2224,7 @@ class __$$_CreateCommentReportCopyWithImpl<$Res>
     Object? reason = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_CreateCommentReport(
+    return _then(_$CreateCommentReportImpl(
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -2241,13 +2244,13 @@ class __$$_CreateCommentReportCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreateCommentReport extends _CreateCommentReport {
-  const _$_CreateCommentReport(
+class _$CreateCommentReportImpl extends _CreateCommentReport {
+  const _$CreateCommentReportImpl(
       {required this.commentId, required this.reason, this.auth})
       : super._();
 
-  factory _$_CreateCommentReport.fromJson(Map<String, dynamic> json) =>
-      _$$_CreateCommentReportFromJson(json);
+  factory _$CreateCommentReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreateCommentReportImplFromJson(json);
 
   @override
   final int commentId;
@@ -2265,7 +2268,7 @@ class _$_CreateCommentReport extends _CreateCommentReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreateCommentReport &&
+            other is _$CreateCommentReportImpl &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
             (identical(other.reason, reason) || other.reason == reason) &&
@@ -2279,13 +2282,13 @@ class _$_CreateCommentReport extends _CreateCommentReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreateCommentReportCopyWith<_$_CreateCommentReport> get copyWith =>
-      __$$_CreateCommentReportCopyWithImpl<_$_CreateCommentReport>(
+  _$$CreateCommentReportImplCopyWith<_$CreateCommentReportImpl> get copyWith =>
+      __$$CreateCommentReportImplCopyWithImpl<_$CreateCommentReportImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreateCommentReportToJson(
+    return _$$CreateCommentReportImplToJson(
       this,
     );
   }
@@ -2295,11 +2298,11 @@ abstract class _CreateCommentReport extends CreateCommentReport {
   const factory _CreateCommentReport(
       {required final int commentId,
       required final String reason,
-      final String? auth}) = _$_CreateCommentReport;
+      final String? auth}) = _$CreateCommentReportImpl;
   const _CreateCommentReport._() : super._();
 
   factory _CreateCommentReport.fromJson(Map<String, dynamic> json) =
-      _$_CreateCommentReport.fromJson;
+      _$CreateCommentReportImpl.fromJson;
 
   @override
   int get commentId;
@@ -2309,7 +2312,7 @@ abstract class _CreateCommentReport extends CreateCommentReport {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreateCommentReportCopyWith<_$_CreateCommentReport> get copyWith =>
+  _$$CreateCommentReportImplCopyWith<_$CreateCommentReportImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2374,22 +2377,22 @@ class _$ResolveCommentReportCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ResolveCommentReportCopyWith<$Res>
+abstract class _$$ResolveCommentReportImplCopyWith<$Res>
     implements $ResolveCommentReportCopyWith<$Res> {
-  factory _$$_ResolveCommentReportCopyWith(_$_ResolveCommentReport value,
-          $Res Function(_$_ResolveCommentReport) then) =
-      __$$_ResolveCommentReportCopyWithImpl<$Res>;
+  factory _$$ResolveCommentReportImplCopyWith(_$ResolveCommentReportImpl value,
+          $Res Function(_$ResolveCommentReportImpl) then) =
+      __$$ResolveCommentReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int reportId, bool resolved, String? auth});
 }
 
 /// @nodoc
-class __$$_ResolveCommentReportCopyWithImpl<$Res>
-    extends _$ResolveCommentReportCopyWithImpl<$Res, _$_ResolveCommentReport>
-    implements _$$_ResolveCommentReportCopyWith<$Res> {
-  __$$_ResolveCommentReportCopyWithImpl(_$_ResolveCommentReport _value,
-      $Res Function(_$_ResolveCommentReport) _then)
+class __$$ResolveCommentReportImplCopyWithImpl<$Res>
+    extends _$ResolveCommentReportCopyWithImpl<$Res, _$ResolveCommentReportImpl>
+    implements _$$ResolveCommentReportImplCopyWith<$Res> {
+  __$$ResolveCommentReportImplCopyWithImpl(_$ResolveCommentReportImpl _value,
+      $Res Function(_$ResolveCommentReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2399,7 +2402,7 @@ class __$$_ResolveCommentReportCopyWithImpl<$Res>
     Object? resolved = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_ResolveCommentReport(
+    return _then(_$ResolveCommentReportImpl(
       reportId: null == reportId
           ? _value.reportId
           : reportId // ignore: cast_nullable_to_non_nullable
@@ -2419,13 +2422,13 @@ class __$$_ResolveCommentReportCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ResolveCommentReport extends _ResolveCommentReport {
-  const _$_ResolveCommentReport(
+class _$ResolveCommentReportImpl extends _ResolveCommentReport {
+  const _$ResolveCommentReportImpl(
       {required this.reportId, required this.resolved, this.auth})
       : super._();
 
-  factory _$_ResolveCommentReport.fromJson(Map<String, dynamic> json) =>
-      _$$_ResolveCommentReportFromJson(json);
+  factory _$ResolveCommentReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ResolveCommentReportImplFromJson(json);
 
   @override
   final int reportId;
@@ -2443,7 +2446,7 @@ class _$_ResolveCommentReport extends _ResolveCommentReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ResolveCommentReport &&
+            other is _$ResolveCommentReportImpl &&
             (identical(other.reportId, reportId) ||
                 other.reportId == reportId) &&
             (identical(other.resolved, resolved) ||
@@ -2458,13 +2461,14 @@ class _$_ResolveCommentReport extends _ResolveCommentReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ResolveCommentReportCopyWith<_$_ResolveCommentReport> get copyWith =>
-      __$$_ResolveCommentReportCopyWithImpl<_$_ResolveCommentReport>(
-          this, _$identity);
+  _$$ResolveCommentReportImplCopyWith<_$ResolveCommentReportImpl>
+      get copyWith =>
+          __$$ResolveCommentReportImplCopyWithImpl<_$ResolveCommentReportImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ResolveCommentReportToJson(
+    return _$$ResolveCommentReportImplToJson(
       this,
     );
   }
@@ -2474,11 +2478,11 @@ abstract class _ResolveCommentReport extends ResolveCommentReport {
   const factory _ResolveCommentReport(
       {required final int reportId,
       required final bool resolved,
-      final String? auth}) = _$_ResolveCommentReport;
+      final String? auth}) = _$ResolveCommentReportImpl;
   const _ResolveCommentReport._() : super._();
 
   factory _ResolveCommentReport.fromJson(Map<String, dynamic> json) =
-      _$_ResolveCommentReport.fromJson;
+      _$ResolveCommentReportImpl.fromJson;
 
   @override
   int get reportId;
@@ -2488,8 +2492,8 @@ abstract class _ResolveCommentReport extends ResolveCommentReport {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ResolveCommentReportCopyWith<_$_ResolveCommentReport> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ResolveCommentReportImplCopyWith<_$ResolveCommentReportImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 ListCommentReports _$ListCommentReportsFromJson(Map<String, dynamic> json) {
@@ -2569,11 +2573,11 @@ class _$ListCommentReportsCopyWithImpl<$Res, $Val extends ListCommentReports>
 }
 
 /// @nodoc
-abstract class _$$_ListCommentReportsCopyWith<$Res>
+abstract class _$$ListCommentReportsImplCopyWith<$Res>
     implements $ListCommentReportsCopyWith<$Res> {
-  factory _$$_ListCommentReportsCopyWith(_$_ListCommentReports value,
-          $Res Function(_$_ListCommentReports) then) =
-      __$$_ListCommentReportsCopyWithImpl<$Res>;
+  factory _$$ListCommentReportsImplCopyWith(_$ListCommentReportsImpl value,
+          $Res Function(_$ListCommentReportsImpl) then) =
+      __$$ListCommentReportsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2585,11 +2589,11 @@ abstract class _$$_ListCommentReportsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ListCommentReportsCopyWithImpl<$Res>
-    extends _$ListCommentReportsCopyWithImpl<$Res, _$_ListCommentReports>
-    implements _$$_ListCommentReportsCopyWith<$Res> {
-  __$$_ListCommentReportsCopyWithImpl(
-      _$_ListCommentReports _value, $Res Function(_$_ListCommentReports) _then)
+class __$$ListCommentReportsImplCopyWithImpl<$Res>
+    extends _$ListCommentReportsCopyWithImpl<$Res, _$ListCommentReportsImpl>
+    implements _$$ListCommentReportsImplCopyWith<$Res> {
+  __$$ListCommentReportsImplCopyWithImpl(_$ListCommentReportsImpl _value,
+      $Res Function(_$ListCommentReportsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2601,7 +2605,7 @@ class __$$_ListCommentReportsCopyWithImpl<$Res>
     Object? communityId = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_ListCommentReports(
+    return _then(_$ListCommentReportsImpl(
       page: freezed == page
           ? _value.page
           : page // ignore: cast_nullable_to_non_nullable
@@ -2629,13 +2633,13 @@ class __$$_ListCommentReportsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ListCommentReports extends _ListCommentReports {
-  const _$_ListCommentReports(
+class _$ListCommentReportsImpl extends _ListCommentReports {
+  const _$ListCommentReportsImpl(
       {this.page, this.limit, this.unresolvedOnly, this.communityId, this.auth})
       : super._();
 
-  factory _$_ListCommentReports.fromJson(Map<String, dynamic> json) =>
-      _$$_ListCommentReportsFromJson(json);
+  factory _$ListCommentReportsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ListCommentReportsImplFromJson(json);
 
   @override
   final int? page;
@@ -2657,7 +2661,7 @@ class _$_ListCommentReports extends _ListCommentReports {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListCommentReports &&
+            other is _$ListCommentReportsImpl &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
             (identical(other.unresolvedOnly, unresolvedOnly) ||
@@ -2675,13 +2679,13 @@ class _$_ListCommentReports extends _ListCommentReports {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListCommentReportsCopyWith<_$_ListCommentReports> get copyWith =>
-      __$$_ListCommentReportsCopyWithImpl<_$_ListCommentReports>(
+  _$$ListCommentReportsImplCopyWith<_$ListCommentReportsImpl> get copyWith =>
+      __$$ListCommentReportsImplCopyWithImpl<_$ListCommentReportsImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListCommentReportsToJson(
+    return _$$ListCommentReportsImplToJson(
       this,
     );
   }
@@ -2693,11 +2697,11 @@ abstract class _ListCommentReports extends ListCommentReports {
       final int? limit,
       final bool? unresolvedOnly,
       final int? communityId,
-      final String? auth}) = _$_ListCommentReports;
+      final String? auth}) = _$ListCommentReportsImpl;
   const _ListCommentReports._() : super._();
 
   factory _ListCommentReports.fromJson(Map<String, dynamic> json) =
-      _$_ListCommentReports.fromJson;
+      _$ListCommentReportsImpl.fromJson;
 
   @override
   int? get page;
@@ -2711,6 +2715,6 @@ abstract class _ListCommentReports extends ListCommentReports {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ListCommentReportsCopyWith<_$_ListCommentReports> get copyWith =>
+  _$$ListCommentReportsImplCopyWith<_$ListCommentReportsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/comment/comment.g.dart
+++ b/lib/src/v3/api/comment/comment.g.dart
@@ -6,8 +6,8 @@ part of 'comment.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CreateComment _$$_CreateCommentFromJson(Map<String, dynamic> json) =>
-    _$_CreateComment(
+_$CreateCommentImpl _$$CreateCommentImplFromJson(Map<String, dynamic> json) =>
+    _$CreateCommentImpl(
       content: json['content'] as String,
       postId: json['post_id'] as int,
       parentId: json['parent_id'] as int?,
@@ -16,7 +16,7 @@ _$_CreateComment _$$_CreateCommentFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_CreateCommentToJson(_$_CreateComment instance) {
+Map<String, dynamic> _$$CreateCommentImplToJson(_$CreateCommentImpl instance) {
   final val = <String, dynamic>{
     'content': instance.content,
     'post_id': instance.postId,
@@ -35,8 +35,8 @@ Map<String, dynamic> _$$_CreateCommentToJson(_$_CreateComment instance) {
   return val;
 }
 
-_$_EditComment _$$_EditCommentFromJson(Map<String, dynamic> json) =>
-    _$_EditComment(
+_$EditCommentImpl _$$EditCommentImplFromJson(Map<String, dynamic> json) =>
+    _$EditCommentImpl(
       commentId: json['comment_id'] as int,
       content: json['content'] as String?,
       languageId: json['language_id'] as int?,
@@ -44,7 +44,7 @@ _$_EditComment _$$_EditCommentFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_EditCommentToJson(_$_EditComment instance) {
+Map<String, dynamic> _$$EditCommentImplToJson(_$EditCommentImpl instance) {
   final val = <String, dynamic>{
     'comment_id': instance.commentId,
   };
@@ -62,14 +62,14 @@ Map<String, dynamic> _$$_EditCommentToJson(_$_EditComment instance) {
   return val;
 }
 
-_$_DeleteComment _$$_DeleteCommentFromJson(Map<String, dynamic> json) =>
-    _$_DeleteComment(
+_$DeleteCommentImpl _$$DeleteCommentImplFromJson(Map<String, dynamic> json) =>
+    _$DeleteCommentImpl(
       commentId: json['comment_id'] as int,
       deleted: json['deleted'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_DeleteCommentToJson(_$_DeleteComment instance) {
+Map<String, dynamic> _$$DeleteCommentImplToJson(_$DeleteCommentImpl instance) {
   final val = <String, dynamic>{
     'comment_id': instance.commentId,
     'deleted': instance.deleted,
@@ -85,15 +85,15 @@ Map<String, dynamic> _$$_DeleteCommentToJson(_$_DeleteComment instance) {
   return val;
 }
 
-_$_RemoveComment _$$_RemoveCommentFromJson(Map<String, dynamic> json) =>
-    _$_RemoveComment(
+_$RemoveCommentImpl _$$RemoveCommentImplFromJson(Map<String, dynamic> json) =>
+    _$RemoveCommentImpl(
       commentId: json['comment_id'] as int,
       removed: json['removed'] as bool,
       reason: json['reason'] as String?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_RemoveCommentToJson(_$_RemoveComment instance) {
+Map<String, dynamic> _$$RemoveCommentImplToJson(_$RemoveCommentImpl instance) {
   final val = <String, dynamic>{
     'comment_id': instance.commentId,
     'removed': instance.removed,
@@ -110,16 +110,16 @@ Map<String, dynamic> _$$_RemoveCommentToJson(_$_RemoveComment instance) {
   return val;
 }
 
-_$_MarkCommentReplyAsRead _$$_MarkCommentReplyAsReadFromJson(
+_$MarkCommentReplyAsReadImpl _$$MarkCommentReplyAsReadImplFromJson(
         Map<String, dynamic> json) =>
-    _$_MarkCommentReplyAsRead(
+    _$MarkCommentReplyAsReadImpl(
       commentReplyId: json['comment_reply_id'] as int,
       read: json['read'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_MarkCommentReplyAsReadToJson(
-    _$_MarkCommentReplyAsRead instance) {
+Map<String, dynamic> _$$MarkCommentReplyAsReadImplToJson(
+    _$MarkCommentReplyAsReadImpl instance) {
   final val = <String, dynamic>{
     'comment_reply_id': instance.commentReplyId,
     'read': instance.read,
@@ -135,15 +135,16 @@ Map<String, dynamic> _$$_MarkCommentReplyAsReadToJson(
   return val;
 }
 
-_$_CreateCommentLike _$$_CreateCommentLikeFromJson(Map<String, dynamic> json) =>
-    _$_CreateCommentLike(
+_$CreateCommentLikeImpl _$$CreateCommentLikeImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CreateCommentLikeImpl(
       commentId: json['comment_id'] as int,
       score: json['score'] as num,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_CreateCommentLikeToJson(
-    _$_CreateCommentLike instance) {
+Map<String, dynamic> _$$CreateCommentLikeImplToJson(
+    _$CreateCommentLikeImpl instance) {
   final val = <String, dynamic>{
     'comment_id': instance.commentId,
     'score': instance.score,
@@ -159,14 +160,14 @@ Map<String, dynamic> _$$_CreateCommentLikeToJson(
   return val;
 }
 
-_$_SaveComment _$$_SaveCommentFromJson(Map<String, dynamic> json) =>
-    _$_SaveComment(
+_$SaveCommentImpl _$$SaveCommentImplFromJson(Map<String, dynamic> json) =>
+    _$SaveCommentImpl(
       commentId: json['comment_id'] as int,
       save: json['save'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_SaveCommentToJson(_$_SaveComment instance) {
+Map<String, dynamic> _$$SaveCommentImplToJson(_$SaveCommentImpl instance) {
   final val = <String, dynamic>{
     'comment_id': instance.commentId,
     'save': instance.save,
@@ -182,16 +183,16 @@ Map<String, dynamic> _$$_SaveCommentToJson(_$_SaveComment instance) {
   return val;
 }
 
-_$_DistinguishComment _$$_DistinguishCommentFromJson(
+_$DistinguishCommentImpl _$$DistinguishCommentImplFromJson(
         Map<String, dynamic> json) =>
-    _$_DistinguishComment(
+    _$DistinguishCommentImpl(
       commentId: json['comment_id'] as int,
       distinguished: json['distinguished'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_DistinguishCommentToJson(
-    _$_DistinguishComment instance) {
+Map<String, dynamic> _$$DistinguishCommentImplToJson(
+    _$DistinguishCommentImpl instance) {
   final val = <String, dynamic>{
     'comment_id': instance.commentId,
     'distinguished': instance.distinguished,
@@ -207,8 +208,8 @@ Map<String, dynamic> _$$_DistinguishCommentToJson(
   return val;
 }
 
-_$_GetComments _$$_GetCommentsFromJson(Map<String, dynamic> json) =>
-    _$_GetComments(
+_$GetCommentsImpl _$$GetCommentsImplFromJson(Map<String, dynamic> json) =>
+    _$GetCommentsImpl(
       type: json['type_'] == null ? null : ListingType.fromJson(json['type_']),
       sort:
           json['sort'] == null ? null : CommentSortType.fromJson(json['sort']),
@@ -225,7 +226,7 @@ _$_GetComments _$$_GetCommentsFromJson(Map<String, dynamic> json) =>
       dislikedOnly: json['disliked_only'] as bool?,
     );
 
-Map<String, dynamic> _$$_GetCommentsToJson(_$_GetComments instance) {
+Map<String, dynamic> _$$GetCommentsImplToJson(_$GetCommentsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -250,13 +251,13 @@ Map<String, dynamic> _$$_GetCommentsToJson(_$_GetComments instance) {
   return val;
 }
 
-_$_GetComment _$$_GetCommentFromJson(Map<String, dynamic> json) =>
-    _$_GetComment(
+_$GetCommentImpl _$$GetCommentImplFromJson(Map<String, dynamic> json) =>
+    _$GetCommentImpl(
       id: json['id'] as int,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetCommentToJson(_$_GetComment instance) {
+Map<String, dynamic> _$$GetCommentImplToJson(_$GetCommentImpl instance) {
   final val = <String, dynamic>{
     'id': instance.id,
   };
@@ -271,16 +272,16 @@ Map<String, dynamic> _$$_GetCommentToJson(_$_GetComment instance) {
   return val;
 }
 
-_$_CreateCommentReport _$$_CreateCommentReportFromJson(
+_$CreateCommentReportImpl _$$CreateCommentReportImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CreateCommentReport(
+    _$CreateCommentReportImpl(
       commentId: json['comment_id'] as int,
       reason: json['reason'] as String,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_CreateCommentReportToJson(
-    _$_CreateCommentReport instance) {
+Map<String, dynamic> _$$CreateCommentReportImplToJson(
+    _$CreateCommentReportImpl instance) {
   final val = <String, dynamic>{
     'comment_id': instance.commentId,
     'reason': instance.reason,
@@ -296,16 +297,16 @@ Map<String, dynamic> _$$_CreateCommentReportToJson(
   return val;
 }
 
-_$_ResolveCommentReport _$$_ResolveCommentReportFromJson(
+_$ResolveCommentReportImpl _$$ResolveCommentReportImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ResolveCommentReport(
+    _$ResolveCommentReportImpl(
       reportId: json['report_id'] as int,
       resolved: json['resolved'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ResolveCommentReportToJson(
-    _$_ResolveCommentReport instance) {
+Map<String, dynamic> _$$ResolveCommentReportImplToJson(
+    _$ResolveCommentReportImpl instance) {
   final val = <String, dynamic>{
     'report_id': instance.reportId,
     'resolved': instance.resolved,
@@ -321,9 +322,9 @@ Map<String, dynamic> _$$_ResolveCommentReportToJson(
   return val;
 }
 
-_$_ListCommentReports _$$_ListCommentReportsFromJson(
+_$ListCommentReportsImpl _$$ListCommentReportsImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ListCommentReports(
+    _$ListCommentReportsImpl(
       page: json['page'] as int?,
       limit: json['limit'] as int?,
       unresolvedOnly: json['unresolved_only'] as bool?,
@@ -331,8 +332,8 @@ _$_ListCommentReports _$$_ListCommentReportsFromJson(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ListCommentReportsToJson(
-    _$_ListCommentReports instance) {
+Map<String, dynamic> _$$ListCommentReportsImplToJson(
+    _$ListCommentReportsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {

--- a/lib/src/v3/api/community/community.freezed.dart
+++ b/lib/src/v3/api/community/community.freezed.dart
@@ -74,22 +74,22 @@ class _$GetCommunityCopyWithImpl<$Res, $Val extends GetCommunity>
 }
 
 /// @nodoc
-abstract class _$$_GetCommunityCopyWith<$Res>
+abstract class _$$GetCommunityImplCopyWith<$Res>
     implements $GetCommunityCopyWith<$Res> {
-  factory _$$_GetCommunityCopyWith(
-          _$_GetCommunity value, $Res Function(_$_GetCommunity) then) =
-      __$$_GetCommunityCopyWithImpl<$Res>;
+  factory _$$GetCommunityImplCopyWith(
+          _$GetCommunityImpl value, $Res Function(_$GetCommunityImpl) then) =
+      __$$GetCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int? id, String? name, String? auth});
 }
 
 /// @nodoc
-class __$$_GetCommunityCopyWithImpl<$Res>
-    extends _$GetCommunityCopyWithImpl<$Res, _$_GetCommunity>
-    implements _$$_GetCommunityCopyWith<$Res> {
-  __$$_GetCommunityCopyWithImpl(
-      _$_GetCommunity _value, $Res Function(_$_GetCommunity) _then)
+class __$$GetCommunityImplCopyWithImpl<$Res>
+    extends _$GetCommunityCopyWithImpl<$Res, _$GetCommunityImpl>
+    implements _$$GetCommunityImplCopyWith<$Res> {
+  __$$GetCommunityImplCopyWithImpl(
+      _$GetCommunityImpl _value, $Res Function(_$GetCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -99,7 +99,7 @@ class __$$_GetCommunityCopyWithImpl<$Res>
     Object? name = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetCommunity(
+    return _then(_$GetCommunityImpl(
       id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -119,11 +119,11 @@ class __$$_GetCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetCommunity extends _GetCommunity {
-  const _$_GetCommunity({this.id, this.name, this.auth}) : super._();
+class _$GetCommunityImpl extends _GetCommunity {
+  const _$GetCommunityImpl({this.id, this.name, this.auth}) : super._();
 
-  factory _$_GetCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_GetCommunityFromJson(json);
+  factory _$GetCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetCommunityImplFromJson(json);
 
   @override
   final int? id;
@@ -141,7 +141,7 @@ class _$_GetCommunity extends _GetCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetCommunity &&
+            other is _$GetCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -154,12 +154,12 @@ class _$_GetCommunity extends _GetCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetCommunityCopyWith<_$_GetCommunity> get copyWith =>
-      __$$_GetCommunityCopyWithImpl<_$_GetCommunity>(this, _$identity);
+  _$$GetCommunityImplCopyWith<_$GetCommunityImpl> get copyWith =>
+      __$$GetCommunityImplCopyWithImpl<_$GetCommunityImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetCommunityToJson(
+    return _$$GetCommunityImplToJson(
       this,
     );
   }
@@ -169,11 +169,11 @@ abstract class _GetCommunity extends GetCommunity {
   const factory _GetCommunity(
       {final int? id,
       final String? name,
-      final String? auth}) = _$_GetCommunity;
+      final String? auth}) = _$GetCommunityImpl;
   const _GetCommunity._() : super._();
 
   factory _GetCommunity.fromJson(Map<String, dynamic> json) =
-      _$_GetCommunity.fromJson;
+      _$GetCommunityImpl.fromJson;
 
   @override
   int? get id;
@@ -183,7 +183,7 @@ abstract class _GetCommunity extends GetCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetCommunityCopyWith<_$_GetCommunity> get copyWith =>
+  _$$GetCommunityImplCopyWith<_$GetCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -292,11 +292,11 @@ class _$CreateCommunityCopyWithImpl<$Res, $Val extends CreateCommunity>
 }
 
 /// @nodoc
-abstract class _$$_CreateCommunityCopyWith<$Res>
+abstract class _$$CreateCommunityImplCopyWith<$Res>
     implements $CreateCommunityCopyWith<$Res> {
-  factory _$$_CreateCommunityCopyWith(
-          _$_CreateCommunity value, $Res Function(_$_CreateCommunity) then) =
-      __$$_CreateCommunityCopyWithImpl<$Res>;
+  factory _$$CreateCommunityImplCopyWith(_$CreateCommunityImpl value,
+          $Res Function(_$CreateCommunityImpl) then) =
+      __$$CreateCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -312,11 +312,11 @@ abstract class _$$_CreateCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CreateCommunityCopyWithImpl<$Res>
-    extends _$CreateCommunityCopyWithImpl<$Res, _$_CreateCommunity>
-    implements _$$_CreateCommunityCopyWith<$Res> {
-  __$$_CreateCommunityCopyWithImpl(
-      _$_CreateCommunity _value, $Res Function(_$_CreateCommunity) _then)
+class __$$CreateCommunityImplCopyWithImpl<$Res>
+    extends _$CreateCommunityCopyWithImpl<$Res, _$CreateCommunityImpl>
+    implements _$$CreateCommunityImplCopyWith<$Res> {
+  __$$CreateCommunityImplCopyWithImpl(
+      _$CreateCommunityImpl _value, $Res Function(_$CreateCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -332,7 +332,7 @@ class __$$_CreateCommunityCopyWithImpl<$Res>
     Object? discussionLanguages = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_CreateCommunity(
+    return _then(_$CreateCommunityImpl(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -376,8 +376,8 @@ class __$$_CreateCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreateCommunity extends _CreateCommunity {
-  const _$_CreateCommunity(
+class _$CreateCommunityImpl extends _CreateCommunity {
+  const _$CreateCommunityImpl(
       {required this.name,
       required this.title,
       this.description,
@@ -390,8 +390,8 @@ class _$_CreateCommunity extends _CreateCommunity {
       : _discussionLanguages = discussionLanguages,
         super._();
 
-  factory _$_CreateCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_CreateCommunityFromJson(json);
+  factory _$CreateCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreateCommunityImplFromJson(json);
 
   @override
   final String name;
@@ -430,7 +430,7 @@ class _$_CreateCommunity extends _CreateCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreateCommunity &&
+            other is _$CreateCommunityImpl &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.description, description) ||
@@ -463,12 +463,13 @@ class _$_CreateCommunity extends _CreateCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreateCommunityCopyWith<_$_CreateCommunity> get copyWith =>
-      __$$_CreateCommunityCopyWithImpl<_$_CreateCommunity>(this, _$identity);
+  _$$CreateCommunityImplCopyWith<_$CreateCommunityImpl> get copyWith =>
+      __$$CreateCommunityImplCopyWithImpl<_$CreateCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreateCommunityToJson(
+    return _$$CreateCommunityImplToJson(
       this,
     );
   }
@@ -484,11 +485,11 @@ abstract class _CreateCommunity extends CreateCommunity {
       final bool? nsfw,
       final bool? postingRestrictedToMods,
       final List<int>? discussionLanguages,
-      final String? auth}) = _$_CreateCommunity;
+      final String? auth}) = _$CreateCommunityImpl;
   const _CreateCommunity._() : super._();
 
   factory _CreateCommunity.fromJson(Map<String, dynamic> json) =
-      _$_CreateCommunity.fromJson;
+      _$CreateCommunityImpl.fromJson;
 
   @override
   String get name;
@@ -510,7 +511,7 @@ abstract class _CreateCommunity extends CreateCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreateCommunityCopyWith<_$_CreateCommunity> get copyWith =>
+  _$$CreateCommunityImplCopyWith<_$CreateCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -619,11 +620,11 @@ class _$EditCommunityCopyWithImpl<$Res, $Val extends EditCommunity>
 }
 
 /// @nodoc
-abstract class _$$_EditCommunityCopyWith<$Res>
+abstract class _$$EditCommunityImplCopyWith<$Res>
     implements $EditCommunityCopyWith<$Res> {
-  factory _$$_EditCommunityCopyWith(
-          _$_EditCommunity value, $Res Function(_$_EditCommunity) then) =
-      __$$_EditCommunityCopyWithImpl<$Res>;
+  factory _$$EditCommunityImplCopyWith(
+          _$EditCommunityImpl value, $Res Function(_$EditCommunityImpl) then) =
+      __$$EditCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -639,11 +640,11 @@ abstract class _$$_EditCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_EditCommunityCopyWithImpl<$Res>
-    extends _$EditCommunityCopyWithImpl<$Res, _$_EditCommunity>
-    implements _$$_EditCommunityCopyWith<$Res> {
-  __$$_EditCommunityCopyWithImpl(
-      _$_EditCommunity _value, $Res Function(_$_EditCommunity) _then)
+class __$$EditCommunityImplCopyWithImpl<$Res>
+    extends _$EditCommunityCopyWithImpl<$Res, _$EditCommunityImpl>
+    implements _$$EditCommunityImplCopyWith<$Res> {
+  __$$EditCommunityImplCopyWithImpl(
+      _$EditCommunityImpl _value, $Res Function(_$EditCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -659,7 +660,7 @@ class __$$_EditCommunityCopyWithImpl<$Res>
     Object? discussionLanguages = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_EditCommunity(
+    return _then(_$EditCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -703,8 +704,8 @@ class __$$_EditCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_EditCommunity extends _EditCommunity {
-  const _$_EditCommunity(
+class _$EditCommunityImpl extends _EditCommunity {
+  const _$EditCommunityImpl(
       {required this.communityId,
       this.title,
       this.description,
@@ -717,8 +718,8 @@ class _$_EditCommunity extends _EditCommunity {
       : _discussionLanguages = discussionLanguages,
         super._();
 
-  factory _$_EditCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_EditCommunityFromJson(json);
+  factory _$EditCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EditCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -757,7 +758,7 @@ class _$_EditCommunity extends _EditCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_EditCommunity &&
+            other is _$EditCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.title, title) || other.title == title) &&
@@ -791,12 +792,12 @@ class _$_EditCommunity extends _EditCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_EditCommunityCopyWith<_$_EditCommunity> get copyWith =>
-      __$$_EditCommunityCopyWithImpl<_$_EditCommunity>(this, _$identity);
+  _$$EditCommunityImplCopyWith<_$EditCommunityImpl> get copyWith =>
+      __$$EditCommunityImplCopyWithImpl<_$EditCommunityImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_EditCommunityToJson(
+    return _$$EditCommunityImplToJson(
       this,
     );
   }
@@ -812,11 +813,11 @@ abstract class _EditCommunity extends EditCommunity {
       final bool? nsfw,
       final bool? postingRestrictedToMods,
       final List<int>? discussionLanguages,
-      final String? auth}) = _$_EditCommunity;
+      final String? auth}) = _$EditCommunityImpl;
   const _EditCommunity._() : super._();
 
   factory _EditCommunity.fromJson(Map<String, dynamic> json) =
-      _$_EditCommunity.fromJson;
+      _$EditCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -838,7 +839,7 @@ abstract class _EditCommunity extends EditCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_EditCommunityCopyWith<_$_EditCommunity> get copyWith =>
+  _$$EditCommunityImplCopyWith<_$EditCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -927,11 +928,11 @@ class _$ListCommunitiesCopyWithImpl<$Res, $Val extends ListCommunities>
 }
 
 /// @nodoc
-abstract class _$$_ListCommunitiesCopyWith<$Res>
+abstract class _$$ListCommunitiesImplCopyWith<$Res>
     implements $ListCommunitiesCopyWith<$Res> {
-  factory _$$_ListCommunitiesCopyWith(
-          _$_ListCommunities value, $Res Function(_$_ListCommunities) then) =
-      __$$_ListCommunitiesCopyWithImpl<$Res>;
+  factory _$$ListCommunitiesImplCopyWith(_$ListCommunitiesImpl value,
+          $Res Function(_$ListCommunitiesImpl) then) =
+      __$$ListCommunitiesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -944,11 +945,11 @@ abstract class _$$_ListCommunitiesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ListCommunitiesCopyWithImpl<$Res>
-    extends _$ListCommunitiesCopyWithImpl<$Res, _$_ListCommunities>
-    implements _$$_ListCommunitiesCopyWith<$Res> {
-  __$$_ListCommunitiesCopyWithImpl(
-      _$_ListCommunities _value, $Res Function(_$_ListCommunities) _then)
+class __$$ListCommunitiesImplCopyWithImpl<$Res>
+    extends _$ListCommunitiesCopyWithImpl<$Res, _$ListCommunitiesImpl>
+    implements _$$ListCommunitiesImplCopyWith<$Res> {
+  __$$ListCommunitiesImplCopyWithImpl(
+      _$ListCommunitiesImpl _value, $Res Function(_$ListCommunitiesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -961,7 +962,7 @@ class __$$_ListCommunitiesCopyWithImpl<$Res>
     Object? limit = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_ListCommunities(
+    return _then(_$ListCommunitiesImpl(
       type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -993,8 +994,8 @@ class __$$_ListCommunitiesCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ListCommunities extends _ListCommunities {
-  const _$_ListCommunities(
+class _$ListCommunitiesImpl extends _ListCommunities {
+  const _$ListCommunitiesImpl(
       {@JsonKey(name: 'type_') this.type,
       this.sort,
       this.showNsfw,
@@ -1003,8 +1004,8 @@ class _$_ListCommunities extends _ListCommunities {
       this.auth})
       : super._();
 
-  factory _$_ListCommunities.fromJson(Map<String, dynamic> json) =>
-      _$$_ListCommunitiesFromJson(json);
+  factory _$ListCommunitiesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ListCommunitiesImplFromJson(json);
 
   @override
   @JsonKey(name: 'type_')
@@ -1029,7 +1030,7 @@ class _$_ListCommunities extends _ListCommunities {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListCommunities &&
+            other is _$ListCommunitiesImpl &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.showNsfw, showNsfw) ||
@@ -1047,12 +1048,13 @@ class _$_ListCommunities extends _ListCommunities {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListCommunitiesCopyWith<_$_ListCommunities> get copyWith =>
-      __$$_ListCommunitiesCopyWithImpl<_$_ListCommunities>(this, _$identity);
+  _$$ListCommunitiesImplCopyWith<_$ListCommunitiesImpl> get copyWith =>
+      __$$ListCommunitiesImplCopyWithImpl<_$ListCommunitiesImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListCommunitiesToJson(
+    return _$$ListCommunitiesImplToJson(
       this,
     );
   }
@@ -1065,11 +1067,11 @@ abstract class _ListCommunities extends ListCommunities {
       final bool? showNsfw,
       final int? page,
       final int? limit,
-      final String? auth}) = _$_ListCommunities;
+      final String? auth}) = _$ListCommunitiesImpl;
   const _ListCommunities._() : super._();
 
   factory _ListCommunities.fromJson(Map<String, dynamic> json) =
-      _$_ListCommunities.fromJson;
+      _$ListCommunitiesImpl.fromJson;
 
   @override
   @JsonKey(name: 'type_')
@@ -1086,7 +1088,7 @@ abstract class _ListCommunities extends ListCommunities {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ListCommunitiesCopyWith<_$_ListCommunities> get copyWith =>
+  _$$ListCommunitiesImplCopyWith<_$ListCommunitiesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1150,22 +1152,22 @@ class _$FollowCommunityCopyWithImpl<$Res, $Val extends FollowCommunity>
 }
 
 /// @nodoc
-abstract class _$$_FollowCommunityCopyWith<$Res>
+abstract class _$$FollowCommunityImplCopyWith<$Res>
     implements $FollowCommunityCopyWith<$Res> {
-  factory _$$_FollowCommunityCopyWith(
-          _$_FollowCommunity value, $Res Function(_$_FollowCommunity) then) =
-      __$$_FollowCommunityCopyWithImpl<$Res>;
+  factory _$$FollowCommunityImplCopyWith(_$FollowCommunityImpl value,
+          $Res Function(_$FollowCommunityImpl) then) =
+      __$$FollowCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, bool follow, String? auth});
 }
 
 /// @nodoc
-class __$$_FollowCommunityCopyWithImpl<$Res>
-    extends _$FollowCommunityCopyWithImpl<$Res, _$_FollowCommunity>
-    implements _$$_FollowCommunityCopyWith<$Res> {
-  __$$_FollowCommunityCopyWithImpl(
-      _$_FollowCommunity _value, $Res Function(_$_FollowCommunity) _then)
+class __$$FollowCommunityImplCopyWithImpl<$Res>
+    extends _$FollowCommunityCopyWithImpl<$Res, _$FollowCommunityImpl>
+    implements _$$FollowCommunityImplCopyWith<$Res> {
+  __$$FollowCommunityImplCopyWithImpl(
+      _$FollowCommunityImpl _value, $Res Function(_$FollowCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1175,7 +1177,7 @@ class __$$_FollowCommunityCopyWithImpl<$Res>
     Object? follow = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_FollowCommunity(
+    return _then(_$FollowCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1195,13 +1197,13 @@ class __$$_FollowCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_FollowCommunity extends _FollowCommunity {
-  const _$_FollowCommunity(
+class _$FollowCommunityImpl extends _FollowCommunity {
+  const _$FollowCommunityImpl(
       {required this.communityId, required this.follow, this.auth})
       : super._();
 
-  factory _$_FollowCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_FollowCommunityFromJson(json);
+  factory _$FollowCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FollowCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -1219,7 +1221,7 @@ class _$_FollowCommunity extends _FollowCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FollowCommunity &&
+            other is _$FollowCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.follow, follow) || other.follow == follow) &&
@@ -1233,12 +1235,13 @@ class _$_FollowCommunity extends _FollowCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FollowCommunityCopyWith<_$_FollowCommunity> get copyWith =>
-      __$$_FollowCommunityCopyWithImpl<_$_FollowCommunity>(this, _$identity);
+  _$$FollowCommunityImplCopyWith<_$FollowCommunityImpl> get copyWith =>
+      __$$FollowCommunityImplCopyWithImpl<_$FollowCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FollowCommunityToJson(
+    return _$$FollowCommunityImplToJson(
       this,
     );
   }
@@ -1248,11 +1251,11 @@ abstract class _FollowCommunity extends FollowCommunity {
   const factory _FollowCommunity(
       {required final int communityId,
       required final bool follow,
-      final String? auth}) = _$_FollowCommunity;
+      final String? auth}) = _$FollowCommunityImpl;
   const _FollowCommunity._() : super._();
 
   factory _FollowCommunity.fromJson(Map<String, dynamic> json) =
-      _$_FollowCommunity.fromJson;
+      _$FollowCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -1262,7 +1265,7 @@ abstract class _FollowCommunity extends FollowCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_FollowCommunityCopyWith<_$_FollowCommunity> get copyWith =>
+  _$$FollowCommunityImplCopyWith<_$FollowCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1326,22 +1329,22 @@ class _$BlockCommunityCopyWithImpl<$Res, $Val extends BlockCommunity>
 }
 
 /// @nodoc
-abstract class _$$_BlockCommunityCopyWith<$Res>
+abstract class _$$BlockCommunityImplCopyWith<$Res>
     implements $BlockCommunityCopyWith<$Res> {
-  factory _$$_BlockCommunityCopyWith(
-          _$_BlockCommunity value, $Res Function(_$_BlockCommunity) then) =
-      __$$_BlockCommunityCopyWithImpl<$Res>;
+  factory _$$BlockCommunityImplCopyWith(_$BlockCommunityImpl value,
+          $Res Function(_$BlockCommunityImpl) then) =
+      __$$BlockCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, bool block, String? auth});
 }
 
 /// @nodoc
-class __$$_BlockCommunityCopyWithImpl<$Res>
-    extends _$BlockCommunityCopyWithImpl<$Res, _$_BlockCommunity>
-    implements _$$_BlockCommunityCopyWith<$Res> {
-  __$$_BlockCommunityCopyWithImpl(
-      _$_BlockCommunity _value, $Res Function(_$_BlockCommunity) _then)
+class __$$BlockCommunityImplCopyWithImpl<$Res>
+    extends _$BlockCommunityCopyWithImpl<$Res, _$BlockCommunityImpl>
+    implements _$$BlockCommunityImplCopyWith<$Res> {
+  __$$BlockCommunityImplCopyWithImpl(
+      _$BlockCommunityImpl _value, $Res Function(_$BlockCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1351,7 +1354,7 @@ class __$$_BlockCommunityCopyWithImpl<$Res>
     Object? block = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_BlockCommunity(
+    return _then(_$BlockCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1371,13 +1374,13 @@ class __$$_BlockCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_BlockCommunity extends _BlockCommunity {
-  const _$_BlockCommunity(
+class _$BlockCommunityImpl extends _BlockCommunity {
+  const _$BlockCommunityImpl(
       {required this.communityId, required this.block, this.auth})
       : super._();
 
-  factory _$_BlockCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_BlockCommunityFromJson(json);
+  factory _$BlockCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BlockCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -1395,7 +1398,7 @@ class _$_BlockCommunity extends _BlockCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BlockCommunity &&
+            other is _$BlockCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.block, block) || other.block == block) &&
@@ -1409,12 +1412,13 @@ class _$_BlockCommunity extends _BlockCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BlockCommunityCopyWith<_$_BlockCommunity> get copyWith =>
-      __$$_BlockCommunityCopyWithImpl<_$_BlockCommunity>(this, _$identity);
+  _$$BlockCommunityImplCopyWith<_$BlockCommunityImpl> get copyWith =>
+      __$$BlockCommunityImplCopyWithImpl<_$BlockCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BlockCommunityToJson(
+    return _$$BlockCommunityImplToJson(
       this,
     );
   }
@@ -1424,11 +1428,11 @@ abstract class _BlockCommunity extends BlockCommunity {
   const factory _BlockCommunity(
       {required final int communityId,
       required final bool block,
-      final String? auth}) = _$_BlockCommunity;
+      final String? auth}) = _$BlockCommunityImpl;
   const _BlockCommunity._() : super._();
 
   factory _BlockCommunity.fromJson(Map<String, dynamic> json) =
-      _$_BlockCommunity.fromJson;
+      _$BlockCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -1438,7 +1442,7 @@ abstract class _BlockCommunity extends BlockCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_BlockCommunityCopyWith<_$_BlockCommunity> get copyWith =>
+  _$$BlockCommunityImplCopyWith<_$BlockCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1502,22 +1506,22 @@ class _$DeleteCommunityCopyWithImpl<$Res, $Val extends DeleteCommunity>
 }
 
 /// @nodoc
-abstract class _$$_DeleteCommunityCopyWith<$Res>
+abstract class _$$DeleteCommunityImplCopyWith<$Res>
     implements $DeleteCommunityCopyWith<$Res> {
-  factory _$$_DeleteCommunityCopyWith(
-          _$_DeleteCommunity value, $Res Function(_$_DeleteCommunity) then) =
-      __$$_DeleteCommunityCopyWithImpl<$Res>;
+  factory _$$DeleteCommunityImplCopyWith(_$DeleteCommunityImpl value,
+          $Res Function(_$DeleteCommunityImpl) then) =
+      __$$DeleteCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, bool deleted, String? auth});
 }
 
 /// @nodoc
-class __$$_DeleteCommunityCopyWithImpl<$Res>
-    extends _$DeleteCommunityCopyWithImpl<$Res, _$_DeleteCommunity>
-    implements _$$_DeleteCommunityCopyWith<$Res> {
-  __$$_DeleteCommunityCopyWithImpl(
-      _$_DeleteCommunity _value, $Res Function(_$_DeleteCommunity) _then)
+class __$$DeleteCommunityImplCopyWithImpl<$Res>
+    extends _$DeleteCommunityCopyWithImpl<$Res, _$DeleteCommunityImpl>
+    implements _$$DeleteCommunityImplCopyWith<$Res> {
+  __$$DeleteCommunityImplCopyWithImpl(
+      _$DeleteCommunityImpl _value, $Res Function(_$DeleteCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1527,7 +1531,7 @@ class __$$_DeleteCommunityCopyWithImpl<$Res>
     Object? deleted = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_DeleteCommunity(
+    return _then(_$DeleteCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1547,13 +1551,13 @@ class __$$_DeleteCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_DeleteCommunity extends _DeleteCommunity {
-  const _$_DeleteCommunity(
+class _$DeleteCommunityImpl extends _DeleteCommunity {
+  const _$DeleteCommunityImpl(
       {required this.communityId, required this.deleted, this.auth})
       : super._();
 
-  factory _$_DeleteCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_DeleteCommunityFromJson(json);
+  factory _$DeleteCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeleteCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -1571,7 +1575,7 @@ class _$_DeleteCommunity extends _DeleteCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeleteCommunity &&
+            other is _$DeleteCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.deleted, deleted) || other.deleted == deleted) &&
@@ -1585,12 +1589,13 @@ class _$_DeleteCommunity extends _DeleteCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeleteCommunityCopyWith<_$_DeleteCommunity> get copyWith =>
-      __$$_DeleteCommunityCopyWithImpl<_$_DeleteCommunity>(this, _$identity);
+  _$$DeleteCommunityImplCopyWith<_$DeleteCommunityImpl> get copyWith =>
+      __$$DeleteCommunityImplCopyWithImpl<_$DeleteCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeleteCommunityToJson(
+    return _$$DeleteCommunityImplToJson(
       this,
     );
   }
@@ -1600,11 +1605,11 @@ abstract class _DeleteCommunity extends DeleteCommunity {
   const factory _DeleteCommunity(
       {required final int communityId,
       required final bool deleted,
-      final String? auth}) = _$_DeleteCommunity;
+      final String? auth}) = _$DeleteCommunityImpl;
   const _DeleteCommunity._() : super._();
 
   factory _DeleteCommunity.fromJson(Map<String, dynamic> json) =
-      _$_DeleteCommunity.fromJson;
+      _$DeleteCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -1614,7 +1619,7 @@ abstract class _DeleteCommunity extends DeleteCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_DeleteCommunityCopyWith<_$_DeleteCommunity> get copyWith =>
+  _$$DeleteCommunityImplCopyWith<_$DeleteCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1684,22 +1689,22 @@ class _$HideCommunityCopyWithImpl<$Res, $Val extends HideCommunity>
 }
 
 /// @nodoc
-abstract class _$$_HideCommunityCopyWith<$Res>
+abstract class _$$HideCommunityImplCopyWith<$Res>
     implements $HideCommunityCopyWith<$Res> {
-  factory _$$_HideCommunityCopyWith(
-          _$_HideCommunity value, $Res Function(_$_HideCommunity) then) =
-      __$$_HideCommunityCopyWithImpl<$Res>;
+  factory _$$HideCommunityImplCopyWith(
+          _$HideCommunityImpl value, $Res Function(_$HideCommunityImpl) then) =
+      __$$HideCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth, int communityId, bool hidden, String? reason});
 }
 
 /// @nodoc
-class __$$_HideCommunityCopyWithImpl<$Res>
-    extends _$HideCommunityCopyWithImpl<$Res, _$_HideCommunity>
-    implements _$$_HideCommunityCopyWith<$Res> {
-  __$$_HideCommunityCopyWithImpl(
-      _$_HideCommunity _value, $Res Function(_$_HideCommunity) _then)
+class __$$HideCommunityImplCopyWithImpl<$Res>
+    extends _$HideCommunityCopyWithImpl<$Res, _$HideCommunityImpl>
+    implements _$$HideCommunityImplCopyWith<$Res> {
+  __$$HideCommunityImplCopyWithImpl(
+      _$HideCommunityImpl _value, $Res Function(_$HideCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1710,7 +1715,7 @@ class __$$_HideCommunityCopyWithImpl<$Res>
     Object? hidden = null,
     Object? reason = freezed,
   }) {
-    return _then(_$_HideCommunity(
+    return _then(_$HideCommunityImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -1734,13 +1739,13 @@ class __$$_HideCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_HideCommunity extends _HideCommunity {
-  const _$_HideCommunity(
+class _$HideCommunityImpl extends _HideCommunity {
+  const _$HideCommunityImpl(
       {this.auth, required this.communityId, required this.hidden, this.reason})
       : super._();
 
-  factory _$_HideCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_HideCommunityFromJson(json);
+  factory _$HideCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$HideCommunityImplFromJson(json);
 
   @override
   final String? auth;
@@ -1760,7 +1765,7 @@ class _$_HideCommunity extends _HideCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_HideCommunity &&
+            other is _$HideCommunityImpl &&
             (identical(other.auth, auth) || other.auth == auth) &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
@@ -1776,12 +1781,12 @@ class _$_HideCommunity extends _HideCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_HideCommunityCopyWith<_$_HideCommunity> get copyWith =>
-      __$$_HideCommunityCopyWithImpl<_$_HideCommunity>(this, _$identity);
+  _$$HideCommunityImplCopyWith<_$HideCommunityImpl> get copyWith =>
+      __$$HideCommunityImplCopyWithImpl<_$HideCommunityImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_HideCommunityToJson(
+    return _$$HideCommunityImplToJson(
       this,
     );
   }
@@ -1792,11 +1797,11 @@ abstract class _HideCommunity extends HideCommunity {
       {final String? auth,
       required final int communityId,
       required final bool hidden,
-      final String? reason}) = _$_HideCommunity;
+      final String? reason}) = _$HideCommunityImpl;
   const _HideCommunity._() : super._();
 
   factory _HideCommunity.fromJson(Map<String, dynamic> json) =
-      _$_HideCommunity.fromJson;
+      _$HideCommunityImpl.fromJson;
 
   @override
   String? get auth;
@@ -1808,7 +1813,7 @@ abstract class _HideCommunity extends HideCommunity {
   String? get reason;
   @override
   @JsonKey(ignore: true)
-  _$$_HideCommunityCopyWith<_$_HideCommunity> get copyWith =>
+  _$$HideCommunityImplCopyWith<_$HideCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1890,11 +1895,11 @@ class _$RemoveCommunityCopyWithImpl<$Res, $Val extends RemoveCommunity>
 }
 
 /// @nodoc
-abstract class _$$_RemoveCommunityCopyWith<$Res>
+abstract class _$$RemoveCommunityImplCopyWith<$Res>
     implements $RemoveCommunityCopyWith<$Res> {
-  factory _$$_RemoveCommunityCopyWith(
-          _$_RemoveCommunity value, $Res Function(_$_RemoveCommunity) then) =
-      __$$_RemoveCommunityCopyWithImpl<$Res>;
+  factory _$$RemoveCommunityImplCopyWith(_$RemoveCommunityImpl value,
+          $Res Function(_$RemoveCommunityImpl) then) =
+      __$$RemoveCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1906,11 +1911,11 @@ abstract class _$$_RemoveCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_RemoveCommunityCopyWithImpl<$Res>
-    extends _$RemoveCommunityCopyWithImpl<$Res, _$_RemoveCommunity>
-    implements _$$_RemoveCommunityCopyWith<$Res> {
-  __$$_RemoveCommunityCopyWithImpl(
-      _$_RemoveCommunity _value, $Res Function(_$_RemoveCommunity) _then)
+class __$$RemoveCommunityImplCopyWithImpl<$Res>
+    extends _$RemoveCommunityCopyWithImpl<$Res, _$RemoveCommunityImpl>
+    implements _$$RemoveCommunityImplCopyWith<$Res> {
+  __$$RemoveCommunityImplCopyWithImpl(
+      _$RemoveCommunityImpl _value, $Res Function(_$RemoveCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1922,7 +1927,7 @@ class __$$_RemoveCommunityCopyWithImpl<$Res>
     Object? expires = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_RemoveCommunity(
+    return _then(_$RemoveCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -1950,8 +1955,8 @@ class __$$_RemoveCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_RemoveCommunity extends _RemoveCommunity {
-  const _$_RemoveCommunity(
+class _$RemoveCommunityImpl extends _RemoveCommunity {
+  const _$RemoveCommunityImpl(
       {required this.communityId,
       required this.removed,
       this.reason,
@@ -1959,8 +1964,8 @@ class _$_RemoveCommunity extends _RemoveCommunity {
       this.auth})
       : super._();
 
-  factory _$_RemoveCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_RemoveCommunityFromJson(json);
+  factory _$RemoveCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RemoveCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -1983,7 +1988,7 @@ class _$_RemoveCommunity extends _RemoveCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_RemoveCommunity &&
+            other is _$RemoveCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.removed, removed) || other.removed == removed) &&
@@ -2000,12 +2005,13 @@ class _$_RemoveCommunity extends _RemoveCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RemoveCommunityCopyWith<_$_RemoveCommunity> get copyWith =>
-      __$$_RemoveCommunityCopyWithImpl<_$_RemoveCommunity>(this, _$identity);
+  _$$RemoveCommunityImplCopyWith<_$RemoveCommunityImpl> get copyWith =>
+      __$$RemoveCommunityImplCopyWithImpl<_$RemoveCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RemoveCommunityToJson(
+    return _$$RemoveCommunityImplToJson(
       this,
     );
   }
@@ -2017,11 +2023,11 @@ abstract class _RemoveCommunity extends RemoveCommunity {
       required final bool removed,
       final String? reason,
       @deprecated final int? expires,
-      final String? auth}) = _$_RemoveCommunity;
+      final String? auth}) = _$RemoveCommunityImpl;
   const _RemoveCommunity._() : super._();
 
   factory _RemoveCommunity.fromJson(Map<String, dynamic> json) =
-      _$_RemoveCommunity.fromJson;
+      _$RemoveCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -2036,7 +2042,7 @@ abstract class _RemoveCommunity extends RemoveCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_RemoveCommunityCopyWith<_$_RemoveCommunity> get copyWith =>
+  _$$RemoveCommunityImplCopyWith<_$RemoveCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2100,22 +2106,22 @@ class _$TransferCommunityCopyWithImpl<$Res, $Val extends TransferCommunity>
 }
 
 /// @nodoc
-abstract class _$$_TransferCommunityCopyWith<$Res>
+abstract class _$$TransferCommunityImplCopyWith<$Res>
     implements $TransferCommunityCopyWith<$Res> {
-  factory _$$_TransferCommunityCopyWith(_$_TransferCommunity value,
-          $Res Function(_$_TransferCommunity) then) =
-      __$$_TransferCommunityCopyWithImpl<$Res>;
+  factory _$$TransferCommunityImplCopyWith(_$TransferCommunityImpl value,
+          $Res Function(_$TransferCommunityImpl) then) =
+      __$$TransferCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, int personId, String? auth});
 }
 
 /// @nodoc
-class __$$_TransferCommunityCopyWithImpl<$Res>
-    extends _$TransferCommunityCopyWithImpl<$Res, _$_TransferCommunity>
-    implements _$$_TransferCommunityCopyWith<$Res> {
-  __$$_TransferCommunityCopyWithImpl(
-      _$_TransferCommunity _value, $Res Function(_$_TransferCommunity) _then)
+class __$$TransferCommunityImplCopyWithImpl<$Res>
+    extends _$TransferCommunityCopyWithImpl<$Res, _$TransferCommunityImpl>
+    implements _$$TransferCommunityImplCopyWith<$Res> {
+  __$$TransferCommunityImplCopyWithImpl(_$TransferCommunityImpl _value,
+      $Res Function(_$TransferCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2125,7 +2131,7 @@ class __$$_TransferCommunityCopyWithImpl<$Res>
     Object? personId = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_TransferCommunity(
+    return _then(_$TransferCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -2145,13 +2151,13 @@ class __$$_TransferCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_TransferCommunity extends _TransferCommunity {
-  const _$_TransferCommunity(
+class _$TransferCommunityImpl extends _TransferCommunity {
+  const _$TransferCommunityImpl(
       {required this.communityId, required this.personId, this.auth})
       : super._();
 
-  factory _$_TransferCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_TransferCommunityFromJson(json);
+  factory _$TransferCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TransferCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -2169,7 +2175,7 @@ class _$_TransferCommunity extends _TransferCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_TransferCommunity &&
+            other is _$TransferCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.personId, personId) ||
@@ -2184,13 +2190,13 @@ class _$_TransferCommunity extends _TransferCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_TransferCommunityCopyWith<_$_TransferCommunity> get copyWith =>
-      __$$_TransferCommunityCopyWithImpl<_$_TransferCommunity>(
+  _$$TransferCommunityImplCopyWith<_$TransferCommunityImpl> get copyWith =>
+      __$$TransferCommunityImplCopyWithImpl<_$TransferCommunityImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_TransferCommunityToJson(
+    return _$$TransferCommunityImplToJson(
       this,
     );
   }
@@ -2200,11 +2206,11 @@ abstract class _TransferCommunity extends TransferCommunity {
   const factory _TransferCommunity(
       {required final int communityId,
       required final int personId,
-      final String? auth}) = _$_TransferCommunity;
+      final String? auth}) = _$TransferCommunityImpl;
   const _TransferCommunity._() : super._();
 
   factory _TransferCommunity.fromJson(Map<String, dynamic> json) =
-      _$_TransferCommunity.fromJson;
+      _$TransferCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -2214,7 +2220,7 @@ abstract class _TransferCommunity extends TransferCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_TransferCommunityCopyWith<_$_TransferCommunity> get copyWith =>
+  _$$TransferCommunityImplCopyWith<_$TransferCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2309,11 +2315,11 @@ class _$BanFromCommunityCopyWithImpl<$Res, $Val extends BanFromCommunity>
 }
 
 /// @nodoc
-abstract class _$$_BanFromCommunityCopyWith<$Res>
+abstract class _$$BanFromCommunityImplCopyWith<$Res>
     implements $BanFromCommunityCopyWith<$Res> {
-  factory _$$_BanFromCommunityCopyWith(
-          _$_BanFromCommunity value, $Res Function(_$_BanFromCommunity) then) =
-      __$$_BanFromCommunityCopyWithImpl<$Res>;
+  factory _$$BanFromCommunityImplCopyWith(_$BanFromCommunityImpl value,
+          $Res Function(_$BanFromCommunityImpl) then) =
+      __$$BanFromCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2327,11 +2333,11 @@ abstract class _$$_BanFromCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_BanFromCommunityCopyWithImpl<$Res>
-    extends _$BanFromCommunityCopyWithImpl<$Res, _$_BanFromCommunity>
-    implements _$$_BanFromCommunityCopyWith<$Res> {
-  __$$_BanFromCommunityCopyWithImpl(
-      _$_BanFromCommunity _value, $Res Function(_$_BanFromCommunity) _then)
+class __$$BanFromCommunityImplCopyWithImpl<$Res>
+    extends _$BanFromCommunityCopyWithImpl<$Res, _$BanFromCommunityImpl>
+    implements _$$BanFromCommunityImplCopyWith<$Res> {
+  __$$BanFromCommunityImplCopyWithImpl(_$BanFromCommunityImpl _value,
+      $Res Function(_$BanFromCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2345,7 +2351,7 @@ class __$$_BanFromCommunityCopyWithImpl<$Res>
     Object? expires = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_BanFromCommunity(
+    return _then(_$BanFromCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -2381,8 +2387,8 @@ class __$$_BanFromCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_BanFromCommunity extends _BanFromCommunity {
-  const _$_BanFromCommunity(
+class _$BanFromCommunityImpl extends _BanFromCommunity {
+  const _$BanFromCommunityImpl(
       {required this.communityId,
       required this.personId,
       required this.ban,
@@ -2392,8 +2398,8 @@ class _$_BanFromCommunity extends _BanFromCommunity {
       this.auth})
       : super._();
 
-  factory _$_BanFromCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_BanFromCommunityFromJson(json);
+  factory _$BanFromCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BanFromCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -2419,7 +2425,7 @@ class _$_BanFromCommunity extends _BanFromCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BanFromCommunity &&
+            other is _$BanFromCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.personId, personId) ||
@@ -2440,12 +2446,13 @@ class _$_BanFromCommunity extends _BanFromCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BanFromCommunityCopyWith<_$_BanFromCommunity> get copyWith =>
-      __$$_BanFromCommunityCopyWithImpl<_$_BanFromCommunity>(this, _$identity);
+  _$$BanFromCommunityImplCopyWith<_$BanFromCommunityImpl> get copyWith =>
+      __$$BanFromCommunityImplCopyWithImpl<_$BanFromCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BanFromCommunityToJson(
+    return _$$BanFromCommunityImplToJson(
       this,
     );
   }
@@ -2459,11 +2466,11 @@ abstract class _BanFromCommunity extends BanFromCommunity {
       final bool? removeData,
       final String? reason,
       final int? expires,
-      final String? auth}) = _$_BanFromCommunity;
+      final String? auth}) = _$BanFromCommunityImpl;
   const _BanFromCommunity._() : super._();
 
   factory _BanFromCommunity.fromJson(Map<String, dynamic> json) =
-      _$_BanFromCommunity.fromJson;
+      _$BanFromCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -2481,7 +2488,7 @@ abstract class _BanFromCommunity extends BanFromCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_BanFromCommunityCopyWith<_$_BanFromCommunity> get copyWith =>
+  _$$BanFromCommunityImplCopyWith<_$BanFromCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2551,22 +2558,22 @@ class _$AddModToCommunityCopyWithImpl<$Res, $Val extends AddModToCommunity>
 }
 
 /// @nodoc
-abstract class _$$_AddModToCommunityCopyWith<$Res>
+abstract class _$$AddModToCommunityImplCopyWith<$Res>
     implements $AddModToCommunityCopyWith<$Res> {
-  factory _$$_AddModToCommunityCopyWith(_$_AddModToCommunity value,
-          $Res Function(_$_AddModToCommunity) then) =
-      __$$_AddModToCommunityCopyWithImpl<$Res>;
+  factory _$$AddModToCommunityImplCopyWith(_$AddModToCommunityImpl value,
+          $Res Function(_$AddModToCommunityImpl) then) =
+      __$$AddModToCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int communityId, int personId, bool added, String? auth});
 }
 
 /// @nodoc
-class __$$_AddModToCommunityCopyWithImpl<$Res>
-    extends _$AddModToCommunityCopyWithImpl<$Res, _$_AddModToCommunity>
-    implements _$$_AddModToCommunityCopyWith<$Res> {
-  __$$_AddModToCommunityCopyWithImpl(
-      _$_AddModToCommunity _value, $Res Function(_$_AddModToCommunity) _then)
+class __$$AddModToCommunityImplCopyWithImpl<$Res>
+    extends _$AddModToCommunityCopyWithImpl<$Res, _$AddModToCommunityImpl>
+    implements _$$AddModToCommunityImplCopyWith<$Res> {
+  __$$AddModToCommunityImplCopyWithImpl(_$AddModToCommunityImpl _value,
+      $Res Function(_$AddModToCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2577,7 +2584,7 @@ class __$$_AddModToCommunityCopyWithImpl<$Res>
     Object? added = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_AddModToCommunity(
+    return _then(_$AddModToCommunityImpl(
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -2601,16 +2608,16 @@ class __$$_AddModToCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_AddModToCommunity extends _AddModToCommunity {
-  const _$_AddModToCommunity(
+class _$AddModToCommunityImpl extends _AddModToCommunity {
+  const _$AddModToCommunityImpl(
       {required this.communityId,
       required this.personId,
       required this.added,
       this.auth})
       : super._();
 
-  factory _$_AddModToCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_AddModToCommunityFromJson(json);
+  factory _$AddModToCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AddModToCommunityImplFromJson(json);
 
   @override
   final int communityId;
@@ -2630,7 +2637,7 @@ class _$_AddModToCommunity extends _AddModToCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AddModToCommunity &&
+            other is _$AddModToCommunityImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.personId, personId) ||
@@ -2647,13 +2654,13 @@ class _$_AddModToCommunity extends _AddModToCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AddModToCommunityCopyWith<_$_AddModToCommunity> get copyWith =>
-      __$$_AddModToCommunityCopyWithImpl<_$_AddModToCommunity>(
+  _$$AddModToCommunityImplCopyWith<_$AddModToCommunityImpl> get copyWith =>
+      __$$AddModToCommunityImplCopyWithImpl<_$AddModToCommunityImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AddModToCommunityToJson(
+    return _$$AddModToCommunityImplToJson(
       this,
     );
   }
@@ -2664,11 +2671,11 @@ abstract class _AddModToCommunity extends AddModToCommunity {
       {required final int communityId,
       required final int personId,
       required final bool added,
-      final String? auth}) = _$_AddModToCommunity;
+      final String? auth}) = _$AddModToCommunityImpl;
   const _AddModToCommunity._() : super._();
 
   factory _AddModToCommunity.fromJson(Map<String, dynamic> json) =
-      _$_AddModToCommunity.fromJson;
+      _$AddModToCommunityImpl.fromJson;
 
   @override
   int get communityId;
@@ -2680,6 +2687,6 @@ abstract class _AddModToCommunity extends AddModToCommunity {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_AddModToCommunityCopyWith<_$_AddModToCommunity> get copyWith =>
+  _$$AddModToCommunityImplCopyWith<_$AddModToCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/community/community.g.dart
+++ b/lib/src/v3/api/community/community.g.dart
@@ -6,14 +6,14 @@ part of 'community.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetCommunity _$$_GetCommunityFromJson(Map<String, dynamic> json) =>
-    _$_GetCommunity(
+_$GetCommunityImpl _$$GetCommunityImplFromJson(Map<String, dynamic> json) =>
+    _$GetCommunityImpl(
       id: json['id'] as int?,
       name: json['name'] as String?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetCommunityToJson(_$_GetCommunity instance) {
+Map<String, dynamic> _$$GetCommunityImplToJson(_$GetCommunityImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -28,8 +28,9 @@ Map<String, dynamic> _$$_GetCommunityToJson(_$_GetCommunity instance) {
   return val;
 }
 
-_$_CreateCommunity _$$_CreateCommunityFromJson(Map<String, dynamic> json) =>
-    _$_CreateCommunity(
+_$CreateCommunityImpl _$$CreateCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CreateCommunityImpl(
       name: json['name'] as String,
       title: json['title'] as String,
       description: json['description'] as String?,
@@ -43,7 +44,8 @@ _$_CreateCommunity _$$_CreateCommunityFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_CreateCommunityToJson(_$_CreateCommunity instance) {
+Map<String, dynamic> _$$CreateCommunityImplToJson(
+    _$CreateCommunityImpl instance) {
   final val = <String, dynamic>{
     'name': instance.name,
     'title': instance.title,
@@ -65,8 +67,8 @@ Map<String, dynamic> _$$_CreateCommunityToJson(_$_CreateCommunity instance) {
   return val;
 }
 
-_$_EditCommunity _$$_EditCommunityFromJson(Map<String, dynamic> json) =>
-    _$_EditCommunity(
+_$EditCommunityImpl _$$EditCommunityImplFromJson(Map<String, dynamic> json) =>
+    _$EditCommunityImpl(
       communityId: json['community_id'] as int,
       title: json['title'] as String?,
       description: json['description'] as String?,
@@ -80,7 +82,7 @@ _$_EditCommunity _$$_EditCommunityFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_EditCommunityToJson(_$_EditCommunity instance) {
+Map<String, dynamic> _$$EditCommunityImplToJson(_$EditCommunityImpl instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
   };
@@ -102,8 +104,9 @@ Map<String, dynamic> _$$_EditCommunityToJson(_$_EditCommunity instance) {
   return val;
 }
 
-_$_ListCommunities _$$_ListCommunitiesFromJson(Map<String, dynamic> json) =>
-    _$_ListCommunities(
+_$ListCommunitiesImpl _$$ListCommunitiesImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ListCommunitiesImpl(
       type: json['type_'] == null ? null : ListingType.fromJson(json['type_']),
       sort: json['sort'] == null ? null : SortType.fromJson(json['sort']),
       showNsfw: json['show_nsfw'] as bool?,
@@ -112,7 +115,8 @@ _$_ListCommunities _$$_ListCommunitiesFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ListCommunitiesToJson(_$_ListCommunities instance) {
+Map<String, dynamic> _$$ListCommunitiesImplToJson(
+    _$ListCommunitiesImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -130,14 +134,16 @@ Map<String, dynamic> _$$_ListCommunitiesToJson(_$_ListCommunities instance) {
   return val;
 }
 
-_$_FollowCommunity _$$_FollowCommunityFromJson(Map<String, dynamic> json) =>
-    _$_FollowCommunity(
+_$FollowCommunityImpl _$$FollowCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$FollowCommunityImpl(
       communityId: json['community_id'] as int,
       follow: json['follow'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_FollowCommunityToJson(_$_FollowCommunity instance) {
+Map<String, dynamic> _$$FollowCommunityImplToJson(
+    _$FollowCommunityImpl instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
     'follow': instance.follow,
@@ -153,14 +159,15 @@ Map<String, dynamic> _$$_FollowCommunityToJson(_$_FollowCommunity instance) {
   return val;
 }
 
-_$_BlockCommunity _$$_BlockCommunityFromJson(Map<String, dynamic> json) =>
-    _$_BlockCommunity(
+_$BlockCommunityImpl _$$BlockCommunityImplFromJson(Map<String, dynamic> json) =>
+    _$BlockCommunityImpl(
       communityId: json['community_id'] as int,
       block: json['block'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_BlockCommunityToJson(_$_BlockCommunity instance) {
+Map<String, dynamic> _$$BlockCommunityImplToJson(
+    _$BlockCommunityImpl instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
     'block': instance.block,
@@ -176,14 +183,16 @@ Map<String, dynamic> _$$_BlockCommunityToJson(_$_BlockCommunity instance) {
   return val;
 }
 
-_$_DeleteCommunity _$$_DeleteCommunityFromJson(Map<String, dynamic> json) =>
-    _$_DeleteCommunity(
+_$DeleteCommunityImpl _$$DeleteCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$DeleteCommunityImpl(
       communityId: json['community_id'] as int,
       deleted: json['deleted'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_DeleteCommunityToJson(_$_DeleteCommunity instance) {
+Map<String, dynamic> _$$DeleteCommunityImplToJson(
+    _$DeleteCommunityImpl instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
     'deleted': instance.deleted,
@@ -199,15 +208,15 @@ Map<String, dynamic> _$$_DeleteCommunityToJson(_$_DeleteCommunity instance) {
   return val;
 }
 
-_$_HideCommunity _$$_HideCommunityFromJson(Map<String, dynamic> json) =>
-    _$_HideCommunity(
+_$HideCommunityImpl _$$HideCommunityImplFromJson(Map<String, dynamic> json) =>
+    _$HideCommunityImpl(
       auth: json['auth'] as String?,
       communityId: json['community_id'] as int,
       hidden: json['hidden'] as bool,
       reason: json['reason'] as String?,
     );
 
-Map<String, dynamic> _$$_HideCommunityToJson(_$_HideCommunity instance) {
+Map<String, dynamic> _$$HideCommunityImplToJson(_$HideCommunityImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -223,8 +232,9 @@ Map<String, dynamic> _$$_HideCommunityToJson(_$_HideCommunity instance) {
   return val;
 }
 
-_$_RemoveCommunity _$$_RemoveCommunityFromJson(Map<String, dynamic> json) =>
-    _$_RemoveCommunity(
+_$RemoveCommunityImpl _$$RemoveCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$RemoveCommunityImpl(
       communityId: json['community_id'] as int,
       removed: json['removed'] as bool,
       reason: json['reason'] as String?,
@@ -232,7 +242,8 @@ _$_RemoveCommunity _$$_RemoveCommunityFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_RemoveCommunityToJson(_$_RemoveCommunity instance) {
+Map<String, dynamic> _$$RemoveCommunityImplToJson(
+    _$RemoveCommunityImpl instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
     'removed': instance.removed,
@@ -250,15 +261,16 @@ Map<String, dynamic> _$$_RemoveCommunityToJson(_$_RemoveCommunity instance) {
   return val;
 }
 
-_$_TransferCommunity _$$_TransferCommunityFromJson(Map<String, dynamic> json) =>
-    _$_TransferCommunity(
+_$TransferCommunityImpl _$$TransferCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$TransferCommunityImpl(
       communityId: json['community_id'] as int,
       personId: json['person_id'] as int,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_TransferCommunityToJson(
-    _$_TransferCommunity instance) {
+Map<String, dynamic> _$$TransferCommunityImplToJson(
+    _$TransferCommunityImpl instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
     'person_id': instance.personId,
@@ -274,8 +286,9 @@ Map<String, dynamic> _$$_TransferCommunityToJson(
   return val;
 }
 
-_$_BanFromCommunity _$$_BanFromCommunityFromJson(Map<String, dynamic> json) =>
-    _$_BanFromCommunity(
+_$BanFromCommunityImpl _$$BanFromCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$BanFromCommunityImpl(
       communityId: json['community_id'] as int,
       personId: json['person_id'] as int,
       ban: json['ban'] as bool,
@@ -285,7 +298,8 @@ _$_BanFromCommunity _$$_BanFromCommunityFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_BanFromCommunityToJson(_$_BanFromCommunity instance) {
+Map<String, dynamic> _$$BanFromCommunityImplToJson(
+    _$BanFromCommunityImpl instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
     'person_id': instance.personId,
@@ -305,16 +319,17 @@ Map<String, dynamic> _$$_BanFromCommunityToJson(_$_BanFromCommunity instance) {
   return val;
 }
 
-_$_AddModToCommunity _$$_AddModToCommunityFromJson(Map<String, dynamic> json) =>
-    _$_AddModToCommunity(
+_$AddModToCommunityImpl _$$AddModToCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$AddModToCommunityImpl(
       communityId: json['community_id'] as int,
       personId: json['person_id'] as int,
       added: json['added'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_AddModToCommunityToJson(
-    _$_AddModToCommunity instance) {
+Map<String, dynamic> _$$AddModToCommunityImplToJson(
+    _$AddModToCommunityImpl instance) {
   final val = <String, dynamic>{
     'community_id': instance.communityId,
     'person_id': instance.personId,

--- a/lib/src/v3/api/custom_emoji/custom_emoji.freezed.dart
+++ b/lib/src/v3/api/custom_emoji/custom_emoji.freezed.dart
@@ -98,11 +98,11 @@ class _$CreateCustomEmojiCopyWithImpl<$Res, $Val extends CreateCustomEmoji>
 }
 
 /// @nodoc
-abstract class _$$_CreateCustomEmojiCopyWith<$Res>
+abstract class _$$CreateCustomEmojiImplCopyWith<$Res>
     implements $CreateCustomEmojiCopyWith<$Res> {
-  factory _$$_CreateCustomEmojiCopyWith(_$_CreateCustomEmoji value,
-          $Res Function(_$_CreateCustomEmoji) then) =
-      __$$_CreateCustomEmojiCopyWithImpl<$Res>;
+  factory _$$CreateCustomEmojiImplCopyWith(_$CreateCustomEmojiImpl value,
+          $Res Function(_$CreateCustomEmojiImpl) then) =
+      __$$CreateCustomEmojiImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -115,11 +115,11 @@ abstract class _$$_CreateCustomEmojiCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CreateCustomEmojiCopyWithImpl<$Res>
-    extends _$CreateCustomEmojiCopyWithImpl<$Res, _$_CreateCustomEmoji>
-    implements _$$_CreateCustomEmojiCopyWith<$Res> {
-  __$$_CreateCustomEmojiCopyWithImpl(
-      _$_CreateCustomEmoji _value, $Res Function(_$_CreateCustomEmoji) _then)
+class __$$CreateCustomEmojiImplCopyWithImpl<$Res>
+    extends _$CreateCustomEmojiCopyWithImpl<$Res, _$CreateCustomEmojiImpl>
+    implements _$$CreateCustomEmojiImplCopyWith<$Res> {
+  __$$CreateCustomEmojiImplCopyWithImpl(_$CreateCustomEmojiImpl _value,
+      $Res Function(_$CreateCustomEmojiImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -132,7 +132,7 @@ class __$$_CreateCustomEmojiCopyWithImpl<$Res>
     Object? keywords = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_CreateCustomEmoji(
+    return _then(_$CreateCustomEmojiImpl(
       category: null == category
           ? _value.category
           : category // ignore: cast_nullable_to_non_nullable
@@ -164,8 +164,8 @@ class __$$_CreateCustomEmojiCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreateCustomEmoji extends _CreateCustomEmoji {
-  const _$_CreateCustomEmoji(
+class _$CreateCustomEmojiImpl extends _CreateCustomEmoji {
+  const _$CreateCustomEmojiImpl(
       {required this.category,
       required this.shortcode,
       required this.imageUrl,
@@ -175,8 +175,8 @@ class _$_CreateCustomEmoji extends _CreateCustomEmoji {
       : _keywords = keywords,
         super._();
 
-  factory _$_CreateCustomEmoji.fromJson(Map<String, dynamic> json) =>
-      _$$_CreateCustomEmojiFromJson(json);
+  factory _$CreateCustomEmojiImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreateCustomEmojiImplFromJson(json);
 
   @override
   final String category;
@@ -206,7 +206,7 @@ class _$_CreateCustomEmoji extends _CreateCustomEmoji {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreateCustomEmoji &&
+            other is _$CreateCustomEmojiImpl &&
             (identical(other.category, category) ||
                 other.category == category) &&
             (identical(other.shortcode, shortcode) ||
@@ -226,13 +226,13 @@ class _$_CreateCustomEmoji extends _CreateCustomEmoji {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreateCustomEmojiCopyWith<_$_CreateCustomEmoji> get copyWith =>
-      __$$_CreateCustomEmojiCopyWithImpl<_$_CreateCustomEmoji>(
+  _$$CreateCustomEmojiImplCopyWith<_$CreateCustomEmojiImpl> get copyWith =>
+      __$$CreateCustomEmojiImplCopyWithImpl<_$CreateCustomEmojiImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreateCustomEmojiToJson(
+    return _$$CreateCustomEmojiImplToJson(
       this,
     );
   }
@@ -245,11 +245,11 @@ abstract class _CreateCustomEmoji extends CreateCustomEmoji {
       required final String imageUrl,
       required final String altText,
       required final List<String> keywords,
-      final String? auth}) = _$_CreateCustomEmoji;
+      final String? auth}) = _$CreateCustomEmojiImpl;
   const _CreateCustomEmoji._() : super._();
 
   factory _CreateCustomEmoji.fromJson(Map<String, dynamic> json) =
-      _$_CreateCustomEmoji.fromJson;
+      _$CreateCustomEmojiImpl.fromJson;
 
   @override
   String get category;
@@ -265,7 +265,7 @@ abstract class _CreateCustomEmoji extends CreateCustomEmoji {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreateCustomEmojiCopyWith<_$_CreateCustomEmoji> get copyWith =>
+  _$$CreateCustomEmojiImplCopyWith<_$CreateCustomEmojiImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -353,11 +353,11 @@ class _$EditCustomEmojiCopyWithImpl<$Res, $Val extends EditCustomEmoji>
 }
 
 /// @nodoc
-abstract class _$$_EditCustomEmojiCopyWith<$Res>
+abstract class _$$EditCustomEmojiImplCopyWith<$Res>
     implements $EditCustomEmojiCopyWith<$Res> {
-  factory _$$_EditCustomEmojiCopyWith(
-          _$_EditCustomEmoji value, $Res Function(_$_EditCustomEmoji) then) =
-      __$$_EditCustomEmojiCopyWithImpl<$Res>;
+  factory _$$EditCustomEmojiImplCopyWith(_$EditCustomEmojiImpl value,
+          $Res Function(_$EditCustomEmojiImpl) then) =
+      __$$EditCustomEmojiImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -370,11 +370,11 @@ abstract class _$$_EditCustomEmojiCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_EditCustomEmojiCopyWithImpl<$Res>
-    extends _$EditCustomEmojiCopyWithImpl<$Res, _$_EditCustomEmoji>
-    implements _$$_EditCustomEmojiCopyWith<$Res> {
-  __$$_EditCustomEmojiCopyWithImpl(
-      _$_EditCustomEmoji _value, $Res Function(_$_EditCustomEmoji) _then)
+class __$$EditCustomEmojiImplCopyWithImpl<$Res>
+    extends _$EditCustomEmojiCopyWithImpl<$Res, _$EditCustomEmojiImpl>
+    implements _$$EditCustomEmojiImplCopyWith<$Res> {
+  __$$EditCustomEmojiImplCopyWithImpl(
+      _$EditCustomEmojiImpl _value, $Res Function(_$EditCustomEmojiImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -387,7 +387,7 @@ class __$$_EditCustomEmojiCopyWithImpl<$Res>
     Object? keywords = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_EditCustomEmoji(
+    return _then(_$EditCustomEmojiImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -419,8 +419,8 @@ class __$$_EditCustomEmojiCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_EditCustomEmoji extends _EditCustomEmoji {
-  const _$_EditCustomEmoji(
+class _$EditCustomEmojiImpl extends _EditCustomEmoji {
+  const _$EditCustomEmojiImpl(
       {required this.id,
       required this.category,
       required this.imageUrl,
@@ -430,8 +430,8 @@ class _$_EditCustomEmoji extends _EditCustomEmoji {
       : _keywords = keywords,
         super._();
 
-  factory _$_EditCustomEmoji.fromJson(Map<String, dynamic> json) =>
-      _$$_EditCustomEmojiFromJson(json);
+  factory _$EditCustomEmojiImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EditCustomEmojiImplFromJson(json);
 
   @override
   final int id;
@@ -461,7 +461,7 @@ class _$_EditCustomEmoji extends _EditCustomEmoji {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_EditCustomEmoji &&
+            other is _$EditCustomEmojiImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.category, category) ||
                 other.category == category) &&
@@ -480,12 +480,13 @@ class _$_EditCustomEmoji extends _EditCustomEmoji {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_EditCustomEmojiCopyWith<_$_EditCustomEmoji> get copyWith =>
-      __$$_EditCustomEmojiCopyWithImpl<_$_EditCustomEmoji>(this, _$identity);
+  _$$EditCustomEmojiImplCopyWith<_$EditCustomEmojiImpl> get copyWith =>
+      __$$EditCustomEmojiImplCopyWithImpl<_$EditCustomEmojiImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_EditCustomEmojiToJson(
+    return _$$EditCustomEmojiImplToJson(
       this,
     );
   }
@@ -498,11 +499,11 @@ abstract class _EditCustomEmoji extends EditCustomEmoji {
       required final String imageUrl,
       required final String altText,
       required final List<String> keywords,
-      final String? auth}) = _$_EditCustomEmoji;
+      final String? auth}) = _$EditCustomEmojiImpl;
   const _EditCustomEmoji._() : super._();
 
   factory _EditCustomEmoji.fromJson(Map<String, dynamic> json) =
-      _$_EditCustomEmoji.fromJson;
+      _$EditCustomEmojiImpl.fromJson;
 
   @override
   int get id;
@@ -518,7 +519,7 @@ abstract class _EditCustomEmoji extends EditCustomEmoji {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_EditCustomEmojiCopyWith<_$_EditCustomEmoji> get copyWith =>
+  _$$EditCustomEmojiImplCopyWith<_$EditCustomEmojiImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -576,22 +577,22 @@ class _$DeleteCustomEmojiCopyWithImpl<$Res, $Val extends DeleteCustomEmoji>
 }
 
 /// @nodoc
-abstract class _$$_DeleteCustomEmojiCopyWith<$Res>
+abstract class _$$DeleteCustomEmojiImplCopyWith<$Res>
     implements $DeleteCustomEmojiCopyWith<$Res> {
-  factory _$$_DeleteCustomEmojiCopyWith(_$_DeleteCustomEmoji value,
-          $Res Function(_$_DeleteCustomEmoji) then) =
-      __$$_DeleteCustomEmojiCopyWithImpl<$Res>;
+  factory _$$DeleteCustomEmojiImplCopyWith(_$DeleteCustomEmojiImpl value,
+          $Res Function(_$DeleteCustomEmojiImpl) then) =
+      __$$DeleteCustomEmojiImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int id, String? auth});
 }
 
 /// @nodoc
-class __$$_DeleteCustomEmojiCopyWithImpl<$Res>
-    extends _$DeleteCustomEmojiCopyWithImpl<$Res, _$_DeleteCustomEmoji>
-    implements _$$_DeleteCustomEmojiCopyWith<$Res> {
-  __$$_DeleteCustomEmojiCopyWithImpl(
-      _$_DeleteCustomEmoji _value, $Res Function(_$_DeleteCustomEmoji) _then)
+class __$$DeleteCustomEmojiImplCopyWithImpl<$Res>
+    extends _$DeleteCustomEmojiCopyWithImpl<$Res, _$DeleteCustomEmojiImpl>
+    implements _$$DeleteCustomEmojiImplCopyWith<$Res> {
+  __$$DeleteCustomEmojiImplCopyWithImpl(_$DeleteCustomEmojiImpl _value,
+      $Res Function(_$DeleteCustomEmojiImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -600,7 +601,7 @@ class __$$_DeleteCustomEmojiCopyWithImpl<$Res>
     Object? id = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_DeleteCustomEmoji(
+    return _then(_$DeleteCustomEmojiImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -616,11 +617,11 @@ class __$$_DeleteCustomEmojiCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_DeleteCustomEmoji extends _DeleteCustomEmoji {
-  const _$_DeleteCustomEmoji({required this.id, this.auth}) : super._();
+class _$DeleteCustomEmojiImpl extends _DeleteCustomEmoji {
+  const _$DeleteCustomEmojiImpl({required this.id, this.auth}) : super._();
 
-  factory _$_DeleteCustomEmoji.fromJson(Map<String, dynamic> json) =>
-      _$$_DeleteCustomEmojiFromJson(json);
+  factory _$DeleteCustomEmojiImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeleteCustomEmojiImplFromJson(json);
 
   @override
   final int id;
@@ -636,7 +637,7 @@ class _$_DeleteCustomEmoji extends _DeleteCustomEmoji {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeleteCustomEmoji &&
+            other is _$DeleteCustomEmojiImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.auth, auth) || other.auth == auth));
   }
@@ -648,13 +649,13 @@ class _$_DeleteCustomEmoji extends _DeleteCustomEmoji {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeleteCustomEmojiCopyWith<_$_DeleteCustomEmoji> get copyWith =>
-      __$$_DeleteCustomEmojiCopyWithImpl<_$_DeleteCustomEmoji>(
+  _$$DeleteCustomEmojiImplCopyWith<_$DeleteCustomEmojiImpl> get copyWith =>
+      __$$DeleteCustomEmojiImplCopyWithImpl<_$DeleteCustomEmojiImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeleteCustomEmojiToJson(
+    return _$$DeleteCustomEmojiImplToJson(
       this,
     );
   }
@@ -662,11 +663,11 @@ class _$_DeleteCustomEmoji extends _DeleteCustomEmoji {
 
 abstract class _DeleteCustomEmoji extends DeleteCustomEmoji {
   const factory _DeleteCustomEmoji(
-      {required final int id, final String? auth}) = _$_DeleteCustomEmoji;
+      {required final int id, final String? auth}) = _$DeleteCustomEmojiImpl;
   const _DeleteCustomEmoji._() : super._();
 
   factory _DeleteCustomEmoji.fromJson(Map<String, dynamic> json) =
-      _$_DeleteCustomEmoji.fromJson;
+      _$DeleteCustomEmojiImpl.fromJson;
 
   @override
   int get id;
@@ -674,6 +675,6 @@ abstract class _DeleteCustomEmoji extends DeleteCustomEmoji {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_DeleteCustomEmojiCopyWith<_$_DeleteCustomEmoji> get copyWith =>
+  _$$DeleteCustomEmojiImplCopyWith<_$DeleteCustomEmojiImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/custom_emoji/custom_emoji.g.dart
+++ b/lib/src/v3/api/custom_emoji/custom_emoji.g.dart
@@ -6,8 +6,9 @@ part of 'custom_emoji.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CreateCustomEmoji _$$_CreateCustomEmojiFromJson(Map<String, dynamic> json) =>
-    _$_CreateCustomEmoji(
+_$CreateCustomEmojiImpl _$$CreateCustomEmojiImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CreateCustomEmojiImpl(
       category: json['category'] as String,
       shortcode: json['shortcode'] as String,
       imageUrl: json['image_url'] as String,
@@ -17,8 +18,8 @@ _$_CreateCustomEmoji _$$_CreateCustomEmojiFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_CreateCustomEmojiToJson(
-    _$_CreateCustomEmoji instance) {
+Map<String, dynamic> _$$CreateCustomEmojiImplToJson(
+    _$CreateCustomEmojiImpl instance) {
   final val = <String, dynamic>{
     'category': instance.category,
     'shortcode': instance.shortcode,
@@ -37,8 +38,9 @@ Map<String, dynamic> _$$_CreateCustomEmojiToJson(
   return val;
 }
 
-_$_EditCustomEmoji _$$_EditCustomEmojiFromJson(Map<String, dynamic> json) =>
-    _$_EditCustomEmoji(
+_$EditCustomEmojiImpl _$$EditCustomEmojiImplFromJson(
+        Map<String, dynamic> json) =>
+    _$EditCustomEmojiImpl(
       id: json['id'] as int,
       category: json['category'] as String,
       imageUrl: json['image_url'] as String,
@@ -48,7 +50,8 @@ _$_EditCustomEmoji _$$_EditCustomEmojiFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_EditCustomEmojiToJson(_$_EditCustomEmoji instance) {
+Map<String, dynamic> _$$EditCustomEmojiImplToJson(
+    _$EditCustomEmojiImpl instance) {
   final val = <String, dynamic>{
     'id': instance.id,
     'category': instance.category,
@@ -67,14 +70,15 @@ Map<String, dynamic> _$$_EditCustomEmojiToJson(_$_EditCustomEmoji instance) {
   return val;
 }
 
-_$_DeleteCustomEmoji _$$_DeleteCustomEmojiFromJson(Map<String, dynamic> json) =>
-    _$_DeleteCustomEmoji(
+_$DeleteCustomEmojiImpl _$$DeleteCustomEmojiImplFromJson(
+        Map<String, dynamic> json) =>
+    _$DeleteCustomEmojiImpl(
       id: json['id'] as int,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_DeleteCustomEmojiToJson(
-    _$_DeleteCustomEmoji instance) {
+Map<String, dynamic> _$$DeleteCustomEmojiImplToJson(
+    _$DeleteCustomEmojiImpl instance) {
   final val = <String, dynamic>{
     'id': instance.id,
   };

--- a/lib/src/v3/api/federated_instances/federated_instances.freezed.dart
+++ b/lib/src/v3/api/federated_instances/federated_instances.freezed.dart
@@ -64,22 +64,24 @@ class _$GetFederatedInstancesCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_GetFederatedInstancesCopyWith<$Res>
+abstract class _$$GetFederatedInstancesImplCopyWith<$Res>
     implements $GetFederatedInstancesCopyWith<$Res> {
-  factory _$$_GetFederatedInstancesCopyWith(_$_GetFederatedInstances value,
-          $Res Function(_$_GetFederatedInstances) then) =
-      __$$_GetFederatedInstancesCopyWithImpl<$Res>;
+  factory _$$GetFederatedInstancesImplCopyWith(
+          _$GetFederatedInstancesImpl value,
+          $Res Function(_$GetFederatedInstancesImpl) then) =
+      __$$GetFederatedInstancesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$_GetFederatedInstancesCopyWithImpl<$Res>
-    extends _$GetFederatedInstancesCopyWithImpl<$Res, _$_GetFederatedInstances>
-    implements _$$_GetFederatedInstancesCopyWith<$Res> {
-  __$$_GetFederatedInstancesCopyWithImpl(_$_GetFederatedInstances _value,
-      $Res Function(_$_GetFederatedInstances) _then)
+class __$$GetFederatedInstancesImplCopyWithImpl<$Res>
+    extends _$GetFederatedInstancesCopyWithImpl<$Res,
+        _$GetFederatedInstancesImpl>
+    implements _$$GetFederatedInstancesImplCopyWith<$Res> {
+  __$$GetFederatedInstancesImplCopyWithImpl(_$GetFederatedInstancesImpl _value,
+      $Res Function(_$GetFederatedInstancesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -87,7 +89,7 @@ class __$$_GetFederatedInstancesCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$_GetFederatedInstances(
+    return _then(_$GetFederatedInstancesImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -99,11 +101,11 @@ class __$$_GetFederatedInstancesCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetFederatedInstances extends _GetFederatedInstances {
-  const _$_GetFederatedInstances({this.auth}) : super._();
+class _$GetFederatedInstancesImpl extends _GetFederatedInstances {
+  const _$GetFederatedInstancesImpl({this.auth}) : super._();
 
-  factory _$_GetFederatedInstances.fromJson(Map<String, dynamic> json) =>
-      _$$_GetFederatedInstancesFromJson(json);
+  factory _$GetFederatedInstancesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetFederatedInstancesImplFromJson(json);
 
   @override
   final String? auth;
@@ -117,7 +119,7 @@ class _$_GetFederatedInstances extends _GetFederatedInstances {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetFederatedInstances &&
+            other is _$GetFederatedInstancesImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -128,13 +130,13 @@ class _$_GetFederatedInstances extends _GetFederatedInstances {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetFederatedInstancesCopyWith<_$_GetFederatedInstances> get copyWith =>
-      __$$_GetFederatedInstancesCopyWithImpl<_$_GetFederatedInstances>(
-          this, _$identity);
+  _$$GetFederatedInstancesImplCopyWith<_$GetFederatedInstancesImpl>
+      get copyWith => __$$GetFederatedInstancesImplCopyWithImpl<
+          _$GetFederatedInstancesImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetFederatedInstancesToJson(
+    return _$$GetFederatedInstancesImplToJson(
       this,
     );
   }
@@ -142,16 +144,16 @@ class _$_GetFederatedInstances extends _GetFederatedInstances {
 
 abstract class _GetFederatedInstances extends GetFederatedInstances {
   const factory _GetFederatedInstances({final String? auth}) =
-      _$_GetFederatedInstances;
+      _$GetFederatedInstancesImpl;
   const _GetFederatedInstances._() : super._();
 
   factory _GetFederatedInstances.fromJson(Map<String, dynamic> json) =
-      _$_GetFederatedInstances.fromJson;
+      _$GetFederatedInstancesImpl.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetFederatedInstancesCopyWith<_$_GetFederatedInstances> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$GetFederatedInstancesImplCopyWith<_$GetFederatedInstancesImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/federated_instances/federated_instances.g.dart
+++ b/lib/src/v3/api/federated_instances/federated_instances.g.dart
@@ -6,14 +6,14 @@ part of 'federated_instances.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetFederatedInstances _$$_GetFederatedInstancesFromJson(
+_$GetFederatedInstancesImpl _$$GetFederatedInstancesImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GetFederatedInstances(
+    _$GetFederatedInstancesImpl(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetFederatedInstancesToJson(
-    _$_GetFederatedInstances instance) {
+Map<String, dynamic> _$$GetFederatedInstancesImplToJson(
+    _$GetFederatedInstancesImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {

--- a/lib/src/v3/api/modlog/modlog.freezed.dart
+++ b/lib/src/v3/api/modlog/modlog.freezed.dart
@@ -105,10 +105,11 @@ class _$GetModlogCopyWithImpl<$Res, $Val extends GetModlog>
 }
 
 /// @nodoc
-abstract class _$$_GetModlogCopyWith<$Res> implements $GetModlogCopyWith<$Res> {
-  factory _$$_GetModlogCopyWith(
-          _$_GetModlog value, $Res Function(_$_GetModlog) then) =
-      __$$_GetModlogCopyWithImpl<$Res>;
+abstract class _$$GetModlogImplCopyWith<$Res>
+    implements $GetModlogCopyWith<$Res> {
+  factory _$$GetModlogImplCopyWith(
+          _$GetModlogImpl value, $Res Function(_$GetModlogImpl) then) =
+      __$$GetModlogImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -122,11 +123,11 @@ abstract class _$$_GetModlogCopyWith<$Res> implements $GetModlogCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_GetModlogCopyWithImpl<$Res>
-    extends _$GetModlogCopyWithImpl<$Res, _$_GetModlog>
-    implements _$$_GetModlogCopyWith<$Res> {
-  __$$_GetModlogCopyWithImpl(
-      _$_GetModlog _value, $Res Function(_$_GetModlog) _then)
+class __$$GetModlogImplCopyWithImpl<$Res>
+    extends _$GetModlogCopyWithImpl<$Res, _$GetModlogImpl>
+    implements _$$GetModlogImplCopyWith<$Res> {
+  __$$GetModlogImplCopyWithImpl(
+      _$GetModlogImpl _value, $Res Function(_$GetModlogImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -140,7 +141,7 @@ class __$$_GetModlogCopyWithImpl<$Res>
     Object? otherPersonId = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetModlog(
+    return _then(_$GetModlogImpl(
       modPersonId: freezed == modPersonId
           ? _value.modPersonId
           : modPersonId // ignore: cast_nullable_to_non_nullable
@@ -176,8 +177,8 @@ class __$$_GetModlogCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetModlog extends _GetModlog {
-  const _$_GetModlog(
+class _$GetModlogImpl extends _GetModlog {
+  const _$GetModlogImpl(
       {this.modPersonId,
       this.communityId,
       this.page,
@@ -187,8 +188,8 @@ class _$_GetModlog extends _GetModlog {
       this.auth})
       : super._();
 
-  factory _$_GetModlog.fromJson(Map<String, dynamic> json) =>
-      _$$_GetModlogFromJson(json);
+  factory _$GetModlogImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetModlogImplFromJson(json);
 
   @override
   final int? modPersonId;
@@ -215,7 +216,7 @@ class _$_GetModlog extends _GetModlog {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetModlog &&
+            other is _$GetModlogImpl &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
             (identical(other.communityId, communityId) ||
@@ -236,12 +237,12 @@ class _$_GetModlog extends _GetModlog {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetModlogCopyWith<_$_GetModlog> get copyWith =>
-      __$$_GetModlogCopyWithImpl<_$_GetModlog>(this, _$identity);
+  _$$GetModlogImplCopyWith<_$GetModlogImpl> get copyWith =>
+      __$$GetModlogImplCopyWithImpl<_$GetModlogImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetModlogToJson(
+    return _$$GetModlogImplToJson(
       this,
     );
   }
@@ -255,11 +256,11 @@ abstract class _GetModlog extends GetModlog {
       final int? limit,
       @JsonKey(name: 'type_') final ModlogActionType? type,
       final int? otherPersonId,
-      final String? auth}) = _$_GetModlog;
+      final String? auth}) = _$GetModlogImpl;
   const _GetModlog._() : super._();
 
   factory _GetModlog.fromJson(Map<String, dynamic> json) =
-      _$_GetModlog.fromJson;
+      _$GetModlogImpl.fromJson;
 
   @override
   int? get modPersonId;
@@ -278,6 +279,6 @@ abstract class _GetModlog extends GetModlog {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetModlogCopyWith<_$_GetModlog> get copyWith =>
+  _$$GetModlogImplCopyWith<_$GetModlogImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/modlog/modlog.g.dart
+++ b/lib/src/v3/api/modlog/modlog.g.dart
@@ -6,7 +6,8 @@ part of 'modlog.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetModlog _$$_GetModlogFromJson(Map<String, dynamic> json) => _$_GetModlog(
+_$GetModlogImpl _$$GetModlogImplFromJson(Map<String, dynamic> json) =>
+    _$GetModlogImpl(
       modPersonId: json['mod_person_id'] as int?,
       communityId: json['community_id'] as int?,
       page: json['page'] as int?,
@@ -18,7 +19,7 @@ _$_GetModlog _$$_GetModlogFromJson(Map<String, dynamic> json) => _$_GetModlog(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetModlogToJson(_$_GetModlog instance) {
+Map<String, dynamic> _$$GetModlogImplToJson(_$GetModlogImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {

--- a/lib/src/v3/api/post/post.freezed.dart
+++ b/lib/src/v3/api/post/post.freezed.dart
@@ -112,11 +112,11 @@ class _$CreatePostCopyWithImpl<$Res, $Val extends CreatePost>
 }
 
 /// @nodoc
-abstract class _$$_CreatePostCopyWith<$Res>
+abstract class _$$CreatePostImplCopyWith<$Res>
     implements $CreatePostCopyWith<$Res> {
-  factory _$$_CreatePostCopyWith(
-          _$_CreatePost value, $Res Function(_$_CreatePost) then) =
-      __$$_CreatePostCopyWithImpl<$Res>;
+  factory _$$CreatePostImplCopyWith(
+          _$CreatePostImpl value, $Res Function(_$CreatePostImpl) then) =
+      __$$CreatePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -131,11 +131,11 @@ abstract class _$$_CreatePostCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CreatePostCopyWithImpl<$Res>
-    extends _$CreatePostCopyWithImpl<$Res, _$_CreatePost>
-    implements _$$_CreatePostCopyWith<$Res> {
-  __$$_CreatePostCopyWithImpl(
-      _$_CreatePost _value, $Res Function(_$_CreatePost) _then)
+class __$$CreatePostImplCopyWithImpl<$Res>
+    extends _$CreatePostCopyWithImpl<$Res, _$CreatePostImpl>
+    implements _$$CreatePostImplCopyWith<$Res> {
+  __$$CreatePostImplCopyWithImpl(
+      _$CreatePostImpl _value, $Res Function(_$CreatePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -150,7 +150,7 @@ class __$$_CreatePostCopyWithImpl<$Res>
     Object? languageId = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_CreatePost(
+    return _then(_$CreatePostImpl(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -190,8 +190,8 @@ class __$$_CreatePostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreatePost extends _CreatePost {
-  const _$_CreatePost(
+class _$CreatePostImpl extends _CreatePost {
+  const _$CreatePostImpl(
       {required this.name,
       required this.communityId,
       this.url,
@@ -202,8 +202,8 @@ class _$_CreatePost extends _CreatePost {
       this.auth})
       : super._();
 
-  factory _$_CreatePost.fromJson(Map<String, dynamic> json) =>
-      _$$_CreatePostFromJson(json);
+  factory _$CreatePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreatePostImplFromJson(json);
 
   @override
   final String name;
@@ -231,7 +231,7 @@ class _$_CreatePost extends _CreatePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreatePost &&
+            other is _$CreatePostImpl &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
@@ -253,12 +253,12 @@ class _$_CreatePost extends _CreatePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreatePostCopyWith<_$_CreatePost> get copyWith =>
-      __$$_CreatePostCopyWithImpl<_$_CreatePost>(this, _$identity);
+  _$$CreatePostImplCopyWith<_$CreatePostImpl> get copyWith =>
+      __$$CreatePostImplCopyWithImpl<_$CreatePostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreatePostToJson(
+    return _$$CreatePostImplToJson(
       this,
     );
   }
@@ -273,11 +273,11 @@ abstract class _CreatePost extends CreatePost {
       final String? honeypot,
       final bool? nsfw,
       final int? languageId,
-      final String? auth}) = _$_CreatePost;
+      final String? auth}) = _$CreatePostImpl;
   const _CreatePost._() : super._();
 
   factory _CreatePost.fromJson(Map<String, dynamic> json) =
-      _$_CreatePost.fromJson;
+      _$CreatePostImpl.fromJson;
 
   @override
   String get name;
@@ -297,7 +297,7 @@ abstract class _CreatePost extends CreatePost {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreatePostCopyWith<_$_CreatePost> get copyWith =>
+  _$$CreatePostImplCopyWith<_$CreatePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -359,20 +359,21 @@ class _$GetPostCopyWithImpl<$Res, $Val extends GetPost>
 }
 
 /// @nodoc
-abstract class _$$_GetPostCopyWith<$Res> implements $GetPostCopyWith<$Res> {
-  factory _$$_GetPostCopyWith(
-          _$_GetPost value, $Res Function(_$_GetPost) then) =
-      __$$_GetPostCopyWithImpl<$Res>;
+abstract class _$$GetPostImplCopyWith<$Res> implements $GetPostCopyWith<$Res> {
+  factory _$$GetPostImplCopyWith(
+          _$GetPostImpl value, $Res Function(_$GetPostImpl) then) =
+      __$$GetPostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int? id, int? commentId, String? auth});
 }
 
 /// @nodoc
-class __$$_GetPostCopyWithImpl<$Res>
-    extends _$GetPostCopyWithImpl<$Res, _$_GetPost>
-    implements _$$_GetPostCopyWith<$Res> {
-  __$$_GetPostCopyWithImpl(_$_GetPost _value, $Res Function(_$_GetPost) _then)
+class __$$GetPostImplCopyWithImpl<$Res>
+    extends _$GetPostCopyWithImpl<$Res, _$GetPostImpl>
+    implements _$$GetPostImplCopyWith<$Res> {
+  __$$GetPostImplCopyWithImpl(
+      _$GetPostImpl _value, $Res Function(_$GetPostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -382,7 +383,7 @@ class __$$_GetPostCopyWithImpl<$Res>
     Object? commentId = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetPost(
+    return _then(_$GetPostImpl(
       id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -402,11 +403,11 @@ class __$$_GetPostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetPost extends _GetPost {
-  const _$_GetPost({this.id, this.commentId, this.auth}) : super._();
+class _$GetPostImpl extends _GetPost {
+  const _$GetPostImpl({this.id, this.commentId, this.auth}) : super._();
 
-  factory _$_GetPost.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPostFromJson(json);
+  factory _$GetPostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPostImplFromJson(json);
 
   @override
   final int? id;
@@ -424,7 +425,7 @@ class _$_GetPost extends _GetPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPost &&
+            other is _$GetPostImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
@@ -438,12 +439,12 @@ class _$_GetPost extends _GetPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPostCopyWith<_$_GetPost> get copyWith =>
-      __$$_GetPostCopyWithImpl<_$_GetPost>(this, _$identity);
+  _$$GetPostImplCopyWith<_$GetPostImpl> get copyWith =>
+      __$$GetPostImplCopyWithImpl<_$GetPostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPostToJson(
+    return _$$GetPostImplToJson(
       this,
     );
   }
@@ -451,10 +452,12 @@ class _$_GetPost extends _GetPost {
 
 abstract class _GetPost extends GetPost {
   const factory _GetPost(
-      {final int? id, final int? commentId, final String? auth}) = _$_GetPost;
+      {final int? id,
+      final int? commentId,
+      final String? auth}) = _$GetPostImpl;
   const _GetPost._() : super._();
 
-  factory _GetPost.fromJson(Map<String, dynamic> json) = _$_GetPost.fromJson;
+  factory _GetPost.fromJson(Map<String, dynamic> json) = _$GetPostImpl.fromJson;
 
   @override
   int? get id;
@@ -464,7 +467,7 @@ abstract class _GetPost extends GetPost {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPostCopyWith<_$_GetPost> get copyWith =>
+  _$$GetPostImplCopyWith<_$GetPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -558,10 +561,11 @@ class _$EditPostCopyWithImpl<$Res, $Val extends EditPost>
 }
 
 /// @nodoc
-abstract class _$$_EditPostCopyWith<$Res> implements $EditPostCopyWith<$Res> {
-  factory _$$_EditPostCopyWith(
-          _$_EditPost value, $Res Function(_$_EditPost) then) =
-      __$$_EditPostCopyWithImpl<$Res>;
+abstract class _$$EditPostImplCopyWith<$Res>
+    implements $EditPostCopyWith<$Res> {
+  factory _$$EditPostImplCopyWith(
+          _$EditPostImpl value, $Res Function(_$EditPostImpl) then) =
+      __$$EditPostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -575,11 +579,11 @@ abstract class _$$_EditPostCopyWith<$Res> implements $EditPostCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_EditPostCopyWithImpl<$Res>
-    extends _$EditPostCopyWithImpl<$Res, _$_EditPost>
-    implements _$$_EditPostCopyWith<$Res> {
-  __$$_EditPostCopyWithImpl(
-      _$_EditPost _value, $Res Function(_$_EditPost) _then)
+class __$$EditPostImplCopyWithImpl<$Res>
+    extends _$EditPostCopyWithImpl<$Res, _$EditPostImpl>
+    implements _$$EditPostImplCopyWith<$Res> {
+  __$$EditPostImplCopyWithImpl(
+      _$EditPostImpl _value, $Res Function(_$EditPostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -593,7 +597,7 @@ class __$$_EditPostCopyWithImpl<$Res>
     Object? languageId = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_EditPost(
+    return _then(_$EditPostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -629,8 +633,8 @@ class __$$_EditPostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_EditPost extends _EditPost {
-  const _$_EditPost(
+class _$EditPostImpl extends _EditPost {
+  const _$EditPostImpl(
       {required this.postId,
       this.name,
       this.url,
@@ -640,8 +644,8 @@ class _$_EditPost extends _EditPost {
       this.auth})
       : super._();
 
-  factory _$_EditPost.fromJson(Map<String, dynamic> json) =>
-      _$$_EditPostFromJson(json);
+  factory _$EditPostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EditPostImplFromJson(json);
 
   @override
   final int postId;
@@ -667,7 +671,7 @@ class _$_EditPost extends _EditPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_EditPost &&
+            other is _$EditPostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.url, url) || other.url == url) &&
@@ -686,12 +690,12 @@ class _$_EditPost extends _EditPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_EditPostCopyWith<_$_EditPost> get copyWith =>
-      __$$_EditPostCopyWithImpl<_$_EditPost>(this, _$identity);
+  _$$EditPostImplCopyWith<_$EditPostImpl> get copyWith =>
+      __$$EditPostImplCopyWithImpl<_$EditPostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_EditPostToJson(
+    return _$$EditPostImplToJson(
       this,
     );
   }
@@ -705,10 +709,11 @@ abstract class _EditPost extends EditPost {
       final String? body,
       final bool? nsfw,
       final int? languageId,
-      final String? auth}) = _$_EditPost;
+      final String? auth}) = _$EditPostImpl;
   const _EditPost._() : super._();
 
-  factory _EditPost.fromJson(Map<String, dynamic> json) = _$_EditPost.fromJson;
+  factory _EditPost.fromJson(Map<String, dynamic> json) =
+      _$EditPostImpl.fromJson;
 
   @override
   int get postId;
@@ -726,7 +731,7 @@ abstract class _EditPost extends EditPost {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_EditPostCopyWith<_$_EditPost> get copyWith =>
+  _$$EditPostImplCopyWith<_$EditPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -790,22 +795,22 @@ class _$DeletePostCopyWithImpl<$Res, $Val extends DeletePost>
 }
 
 /// @nodoc
-abstract class _$$_DeletePostCopyWith<$Res>
+abstract class _$$DeletePostImplCopyWith<$Res>
     implements $DeletePostCopyWith<$Res> {
-  factory _$$_DeletePostCopyWith(
-          _$_DeletePost value, $Res Function(_$_DeletePost) then) =
-      __$$_DeletePostCopyWithImpl<$Res>;
+  factory _$$DeletePostImplCopyWith(
+          _$DeletePostImpl value, $Res Function(_$DeletePostImpl) then) =
+      __$$DeletePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool deleted, String? auth});
 }
 
 /// @nodoc
-class __$$_DeletePostCopyWithImpl<$Res>
-    extends _$DeletePostCopyWithImpl<$Res, _$_DeletePost>
-    implements _$$_DeletePostCopyWith<$Res> {
-  __$$_DeletePostCopyWithImpl(
-      _$_DeletePost _value, $Res Function(_$_DeletePost) _then)
+class __$$DeletePostImplCopyWithImpl<$Res>
+    extends _$DeletePostCopyWithImpl<$Res, _$DeletePostImpl>
+    implements _$$DeletePostImplCopyWith<$Res> {
+  __$$DeletePostImplCopyWithImpl(
+      _$DeletePostImpl _value, $Res Function(_$DeletePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -815,7 +820,7 @@ class __$$_DeletePostCopyWithImpl<$Res>
     Object? deleted = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_DeletePost(
+    return _then(_$DeletePostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -835,12 +840,13 @@ class __$$_DeletePostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_DeletePost extends _DeletePost {
-  const _$_DeletePost({required this.postId, required this.deleted, this.auth})
+class _$DeletePostImpl extends _DeletePost {
+  const _$DeletePostImpl(
+      {required this.postId, required this.deleted, this.auth})
       : super._();
 
-  factory _$_DeletePost.fromJson(Map<String, dynamic> json) =>
-      _$$_DeletePostFromJson(json);
+  factory _$DeletePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeletePostImplFromJson(json);
 
   @override
   final int postId;
@@ -858,7 +864,7 @@ class _$_DeletePost extends _DeletePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeletePost &&
+            other is _$DeletePostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.deleted, deleted) || other.deleted == deleted) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -871,12 +877,12 @@ class _$_DeletePost extends _DeletePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeletePostCopyWith<_$_DeletePost> get copyWith =>
-      __$$_DeletePostCopyWithImpl<_$_DeletePost>(this, _$identity);
+  _$$DeletePostImplCopyWith<_$DeletePostImpl> get copyWith =>
+      __$$DeletePostImplCopyWithImpl<_$DeletePostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeletePostToJson(
+    return _$$DeletePostImplToJson(
       this,
     );
   }
@@ -886,11 +892,11 @@ abstract class _DeletePost extends DeletePost {
   const factory _DeletePost(
       {required final int postId,
       required final bool deleted,
-      final String? auth}) = _$_DeletePost;
+      final String? auth}) = _$DeletePostImpl;
   const _DeletePost._() : super._();
 
   factory _DeletePost.fromJson(Map<String, dynamic> json) =
-      _$_DeletePost.fromJson;
+      _$DeletePostImpl.fromJson;
 
   @override
   int get postId;
@@ -900,7 +906,7 @@ abstract class _DeletePost extends DeletePost {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_DeletePostCopyWith<_$_DeletePost> get copyWith =>
+  _$$DeletePostImplCopyWith<_$DeletePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -970,22 +976,22 @@ class _$RemovePostCopyWithImpl<$Res, $Val extends RemovePost>
 }
 
 /// @nodoc
-abstract class _$$_RemovePostCopyWith<$Res>
+abstract class _$$RemovePostImplCopyWith<$Res>
     implements $RemovePostCopyWith<$Res> {
-  factory _$$_RemovePostCopyWith(
-          _$_RemovePost value, $Res Function(_$_RemovePost) then) =
-      __$$_RemovePostCopyWithImpl<$Res>;
+  factory _$$RemovePostImplCopyWith(
+          _$RemovePostImpl value, $Res Function(_$RemovePostImpl) then) =
+      __$$RemovePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool removed, String? reason, String? auth});
 }
 
 /// @nodoc
-class __$$_RemovePostCopyWithImpl<$Res>
-    extends _$RemovePostCopyWithImpl<$Res, _$_RemovePost>
-    implements _$$_RemovePostCopyWith<$Res> {
-  __$$_RemovePostCopyWithImpl(
-      _$_RemovePost _value, $Res Function(_$_RemovePost) _then)
+class __$$RemovePostImplCopyWithImpl<$Res>
+    extends _$RemovePostCopyWithImpl<$Res, _$RemovePostImpl>
+    implements _$$RemovePostImplCopyWith<$Res> {
+  __$$RemovePostImplCopyWithImpl(
+      _$RemovePostImpl _value, $Res Function(_$RemovePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -996,7 +1002,7 @@ class __$$_RemovePostCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_RemovePost(
+    return _then(_$RemovePostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1020,13 +1026,13 @@ class __$$_RemovePostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_RemovePost extends _RemovePost {
-  const _$_RemovePost(
+class _$RemovePostImpl extends _RemovePost {
+  const _$RemovePostImpl(
       {required this.postId, required this.removed, this.reason, this.auth})
       : super._();
 
-  factory _$_RemovePost.fromJson(Map<String, dynamic> json) =>
-      _$$_RemovePostFromJson(json);
+  factory _$RemovePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RemovePostImplFromJson(json);
 
   @override
   final int postId;
@@ -1046,7 +1052,7 @@ class _$_RemovePost extends _RemovePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_RemovePost &&
+            other is _$RemovePostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.removed, removed) || other.removed == removed) &&
             (identical(other.reason, reason) || other.reason == reason) &&
@@ -1060,12 +1066,12 @@ class _$_RemovePost extends _RemovePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RemovePostCopyWith<_$_RemovePost> get copyWith =>
-      __$$_RemovePostCopyWithImpl<_$_RemovePost>(this, _$identity);
+  _$$RemovePostImplCopyWith<_$RemovePostImpl> get copyWith =>
+      __$$RemovePostImplCopyWithImpl<_$RemovePostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RemovePostToJson(
+    return _$$RemovePostImplToJson(
       this,
     );
   }
@@ -1076,11 +1082,11 @@ abstract class _RemovePost extends RemovePost {
       {required final int postId,
       required final bool removed,
       final String? reason,
-      final String? auth}) = _$_RemovePost;
+      final String? auth}) = _$RemovePostImpl;
   const _RemovePost._() : super._();
 
   factory _RemovePost.fromJson(Map<String, dynamic> json) =
-      _$_RemovePost.fromJson;
+      _$RemovePostImpl.fromJson;
 
   @override
   int get postId;
@@ -1092,7 +1098,7 @@ abstract class _RemovePost extends RemovePost {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_RemovePostCopyWith<_$_RemovePost> get copyWith =>
+  _$$RemovePostImplCopyWith<_$RemovePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1163,22 +1169,22 @@ class _$MarkPostAsReadCopyWithImpl<$Res, $Val extends MarkPostAsRead>
 }
 
 /// @nodoc
-abstract class _$$_MarkPostAsReadCopyWith<$Res>
+abstract class _$$MarkPostAsReadImplCopyWith<$Res>
     implements $MarkPostAsReadCopyWith<$Res> {
-  factory _$$_MarkPostAsReadCopyWith(
-          _$_MarkPostAsRead value, $Res Function(_$_MarkPostAsRead) then) =
-      __$$_MarkPostAsReadCopyWithImpl<$Res>;
+  factory _$$MarkPostAsReadImplCopyWith(_$MarkPostAsReadImpl value,
+          $Res Function(_$MarkPostAsReadImpl) then) =
+      __$$MarkPostAsReadImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int? postId, List<int>? postIds, bool read, String? auth});
 }
 
 /// @nodoc
-class __$$_MarkPostAsReadCopyWithImpl<$Res>
-    extends _$MarkPostAsReadCopyWithImpl<$Res, _$_MarkPostAsRead>
-    implements _$$_MarkPostAsReadCopyWith<$Res> {
-  __$$_MarkPostAsReadCopyWithImpl(
-      _$_MarkPostAsRead _value, $Res Function(_$_MarkPostAsRead) _then)
+class __$$MarkPostAsReadImplCopyWithImpl<$Res>
+    extends _$MarkPostAsReadCopyWithImpl<$Res, _$MarkPostAsReadImpl>
+    implements _$$MarkPostAsReadImplCopyWith<$Res> {
+  __$$MarkPostAsReadImplCopyWithImpl(
+      _$MarkPostAsReadImpl _value, $Res Function(_$MarkPostAsReadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1189,7 +1195,7 @@ class __$$_MarkPostAsReadCopyWithImpl<$Res>
     Object? read = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_MarkPostAsRead(
+    return _then(_$MarkPostAsReadImpl(
       postId: freezed == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1213,14 +1219,14 @@ class __$$_MarkPostAsReadCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_MarkPostAsRead extends _MarkPostAsRead {
-  const _$_MarkPostAsRead(
+class _$MarkPostAsReadImpl extends _MarkPostAsRead {
+  const _$MarkPostAsReadImpl(
       {this.postId, final List<int>? postIds, required this.read, this.auth})
       : _postIds = postIds,
         super._();
 
-  factory _$_MarkPostAsRead.fromJson(Map<String, dynamic> json) =>
-      _$$_MarkPostAsReadFromJson(json);
+  factory _$MarkPostAsReadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MarkPostAsReadImplFromJson(json);
 
   @override
   final int? postId;
@@ -1249,7 +1255,7 @@ class _$_MarkPostAsRead extends _MarkPostAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MarkPostAsRead &&
+            other is _$MarkPostAsReadImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             const DeepCollectionEquality().equals(other._postIds, _postIds) &&
             (identical(other.read, read) || other.read == read) &&
@@ -1264,12 +1270,13 @@ class _$_MarkPostAsRead extends _MarkPostAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MarkPostAsReadCopyWith<_$_MarkPostAsRead> get copyWith =>
-      __$$_MarkPostAsReadCopyWithImpl<_$_MarkPostAsRead>(this, _$identity);
+  _$$MarkPostAsReadImplCopyWith<_$MarkPostAsReadImpl> get copyWith =>
+      __$$MarkPostAsReadImplCopyWithImpl<_$MarkPostAsReadImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MarkPostAsReadToJson(
+    return _$$MarkPostAsReadImplToJson(
       this,
     );
   }
@@ -1280,11 +1287,11 @@ abstract class _MarkPostAsRead extends MarkPostAsRead {
       {final int? postId,
       final List<int>? postIds,
       required final bool read,
-      final String? auth}) = _$_MarkPostAsRead;
+      final String? auth}) = _$MarkPostAsReadImpl;
   const _MarkPostAsRead._() : super._();
 
   factory _MarkPostAsRead.fromJson(Map<String, dynamic> json) =
-      _$_MarkPostAsRead.fromJson;
+      _$MarkPostAsReadImpl.fromJson;
 
   @override
   int? get postId;
@@ -1296,7 +1303,7 @@ abstract class _MarkPostAsRead extends MarkPostAsRead {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_MarkPostAsReadCopyWith<_$_MarkPostAsRead> get copyWith =>
+  _$$MarkPostAsReadImplCopyWith<_$MarkPostAsReadImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1359,21 +1366,22 @@ class _$LockPostCopyWithImpl<$Res, $Val extends LockPost>
 }
 
 /// @nodoc
-abstract class _$$_LockPostCopyWith<$Res> implements $LockPostCopyWith<$Res> {
-  factory _$$_LockPostCopyWith(
-          _$_LockPost value, $Res Function(_$_LockPost) then) =
-      __$$_LockPostCopyWithImpl<$Res>;
+abstract class _$$LockPostImplCopyWith<$Res>
+    implements $LockPostCopyWith<$Res> {
+  factory _$$LockPostImplCopyWith(
+          _$LockPostImpl value, $Res Function(_$LockPostImpl) then) =
+      __$$LockPostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool locked, String? auth});
 }
 
 /// @nodoc
-class __$$_LockPostCopyWithImpl<$Res>
-    extends _$LockPostCopyWithImpl<$Res, _$_LockPost>
-    implements _$$_LockPostCopyWith<$Res> {
-  __$$_LockPostCopyWithImpl(
-      _$_LockPost _value, $Res Function(_$_LockPost) _then)
+class __$$LockPostImplCopyWithImpl<$Res>
+    extends _$LockPostCopyWithImpl<$Res, _$LockPostImpl>
+    implements _$$LockPostImplCopyWith<$Res> {
+  __$$LockPostImplCopyWithImpl(
+      _$LockPostImpl _value, $Res Function(_$LockPostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1383,7 +1391,7 @@ class __$$_LockPostCopyWithImpl<$Res>
     Object? locked = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_LockPost(
+    return _then(_$LockPostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1403,12 +1411,12 @@ class __$$_LockPostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_LockPost extends _LockPost {
-  const _$_LockPost({required this.postId, required this.locked, this.auth})
+class _$LockPostImpl extends _LockPost {
+  const _$LockPostImpl({required this.postId, required this.locked, this.auth})
       : super._();
 
-  factory _$_LockPost.fromJson(Map<String, dynamic> json) =>
-      _$$_LockPostFromJson(json);
+  factory _$LockPostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LockPostImplFromJson(json);
 
   @override
   final int postId;
@@ -1426,7 +1434,7 @@ class _$_LockPost extends _LockPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LockPost &&
+            other is _$LockPostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.locked, locked) || other.locked == locked) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -1439,12 +1447,12 @@ class _$_LockPost extends _LockPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LockPostCopyWith<_$_LockPost> get copyWith =>
-      __$$_LockPostCopyWithImpl<_$_LockPost>(this, _$identity);
+  _$$LockPostImplCopyWith<_$LockPostImpl> get copyWith =>
+      __$$LockPostImplCopyWithImpl<_$LockPostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LockPostToJson(
+    return _$$LockPostImplToJson(
       this,
     );
   }
@@ -1454,10 +1462,11 @@ abstract class _LockPost extends LockPost {
   const factory _LockPost(
       {required final int postId,
       required final bool locked,
-      final String? auth}) = _$_LockPost;
+      final String? auth}) = _$LockPostImpl;
   const _LockPost._() : super._();
 
-  factory _LockPost.fromJson(Map<String, dynamic> json) = _$_LockPost.fromJson;
+  factory _LockPost.fromJson(Map<String, dynamic> json) =
+      _$LockPostImpl.fromJson;
 
   @override
   int get postId;
@@ -1467,7 +1476,7 @@ abstract class _LockPost extends LockPost {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_LockPostCopyWith<_$_LockPost> get copyWith =>
+  _$$LockPostImplCopyWith<_$LockPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1538,11 +1547,11 @@ class _$FeaturePostCopyWithImpl<$Res, $Val extends FeaturePost>
 }
 
 /// @nodoc
-abstract class _$$_FeaturePostCopyWith<$Res>
+abstract class _$$FeaturePostImplCopyWith<$Res>
     implements $FeaturePostCopyWith<$Res> {
-  factory _$$_FeaturePostCopyWith(
-          _$_FeaturePost value, $Res Function(_$_FeaturePost) then) =
-      __$$_FeaturePostCopyWithImpl<$Res>;
+  factory _$$FeaturePostImplCopyWith(
+          _$FeaturePostImpl value, $Res Function(_$FeaturePostImpl) then) =
+      __$$FeaturePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1550,11 +1559,11 @@ abstract class _$$_FeaturePostCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_FeaturePostCopyWithImpl<$Res>
-    extends _$FeaturePostCopyWithImpl<$Res, _$_FeaturePost>
-    implements _$$_FeaturePostCopyWith<$Res> {
-  __$$_FeaturePostCopyWithImpl(
-      _$_FeaturePost _value, $Res Function(_$_FeaturePost) _then)
+class __$$FeaturePostImplCopyWithImpl<$Res>
+    extends _$FeaturePostCopyWithImpl<$Res, _$FeaturePostImpl>
+    implements _$$FeaturePostImplCopyWith<$Res> {
+  __$$FeaturePostImplCopyWithImpl(
+      _$FeaturePostImpl _value, $Res Function(_$FeaturePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1565,7 +1574,7 @@ class __$$_FeaturePostCopyWithImpl<$Res>
     Object? featureType = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_FeaturePost(
+    return _then(_$FeaturePostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -1589,16 +1598,16 @@ class __$$_FeaturePostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_FeaturePost extends _FeaturePost {
-  const _$_FeaturePost(
+class _$FeaturePostImpl extends _FeaturePost {
+  const _$FeaturePostImpl(
       {required this.postId,
       required this.featured,
       required this.featureType,
       this.auth})
       : super._();
 
-  factory _$_FeaturePost.fromJson(Map<String, dynamic> json) =>
-      _$$_FeaturePostFromJson(json);
+  factory _$FeaturePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FeaturePostImplFromJson(json);
 
   @override
   final int postId;
@@ -1618,7 +1627,7 @@ class _$_FeaturePost extends _FeaturePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FeaturePost &&
+            other is _$FeaturePostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.featured, featured) ||
                 other.featured == featured) &&
@@ -1635,12 +1644,12 @@ class _$_FeaturePost extends _FeaturePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FeaturePostCopyWith<_$_FeaturePost> get copyWith =>
-      __$$_FeaturePostCopyWithImpl<_$_FeaturePost>(this, _$identity);
+  _$$FeaturePostImplCopyWith<_$FeaturePostImpl> get copyWith =>
+      __$$FeaturePostImplCopyWithImpl<_$FeaturePostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FeaturePostToJson(
+    return _$$FeaturePostImplToJson(
       this,
     );
   }
@@ -1651,11 +1660,11 @@ abstract class _FeaturePost extends FeaturePost {
       {required final int postId,
       required final bool featured,
       required final PostFeatureType featureType,
-      final String? auth}) = _$_FeaturePost;
+      final String? auth}) = _$FeaturePostImpl;
   const _FeaturePost._() : super._();
 
   factory _FeaturePost.fromJson(Map<String, dynamic> json) =
-      _$_FeaturePost.fromJson;
+      _$FeaturePostImpl.fromJson;
 
   @override
   int get postId;
@@ -1667,7 +1676,7 @@ abstract class _FeaturePost extends FeaturePost {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_FeaturePostCopyWith<_$_FeaturePost> get copyWith =>
+  _$$FeaturePostImplCopyWith<_$FeaturePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1800,10 +1809,11 @@ class _$GetPostsCopyWithImpl<$Res, $Val extends GetPosts>
 }
 
 /// @nodoc
-abstract class _$$_GetPostsCopyWith<$Res> implements $GetPostsCopyWith<$Res> {
-  factory _$$_GetPostsCopyWith(
-          _$_GetPosts value, $Res Function(_$_GetPosts) then) =
-      __$$_GetPostsCopyWithImpl<$Res>;
+abstract class _$$GetPostsImplCopyWith<$Res>
+    implements $GetPostsCopyWith<$Res> {
+  factory _$$GetPostsImplCopyWith(
+          _$GetPostsImpl value, $Res Function(_$GetPostsImpl) then) =
+      __$$GetPostsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1822,11 +1832,11 @@ abstract class _$$_GetPostsCopyWith<$Res> implements $GetPostsCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_GetPostsCopyWithImpl<$Res>
-    extends _$GetPostsCopyWithImpl<$Res, _$_GetPosts>
-    implements _$$_GetPostsCopyWith<$Res> {
-  __$$_GetPostsCopyWithImpl(
-      _$_GetPosts _value, $Res Function(_$_GetPosts) _then)
+class __$$GetPostsImplCopyWithImpl<$Res>
+    extends _$GetPostsCopyWithImpl<$Res, _$GetPostsImpl>
+    implements _$$GetPostsImplCopyWith<$Res> {
+  __$$GetPostsImplCopyWithImpl(
+      _$GetPostsImpl _value, $Res Function(_$GetPostsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1845,7 +1855,7 @@ class __$$_GetPostsCopyWithImpl<$Res>
     Object? dislikedOnly = freezed,
     Object? pageCursor = freezed,
   }) {
-    return _then(_$_GetPosts(
+    return _then(_$GetPostsImpl(
       type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -1901,8 +1911,8 @@ class __$$_GetPostsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetPosts extends _GetPosts {
-  const _$_GetPosts(
+class _$GetPostsImpl extends _GetPosts {
+  const _$GetPostsImpl(
       {@JsonKey(name: 'type_') this.type,
       this.sort,
       this.page,
@@ -1917,8 +1927,8 @@ class _$_GetPosts extends _GetPosts {
       this.pageCursor})
       : super._();
 
-  factory _$_GetPosts.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPostsFromJson(json);
+  factory _$GetPostsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPostsImplFromJson(json);
 
   @override
   @JsonKey(name: 'type_')
@@ -1958,7 +1968,7 @@ class _$_GetPosts extends _GetPosts {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPosts &&
+            other is _$GetPostsImpl &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
@@ -2000,12 +2010,12 @@ class _$_GetPosts extends _GetPosts {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPostsCopyWith<_$_GetPosts> get copyWith =>
-      __$$_GetPostsCopyWithImpl<_$_GetPosts>(this, _$identity);
+  _$$GetPostsImplCopyWith<_$GetPostsImpl> get copyWith =>
+      __$$GetPostsImplCopyWithImpl<_$GetPostsImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPostsToJson(
+    return _$$GetPostsImplToJson(
       this,
     );
   }
@@ -2024,10 +2034,11 @@ abstract class _GetPosts extends GetPosts {
       final String? auth,
       final bool? likedOnly,
       final bool? dislikedOnly,
-      final String? pageCursor}) = _$_GetPosts;
+      final String? pageCursor}) = _$GetPostsImpl;
   const _GetPosts._() : super._();
 
-  factory _GetPosts.fromJson(Map<String, dynamic> json) = _$_GetPosts.fromJson;
+  factory _GetPosts.fromJson(Map<String, dynamic> json) =
+      _$GetPostsImpl.fromJson;
 
   @override
   @JsonKey(name: 'type_')
@@ -2057,7 +2068,7 @@ abstract class _GetPosts extends GetPosts {
   String? get pageCursor;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPostsCopyWith<_$_GetPosts> get copyWith =>
+  _$$GetPostsImplCopyWith<_$GetPostsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2121,22 +2132,22 @@ class _$CreatePostLikeCopyWithImpl<$Res, $Val extends CreatePostLike>
 }
 
 /// @nodoc
-abstract class _$$_CreatePostLikeCopyWith<$Res>
+abstract class _$$CreatePostLikeImplCopyWith<$Res>
     implements $CreatePostLikeCopyWith<$Res> {
-  factory _$$_CreatePostLikeCopyWith(
-          _$_CreatePostLike value, $Res Function(_$_CreatePostLike) then) =
-      __$$_CreatePostLikeCopyWithImpl<$Res>;
+  factory _$$CreatePostLikeImplCopyWith(_$CreatePostLikeImpl value,
+          $Res Function(_$CreatePostLikeImpl) then) =
+      __$$CreatePostLikeImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, num score, String? auth});
 }
 
 /// @nodoc
-class __$$_CreatePostLikeCopyWithImpl<$Res>
-    extends _$CreatePostLikeCopyWithImpl<$Res, _$_CreatePostLike>
-    implements _$$_CreatePostLikeCopyWith<$Res> {
-  __$$_CreatePostLikeCopyWithImpl(
-      _$_CreatePostLike _value, $Res Function(_$_CreatePostLike) _then)
+class __$$CreatePostLikeImplCopyWithImpl<$Res>
+    extends _$CreatePostLikeCopyWithImpl<$Res, _$CreatePostLikeImpl>
+    implements _$$CreatePostLikeImplCopyWith<$Res> {
+  __$$CreatePostLikeImplCopyWithImpl(
+      _$CreatePostLikeImpl _value, $Res Function(_$CreatePostLikeImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2146,7 +2157,7 @@ class __$$_CreatePostLikeCopyWithImpl<$Res>
     Object? score = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_CreatePostLike(
+    return _then(_$CreatePostLikeImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -2166,13 +2177,13 @@ class __$$_CreatePostLikeCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreatePostLike extends _CreatePostLike {
-  const _$_CreatePostLike(
+class _$CreatePostLikeImpl extends _CreatePostLike {
+  const _$CreatePostLikeImpl(
       {required this.postId, required this.score, this.auth})
       : super._();
 
-  factory _$_CreatePostLike.fromJson(Map<String, dynamic> json) =>
-      _$$_CreatePostLikeFromJson(json);
+  factory _$CreatePostLikeImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreatePostLikeImplFromJson(json);
 
   @override
   final int postId;
@@ -2190,7 +2201,7 @@ class _$_CreatePostLike extends _CreatePostLike {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreatePostLike &&
+            other is _$CreatePostLikeImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.score, score) || other.score == score) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -2203,12 +2214,13 @@ class _$_CreatePostLike extends _CreatePostLike {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreatePostLikeCopyWith<_$_CreatePostLike> get copyWith =>
-      __$$_CreatePostLikeCopyWithImpl<_$_CreatePostLike>(this, _$identity);
+  _$$CreatePostLikeImplCopyWith<_$CreatePostLikeImpl> get copyWith =>
+      __$$CreatePostLikeImplCopyWithImpl<_$CreatePostLikeImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreatePostLikeToJson(
+    return _$$CreatePostLikeImplToJson(
       this,
     );
   }
@@ -2218,11 +2230,11 @@ abstract class _CreatePostLike extends CreatePostLike {
   const factory _CreatePostLike(
       {required final int postId,
       required final num score,
-      final String? auth}) = _$_CreatePostLike;
+      final String? auth}) = _$CreatePostLikeImpl;
   const _CreatePostLike._() : super._();
 
   factory _CreatePostLike.fromJson(Map<String, dynamic> json) =
-      _$_CreatePostLike.fromJson;
+      _$CreatePostLikeImpl.fromJson;
 
   @override
   int get postId;
@@ -2232,7 +2244,7 @@ abstract class _CreatePostLike extends CreatePostLike {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreatePostLikeCopyWith<_$_CreatePostLike> get copyWith =>
+  _$$CreatePostLikeImplCopyWith<_$CreatePostLikeImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2295,21 +2307,22 @@ class _$SavePostCopyWithImpl<$Res, $Val extends SavePost>
 }
 
 /// @nodoc
-abstract class _$$_SavePostCopyWith<$Res> implements $SavePostCopyWith<$Res> {
-  factory _$$_SavePostCopyWith(
-          _$_SavePost value, $Res Function(_$_SavePost) then) =
-      __$$_SavePostCopyWithImpl<$Res>;
+abstract class _$$SavePostImplCopyWith<$Res>
+    implements $SavePostCopyWith<$Res> {
+  factory _$$SavePostImplCopyWith(
+          _$SavePostImpl value, $Res Function(_$SavePostImpl) then) =
+      __$$SavePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, bool save, String? auth});
 }
 
 /// @nodoc
-class __$$_SavePostCopyWithImpl<$Res>
-    extends _$SavePostCopyWithImpl<$Res, _$_SavePost>
-    implements _$$_SavePostCopyWith<$Res> {
-  __$$_SavePostCopyWithImpl(
-      _$_SavePost _value, $Res Function(_$_SavePost) _then)
+class __$$SavePostImplCopyWithImpl<$Res>
+    extends _$SavePostCopyWithImpl<$Res, _$SavePostImpl>
+    implements _$$SavePostImplCopyWith<$Res> {
+  __$$SavePostImplCopyWithImpl(
+      _$SavePostImpl _value, $Res Function(_$SavePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2319,7 +2332,7 @@ class __$$_SavePostCopyWithImpl<$Res>
     Object? save = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_SavePost(
+    return _then(_$SavePostImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -2339,12 +2352,12 @@ class __$$_SavePostCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_SavePost extends _SavePost {
-  const _$_SavePost({required this.postId, required this.save, this.auth})
+class _$SavePostImpl extends _SavePost {
+  const _$SavePostImpl({required this.postId, required this.save, this.auth})
       : super._();
 
-  factory _$_SavePost.fromJson(Map<String, dynamic> json) =>
-      _$$_SavePostFromJson(json);
+  factory _$SavePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SavePostImplFromJson(json);
 
   @override
   final int postId;
@@ -2362,7 +2375,7 @@ class _$_SavePost extends _SavePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SavePost &&
+            other is _$SavePostImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.save, save) || other.save == save) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -2375,12 +2388,12 @@ class _$_SavePost extends _SavePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SavePostCopyWith<_$_SavePost> get copyWith =>
-      __$$_SavePostCopyWithImpl<_$_SavePost>(this, _$identity);
+  _$$SavePostImplCopyWith<_$SavePostImpl> get copyWith =>
+      __$$SavePostImplCopyWithImpl<_$SavePostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SavePostToJson(
+    return _$$SavePostImplToJson(
       this,
     );
   }
@@ -2390,10 +2403,11 @@ abstract class _SavePost extends SavePost {
   const factory _SavePost(
       {required final int postId,
       required final bool save,
-      final String? auth}) = _$_SavePost;
+      final String? auth}) = _$SavePostImpl;
   const _SavePost._() : super._();
 
-  factory _SavePost.fromJson(Map<String, dynamic> json) = _$_SavePost.fromJson;
+  factory _SavePost.fromJson(Map<String, dynamic> json) =
+      _$SavePostImpl.fromJson;
 
   @override
   int get postId;
@@ -2403,7 +2417,7 @@ abstract class _SavePost extends SavePost {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_SavePostCopyWith<_$_SavePost> get copyWith =>
+  _$$SavePostImplCopyWith<_$SavePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2467,22 +2481,22 @@ class _$CreatePostReportCopyWithImpl<$Res, $Val extends CreatePostReport>
 }
 
 /// @nodoc
-abstract class _$$_CreatePostReportCopyWith<$Res>
+abstract class _$$CreatePostReportImplCopyWith<$Res>
     implements $CreatePostReportCopyWith<$Res> {
-  factory _$$_CreatePostReportCopyWith(
-          _$_CreatePostReport value, $Res Function(_$_CreatePostReport) then) =
-      __$$_CreatePostReportCopyWithImpl<$Res>;
+  factory _$$CreatePostReportImplCopyWith(_$CreatePostReportImpl value,
+          $Res Function(_$CreatePostReportImpl) then) =
+      __$$CreatePostReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int postId, String reason, String? auth});
 }
 
 /// @nodoc
-class __$$_CreatePostReportCopyWithImpl<$Res>
-    extends _$CreatePostReportCopyWithImpl<$Res, _$_CreatePostReport>
-    implements _$$_CreatePostReportCopyWith<$Res> {
-  __$$_CreatePostReportCopyWithImpl(
-      _$_CreatePostReport _value, $Res Function(_$_CreatePostReport) _then)
+class __$$CreatePostReportImplCopyWithImpl<$Res>
+    extends _$CreatePostReportCopyWithImpl<$Res, _$CreatePostReportImpl>
+    implements _$$CreatePostReportImplCopyWith<$Res> {
+  __$$CreatePostReportImplCopyWithImpl(_$CreatePostReportImpl _value,
+      $Res Function(_$CreatePostReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2492,7 +2506,7 @@ class __$$_CreatePostReportCopyWithImpl<$Res>
     Object? reason = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_CreatePostReport(
+    return _then(_$CreatePostReportImpl(
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -2512,13 +2526,13 @@ class __$$_CreatePostReportCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreatePostReport extends _CreatePostReport {
-  const _$_CreatePostReport(
+class _$CreatePostReportImpl extends _CreatePostReport {
+  const _$CreatePostReportImpl(
       {required this.postId, required this.reason, this.auth})
       : super._();
 
-  factory _$_CreatePostReport.fromJson(Map<String, dynamic> json) =>
-      _$$_CreatePostReportFromJson(json);
+  factory _$CreatePostReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreatePostReportImplFromJson(json);
 
   @override
   final int postId;
@@ -2536,7 +2550,7 @@ class _$_CreatePostReport extends _CreatePostReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreatePostReport &&
+            other is _$CreatePostReportImpl &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.reason, reason) || other.reason == reason) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -2549,12 +2563,13 @@ class _$_CreatePostReport extends _CreatePostReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreatePostReportCopyWith<_$_CreatePostReport> get copyWith =>
-      __$$_CreatePostReportCopyWithImpl<_$_CreatePostReport>(this, _$identity);
+  _$$CreatePostReportImplCopyWith<_$CreatePostReportImpl> get copyWith =>
+      __$$CreatePostReportImplCopyWithImpl<_$CreatePostReportImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreatePostReportToJson(
+    return _$$CreatePostReportImplToJson(
       this,
     );
   }
@@ -2564,11 +2579,11 @@ abstract class _CreatePostReport extends CreatePostReport {
   const factory _CreatePostReport(
       {required final int postId,
       required final String reason,
-      final String? auth}) = _$_CreatePostReport;
+      final String? auth}) = _$CreatePostReportImpl;
   const _CreatePostReport._() : super._();
 
   factory _CreatePostReport.fromJson(Map<String, dynamic> json) =
-      _$_CreatePostReport.fromJson;
+      _$CreatePostReportImpl.fromJson;
 
   @override
   int get postId;
@@ -2578,7 +2593,7 @@ abstract class _CreatePostReport extends CreatePostReport {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreatePostReportCopyWith<_$_CreatePostReport> get copyWith =>
+  _$$CreatePostReportImplCopyWith<_$CreatePostReportImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2642,22 +2657,22 @@ class _$ResolvePostReportCopyWithImpl<$Res, $Val extends ResolvePostReport>
 }
 
 /// @nodoc
-abstract class _$$_ResolvePostReportCopyWith<$Res>
+abstract class _$$ResolvePostReportImplCopyWith<$Res>
     implements $ResolvePostReportCopyWith<$Res> {
-  factory _$$_ResolvePostReportCopyWith(_$_ResolvePostReport value,
-          $Res Function(_$_ResolvePostReport) then) =
-      __$$_ResolvePostReportCopyWithImpl<$Res>;
+  factory _$$ResolvePostReportImplCopyWith(_$ResolvePostReportImpl value,
+          $Res Function(_$ResolvePostReportImpl) then) =
+      __$$ResolvePostReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int reportId, bool resolved, String? auth});
 }
 
 /// @nodoc
-class __$$_ResolvePostReportCopyWithImpl<$Res>
-    extends _$ResolvePostReportCopyWithImpl<$Res, _$_ResolvePostReport>
-    implements _$$_ResolvePostReportCopyWith<$Res> {
-  __$$_ResolvePostReportCopyWithImpl(
-      _$_ResolvePostReport _value, $Res Function(_$_ResolvePostReport) _then)
+class __$$ResolvePostReportImplCopyWithImpl<$Res>
+    extends _$ResolvePostReportCopyWithImpl<$Res, _$ResolvePostReportImpl>
+    implements _$$ResolvePostReportImplCopyWith<$Res> {
+  __$$ResolvePostReportImplCopyWithImpl(_$ResolvePostReportImpl _value,
+      $Res Function(_$ResolvePostReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2667,7 +2682,7 @@ class __$$_ResolvePostReportCopyWithImpl<$Res>
     Object? resolved = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_ResolvePostReport(
+    return _then(_$ResolvePostReportImpl(
       reportId: null == reportId
           ? _value.reportId
           : reportId // ignore: cast_nullable_to_non_nullable
@@ -2687,13 +2702,13 @@ class __$$_ResolvePostReportCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ResolvePostReport extends _ResolvePostReport {
-  const _$_ResolvePostReport(
+class _$ResolvePostReportImpl extends _ResolvePostReport {
+  const _$ResolvePostReportImpl(
       {required this.reportId, required this.resolved, this.auth})
       : super._();
 
-  factory _$_ResolvePostReport.fromJson(Map<String, dynamic> json) =>
-      _$$_ResolvePostReportFromJson(json);
+  factory _$ResolvePostReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ResolvePostReportImplFromJson(json);
 
   @override
   final int reportId;
@@ -2711,7 +2726,7 @@ class _$_ResolvePostReport extends _ResolvePostReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ResolvePostReport &&
+            other is _$ResolvePostReportImpl &&
             (identical(other.reportId, reportId) ||
                 other.reportId == reportId) &&
             (identical(other.resolved, resolved) ||
@@ -2726,13 +2741,13 @@ class _$_ResolvePostReport extends _ResolvePostReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ResolvePostReportCopyWith<_$_ResolvePostReport> get copyWith =>
-      __$$_ResolvePostReportCopyWithImpl<_$_ResolvePostReport>(
+  _$$ResolvePostReportImplCopyWith<_$ResolvePostReportImpl> get copyWith =>
+      __$$ResolvePostReportImplCopyWithImpl<_$ResolvePostReportImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ResolvePostReportToJson(
+    return _$$ResolvePostReportImplToJson(
       this,
     );
   }
@@ -2742,11 +2757,11 @@ abstract class _ResolvePostReport extends ResolvePostReport {
   const factory _ResolvePostReport(
       {required final int reportId,
       required final bool resolved,
-      final String? auth}) = _$_ResolvePostReport;
+      final String? auth}) = _$ResolvePostReportImpl;
   const _ResolvePostReport._() : super._();
 
   factory _ResolvePostReport.fromJson(Map<String, dynamic> json) =
-      _$_ResolvePostReport.fromJson;
+      _$ResolvePostReportImpl.fromJson;
 
   @override
   int get reportId;
@@ -2756,7 +2771,7 @@ abstract class _ResolvePostReport extends ResolvePostReport {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ResolvePostReportCopyWith<_$_ResolvePostReport> get copyWith =>
+  _$$ResolvePostReportImplCopyWith<_$ResolvePostReportImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2837,11 +2852,11 @@ class _$ListPostReportsCopyWithImpl<$Res, $Val extends ListPostReports>
 }
 
 /// @nodoc
-abstract class _$$_ListPostReportsCopyWith<$Res>
+abstract class _$$ListPostReportsImplCopyWith<$Res>
     implements $ListPostReportsCopyWith<$Res> {
-  factory _$$_ListPostReportsCopyWith(
-          _$_ListPostReports value, $Res Function(_$_ListPostReports) then) =
-      __$$_ListPostReportsCopyWithImpl<$Res>;
+  factory _$$ListPostReportsImplCopyWith(_$ListPostReportsImpl value,
+          $Res Function(_$ListPostReportsImpl) then) =
+      __$$ListPostReportsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2853,11 +2868,11 @@ abstract class _$$_ListPostReportsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ListPostReportsCopyWithImpl<$Res>
-    extends _$ListPostReportsCopyWithImpl<$Res, _$_ListPostReports>
-    implements _$$_ListPostReportsCopyWith<$Res> {
-  __$$_ListPostReportsCopyWithImpl(
-      _$_ListPostReports _value, $Res Function(_$_ListPostReports) _then)
+class __$$ListPostReportsImplCopyWithImpl<$Res>
+    extends _$ListPostReportsCopyWithImpl<$Res, _$ListPostReportsImpl>
+    implements _$$ListPostReportsImplCopyWith<$Res> {
+  __$$ListPostReportsImplCopyWithImpl(
+      _$ListPostReportsImpl _value, $Res Function(_$ListPostReportsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2869,7 +2884,7 @@ class __$$_ListPostReportsCopyWithImpl<$Res>
     Object? communityId = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_ListPostReports(
+    return _then(_$ListPostReportsImpl(
       page: freezed == page
           ? _value.page
           : page // ignore: cast_nullable_to_non_nullable
@@ -2897,13 +2912,13 @@ class __$$_ListPostReportsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ListPostReports extends _ListPostReports {
-  const _$_ListPostReports(
+class _$ListPostReportsImpl extends _ListPostReports {
+  const _$ListPostReportsImpl(
       {this.page, this.limit, this.unresolvedOnly, this.communityId, this.auth})
       : super._();
 
-  factory _$_ListPostReports.fromJson(Map<String, dynamic> json) =>
-      _$$_ListPostReportsFromJson(json);
+  factory _$ListPostReportsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ListPostReportsImplFromJson(json);
 
   @override
   final int? page;
@@ -2925,7 +2940,7 @@ class _$_ListPostReports extends _ListPostReports {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListPostReports &&
+            other is _$ListPostReportsImpl &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
             (identical(other.unresolvedOnly, unresolvedOnly) ||
@@ -2943,12 +2958,13 @@ class _$_ListPostReports extends _ListPostReports {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListPostReportsCopyWith<_$_ListPostReports> get copyWith =>
-      __$$_ListPostReportsCopyWithImpl<_$_ListPostReports>(this, _$identity);
+  _$$ListPostReportsImplCopyWith<_$ListPostReportsImpl> get copyWith =>
+      __$$ListPostReportsImplCopyWithImpl<_$ListPostReportsImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListPostReportsToJson(
+    return _$$ListPostReportsImplToJson(
       this,
     );
   }
@@ -2960,11 +2976,11 @@ abstract class _ListPostReports extends ListPostReports {
       final int? limit,
       final bool? unresolvedOnly,
       final int? communityId,
-      final String? auth}) = _$_ListPostReports;
+      final String? auth}) = _$ListPostReportsImpl;
   const _ListPostReports._() : super._();
 
   factory _ListPostReports.fromJson(Map<String, dynamic> json) =
-      _$_ListPostReports.fromJson;
+      _$ListPostReportsImpl.fromJson;
 
   @override
   int? get page;
@@ -2978,7 +2994,7 @@ abstract class _ListPostReports extends ListPostReports {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ListPostReportsCopyWith<_$_ListPostReports> get copyWith =>
+  _$$ListPostReportsImplCopyWith<_$ListPostReportsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3030,22 +3046,22 @@ class _$GetSiteMetadataCopyWithImpl<$Res, $Val extends GetSiteMetadata>
 }
 
 /// @nodoc
-abstract class _$$_GetSiteMetadataCopyWith<$Res>
+abstract class _$$GetSiteMetadataImplCopyWith<$Res>
     implements $GetSiteMetadataCopyWith<$Res> {
-  factory _$$_GetSiteMetadataCopyWith(
-          _$_GetSiteMetadata value, $Res Function(_$_GetSiteMetadata) then) =
-      __$$_GetSiteMetadataCopyWithImpl<$Res>;
+  factory _$$GetSiteMetadataImplCopyWith(_$GetSiteMetadataImpl value,
+          $Res Function(_$GetSiteMetadataImpl) then) =
+      __$$GetSiteMetadataImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String url});
 }
 
 /// @nodoc
-class __$$_GetSiteMetadataCopyWithImpl<$Res>
-    extends _$GetSiteMetadataCopyWithImpl<$Res, _$_GetSiteMetadata>
-    implements _$$_GetSiteMetadataCopyWith<$Res> {
-  __$$_GetSiteMetadataCopyWithImpl(
-      _$_GetSiteMetadata _value, $Res Function(_$_GetSiteMetadata) _then)
+class __$$GetSiteMetadataImplCopyWithImpl<$Res>
+    extends _$GetSiteMetadataCopyWithImpl<$Res, _$GetSiteMetadataImpl>
+    implements _$$GetSiteMetadataImplCopyWith<$Res> {
+  __$$GetSiteMetadataImplCopyWithImpl(
+      _$GetSiteMetadataImpl _value, $Res Function(_$GetSiteMetadataImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3053,7 +3069,7 @@ class __$$_GetSiteMetadataCopyWithImpl<$Res>
   $Res call({
     Object? url = null,
   }) {
-    return _then(_$_GetSiteMetadata(
+    return _then(_$GetSiteMetadataImpl(
       url: null == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
@@ -3065,11 +3081,11 @@ class __$$_GetSiteMetadataCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetSiteMetadata extends _GetSiteMetadata {
-  const _$_GetSiteMetadata({required this.url}) : super._();
+class _$GetSiteMetadataImpl extends _GetSiteMetadata {
+  const _$GetSiteMetadataImpl({required this.url}) : super._();
 
-  factory _$_GetSiteMetadata.fromJson(Map<String, dynamic> json) =>
-      _$$_GetSiteMetadataFromJson(json);
+  factory _$GetSiteMetadataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetSiteMetadataImplFromJson(json);
 
   @override
   final String url;
@@ -3083,7 +3099,7 @@ class _$_GetSiteMetadata extends _GetSiteMetadata {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetSiteMetadata &&
+            other is _$GetSiteMetadataImpl &&
             (identical(other.url, url) || other.url == url));
   }
 
@@ -3094,12 +3110,13 @@ class _$_GetSiteMetadata extends _GetSiteMetadata {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetSiteMetadataCopyWith<_$_GetSiteMetadata> get copyWith =>
-      __$$_GetSiteMetadataCopyWithImpl<_$_GetSiteMetadata>(this, _$identity);
+  _$$GetSiteMetadataImplCopyWith<_$GetSiteMetadataImpl> get copyWith =>
+      __$$GetSiteMetadataImplCopyWithImpl<_$GetSiteMetadataImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetSiteMetadataToJson(
+    return _$$GetSiteMetadataImplToJson(
       this,
     );
   }
@@ -3107,16 +3124,16 @@ class _$_GetSiteMetadata extends _GetSiteMetadata {
 
 abstract class _GetSiteMetadata extends GetSiteMetadata {
   const factory _GetSiteMetadata({required final String url}) =
-      _$_GetSiteMetadata;
+      _$GetSiteMetadataImpl;
   const _GetSiteMetadata._() : super._();
 
   factory _GetSiteMetadata.fromJson(Map<String, dynamic> json) =
-      _$_GetSiteMetadata.fromJson;
+      _$GetSiteMetadataImpl.fromJson;
 
   @override
   String get url;
   @override
   @JsonKey(ignore: true)
-  _$$_GetSiteMetadataCopyWith<_$_GetSiteMetadata> get copyWith =>
+  _$$GetSiteMetadataImplCopyWith<_$GetSiteMetadataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/post/post.g.dart
+++ b/lib/src/v3/api/post/post.g.dart
@@ -6,8 +6,8 @@ part of 'post.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CreatePost _$$_CreatePostFromJson(Map<String, dynamic> json) =>
-    _$_CreatePost(
+_$CreatePostImpl _$$CreatePostImplFromJson(Map<String, dynamic> json) =>
+    _$CreatePostImpl(
       name: json['name'] as String,
       communityId: json['community_id'] as int,
       url: json['url'] as String?,
@@ -18,7 +18,7 @@ _$_CreatePost _$$_CreatePostFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_CreatePostToJson(_$_CreatePost instance) {
+Map<String, dynamic> _$$CreatePostImplToJson(_$CreatePostImpl instance) {
   final val = <String, dynamic>{
     'name': instance.name,
     'community_id': instance.communityId,
@@ -39,13 +39,14 @@ Map<String, dynamic> _$$_CreatePostToJson(_$_CreatePost instance) {
   return val;
 }
 
-_$_GetPost _$$_GetPostFromJson(Map<String, dynamic> json) => _$_GetPost(
+_$GetPostImpl _$$GetPostImplFromJson(Map<String, dynamic> json) =>
+    _$GetPostImpl(
       id: json['id'] as int?,
       commentId: json['comment_id'] as int?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetPostToJson(_$_GetPost instance) {
+Map<String, dynamic> _$$GetPostImplToJson(_$GetPostImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -60,7 +61,8 @@ Map<String, dynamic> _$$_GetPostToJson(_$_GetPost instance) {
   return val;
 }
 
-_$_EditPost _$$_EditPostFromJson(Map<String, dynamic> json) => _$_EditPost(
+_$EditPostImpl _$$EditPostImplFromJson(Map<String, dynamic> json) =>
+    _$EditPostImpl(
       postId: json['post_id'] as int,
       name: json['name'] as String?,
       url: json['url'] as String?,
@@ -70,7 +72,7 @@ _$_EditPost _$$_EditPostFromJson(Map<String, dynamic> json) => _$_EditPost(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_EditPostToJson(_$_EditPost instance) {
+Map<String, dynamic> _$$EditPostImplToJson(_$EditPostImpl instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
   };
@@ -90,14 +92,14 @@ Map<String, dynamic> _$$_EditPostToJson(_$_EditPost instance) {
   return val;
 }
 
-_$_DeletePost _$$_DeletePostFromJson(Map<String, dynamic> json) =>
-    _$_DeletePost(
+_$DeletePostImpl _$$DeletePostImplFromJson(Map<String, dynamic> json) =>
+    _$DeletePostImpl(
       postId: json['post_id'] as int,
       deleted: json['deleted'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_DeletePostToJson(_$_DeletePost instance) {
+Map<String, dynamic> _$$DeletePostImplToJson(_$DeletePostImpl instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
     'deleted': instance.deleted,
@@ -113,15 +115,15 @@ Map<String, dynamic> _$$_DeletePostToJson(_$_DeletePost instance) {
   return val;
 }
 
-_$_RemovePost _$$_RemovePostFromJson(Map<String, dynamic> json) =>
-    _$_RemovePost(
+_$RemovePostImpl _$$RemovePostImplFromJson(Map<String, dynamic> json) =>
+    _$RemovePostImpl(
       postId: json['post_id'] as int,
       removed: json['removed'] as bool,
       reason: json['reason'] as String?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_RemovePostToJson(_$_RemovePost instance) {
+Map<String, dynamic> _$$RemovePostImplToJson(_$RemovePostImpl instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
     'removed': instance.removed,
@@ -138,8 +140,8 @@ Map<String, dynamic> _$$_RemovePostToJson(_$_RemovePost instance) {
   return val;
 }
 
-_$_MarkPostAsRead _$$_MarkPostAsReadFromJson(Map<String, dynamic> json) =>
-    _$_MarkPostAsRead(
+_$MarkPostAsReadImpl _$$MarkPostAsReadImplFromJson(Map<String, dynamic> json) =>
+    _$MarkPostAsReadImpl(
       postId: json['post_id'] as int?,
       postIds:
           (json['post_ids'] as List<dynamic>?)?.map((e) => e as int).toList(),
@@ -147,7 +149,8 @@ _$_MarkPostAsRead _$$_MarkPostAsReadFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_MarkPostAsReadToJson(_$_MarkPostAsRead instance) {
+Map<String, dynamic> _$$MarkPostAsReadImplToJson(
+    _$MarkPostAsReadImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -163,13 +166,14 @@ Map<String, dynamic> _$$_MarkPostAsReadToJson(_$_MarkPostAsRead instance) {
   return val;
 }
 
-_$_LockPost _$$_LockPostFromJson(Map<String, dynamic> json) => _$_LockPost(
+_$LockPostImpl _$$LockPostImplFromJson(Map<String, dynamic> json) =>
+    _$LockPostImpl(
       postId: json['post_id'] as int,
       locked: json['locked'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_LockPostToJson(_$_LockPost instance) {
+Map<String, dynamic> _$$LockPostImplToJson(_$LockPostImpl instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
     'locked': instance.locked,
@@ -185,15 +189,15 @@ Map<String, dynamic> _$$_LockPostToJson(_$_LockPost instance) {
   return val;
 }
 
-_$_FeaturePost _$$_FeaturePostFromJson(Map<String, dynamic> json) =>
-    _$_FeaturePost(
+_$FeaturePostImpl _$$FeaturePostImplFromJson(Map<String, dynamic> json) =>
+    _$FeaturePostImpl(
       postId: json['post_id'] as int,
       featured: json['featured'] as bool,
       featureType: PostFeatureType.fromJson(json['feature_type'] as String),
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_FeaturePostToJson(_$_FeaturePost instance) {
+Map<String, dynamic> _$$FeaturePostImplToJson(_$FeaturePostImpl instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
     'featured': instance.featured,
@@ -210,7 +214,8 @@ Map<String, dynamic> _$$_FeaturePostToJson(_$_FeaturePost instance) {
   return val;
 }
 
-_$_GetPosts _$$_GetPostsFromJson(Map<String, dynamic> json) => _$_GetPosts(
+_$GetPostsImpl _$$GetPostsImplFromJson(Map<String, dynamic> json) =>
+    _$GetPostsImpl(
       type: json['type_'] == null ? null : ListingType.fromJson(json['type_']),
       sort: json['sort'] == null ? null : SortType.fromJson(json['sort']),
       page: json['page'] as int?,
@@ -225,7 +230,7 @@ _$_GetPosts _$$_GetPostsFromJson(Map<String, dynamic> json) => _$_GetPosts(
       pageCursor: json['page_cursor'] as String?,
     );
 
-Map<String, dynamic> _$$_GetPostsToJson(_$_GetPosts instance) {
+Map<String, dynamic> _$$GetPostsImplToJson(_$GetPostsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -249,14 +254,15 @@ Map<String, dynamic> _$$_GetPostsToJson(_$_GetPosts instance) {
   return val;
 }
 
-_$_CreatePostLike _$$_CreatePostLikeFromJson(Map<String, dynamic> json) =>
-    _$_CreatePostLike(
+_$CreatePostLikeImpl _$$CreatePostLikeImplFromJson(Map<String, dynamic> json) =>
+    _$CreatePostLikeImpl(
       postId: json['post_id'] as int,
       score: json['score'] as num,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_CreatePostLikeToJson(_$_CreatePostLike instance) {
+Map<String, dynamic> _$$CreatePostLikeImplToJson(
+    _$CreatePostLikeImpl instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
     'score': instance.score,
@@ -272,13 +278,14 @@ Map<String, dynamic> _$$_CreatePostLikeToJson(_$_CreatePostLike instance) {
   return val;
 }
 
-_$_SavePost _$$_SavePostFromJson(Map<String, dynamic> json) => _$_SavePost(
+_$SavePostImpl _$$SavePostImplFromJson(Map<String, dynamic> json) =>
+    _$SavePostImpl(
       postId: json['post_id'] as int,
       save: json['save'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_SavePostToJson(_$_SavePost instance) {
+Map<String, dynamic> _$$SavePostImplToJson(_$SavePostImpl instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
     'save': instance.save,
@@ -294,14 +301,16 @@ Map<String, dynamic> _$$_SavePostToJson(_$_SavePost instance) {
   return val;
 }
 
-_$_CreatePostReport _$$_CreatePostReportFromJson(Map<String, dynamic> json) =>
-    _$_CreatePostReport(
+_$CreatePostReportImpl _$$CreatePostReportImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CreatePostReportImpl(
       postId: json['post_id'] as int,
       reason: json['reason'] as String,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_CreatePostReportToJson(_$_CreatePostReport instance) {
+Map<String, dynamic> _$$CreatePostReportImplToJson(
+    _$CreatePostReportImpl instance) {
   final val = <String, dynamic>{
     'post_id': instance.postId,
     'reason': instance.reason,
@@ -317,15 +326,16 @@ Map<String, dynamic> _$$_CreatePostReportToJson(_$_CreatePostReport instance) {
   return val;
 }
 
-_$_ResolvePostReport _$$_ResolvePostReportFromJson(Map<String, dynamic> json) =>
-    _$_ResolvePostReport(
+_$ResolvePostReportImpl _$$ResolvePostReportImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ResolvePostReportImpl(
       reportId: json['report_id'] as int,
       resolved: json['resolved'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ResolvePostReportToJson(
-    _$_ResolvePostReport instance) {
+Map<String, dynamic> _$$ResolvePostReportImplToJson(
+    _$ResolvePostReportImpl instance) {
   final val = <String, dynamic>{
     'report_id': instance.reportId,
     'resolved': instance.resolved,
@@ -341,8 +351,9 @@ Map<String, dynamic> _$$_ResolvePostReportToJson(
   return val;
 }
 
-_$_ListPostReports _$$_ListPostReportsFromJson(Map<String, dynamic> json) =>
-    _$_ListPostReports(
+_$ListPostReportsImpl _$$ListPostReportsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ListPostReportsImpl(
       page: json['page'] as int?,
       limit: json['limit'] as int?,
       unresolvedOnly: json['unresolved_only'] as bool?,
@@ -350,7 +361,8 @@ _$_ListPostReports _$$_ListPostReportsFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ListPostReportsToJson(_$_ListPostReports instance) {
+Map<String, dynamic> _$$ListPostReportsImplToJson(
+    _$ListPostReportsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -367,12 +379,14 @@ Map<String, dynamic> _$$_ListPostReportsToJson(_$_ListPostReports instance) {
   return val;
 }
 
-_$_GetSiteMetadata _$$_GetSiteMetadataFromJson(Map<String, dynamic> json) =>
-    _$_GetSiteMetadata(
+_$GetSiteMetadataImpl _$$GetSiteMetadataImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GetSiteMetadataImpl(
       url: json['url'] as String,
     );
 
-Map<String, dynamic> _$$_GetSiteMetadataToJson(_$_GetSiteMetadata instance) =>
+Map<String, dynamic> _$$GetSiteMetadataImplToJson(
+        _$GetSiteMetadataImpl instance) =>
     <String, dynamic>{
       'url': instance.url,
     };

--- a/lib/src/v3/api/private_message/private_message.freezed.dart
+++ b/lib/src/v3/api/private_message/private_message.freezed.dart
@@ -87,11 +87,11 @@ class _$GetPrivateMessagesCopyWithImpl<$Res, $Val extends GetPrivateMessages>
 }
 
 /// @nodoc
-abstract class _$$_GetPrivateMessagesCopyWith<$Res>
+abstract class _$$GetPrivateMessagesImplCopyWith<$Res>
     implements $GetPrivateMessagesCopyWith<$Res> {
-  factory _$$_GetPrivateMessagesCopyWith(_$_GetPrivateMessages value,
-          $Res Function(_$_GetPrivateMessages) then) =
-      __$$_GetPrivateMessagesCopyWithImpl<$Res>;
+  factory _$$GetPrivateMessagesImplCopyWith(_$GetPrivateMessagesImpl value,
+          $Res Function(_$GetPrivateMessagesImpl) then) =
+      __$$GetPrivateMessagesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -99,11 +99,11 @@ abstract class _$$_GetPrivateMessagesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetPrivateMessagesCopyWithImpl<$Res>
-    extends _$GetPrivateMessagesCopyWithImpl<$Res, _$_GetPrivateMessages>
-    implements _$$_GetPrivateMessagesCopyWith<$Res> {
-  __$$_GetPrivateMessagesCopyWithImpl(
-      _$_GetPrivateMessages _value, $Res Function(_$_GetPrivateMessages) _then)
+class __$$GetPrivateMessagesImplCopyWithImpl<$Res>
+    extends _$GetPrivateMessagesCopyWithImpl<$Res, _$GetPrivateMessagesImpl>
+    implements _$$GetPrivateMessagesImplCopyWith<$Res> {
+  __$$GetPrivateMessagesImplCopyWithImpl(_$GetPrivateMessagesImpl _value,
+      $Res Function(_$GetPrivateMessagesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -115,7 +115,7 @@ class __$$_GetPrivateMessagesCopyWithImpl<$Res>
     Object? auth = freezed,
     Object? creatorId = freezed,
   }) {
-    return _then(_$_GetPrivateMessages(
+    return _then(_$GetPrivateMessagesImpl(
       unreadOnly: freezed == unreadOnly
           ? _value.unreadOnly
           : unreadOnly // ignore: cast_nullable_to_non_nullable
@@ -143,13 +143,13 @@ class __$$_GetPrivateMessagesCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetPrivateMessages extends _GetPrivateMessages {
-  const _$_GetPrivateMessages(
+class _$GetPrivateMessagesImpl extends _GetPrivateMessages {
+  const _$GetPrivateMessagesImpl(
       {this.unreadOnly, this.page, this.limit, this.auth, this.creatorId})
       : super._();
 
-  factory _$_GetPrivateMessages.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPrivateMessagesFromJson(json);
+  factory _$GetPrivateMessagesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPrivateMessagesImplFromJson(json);
 
   @override
   final bool? unreadOnly;
@@ -171,7 +171,7 @@ class _$_GetPrivateMessages extends _GetPrivateMessages {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPrivateMessages &&
+            other is _$GetPrivateMessagesImpl &&
             (identical(other.unreadOnly, unreadOnly) ||
                 other.unreadOnly == unreadOnly) &&
             (identical(other.page, page) || other.page == page) &&
@@ -189,13 +189,13 @@ class _$_GetPrivateMessages extends _GetPrivateMessages {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPrivateMessagesCopyWith<_$_GetPrivateMessages> get copyWith =>
-      __$$_GetPrivateMessagesCopyWithImpl<_$_GetPrivateMessages>(
+  _$$GetPrivateMessagesImplCopyWith<_$GetPrivateMessagesImpl> get copyWith =>
+      __$$GetPrivateMessagesImplCopyWithImpl<_$GetPrivateMessagesImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPrivateMessagesToJson(
+    return _$$GetPrivateMessagesImplToJson(
       this,
     );
   }
@@ -207,11 +207,11 @@ abstract class _GetPrivateMessages extends GetPrivateMessages {
       final int? page,
       final int? limit,
       final String? auth,
-      final int? creatorId}) = _$_GetPrivateMessages;
+      final int? creatorId}) = _$GetPrivateMessagesImpl;
   const _GetPrivateMessages._() : super._();
 
   factory _GetPrivateMessages.fromJson(Map<String, dynamic> json) =
-      _$_GetPrivateMessages.fromJson;
+      _$GetPrivateMessagesImpl.fromJson;
 
   @override
   bool? get unreadOnly;
@@ -225,7 +225,7 @@ abstract class _GetPrivateMessages extends GetPrivateMessages {
   int? get creatorId;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPrivateMessagesCopyWith<_$_GetPrivateMessages> get copyWith =>
+  _$$GetPrivateMessagesImplCopyWith<_$GetPrivateMessagesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -290,22 +290,22 @@ class _$CreatePrivateMessageCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_CreatePrivateMessageCopyWith<$Res>
+abstract class _$$CreatePrivateMessageImplCopyWith<$Res>
     implements $CreatePrivateMessageCopyWith<$Res> {
-  factory _$$_CreatePrivateMessageCopyWith(_$_CreatePrivateMessage value,
-          $Res Function(_$_CreatePrivateMessage) then) =
-      __$$_CreatePrivateMessageCopyWithImpl<$Res>;
+  factory _$$CreatePrivateMessageImplCopyWith(_$CreatePrivateMessageImpl value,
+          $Res Function(_$CreatePrivateMessageImpl) then) =
+      __$$CreatePrivateMessageImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String content, int recipientId, String? auth});
 }
 
 /// @nodoc
-class __$$_CreatePrivateMessageCopyWithImpl<$Res>
-    extends _$CreatePrivateMessageCopyWithImpl<$Res, _$_CreatePrivateMessage>
-    implements _$$_CreatePrivateMessageCopyWith<$Res> {
-  __$$_CreatePrivateMessageCopyWithImpl(_$_CreatePrivateMessage _value,
-      $Res Function(_$_CreatePrivateMessage) _then)
+class __$$CreatePrivateMessageImplCopyWithImpl<$Res>
+    extends _$CreatePrivateMessageCopyWithImpl<$Res, _$CreatePrivateMessageImpl>
+    implements _$$CreatePrivateMessageImplCopyWith<$Res> {
+  __$$CreatePrivateMessageImplCopyWithImpl(_$CreatePrivateMessageImpl _value,
+      $Res Function(_$CreatePrivateMessageImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -315,7 +315,7 @@ class __$$_CreatePrivateMessageCopyWithImpl<$Res>
     Object? recipientId = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_CreatePrivateMessage(
+    return _then(_$CreatePrivateMessageImpl(
       content: null == content
           ? _value.content
           : content // ignore: cast_nullable_to_non_nullable
@@ -335,13 +335,13 @@ class __$$_CreatePrivateMessageCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreatePrivateMessage extends _CreatePrivateMessage {
-  const _$_CreatePrivateMessage(
+class _$CreatePrivateMessageImpl extends _CreatePrivateMessage {
+  const _$CreatePrivateMessageImpl(
       {required this.content, required this.recipientId, this.auth})
       : super._();
 
-  factory _$_CreatePrivateMessage.fromJson(Map<String, dynamic> json) =>
-      _$$_CreatePrivateMessageFromJson(json);
+  factory _$CreatePrivateMessageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreatePrivateMessageImplFromJson(json);
 
   @override
   final String content;
@@ -359,7 +359,7 @@ class _$_CreatePrivateMessage extends _CreatePrivateMessage {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreatePrivateMessage &&
+            other is _$CreatePrivateMessageImpl &&
             (identical(other.content, content) || other.content == content) &&
             (identical(other.recipientId, recipientId) ||
                 other.recipientId == recipientId) &&
@@ -373,13 +373,14 @@ class _$_CreatePrivateMessage extends _CreatePrivateMessage {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreatePrivateMessageCopyWith<_$_CreatePrivateMessage> get copyWith =>
-      __$$_CreatePrivateMessageCopyWithImpl<_$_CreatePrivateMessage>(
-          this, _$identity);
+  _$$CreatePrivateMessageImplCopyWith<_$CreatePrivateMessageImpl>
+      get copyWith =>
+          __$$CreatePrivateMessageImplCopyWithImpl<_$CreatePrivateMessageImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreatePrivateMessageToJson(
+    return _$$CreatePrivateMessageImplToJson(
       this,
     );
   }
@@ -389,11 +390,11 @@ abstract class _CreatePrivateMessage extends CreatePrivateMessage {
   const factory _CreatePrivateMessage(
       {required final String content,
       required final int recipientId,
-      final String? auth}) = _$_CreatePrivateMessage;
+      final String? auth}) = _$CreatePrivateMessageImpl;
   const _CreatePrivateMessage._() : super._();
 
   factory _CreatePrivateMessage.fromJson(Map<String, dynamic> json) =
-      _$_CreatePrivateMessage.fromJson;
+      _$CreatePrivateMessageImpl.fromJson;
 
   @override
   String get content;
@@ -403,8 +404,8 @@ abstract class _CreatePrivateMessage extends CreatePrivateMessage {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreatePrivateMessageCopyWith<_$_CreatePrivateMessage> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$CreatePrivateMessageImplCopyWith<_$CreatePrivateMessageImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 EditPrivateMessage _$EditPrivateMessageFromJson(Map<String, dynamic> json) {
@@ -467,22 +468,22 @@ class _$EditPrivateMessageCopyWithImpl<$Res, $Val extends EditPrivateMessage>
 }
 
 /// @nodoc
-abstract class _$$_EditPrivateMessageCopyWith<$Res>
+abstract class _$$EditPrivateMessageImplCopyWith<$Res>
     implements $EditPrivateMessageCopyWith<$Res> {
-  factory _$$_EditPrivateMessageCopyWith(_$_EditPrivateMessage value,
-          $Res Function(_$_EditPrivateMessage) then) =
-      __$$_EditPrivateMessageCopyWithImpl<$Res>;
+  factory _$$EditPrivateMessageImplCopyWith(_$EditPrivateMessageImpl value,
+          $Res Function(_$EditPrivateMessageImpl) then) =
+      __$$EditPrivateMessageImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int privateMessageId, String content, String? auth});
 }
 
 /// @nodoc
-class __$$_EditPrivateMessageCopyWithImpl<$Res>
-    extends _$EditPrivateMessageCopyWithImpl<$Res, _$_EditPrivateMessage>
-    implements _$$_EditPrivateMessageCopyWith<$Res> {
-  __$$_EditPrivateMessageCopyWithImpl(
-      _$_EditPrivateMessage _value, $Res Function(_$_EditPrivateMessage) _then)
+class __$$EditPrivateMessageImplCopyWithImpl<$Res>
+    extends _$EditPrivateMessageCopyWithImpl<$Res, _$EditPrivateMessageImpl>
+    implements _$$EditPrivateMessageImplCopyWith<$Res> {
+  __$$EditPrivateMessageImplCopyWithImpl(_$EditPrivateMessageImpl _value,
+      $Res Function(_$EditPrivateMessageImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -492,7 +493,7 @@ class __$$_EditPrivateMessageCopyWithImpl<$Res>
     Object? content = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_EditPrivateMessage(
+    return _then(_$EditPrivateMessageImpl(
       privateMessageId: null == privateMessageId
           ? _value.privateMessageId
           : privateMessageId // ignore: cast_nullable_to_non_nullable
@@ -512,13 +513,13 @@ class __$$_EditPrivateMessageCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_EditPrivateMessage extends _EditPrivateMessage {
-  const _$_EditPrivateMessage(
+class _$EditPrivateMessageImpl extends _EditPrivateMessage {
+  const _$EditPrivateMessageImpl(
       {required this.privateMessageId, required this.content, this.auth})
       : super._();
 
-  factory _$_EditPrivateMessage.fromJson(Map<String, dynamic> json) =>
-      _$$_EditPrivateMessageFromJson(json);
+  factory _$EditPrivateMessageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EditPrivateMessageImplFromJson(json);
 
   @override
   final int privateMessageId;
@@ -536,7 +537,7 @@ class _$_EditPrivateMessage extends _EditPrivateMessage {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_EditPrivateMessage &&
+            other is _$EditPrivateMessageImpl &&
             (identical(other.privateMessageId, privateMessageId) ||
                 other.privateMessageId == privateMessageId) &&
             (identical(other.content, content) || other.content == content) &&
@@ -550,13 +551,13 @@ class _$_EditPrivateMessage extends _EditPrivateMessage {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_EditPrivateMessageCopyWith<_$_EditPrivateMessage> get copyWith =>
-      __$$_EditPrivateMessageCopyWithImpl<_$_EditPrivateMessage>(
+  _$$EditPrivateMessageImplCopyWith<_$EditPrivateMessageImpl> get copyWith =>
+      __$$EditPrivateMessageImplCopyWithImpl<_$EditPrivateMessageImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_EditPrivateMessageToJson(
+    return _$$EditPrivateMessageImplToJson(
       this,
     );
   }
@@ -566,11 +567,11 @@ abstract class _EditPrivateMessage extends EditPrivateMessage {
   const factory _EditPrivateMessage(
       {required final int privateMessageId,
       required final String content,
-      final String? auth}) = _$_EditPrivateMessage;
+      final String? auth}) = _$EditPrivateMessageImpl;
   const _EditPrivateMessage._() : super._();
 
   factory _EditPrivateMessage.fromJson(Map<String, dynamic> json) =
-      _$_EditPrivateMessage.fromJson;
+      _$EditPrivateMessageImpl.fromJson;
 
   @override
   int get privateMessageId;
@@ -580,7 +581,7 @@ abstract class _EditPrivateMessage extends EditPrivateMessage {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_EditPrivateMessageCopyWith<_$_EditPrivateMessage> get copyWith =>
+  _$$EditPrivateMessageImplCopyWith<_$EditPrivateMessageImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -645,22 +646,22 @@ class _$DeletePrivateMessageCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_DeletePrivateMessageCopyWith<$Res>
+abstract class _$$DeletePrivateMessageImplCopyWith<$Res>
     implements $DeletePrivateMessageCopyWith<$Res> {
-  factory _$$_DeletePrivateMessageCopyWith(_$_DeletePrivateMessage value,
-          $Res Function(_$_DeletePrivateMessage) then) =
-      __$$_DeletePrivateMessageCopyWithImpl<$Res>;
+  factory _$$DeletePrivateMessageImplCopyWith(_$DeletePrivateMessageImpl value,
+          $Res Function(_$DeletePrivateMessageImpl) then) =
+      __$$DeletePrivateMessageImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int privateMessageId, bool deleted, String? auth});
 }
 
 /// @nodoc
-class __$$_DeletePrivateMessageCopyWithImpl<$Res>
-    extends _$DeletePrivateMessageCopyWithImpl<$Res, _$_DeletePrivateMessage>
-    implements _$$_DeletePrivateMessageCopyWith<$Res> {
-  __$$_DeletePrivateMessageCopyWithImpl(_$_DeletePrivateMessage _value,
-      $Res Function(_$_DeletePrivateMessage) _then)
+class __$$DeletePrivateMessageImplCopyWithImpl<$Res>
+    extends _$DeletePrivateMessageCopyWithImpl<$Res, _$DeletePrivateMessageImpl>
+    implements _$$DeletePrivateMessageImplCopyWith<$Res> {
+  __$$DeletePrivateMessageImplCopyWithImpl(_$DeletePrivateMessageImpl _value,
+      $Res Function(_$DeletePrivateMessageImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -670,7 +671,7 @@ class __$$_DeletePrivateMessageCopyWithImpl<$Res>
     Object? deleted = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_DeletePrivateMessage(
+    return _then(_$DeletePrivateMessageImpl(
       privateMessageId: null == privateMessageId
           ? _value.privateMessageId
           : privateMessageId // ignore: cast_nullable_to_non_nullable
@@ -690,13 +691,13 @@ class __$$_DeletePrivateMessageCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_DeletePrivateMessage extends _DeletePrivateMessage {
-  const _$_DeletePrivateMessage(
+class _$DeletePrivateMessageImpl extends _DeletePrivateMessage {
+  const _$DeletePrivateMessageImpl(
       {required this.privateMessageId, required this.deleted, this.auth})
       : super._();
 
-  factory _$_DeletePrivateMessage.fromJson(Map<String, dynamic> json) =>
-      _$$_DeletePrivateMessageFromJson(json);
+  factory _$DeletePrivateMessageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeletePrivateMessageImplFromJson(json);
 
   @override
   final int privateMessageId;
@@ -714,7 +715,7 @@ class _$_DeletePrivateMessage extends _DeletePrivateMessage {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeletePrivateMessage &&
+            other is _$DeletePrivateMessageImpl &&
             (identical(other.privateMessageId, privateMessageId) ||
                 other.privateMessageId == privateMessageId) &&
             (identical(other.deleted, deleted) || other.deleted == deleted) &&
@@ -728,13 +729,14 @@ class _$_DeletePrivateMessage extends _DeletePrivateMessage {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeletePrivateMessageCopyWith<_$_DeletePrivateMessage> get copyWith =>
-      __$$_DeletePrivateMessageCopyWithImpl<_$_DeletePrivateMessage>(
-          this, _$identity);
+  _$$DeletePrivateMessageImplCopyWith<_$DeletePrivateMessageImpl>
+      get copyWith =>
+          __$$DeletePrivateMessageImplCopyWithImpl<_$DeletePrivateMessageImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeletePrivateMessageToJson(
+    return _$$DeletePrivateMessageImplToJson(
       this,
     );
   }
@@ -744,11 +746,11 @@ abstract class _DeletePrivateMessage extends DeletePrivateMessage {
   const factory _DeletePrivateMessage(
       {required final int privateMessageId,
       required final bool deleted,
-      final String? auth}) = _$_DeletePrivateMessage;
+      final String? auth}) = _$DeletePrivateMessageImpl;
   const _DeletePrivateMessage._() : super._();
 
   factory _DeletePrivateMessage.fromJson(Map<String, dynamic> json) =
-      _$_DeletePrivateMessage.fromJson;
+      _$DeletePrivateMessageImpl.fromJson;
 
   @override
   int get privateMessageId;
@@ -758,8 +760,8 @@ abstract class _DeletePrivateMessage extends DeletePrivateMessage {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_DeletePrivateMessageCopyWith<_$_DeletePrivateMessage> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$DeletePrivateMessageImplCopyWith<_$DeletePrivateMessageImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 MarkPrivateMessageAsRead _$MarkPrivateMessageAsReadFromJson(
@@ -824,24 +826,25 @@ class _$MarkPrivateMessageAsReadCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_MarkPrivateMessageAsReadCopyWith<$Res>
+abstract class _$$MarkPrivateMessageAsReadImplCopyWith<$Res>
     implements $MarkPrivateMessageAsReadCopyWith<$Res> {
-  factory _$$_MarkPrivateMessageAsReadCopyWith(
-          _$_MarkPrivateMessageAsRead value,
-          $Res Function(_$_MarkPrivateMessageAsRead) then) =
-      __$$_MarkPrivateMessageAsReadCopyWithImpl<$Res>;
+  factory _$$MarkPrivateMessageAsReadImplCopyWith(
+          _$MarkPrivateMessageAsReadImpl value,
+          $Res Function(_$MarkPrivateMessageAsReadImpl) then) =
+      __$$MarkPrivateMessageAsReadImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int privateMessageId, bool read, String? auth});
 }
 
 /// @nodoc
-class __$$_MarkPrivateMessageAsReadCopyWithImpl<$Res>
+class __$$MarkPrivateMessageAsReadImplCopyWithImpl<$Res>
     extends _$MarkPrivateMessageAsReadCopyWithImpl<$Res,
-        _$_MarkPrivateMessageAsRead>
-    implements _$$_MarkPrivateMessageAsReadCopyWith<$Res> {
-  __$$_MarkPrivateMessageAsReadCopyWithImpl(_$_MarkPrivateMessageAsRead _value,
-      $Res Function(_$_MarkPrivateMessageAsRead) _then)
+        _$MarkPrivateMessageAsReadImpl>
+    implements _$$MarkPrivateMessageAsReadImplCopyWith<$Res> {
+  __$$MarkPrivateMessageAsReadImplCopyWithImpl(
+      _$MarkPrivateMessageAsReadImpl _value,
+      $Res Function(_$MarkPrivateMessageAsReadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -851,7 +854,7 @@ class __$$_MarkPrivateMessageAsReadCopyWithImpl<$Res>
     Object? read = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_MarkPrivateMessageAsRead(
+    return _then(_$MarkPrivateMessageAsReadImpl(
       privateMessageId: null == privateMessageId
           ? _value.privateMessageId
           : privateMessageId // ignore: cast_nullable_to_non_nullable
@@ -871,13 +874,13 @@ class __$$_MarkPrivateMessageAsReadCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_MarkPrivateMessageAsRead extends _MarkPrivateMessageAsRead {
-  const _$_MarkPrivateMessageAsRead(
+class _$MarkPrivateMessageAsReadImpl extends _MarkPrivateMessageAsRead {
+  const _$MarkPrivateMessageAsReadImpl(
       {required this.privateMessageId, required this.read, this.auth})
       : super._();
 
-  factory _$_MarkPrivateMessageAsRead.fromJson(Map<String, dynamic> json) =>
-      _$$_MarkPrivateMessageAsReadFromJson(json);
+  factory _$MarkPrivateMessageAsReadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MarkPrivateMessageAsReadImplFromJson(json);
 
   @override
   final int privateMessageId;
@@ -895,7 +898,7 @@ class _$_MarkPrivateMessageAsRead extends _MarkPrivateMessageAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MarkPrivateMessageAsRead &&
+            other is _$MarkPrivateMessageAsReadImpl &&
             (identical(other.privateMessageId, privateMessageId) ||
                 other.privateMessageId == privateMessageId) &&
             (identical(other.read, read) || other.read == read) &&
@@ -909,13 +912,13 @@ class _$_MarkPrivateMessageAsRead extends _MarkPrivateMessageAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MarkPrivateMessageAsReadCopyWith<_$_MarkPrivateMessageAsRead>
-      get copyWith => __$$_MarkPrivateMessageAsReadCopyWithImpl<
-          _$_MarkPrivateMessageAsRead>(this, _$identity);
+  _$$MarkPrivateMessageAsReadImplCopyWith<_$MarkPrivateMessageAsReadImpl>
+      get copyWith => __$$MarkPrivateMessageAsReadImplCopyWithImpl<
+          _$MarkPrivateMessageAsReadImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MarkPrivateMessageAsReadToJson(
+    return _$$MarkPrivateMessageAsReadImplToJson(
       this,
     );
   }
@@ -925,11 +928,11 @@ abstract class _MarkPrivateMessageAsRead extends MarkPrivateMessageAsRead {
   const factory _MarkPrivateMessageAsRead(
       {required final int privateMessageId,
       required final bool read,
-      final String? auth}) = _$_MarkPrivateMessageAsRead;
+      final String? auth}) = _$MarkPrivateMessageAsReadImpl;
   const _MarkPrivateMessageAsRead._() : super._();
 
   factory _MarkPrivateMessageAsRead.fromJson(Map<String, dynamic> json) =
-      _$_MarkPrivateMessageAsRead.fromJson;
+      _$MarkPrivateMessageAsReadImpl.fromJson;
 
   @override
   int get privateMessageId;
@@ -939,7 +942,7 @@ abstract class _MarkPrivateMessageAsRead extends MarkPrivateMessageAsRead {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_MarkPrivateMessageAsReadCopyWith<_$_MarkPrivateMessageAsRead>
+  _$$MarkPrivateMessageAsReadImplCopyWith<_$MarkPrivateMessageAsReadImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -1006,25 +1009,25 @@ class _$CreatePrivateMessageReportCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_CreatePrivateMessageReportCopyWith<$Res>
+abstract class _$$CreatePrivateMessageReportImplCopyWith<$Res>
     implements $CreatePrivateMessageReportCopyWith<$Res> {
-  factory _$$_CreatePrivateMessageReportCopyWith(
-          _$_CreatePrivateMessageReport value,
-          $Res Function(_$_CreatePrivateMessageReport) then) =
-      __$$_CreatePrivateMessageReportCopyWithImpl<$Res>;
+  factory _$$CreatePrivateMessageReportImplCopyWith(
+          _$CreatePrivateMessageReportImpl value,
+          $Res Function(_$CreatePrivateMessageReportImpl) then) =
+      __$$CreatePrivateMessageReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int privateMessageId, String reason, String? auth});
 }
 
 /// @nodoc
-class __$$_CreatePrivateMessageReportCopyWithImpl<$Res>
+class __$$CreatePrivateMessageReportImplCopyWithImpl<$Res>
     extends _$CreatePrivateMessageReportCopyWithImpl<$Res,
-        _$_CreatePrivateMessageReport>
-    implements _$$_CreatePrivateMessageReportCopyWith<$Res> {
-  __$$_CreatePrivateMessageReportCopyWithImpl(
-      _$_CreatePrivateMessageReport _value,
-      $Res Function(_$_CreatePrivateMessageReport) _then)
+        _$CreatePrivateMessageReportImpl>
+    implements _$$CreatePrivateMessageReportImplCopyWith<$Res> {
+  __$$CreatePrivateMessageReportImplCopyWithImpl(
+      _$CreatePrivateMessageReportImpl _value,
+      $Res Function(_$CreatePrivateMessageReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1034,7 +1037,7 @@ class __$$_CreatePrivateMessageReportCopyWithImpl<$Res>
     Object? reason = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_CreatePrivateMessageReport(
+    return _then(_$CreatePrivateMessageReportImpl(
       privateMessageId: null == privateMessageId
           ? _value.privateMessageId
           : privateMessageId // ignore: cast_nullable_to_non_nullable
@@ -1054,13 +1057,14 @@ class __$$_CreatePrivateMessageReportCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreatePrivateMessageReport extends _CreatePrivateMessageReport {
-  const _$_CreatePrivateMessageReport(
+class _$CreatePrivateMessageReportImpl extends _CreatePrivateMessageReport {
+  const _$CreatePrivateMessageReportImpl(
       {required this.privateMessageId, required this.reason, this.auth})
       : super._();
 
-  factory _$_CreatePrivateMessageReport.fromJson(Map<String, dynamic> json) =>
-      _$$_CreatePrivateMessageReportFromJson(json);
+  factory _$CreatePrivateMessageReportImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$CreatePrivateMessageReportImplFromJson(json);
 
   @override
   final int privateMessageId;
@@ -1078,7 +1082,7 @@ class _$_CreatePrivateMessageReport extends _CreatePrivateMessageReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreatePrivateMessageReport &&
+            other is _$CreatePrivateMessageReportImpl &&
             (identical(other.privateMessageId, privateMessageId) ||
                 other.privateMessageId == privateMessageId) &&
             (identical(other.reason, reason) || other.reason == reason) &&
@@ -1092,13 +1096,13 @@ class _$_CreatePrivateMessageReport extends _CreatePrivateMessageReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreatePrivateMessageReportCopyWith<_$_CreatePrivateMessageReport>
-      get copyWith => __$$_CreatePrivateMessageReportCopyWithImpl<
-          _$_CreatePrivateMessageReport>(this, _$identity);
+  _$$CreatePrivateMessageReportImplCopyWith<_$CreatePrivateMessageReportImpl>
+      get copyWith => __$$CreatePrivateMessageReportImplCopyWithImpl<
+          _$CreatePrivateMessageReportImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreatePrivateMessageReportToJson(
+    return _$$CreatePrivateMessageReportImplToJson(
       this,
     );
   }
@@ -1108,11 +1112,11 @@ abstract class _CreatePrivateMessageReport extends CreatePrivateMessageReport {
   const factory _CreatePrivateMessageReport(
       {required final int privateMessageId,
       required final String reason,
-      final String? auth}) = _$_CreatePrivateMessageReport;
+      final String? auth}) = _$CreatePrivateMessageReportImpl;
   const _CreatePrivateMessageReport._() : super._();
 
   factory _CreatePrivateMessageReport.fromJson(Map<String, dynamic> json) =
-      _$_CreatePrivateMessageReport.fromJson;
+      _$CreatePrivateMessageReportImpl.fromJson;
 
   @override
   int get privateMessageId;
@@ -1122,7 +1126,7 @@ abstract class _CreatePrivateMessageReport extends CreatePrivateMessageReport {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreatePrivateMessageReportCopyWith<_$_CreatePrivateMessageReport>
+  _$$CreatePrivateMessageReportImplCopyWith<_$CreatePrivateMessageReportImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -1190,25 +1194,25 @@ class _$ResolvePrivateMessageReportCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ResolvePrivateMessageReportCopyWith<$Res>
+abstract class _$$ResolvePrivateMessageReportImplCopyWith<$Res>
     implements $ResolvePrivateMessageReportCopyWith<$Res> {
-  factory _$$_ResolvePrivateMessageReportCopyWith(
-          _$_ResolvePrivateMessageReport value,
-          $Res Function(_$_ResolvePrivateMessageReport) then) =
-      __$$_ResolvePrivateMessageReportCopyWithImpl<$Res>;
+  factory _$$ResolvePrivateMessageReportImplCopyWith(
+          _$ResolvePrivateMessageReportImpl value,
+          $Res Function(_$ResolvePrivateMessageReportImpl) then) =
+      __$$ResolvePrivateMessageReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int reportId, bool resolved, String? auth});
 }
 
 /// @nodoc
-class __$$_ResolvePrivateMessageReportCopyWithImpl<$Res>
+class __$$ResolvePrivateMessageReportImplCopyWithImpl<$Res>
     extends _$ResolvePrivateMessageReportCopyWithImpl<$Res,
-        _$_ResolvePrivateMessageReport>
-    implements _$$_ResolvePrivateMessageReportCopyWith<$Res> {
-  __$$_ResolvePrivateMessageReportCopyWithImpl(
-      _$_ResolvePrivateMessageReport _value,
-      $Res Function(_$_ResolvePrivateMessageReport) _then)
+        _$ResolvePrivateMessageReportImpl>
+    implements _$$ResolvePrivateMessageReportImplCopyWith<$Res> {
+  __$$ResolvePrivateMessageReportImplCopyWithImpl(
+      _$ResolvePrivateMessageReportImpl _value,
+      $Res Function(_$ResolvePrivateMessageReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1218,7 +1222,7 @@ class __$$_ResolvePrivateMessageReportCopyWithImpl<$Res>
     Object? resolved = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_ResolvePrivateMessageReport(
+    return _then(_$ResolvePrivateMessageReportImpl(
       reportId: null == reportId
           ? _value.reportId
           : reportId // ignore: cast_nullable_to_non_nullable
@@ -1238,13 +1242,14 @@ class __$$_ResolvePrivateMessageReportCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ResolvePrivateMessageReport extends _ResolvePrivateMessageReport {
-  const _$_ResolvePrivateMessageReport(
+class _$ResolvePrivateMessageReportImpl extends _ResolvePrivateMessageReport {
+  const _$ResolvePrivateMessageReportImpl(
       {required this.reportId, required this.resolved, this.auth})
       : super._();
 
-  factory _$_ResolvePrivateMessageReport.fromJson(Map<String, dynamic> json) =>
-      _$$_ResolvePrivateMessageReportFromJson(json);
+  factory _$ResolvePrivateMessageReportImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$ResolvePrivateMessageReportImplFromJson(json);
 
   @override
   final int reportId;
@@ -1262,7 +1267,7 @@ class _$_ResolvePrivateMessageReport extends _ResolvePrivateMessageReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ResolvePrivateMessageReport &&
+            other is _$ResolvePrivateMessageReportImpl &&
             (identical(other.reportId, reportId) ||
                 other.reportId == reportId) &&
             (identical(other.resolved, resolved) ||
@@ -1277,13 +1282,13 @@ class _$_ResolvePrivateMessageReport extends _ResolvePrivateMessageReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ResolvePrivateMessageReportCopyWith<_$_ResolvePrivateMessageReport>
-      get copyWith => __$$_ResolvePrivateMessageReportCopyWithImpl<
-          _$_ResolvePrivateMessageReport>(this, _$identity);
+  _$$ResolvePrivateMessageReportImplCopyWith<_$ResolvePrivateMessageReportImpl>
+      get copyWith => __$$ResolvePrivateMessageReportImplCopyWithImpl<
+          _$ResolvePrivateMessageReportImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ResolvePrivateMessageReportToJson(
+    return _$$ResolvePrivateMessageReportImplToJson(
       this,
     );
   }
@@ -1294,11 +1299,11 @@ abstract class _ResolvePrivateMessageReport
   const factory _ResolvePrivateMessageReport(
       {required final int reportId,
       required final bool resolved,
-      final String? auth}) = _$_ResolvePrivateMessageReport;
+      final String? auth}) = _$ResolvePrivateMessageReportImpl;
   const _ResolvePrivateMessageReport._() : super._();
 
   factory _ResolvePrivateMessageReport.fromJson(Map<String, dynamic> json) =
-      _$_ResolvePrivateMessageReport.fromJson;
+      _$ResolvePrivateMessageReportImpl.fromJson;
 
   @override
   int get reportId;
@@ -1308,7 +1313,7 @@ abstract class _ResolvePrivateMessageReport
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ResolvePrivateMessageReportCopyWith<_$_ResolvePrivateMessageReport>
+  _$$ResolvePrivateMessageReportImplCopyWith<_$ResolvePrivateMessageReportImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -1391,12 +1396,12 @@ class _$ListPrivateMessageReportsCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ListPrivateMessageReportsCopyWith<$Res>
+abstract class _$$ListPrivateMessageReportsImplCopyWith<$Res>
     implements $ListPrivateMessageReportsCopyWith<$Res> {
-  factory _$$_ListPrivateMessageReportsCopyWith(
-          _$_ListPrivateMessageReports value,
-          $Res Function(_$_ListPrivateMessageReports) then) =
-      __$$_ListPrivateMessageReportsCopyWithImpl<$Res>;
+  factory _$$ListPrivateMessageReportsImplCopyWith(
+          _$ListPrivateMessageReportsImpl value,
+          $Res Function(_$ListPrivateMessageReportsImpl) then) =
+      __$$ListPrivateMessageReportsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1408,13 +1413,13 @@ abstract class _$$_ListPrivateMessageReportsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ListPrivateMessageReportsCopyWithImpl<$Res>
+class __$$ListPrivateMessageReportsImplCopyWithImpl<$Res>
     extends _$ListPrivateMessageReportsCopyWithImpl<$Res,
-        _$_ListPrivateMessageReports>
-    implements _$$_ListPrivateMessageReportsCopyWith<$Res> {
-  __$$_ListPrivateMessageReportsCopyWithImpl(
-      _$_ListPrivateMessageReports _value,
-      $Res Function(_$_ListPrivateMessageReports) _then)
+        _$ListPrivateMessageReportsImpl>
+    implements _$$ListPrivateMessageReportsImplCopyWith<$Res> {
+  __$$ListPrivateMessageReportsImplCopyWithImpl(
+      _$ListPrivateMessageReportsImpl _value,
+      $Res Function(_$ListPrivateMessageReportsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1426,7 +1431,7 @@ class __$$_ListPrivateMessageReportsCopyWithImpl<$Res>
     Object? communityId = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_ListPrivateMessageReports(
+    return _then(_$ListPrivateMessageReportsImpl(
       page: freezed == page
           ? _value.page
           : page // ignore: cast_nullable_to_non_nullable
@@ -1454,13 +1459,13 @@ class __$$_ListPrivateMessageReportsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ListPrivateMessageReports extends _ListPrivateMessageReports {
-  const _$_ListPrivateMessageReports(
+class _$ListPrivateMessageReportsImpl extends _ListPrivateMessageReports {
+  const _$ListPrivateMessageReportsImpl(
       {this.page, this.limit, this.unresolvedOnly, this.communityId, this.auth})
       : super._();
 
-  factory _$_ListPrivateMessageReports.fromJson(Map<String, dynamic> json) =>
-      _$$_ListPrivateMessageReportsFromJson(json);
+  factory _$ListPrivateMessageReportsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ListPrivateMessageReportsImplFromJson(json);
 
   @override
   final int? page;
@@ -1482,7 +1487,7 @@ class _$_ListPrivateMessageReports extends _ListPrivateMessageReports {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListPrivateMessageReports &&
+            other is _$ListPrivateMessageReportsImpl &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
             (identical(other.unresolvedOnly, unresolvedOnly) ||
@@ -1500,13 +1505,13 @@ class _$_ListPrivateMessageReports extends _ListPrivateMessageReports {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListPrivateMessageReportsCopyWith<_$_ListPrivateMessageReports>
-      get copyWith => __$$_ListPrivateMessageReportsCopyWithImpl<
-          _$_ListPrivateMessageReports>(this, _$identity);
+  _$$ListPrivateMessageReportsImplCopyWith<_$ListPrivateMessageReportsImpl>
+      get copyWith => __$$ListPrivateMessageReportsImplCopyWithImpl<
+          _$ListPrivateMessageReportsImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListPrivateMessageReportsToJson(
+    return _$$ListPrivateMessageReportsImplToJson(
       this,
     );
   }
@@ -1518,11 +1523,11 @@ abstract class _ListPrivateMessageReports extends ListPrivateMessageReports {
       final int? limit,
       final bool? unresolvedOnly,
       final int? communityId,
-      final String? auth}) = _$_ListPrivateMessageReports;
+      final String? auth}) = _$ListPrivateMessageReportsImpl;
   const _ListPrivateMessageReports._() : super._();
 
   factory _ListPrivateMessageReports.fromJson(Map<String, dynamic> json) =
-      _$_ListPrivateMessageReports.fromJson;
+      _$ListPrivateMessageReportsImpl.fromJson;
 
   @override
   int? get page;
@@ -1536,6 +1541,6 @@ abstract class _ListPrivateMessageReports extends ListPrivateMessageReports {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ListPrivateMessageReportsCopyWith<_$_ListPrivateMessageReports>
+  _$$ListPrivateMessageReportsImplCopyWith<_$ListPrivateMessageReportsImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/private_message/private_message.g.dart
+++ b/lib/src/v3/api/private_message/private_message.g.dart
@@ -6,9 +6,9 @@ part of 'private_message.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetPrivateMessages _$$_GetPrivateMessagesFromJson(
+_$GetPrivateMessagesImpl _$$GetPrivateMessagesImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GetPrivateMessages(
+    _$GetPrivateMessagesImpl(
       unreadOnly: json['unread_only'] as bool?,
       page: json['page'] as int?,
       limit: json['limit'] as int?,
@@ -16,8 +16,8 @@ _$_GetPrivateMessages _$$_GetPrivateMessagesFromJson(
       creatorId: json['creator_id'] as int?,
     );
 
-Map<String, dynamic> _$$_GetPrivateMessagesToJson(
-    _$_GetPrivateMessages instance) {
+Map<String, dynamic> _$$GetPrivateMessagesImplToJson(
+    _$GetPrivateMessagesImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -34,16 +34,16 @@ Map<String, dynamic> _$$_GetPrivateMessagesToJson(
   return val;
 }
 
-_$_CreatePrivateMessage _$$_CreatePrivateMessageFromJson(
+_$CreatePrivateMessageImpl _$$CreatePrivateMessageImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CreatePrivateMessage(
+    _$CreatePrivateMessageImpl(
       content: json['content'] as String,
       recipientId: json['recipient_id'] as int,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_CreatePrivateMessageToJson(
-    _$_CreatePrivateMessage instance) {
+Map<String, dynamic> _$$CreatePrivateMessageImplToJson(
+    _$CreatePrivateMessageImpl instance) {
   final val = <String, dynamic>{
     'content': instance.content,
     'recipient_id': instance.recipientId,
@@ -59,16 +59,16 @@ Map<String, dynamic> _$$_CreatePrivateMessageToJson(
   return val;
 }
 
-_$_EditPrivateMessage _$$_EditPrivateMessageFromJson(
+_$EditPrivateMessageImpl _$$EditPrivateMessageImplFromJson(
         Map<String, dynamic> json) =>
-    _$_EditPrivateMessage(
+    _$EditPrivateMessageImpl(
       privateMessageId: json['private_message_id'] as int,
       content: json['content'] as String,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_EditPrivateMessageToJson(
-    _$_EditPrivateMessage instance) {
+Map<String, dynamic> _$$EditPrivateMessageImplToJson(
+    _$EditPrivateMessageImpl instance) {
   final val = <String, dynamic>{
     'private_message_id': instance.privateMessageId,
     'content': instance.content,
@@ -84,16 +84,16 @@ Map<String, dynamic> _$$_EditPrivateMessageToJson(
   return val;
 }
 
-_$_DeletePrivateMessage _$$_DeletePrivateMessageFromJson(
+_$DeletePrivateMessageImpl _$$DeletePrivateMessageImplFromJson(
         Map<String, dynamic> json) =>
-    _$_DeletePrivateMessage(
+    _$DeletePrivateMessageImpl(
       privateMessageId: json['private_message_id'] as int,
       deleted: json['deleted'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_DeletePrivateMessageToJson(
-    _$_DeletePrivateMessage instance) {
+Map<String, dynamic> _$$DeletePrivateMessageImplToJson(
+    _$DeletePrivateMessageImpl instance) {
   final val = <String, dynamic>{
     'private_message_id': instance.privateMessageId,
     'deleted': instance.deleted,
@@ -109,16 +109,16 @@ Map<String, dynamic> _$$_DeletePrivateMessageToJson(
   return val;
 }
 
-_$_MarkPrivateMessageAsRead _$$_MarkPrivateMessageAsReadFromJson(
+_$MarkPrivateMessageAsReadImpl _$$MarkPrivateMessageAsReadImplFromJson(
         Map<String, dynamic> json) =>
-    _$_MarkPrivateMessageAsRead(
+    _$MarkPrivateMessageAsReadImpl(
       privateMessageId: json['private_message_id'] as int,
       read: json['read'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_MarkPrivateMessageAsReadToJson(
-    _$_MarkPrivateMessageAsRead instance) {
+Map<String, dynamic> _$$MarkPrivateMessageAsReadImplToJson(
+    _$MarkPrivateMessageAsReadImpl instance) {
   final val = <String, dynamic>{
     'private_message_id': instance.privateMessageId,
     'read': instance.read,
@@ -134,16 +134,16 @@ Map<String, dynamic> _$$_MarkPrivateMessageAsReadToJson(
   return val;
 }
 
-_$_CreatePrivateMessageReport _$$_CreatePrivateMessageReportFromJson(
+_$CreatePrivateMessageReportImpl _$$CreatePrivateMessageReportImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CreatePrivateMessageReport(
+    _$CreatePrivateMessageReportImpl(
       privateMessageId: json['private_message_id'] as int,
       reason: json['reason'] as String,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_CreatePrivateMessageReportToJson(
-    _$_CreatePrivateMessageReport instance) {
+Map<String, dynamic> _$$CreatePrivateMessageReportImplToJson(
+    _$CreatePrivateMessageReportImpl instance) {
   final val = <String, dynamic>{
     'private_message_id': instance.privateMessageId,
     'reason': instance.reason,
@@ -159,16 +159,16 @@ Map<String, dynamic> _$$_CreatePrivateMessageReportToJson(
   return val;
 }
 
-_$_ResolvePrivateMessageReport _$$_ResolvePrivateMessageReportFromJson(
+_$ResolvePrivateMessageReportImpl _$$ResolvePrivateMessageReportImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ResolvePrivateMessageReport(
+    _$ResolvePrivateMessageReportImpl(
       reportId: json['report_id'] as int,
       resolved: json['resolved'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ResolvePrivateMessageReportToJson(
-    _$_ResolvePrivateMessageReport instance) {
+Map<String, dynamic> _$$ResolvePrivateMessageReportImplToJson(
+    _$ResolvePrivateMessageReportImpl instance) {
   final val = <String, dynamic>{
     'report_id': instance.reportId,
     'resolved': instance.resolved,
@@ -184,9 +184,9 @@ Map<String, dynamic> _$$_ResolvePrivateMessageReportToJson(
   return val;
 }
 
-_$_ListPrivateMessageReports _$$_ListPrivateMessageReportsFromJson(
+_$ListPrivateMessageReportsImpl _$$ListPrivateMessageReportsImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ListPrivateMessageReports(
+    _$ListPrivateMessageReportsImpl(
       page: json['page'] as int?,
       limit: json['limit'] as int?,
       unresolvedOnly: json['unresolved_only'] as bool?,
@@ -194,8 +194,8 @@ _$_ListPrivateMessageReports _$$_ListPrivateMessageReportsFromJson(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ListPrivateMessageReportsToJson(
-    _$_ListPrivateMessageReports instance) {
+Map<String, dynamic> _$$ListPrivateMessageReportsImplToJson(
+    _$ListPrivateMessageReportsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {

--- a/lib/src/v3/api/resolve_object/resolve_object.freezed.dart
+++ b/lib/src/v3/api/resolve_object/resolve_object.freezed.dart
@@ -68,22 +68,22 @@ class _$ResolveObjectCopyWithImpl<$Res, $Val extends ResolveObject>
 }
 
 /// @nodoc
-abstract class _$$_ResolveObjectCopyWith<$Res>
+abstract class _$$ResolveObjectImplCopyWith<$Res>
     implements $ResolveObjectCopyWith<$Res> {
-  factory _$$_ResolveObjectCopyWith(
-          _$_ResolveObject value, $Res Function(_$_ResolveObject) then) =
-      __$$_ResolveObjectCopyWithImpl<$Res>;
+  factory _$$ResolveObjectImplCopyWith(
+          _$ResolveObjectImpl value, $Res Function(_$ResolveObjectImpl) then) =
+      __$$ResolveObjectImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String q, String? auth});
 }
 
 /// @nodoc
-class __$$_ResolveObjectCopyWithImpl<$Res>
-    extends _$ResolveObjectCopyWithImpl<$Res, _$_ResolveObject>
-    implements _$$_ResolveObjectCopyWith<$Res> {
-  __$$_ResolveObjectCopyWithImpl(
-      _$_ResolveObject _value, $Res Function(_$_ResolveObject) _then)
+class __$$ResolveObjectImplCopyWithImpl<$Res>
+    extends _$ResolveObjectCopyWithImpl<$Res, _$ResolveObjectImpl>
+    implements _$$ResolveObjectImplCopyWith<$Res> {
+  __$$ResolveObjectImplCopyWithImpl(
+      _$ResolveObjectImpl _value, $Res Function(_$ResolveObjectImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -92,7 +92,7 @@ class __$$_ResolveObjectCopyWithImpl<$Res>
     Object? q = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_ResolveObject(
+    return _then(_$ResolveObjectImpl(
       q: null == q
           ? _value.q
           : q // ignore: cast_nullable_to_non_nullable
@@ -108,11 +108,11 @@ class __$$_ResolveObjectCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ResolveObject extends _ResolveObject {
-  const _$_ResolveObject({required this.q, this.auth}) : super._();
+class _$ResolveObjectImpl extends _ResolveObject {
+  const _$ResolveObjectImpl({required this.q, this.auth}) : super._();
 
-  factory _$_ResolveObject.fromJson(Map<String, dynamic> json) =>
-      _$$_ResolveObjectFromJson(json);
+  factory _$ResolveObjectImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ResolveObjectImplFromJson(json);
 
   @override
   final String q;
@@ -128,7 +128,7 @@ class _$_ResolveObject extends _ResolveObject {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ResolveObject &&
+            other is _$ResolveObjectImpl &&
             (identical(other.q, q) || other.q == q) &&
             (identical(other.auth, auth) || other.auth == auth));
   }
@@ -140,12 +140,12 @@ class _$_ResolveObject extends _ResolveObject {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ResolveObjectCopyWith<_$_ResolveObject> get copyWith =>
-      __$$_ResolveObjectCopyWithImpl<_$_ResolveObject>(this, _$identity);
+  _$$ResolveObjectImplCopyWith<_$ResolveObjectImpl> get copyWith =>
+      __$$ResolveObjectImplCopyWithImpl<_$ResolveObjectImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ResolveObjectToJson(
+    return _$$ResolveObjectImplToJson(
       this,
     );
   }
@@ -153,11 +153,11 @@ class _$_ResolveObject extends _ResolveObject {
 
 abstract class _ResolveObject extends ResolveObject {
   const factory _ResolveObject({required final String q, final String? auth}) =
-      _$_ResolveObject;
+      _$ResolveObjectImpl;
   const _ResolveObject._() : super._();
 
   factory _ResolveObject.fromJson(Map<String, dynamic> json) =
-      _$_ResolveObject.fromJson;
+      _$ResolveObjectImpl.fromJson;
 
   @override
   String get q;
@@ -165,6 +165,6 @@ abstract class _ResolveObject extends ResolveObject {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ResolveObjectCopyWith<_$_ResolveObject> get copyWith =>
+  _$$ResolveObjectImplCopyWith<_$ResolveObjectImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/resolve_object/resolve_object.g.dart
+++ b/lib/src/v3/api/resolve_object/resolve_object.g.dart
@@ -6,13 +6,13 @@ part of 'resolve_object.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ResolveObject _$$_ResolveObjectFromJson(Map<String, dynamic> json) =>
-    _$_ResolveObject(
+_$ResolveObjectImpl _$$ResolveObjectImplFromJson(Map<String, dynamic> json) =>
+    _$ResolveObjectImpl(
       q: json['q'] as String,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ResolveObjectToJson(_$_ResolveObject instance) {
+Map<String, dynamic> _$$ResolveObjectImplToJson(_$ResolveObjectImpl instance) {
   final val = <String, dynamic>{
     'q': instance.q,
   };

--- a/lib/src/v3/api/search/search.freezed.dart
+++ b/lib/src/v3/api/search/search.freezed.dart
@@ -125,9 +125,10 @@ class _$SearchCopyWithImpl<$Res, $Val extends Search>
 }
 
 /// @nodoc
-abstract class _$$_SearchCopyWith<$Res> implements $SearchCopyWith<$Res> {
-  factory _$$_SearchCopyWith(_$_Search value, $Res Function(_$_Search) then) =
-      __$$_SearchCopyWithImpl<$Res>;
+abstract class _$$SearchImplCopyWith<$Res> implements $SearchCopyWith<$Res> {
+  factory _$$SearchImplCopyWith(
+          _$SearchImpl value, $Res Function(_$SearchImpl) then) =
+      __$$SearchImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -144,10 +145,11 @@ abstract class _$$_SearchCopyWith<$Res> implements $SearchCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_SearchCopyWithImpl<$Res>
-    extends _$SearchCopyWithImpl<$Res, _$_Search>
-    implements _$$_SearchCopyWith<$Res> {
-  __$$_SearchCopyWithImpl(_$_Search _value, $Res Function(_$_Search) _then)
+class __$$SearchImplCopyWithImpl<$Res>
+    extends _$SearchCopyWithImpl<$Res, _$SearchImpl>
+    implements _$$SearchImplCopyWith<$Res> {
+  __$$SearchImplCopyWithImpl(
+      _$SearchImpl _value, $Res Function(_$SearchImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -164,7 +166,7 @@ class __$$_SearchCopyWithImpl<$Res>
     Object? limit = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_Search(
+    return _then(_$SearchImpl(
       q: null == q
           ? _value.q
           : q // ignore: cast_nullable_to_non_nullable
@@ -212,8 +214,8 @@ class __$$_SearchCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_Search extends _Search {
-  const _$_Search(
+class _$SearchImpl extends _Search {
+  const _$SearchImpl(
       {required this.q,
       this.communityId,
       this.communityName,
@@ -226,8 +228,8 @@ class _$_Search extends _Search {
       this.auth})
       : super._();
 
-  factory _$_Search.fromJson(Map<String, dynamic> json) =>
-      _$$_SearchFromJson(json);
+  factory _$SearchImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SearchImplFromJson(json);
 
   @override
   final String q;
@@ -260,7 +262,7 @@ class _$_Search extends _Search {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Search &&
+            other is _$SearchImpl &&
             (identical(other.q, q) || other.q == q) &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
@@ -285,12 +287,12 @@ class _$_Search extends _Search {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SearchCopyWith<_$_Search> get copyWith =>
-      __$$_SearchCopyWithImpl<_$_Search>(this, _$identity);
+  _$$SearchImplCopyWith<_$SearchImpl> get copyWith =>
+      __$$SearchImplCopyWithImpl<_$SearchImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SearchToJson(
+    return _$$SearchImplToJson(
       this,
     );
   }
@@ -307,10 +309,10 @@ abstract class _Search extends Search {
       final ListingType? listingType,
       final int? page,
       final int? limit,
-      final String? auth}) = _$_Search;
+      final String? auth}) = _$SearchImpl;
   const _Search._() : super._();
 
-  factory _Search.fromJson(Map<String, dynamic> json) = _$_Search.fromJson;
+  factory _Search.fromJson(Map<String, dynamic> json) = _$SearchImpl.fromJson;
 
   @override
   String get q;
@@ -335,6 +337,6 @@ abstract class _Search extends Search {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_SearchCopyWith<_$_Search> get copyWith =>
+  _$$SearchImplCopyWith<_$SearchImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/search/search.g.dart
+++ b/lib/src/v3/api/search/search.g.dart
@@ -6,7 +6,7 @@ part of 'search.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Search _$$_SearchFromJson(Map<String, dynamic> json) => _$_Search(
+_$SearchImpl _$$SearchImplFromJson(Map<String, dynamic> json) => _$SearchImpl(
       q: json['q'] as String,
       communityId: json['community_id'] as int?,
       communityName: json['community_name'] as String?,
@@ -23,7 +23,7 @@ _$_Search _$$_SearchFromJson(Map<String, dynamic> json) => _$_Search(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_SearchToJson(_$_Search instance) {
+Map<String, dynamic> _$$SearchImplToJson(_$SearchImpl instance) {
   final val = <String, dynamic>{
     'q': instance.q,
   };

--- a/lib/src/v3/api/site/site.freezed.dart
+++ b/lib/src/v3/api/site/site.freezed.dart
@@ -60,20 +60,21 @@ class _$GetSiteCopyWithImpl<$Res, $Val extends GetSite>
 }
 
 /// @nodoc
-abstract class _$$_GetSiteCopyWith<$Res> implements $GetSiteCopyWith<$Res> {
-  factory _$$_GetSiteCopyWith(
-          _$_GetSite value, $Res Function(_$_GetSite) then) =
-      __$$_GetSiteCopyWithImpl<$Res>;
+abstract class _$$GetSiteImplCopyWith<$Res> implements $GetSiteCopyWith<$Res> {
+  factory _$$GetSiteImplCopyWith(
+          _$GetSiteImpl value, $Res Function(_$GetSiteImpl) then) =
+      __$$GetSiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$_GetSiteCopyWithImpl<$Res>
-    extends _$GetSiteCopyWithImpl<$Res, _$_GetSite>
-    implements _$$_GetSiteCopyWith<$Res> {
-  __$$_GetSiteCopyWithImpl(_$_GetSite _value, $Res Function(_$_GetSite) _then)
+class __$$GetSiteImplCopyWithImpl<$Res>
+    extends _$GetSiteCopyWithImpl<$Res, _$GetSiteImpl>
+    implements _$$GetSiteImplCopyWith<$Res> {
+  __$$GetSiteImplCopyWithImpl(
+      _$GetSiteImpl _value, $Res Function(_$GetSiteImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -81,7 +82,7 @@ class __$$_GetSiteCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$_GetSite(
+    return _then(_$GetSiteImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -93,11 +94,11 @@ class __$$_GetSiteCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetSite extends _GetSite {
-  const _$_GetSite({this.auth}) : super._();
+class _$GetSiteImpl extends _GetSite {
+  const _$GetSiteImpl({this.auth}) : super._();
 
-  factory _$_GetSite.fromJson(Map<String, dynamic> json) =>
-      _$$_GetSiteFromJson(json);
+  factory _$GetSiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetSiteImplFromJson(json);
 
   @override
   final String? auth;
@@ -111,7 +112,7 @@ class _$_GetSite extends _GetSite {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetSite &&
+            other is _$GetSiteImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -122,28 +123,28 @@ class _$_GetSite extends _GetSite {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetSiteCopyWith<_$_GetSite> get copyWith =>
-      __$$_GetSiteCopyWithImpl<_$_GetSite>(this, _$identity);
+  _$$GetSiteImplCopyWith<_$GetSiteImpl> get copyWith =>
+      __$$GetSiteImplCopyWithImpl<_$GetSiteImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetSiteToJson(
+    return _$$GetSiteImplToJson(
       this,
     );
   }
 }
 
 abstract class _GetSite extends GetSite {
-  const factory _GetSite({final String? auth}) = _$_GetSite;
+  const factory _GetSite({final String? auth}) = _$GetSiteImpl;
   const _GetSite._() : super._();
 
-  factory _GetSite.fromJson(Map<String, dynamic> json) = _$_GetSite.fromJson;
+  factory _GetSite.fromJson(Map<String, dynamic> json) = _$GetSiteImpl.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetSiteCopyWith<_$_GetSite> get copyWith =>
+  _$$GetSiteImplCopyWith<_$GetSiteImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -469,11 +470,11 @@ class _$CreateSiteCopyWithImpl<$Res, $Val extends CreateSite>
 }
 
 /// @nodoc
-abstract class _$$_CreateSiteCopyWith<$Res>
+abstract class _$$CreateSiteImplCopyWith<$Res>
     implements $CreateSiteCopyWith<$Res> {
-  factory _$$_CreateSiteCopyWith(
-          _$_CreateSite value, $Res Function(_$_CreateSite) then) =
-      __$$_CreateSiteCopyWithImpl<$Res>;
+  factory _$$CreateSiteImplCopyWith(
+          _$CreateSiteImpl value, $Res Function(_$CreateSiteImpl) then) =
+      __$$CreateSiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -520,11 +521,11 @@ abstract class _$$_CreateSiteCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CreateSiteCopyWithImpl<$Res>
-    extends _$CreateSiteCopyWithImpl<$Res, _$_CreateSite>
-    implements _$$_CreateSiteCopyWith<$Res> {
-  __$$_CreateSiteCopyWithImpl(
-      _$_CreateSite _value, $Res Function(_$_CreateSite) _then)
+class __$$CreateSiteImplCopyWithImpl<$Res>
+    extends _$CreateSiteCopyWithImpl<$Res, _$CreateSiteImpl>
+    implements _$$CreateSiteImplCopyWith<$Res> {
+  __$$CreateSiteImplCopyWithImpl(
+      _$CreateSiteImpl _value, $Res Function(_$CreateSiteImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -571,7 +572,7 @@ class __$$_CreateSiteCopyWithImpl<$Res>
     Object? registrationMode = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_CreateSite(
+    return _then(_$CreateSiteImpl(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -739,8 +740,8 @@ class __$$_CreateSiteCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_CreateSite extends _CreateSite {
-  const _$_CreateSite(
+class _$CreateSiteImpl extends _CreateSite {
+  const _$CreateSiteImpl(
       {required this.name,
       this.sidebar,
       this.description,
@@ -787,8 +788,8 @@ class _$_CreateSite extends _CreateSite {
         _taglines = taglines,
         super._();
 
-  factory _$_CreateSite.fromJson(Map<String, dynamic> json) =>
-      _$$_CreateSiteFromJson(json);
+  factory _$CreateSiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CreateSiteImplFromJson(json);
 
   @override
   final String name;
@@ -915,7 +916,7 @@ class _$_CreateSite extends _CreateSite {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CreateSite &&
+            other is _$CreateSiteImpl &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.sidebar, sidebar) || other.sidebar == sidebar) &&
             (identical(other.description, description) ||
@@ -1034,12 +1035,12 @@ class _$_CreateSite extends _CreateSite {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CreateSiteCopyWith<_$_CreateSite> get copyWith =>
-      __$$_CreateSiteCopyWithImpl<_$_CreateSite>(this, _$identity);
+  _$$CreateSiteImplCopyWith<_$CreateSiteImpl> get copyWith =>
+      __$$CreateSiteImplCopyWithImpl<_$CreateSiteImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CreateSiteToJson(
+    return _$$CreateSiteImplToJson(
       this,
     );
   }
@@ -1086,11 +1087,11 @@ abstract class _CreateSite extends CreateSite {
       final List<String>? blockedInstances,
       final List<String>? taglines,
       required final RegistrationMode registrationMode,
-      final String? auth}) = _$_CreateSite;
+      final String? auth}) = _$CreateSiteImpl;
   const _CreateSite._() : super._();
 
   factory _CreateSite.fromJson(Map<String, dynamic> json) =
-      _$_CreateSite.fromJson;
+      _$CreateSiteImpl.fromJson;
 
   @override
   String get name;
@@ -1174,7 +1175,7 @@ abstract class _CreateSite extends CreateSite {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_CreateSiteCopyWith<_$_CreateSite> get copyWith =>
+  _$$CreateSiteImplCopyWith<_$CreateSiteImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1506,10 +1507,11 @@ class _$EditSiteCopyWithImpl<$Res, $Val extends EditSite>
 }
 
 /// @nodoc
-abstract class _$$_EditSiteCopyWith<$Res> implements $EditSiteCopyWith<$Res> {
-  factory _$$_EditSiteCopyWith(
-          _$_EditSite value, $Res Function(_$_EditSite) then) =
-      __$$_EditSiteCopyWithImpl<$Res>;
+abstract class _$$EditSiteImplCopyWith<$Res>
+    implements $EditSiteCopyWith<$Res> {
+  factory _$$EditSiteImplCopyWith(
+          _$EditSiteImpl value, $Res Function(_$EditSiteImpl) then) =
+      __$$EditSiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1557,11 +1559,11 @@ abstract class _$$_EditSiteCopyWith<$Res> implements $EditSiteCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_EditSiteCopyWithImpl<$Res>
-    extends _$EditSiteCopyWithImpl<$Res, _$_EditSite>
-    implements _$$_EditSiteCopyWith<$Res> {
-  __$$_EditSiteCopyWithImpl(
-      _$_EditSite _value, $Res Function(_$_EditSite) _then)
+class __$$EditSiteImplCopyWithImpl<$Res>
+    extends _$EditSiteCopyWithImpl<$Res, _$EditSiteImpl>
+    implements _$$EditSiteImplCopyWith<$Res> {
+  __$$EditSiteImplCopyWithImpl(
+      _$EditSiteImpl _value, $Res Function(_$EditSiteImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1609,7 +1611,7 @@ class __$$_EditSiteCopyWithImpl<$Res>
     Object? reportsEmailAdmins = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_EditSite(
+    return _then(_$EditSiteImpl(
       name: freezed == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -1781,8 +1783,8 @@ class __$$_EditSiteCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_EditSite extends _EditSite {
-  const _$_EditSite(
+class _$EditSiteImpl extends _EditSite {
+  const _$EditSiteImpl(
       {this.name,
       this.sidebar,
       this.description,
@@ -1830,8 +1832,8 @@ class _$_EditSite extends _EditSite {
         _taglines = taglines,
         super._();
 
-  factory _$_EditSite.fromJson(Map<String, dynamic> json) =>
-      _$$_EditSiteFromJson(json);
+  factory _$EditSiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EditSiteImplFromJson(json);
 
   @override
   final String? name;
@@ -1960,7 +1962,7 @@ class _$_EditSite extends _EditSite {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_EditSite &&
+            other is _$EditSiteImpl &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.sidebar, sidebar) || other.sidebar == sidebar) &&
             (identical(other.description, description) ||
@@ -2081,12 +2083,12 @@ class _$_EditSite extends _EditSite {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_EditSiteCopyWith<_$_EditSite> get copyWith =>
-      __$$_EditSiteCopyWithImpl<_$_EditSite>(this, _$identity);
+  _$$EditSiteImplCopyWith<_$EditSiteImpl> get copyWith =>
+      __$$EditSiteImplCopyWithImpl<_$EditSiteImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_EditSiteToJson(
+    return _$$EditSiteImplToJson(
       this,
     );
   }
@@ -2134,10 +2136,11 @@ abstract class _EditSite extends EditSite {
       final List<String>? taglines,
       final RegistrationMode? registrationMode,
       final bool? reportsEmailAdmins,
-      final String? auth}) = _$_EditSite;
+      final String? auth}) = _$EditSiteImpl;
   const _EditSite._() : super._();
 
-  factory _EditSite.fromJson(Map<String, dynamic> json) = _$_EditSite.fromJson;
+  factory _EditSite.fromJson(Map<String, dynamic> json) =
+      _$EditSiteImpl.fromJson;
 
   @override
   String? get name;
@@ -2223,7 +2226,7 @@ abstract class _EditSite extends EditSite {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_EditSiteCopyWith<_$_EditSite> get copyWith =>
+  _$$EditSiteImplCopyWith<_$EditSiteImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2287,22 +2290,22 @@ class _$BlockInstanceCopyWithImpl<$Res, $Val extends BlockInstance>
 }
 
 /// @nodoc
-abstract class _$$_BlockInstanceCopyWith<$Res>
+abstract class _$$BlockInstanceImplCopyWith<$Res>
     implements $BlockInstanceCopyWith<$Res> {
-  factory _$$_BlockInstanceCopyWith(
-          _$_BlockInstance value, $Res Function(_$_BlockInstance) then) =
-      __$$_BlockInstanceCopyWithImpl<$Res>;
+  factory _$$BlockInstanceImplCopyWith(
+          _$BlockInstanceImpl value, $Res Function(_$BlockInstanceImpl) then) =
+      __$$BlockInstanceImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth, int instanceId, bool block});
 }
 
 /// @nodoc
-class __$$_BlockInstanceCopyWithImpl<$Res>
-    extends _$BlockInstanceCopyWithImpl<$Res, _$_BlockInstance>
-    implements _$$_BlockInstanceCopyWith<$Res> {
-  __$$_BlockInstanceCopyWithImpl(
-      _$_BlockInstance _value, $Res Function(_$_BlockInstance) _then)
+class __$$BlockInstanceImplCopyWithImpl<$Res>
+    extends _$BlockInstanceCopyWithImpl<$Res, _$BlockInstanceImpl>
+    implements _$$BlockInstanceImplCopyWith<$Res> {
+  __$$BlockInstanceImplCopyWithImpl(
+      _$BlockInstanceImpl _value, $Res Function(_$BlockInstanceImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2312,7 +2315,7 @@ class __$$_BlockInstanceCopyWithImpl<$Res>
     Object? instanceId = null,
     Object? block = null,
   }) {
-    return _then(_$_BlockInstance(
+    return _then(_$BlockInstanceImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -2332,13 +2335,13 @@ class __$$_BlockInstanceCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_BlockInstance extends _BlockInstance {
-  const _$_BlockInstance(
+class _$BlockInstanceImpl extends _BlockInstance {
+  const _$BlockInstanceImpl(
       {this.auth, required this.instanceId, required this.block})
       : super._();
 
-  factory _$_BlockInstance.fromJson(Map<String, dynamic> json) =>
-      _$$_BlockInstanceFromJson(json);
+  factory _$BlockInstanceImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BlockInstanceImplFromJson(json);
 
   @override
   final String? auth;
@@ -2356,7 +2359,7 @@ class _$_BlockInstance extends _BlockInstance {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BlockInstance &&
+            other is _$BlockInstanceImpl &&
             (identical(other.auth, auth) || other.auth == auth) &&
             (identical(other.instanceId, instanceId) ||
                 other.instanceId == instanceId) &&
@@ -2370,12 +2373,12 @@ class _$_BlockInstance extends _BlockInstance {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BlockInstanceCopyWith<_$_BlockInstance> get copyWith =>
-      __$$_BlockInstanceCopyWithImpl<_$_BlockInstance>(this, _$identity);
+  _$$BlockInstanceImplCopyWith<_$BlockInstanceImpl> get copyWith =>
+      __$$BlockInstanceImplCopyWithImpl<_$BlockInstanceImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BlockInstanceToJson(
+    return _$$BlockInstanceImplToJson(
       this,
     );
   }
@@ -2385,11 +2388,11 @@ abstract class _BlockInstance extends BlockInstance {
   const factory _BlockInstance(
       {final String? auth,
       required final int instanceId,
-      required final bool block}) = _$_BlockInstance;
+      required final bool block}) = _$BlockInstanceImpl;
   const _BlockInstance._() : super._();
 
   factory _BlockInstance.fromJson(Map<String, dynamic> json) =
-      _$_BlockInstance.fromJson;
+      _$BlockInstanceImpl.fromJson;
 
   @override
   String? get auth;
@@ -2399,6 +2402,6 @@ abstract class _BlockInstance extends BlockInstance {
   bool get block;
   @override
   @JsonKey(ignore: true)
-  _$$_BlockInstanceCopyWith<_$_BlockInstance> get copyWith =>
+  _$$BlockInstanceImplCopyWith<_$BlockInstanceImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/site/site.g.dart
+++ b/lib/src/v3/api/site/site.g.dart
@@ -6,11 +6,12 @@ part of 'site.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetSite _$$_GetSiteFromJson(Map<String, dynamic> json) => _$_GetSite(
+_$GetSiteImpl _$$GetSiteImplFromJson(Map<String, dynamic> json) =>
+    _$GetSiteImpl(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetSiteToJson(_$_GetSite instance) {
+Map<String, dynamic> _$$GetSiteImplToJson(_$GetSiteImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -23,8 +24,8 @@ Map<String, dynamic> _$$_GetSiteToJson(_$_GetSite instance) {
   return val;
 }
 
-_$_CreateSite _$$_CreateSiteFromJson(Map<String, dynamic> json) =>
-    _$_CreateSite(
+_$CreateSiteImpl _$$CreateSiteImplFromJson(Map<String, dynamic> json) =>
+    _$CreateSiteImpl(
       name: json['name'] as String,
       sidebar: json['sidebar'] as String?,
       description: json['description'] as String?,
@@ -80,7 +81,7 @@ _$_CreateSite _$$_CreateSiteFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_CreateSiteToJson(_$_CreateSite instance) {
+Map<String, dynamic> _$$CreateSiteImplToJson(_$CreateSiteImpl instance) {
   final val = <String, dynamic>{
     'name': instance.name,
   };
@@ -139,7 +140,8 @@ Map<String, dynamic> _$$_CreateSiteToJson(_$_CreateSite instance) {
   return val;
 }
 
-_$_EditSite _$$_EditSiteFromJson(Map<String, dynamic> json) => _$_EditSite(
+_$EditSiteImpl _$$EditSiteImplFromJson(Map<String, dynamic> json) =>
+    _$EditSiteImpl(
       name: json['name'] as String?,
       sidebar: json['sidebar'] as String?,
       description: json['description'] as String?,
@@ -197,7 +199,7 @@ _$_EditSite _$$_EditSiteFromJson(Map<String, dynamic> json) => _$_EditSite(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_EditSiteToJson(_$_EditSite instance) {
+Map<String, dynamic> _$$EditSiteImplToJson(_$EditSiteImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -256,14 +258,14 @@ Map<String, dynamic> _$$_EditSiteToJson(_$_EditSite instance) {
   return val;
 }
 
-_$_BlockInstance _$$_BlockInstanceFromJson(Map<String, dynamic> json) =>
-    _$_BlockInstance(
+_$BlockInstanceImpl _$$BlockInstanceImplFromJson(Map<String, dynamic> json) =>
+    _$BlockInstanceImpl(
       auth: json['auth'] as String?,
       instanceId: json['instance_id'] as int,
       block: json['block'] as bool,
     );
 
-Map<String, dynamic> _$$_BlockInstanceToJson(_$_BlockInstance instance) {
+Map<String, dynamic> _$$BlockInstanceImplToJson(_$BlockInstanceImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {

--- a/lib/src/v3/api/user/user.dart
+++ b/lib/src/v3/api/user/user.dart
@@ -644,6 +644,7 @@ class SaveUserSettings
     String? postListingMode, // Available in lemmy v0.19.0 and above
     bool? enableKeyboardNavigation, // Available in lemmy v0.19.0 and above
     bool? enableAnimatedImages, // Available in lemmy v0.19.0 and above
+    bool? collapseBotComments, // Available in lemmy v0.19.0 and above
   }) = _SaveUserSettings;
 
   const SaveUserSettings._();

--- a/lib/src/v3/api/user/user.freezed.dart
+++ b/lib/src/v3/api/user/user.freezed.dart
@@ -62,22 +62,22 @@ class _$LeaveAdminCopyWithImpl<$Res, $Val extends LeaveAdmin>
 }
 
 /// @nodoc
-abstract class _$$_LeaveAdminCopyWith<$Res>
+abstract class _$$LeaveAdminImplCopyWith<$Res>
     implements $LeaveAdminCopyWith<$Res> {
-  factory _$$_LeaveAdminCopyWith(
-          _$_LeaveAdmin value, $Res Function(_$_LeaveAdmin) then) =
-      __$$_LeaveAdminCopyWithImpl<$Res>;
+  factory _$$LeaveAdminImplCopyWith(
+          _$LeaveAdminImpl value, $Res Function(_$LeaveAdminImpl) then) =
+      __$$LeaveAdminImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$_LeaveAdminCopyWithImpl<$Res>
-    extends _$LeaveAdminCopyWithImpl<$Res, _$_LeaveAdmin>
-    implements _$$_LeaveAdminCopyWith<$Res> {
-  __$$_LeaveAdminCopyWithImpl(
-      _$_LeaveAdmin _value, $Res Function(_$_LeaveAdmin) _then)
+class __$$LeaveAdminImplCopyWithImpl<$Res>
+    extends _$LeaveAdminCopyWithImpl<$Res, _$LeaveAdminImpl>
+    implements _$$LeaveAdminImplCopyWith<$Res> {
+  __$$LeaveAdminImplCopyWithImpl(
+      _$LeaveAdminImpl _value, $Res Function(_$LeaveAdminImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -85,7 +85,7 @@ class __$$_LeaveAdminCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$_LeaveAdmin(
+    return _then(_$LeaveAdminImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -97,11 +97,11 @@ class __$$_LeaveAdminCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_LeaveAdmin extends _LeaveAdmin {
-  const _$_LeaveAdmin({this.auth}) : super._();
+class _$LeaveAdminImpl extends _LeaveAdmin {
+  const _$LeaveAdminImpl({this.auth}) : super._();
 
-  factory _$_LeaveAdmin.fromJson(Map<String, dynamic> json) =>
-      _$$_LeaveAdminFromJson(json);
+  factory _$LeaveAdminImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LeaveAdminImplFromJson(json);
 
   @override
   final String? auth;
@@ -115,7 +115,7 @@ class _$_LeaveAdmin extends _LeaveAdmin {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LeaveAdmin &&
+            other is _$LeaveAdminImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -126,29 +126,29 @@ class _$_LeaveAdmin extends _LeaveAdmin {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LeaveAdminCopyWith<_$_LeaveAdmin> get copyWith =>
-      __$$_LeaveAdminCopyWithImpl<_$_LeaveAdmin>(this, _$identity);
+  _$$LeaveAdminImplCopyWith<_$LeaveAdminImpl> get copyWith =>
+      __$$LeaveAdminImplCopyWithImpl<_$LeaveAdminImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LeaveAdminToJson(
+    return _$$LeaveAdminImplToJson(
       this,
     );
   }
 }
 
 abstract class _LeaveAdmin extends LeaveAdmin {
-  const factory _LeaveAdmin({final String? auth}) = _$_LeaveAdmin;
+  const factory _LeaveAdmin({final String? auth}) = _$LeaveAdminImpl;
   const _LeaveAdmin._() : super._();
 
   factory _LeaveAdmin.fromJson(Map<String, dynamic> json) =
-      _$_LeaveAdmin.fromJson;
+      _$LeaveAdminImpl.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_LeaveAdminCopyWith<_$_LeaveAdmin> get copyWith =>
+  _$$LeaveAdminImplCopyWith<_$LeaveAdminImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -200,22 +200,22 @@ class _$GenerateTotpSecretCopyWithImpl<$Res, $Val extends GenerateTotpSecret>
 }
 
 /// @nodoc
-abstract class _$$_GenerateTotpSecretCopyWith<$Res>
+abstract class _$$GenerateTotpSecretImplCopyWith<$Res>
     implements $GenerateTotpSecretCopyWith<$Res> {
-  factory _$$_GenerateTotpSecretCopyWith(_$_GenerateTotpSecret value,
-          $Res Function(_$_GenerateTotpSecret) then) =
-      __$$_GenerateTotpSecretCopyWithImpl<$Res>;
+  factory _$$GenerateTotpSecretImplCopyWith(_$GenerateTotpSecretImpl value,
+          $Res Function(_$GenerateTotpSecretImpl) then) =
+      __$$GenerateTotpSecretImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$_GenerateTotpSecretCopyWithImpl<$Res>
-    extends _$GenerateTotpSecretCopyWithImpl<$Res, _$_GenerateTotpSecret>
-    implements _$$_GenerateTotpSecretCopyWith<$Res> {
-  __$$_GenerateTotpSecretCopyWithImpl(
-      _$_GenerateTotpSecret _value, $Res Function(_$_GenerateTotpSecret) _then)
+class __$$GenerateTotpSecretImplCopyWithImpl<$Res>
+    extends _$GenerateTotpSecretCopyWithImpl<$Res, _$GenerateTotpSecretImpl>
+    implements _$$GenerateTotpSecretImplCopyWith<$Res> {
+  __$$GenerateTotpSecretImplCopyWithImpl(_$GenerateTotpSecretImpl _value,
+      $Res Function(_$GenerateTotpSecretImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -223,7 +223,7 @@ class __$$_GenerateTotpSecretCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$_GenerateTotpSecret(
+    return _then(_$GenerateTotpSecretImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -235,11 +235,11 @@ class __$$_GenerateTotpSecretCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GenerateTotpSecret extends _GenerateTotpSecret {
-  const _$_GenerateTotpSecret({this.auth}) : super._();
+class _$GenerateTotpSecretImpl extends _GenerateTotpSecret {
+  const _$GenerateTotpSecretImpl({this.auth}) : super._();
 
-  factory _$_GenerateTotpSecret.fromJson(Map<String, dynamic> json) =>
-      _$$_GenerateTotpSecretFromJson(json);
+  factory _$GenerateTotpSecretImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GenerateTotpSecretImplFromJson(json);
 
   @override
   final String? auth;
@@ -253,7 +253,7 @@ class _$_GenerateTotpSecret extends _GenerateTotpSecret {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GenerateTotpSecret &&
+            other is _$GenerateTotpSecretImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -264,13 +264,13 @@ class _$_GenerateTotpSecret extends _GenerateTotpSecret {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GenerateTotpSecretCopyWith<_$_GenerateTotpSecret> get copyWith =>
-      __$$_GenerateTotpSecretCopyWithImpl<_$_GenerateTotpSecret>(
+  _$$GenerateTotpSecretImplCopyWith<_$GenerateTotpSecretImpl> get copyWith =>
+      __$$GenerateTotpSecretImplCopyWithImpl<_$GenerateTotpSecretImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GenerateTotpSecretToJson(
+    return _$$GenerateTotpSecretImplToJson(
       this,
     );
   }
@@ -278,17 +278,17 @@ class _$_GenerateTotpSecret extends _GenerateTotpSecret {
 
 abstract class _GenerateTotpSecret extends GenerateTotpSecret {
   const factory _GenerateTotpSecret({final String? auth}) =
-      _$_GenerateTotpSecret;
+      _$GenerateTotpSecretImpl;
   const _GenerateTotpSecret._() : super._();
 
   factory _GenerateTotpSecret.fromJson(Map<String, dynamic> json) =
-      _$_GenerateTotpSecret.fromJson;
+      _$GenerateTotpSecretImpl.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GenerateTotpSecretCopyWith<_$_GenerateTotpSecret> get copyWith =>
+  _$$GenerateTotpSecretImplCopyWith<_$GenerateTotpSecretImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -340,22 +340,22 @@ class _$ExportSettingsCopyWithImpl<$Res, $Val extends ExportSettings>
 }
 
 /// @nodoc
-abstract class _$$_ExportSettingsCopyWith<$Res>
+abstract class _$$ExportSettingsImplCopyWith<$Res>
     implements $ExportSettingsCopyWith<$Res> {
-  factory _$$_ExportSettingsCopyWith(
-          _$_ExportSettings value, $Res Function(_$_ExportSettings) then) =
-      __$$_ExportSettingsCopyWithImpl<$Res>;
+  factory _$$ExportSettingsImplCopyWith(_$ExportSettingsImpl value,
+          $Res Function(_$ExportSettingsImpl) then) =
+      __$$ExportSettingsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$_ExportSettingsCopyWithImpl<$Res>
-    extends _$ExportSettingsCopyWithImpl<$Res, _$_ExportSettings>
-    implements _$$_ExportSettingsCopyWith<$Res> {
-  __$$_ExportSettingsCopyWithImpl(
-      _$_ExportSettings _value, $Res Function(_$_ExportSettings) _then)
+class __$$ExportSettingsImplCopyWithImpl<$Res>
+    extends _$ExportSettingsCopyWithImpl<$Res, _$ExportSettingsImpl>
+    implements _$$ExportSettingsImplCopyWith<$Res> {
+  __$$ExportSettingsImplCopyWithImpl(
+      _$ExportSettingsImpl _value, $Res Function(_$ExportSettingsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -363,7 +363,7 @@ class __$$_ExportSettingsCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$_ExportSettings(
+    return _then(_$ExportSettingsImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -375,11 +375,11 @@ class __$$_ExportSettingsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ExportSettings extends _ExportSettings {
-  const _$_ExportSettings({this.auth}) : super._();
+class _$ExportSettingsImpl extends _ExportSettings {
+  const _$ExportSettingsImpl({this.auth}) : super._();
 
-  factory _$_ExportSettings.fromJson(Map<String, dynamic> json) =>
-      _$$_ExportSettingsFromJson(json);
+  factory _$ExportSettingsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ExportSettingsImplFromJson(json);
 
   @override
   final String? auth;
@@ -393,7 +393,7 @@ class _$_ExportSettings extends _ExportSettings {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ExportSettings &&
+            other is _$ExportSettingsImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -404,29 +404,30 @@ class _$_ExportSettings extends _ExportSettings {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ExportSettingsCopyWith<_$_ExportSettings> get copyWith =>
-      __$$_ExportSettingsCopyWithImpl<_$_ExportSettings>(this, _$identity);
+  _$$ExportSettingsImplCopyWith<_$ExportSettingsImpl> get copyWith =>
+      __$$ExportSettingsImplCopyWithImpl<_$ExportSettingsImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ExportSettingsToJson(
+    return _$$ExportSettingsImplToJson(
       this,
     );
   }
 }
 
 abstract class _ExportSettings extends ExportSettings {
-  const factory _ExportSettings({final String? auth}) = _$_ExportSettings;
+  const factory _ExportSettings({final String? auth}) = _$ExportSettingsImpl;
   const _ExportSettings._() : super._();
 
   factory _ExportSettings.fromJson(Map<String, dynamic> json) =
-      _$_ExportSettings.fromJson;
+      _$ExportSettingsImpl.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ExportSettingsCopyWith<_$_ExportSettings> get copyWith =>
+  _$$ExportSettingsImplCopyWith<_$ExportSettingsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -484,22 +485,22 @@ class _$ImportSettingsCopyWithImpl<$Res, $Val extends ImportSettings>
 }
 
 /// @nodoc
-abstract class _$$_ImportSettingsCopyWith<$Res>
+abstract class _$$ImportSettingsImplCopyWith<$Res>
     implements $ImportSettingsCopyWith<$Res> {
-  factory _$$_ImportSettingsCopyWith(
-          _$_ImportSettings value, $Res Function(_$_ImportSettings) then) =
-      __$$_ImportSettingsCopyWithImpl<$Res>;
+  factory _$$ImportSettingsImplCopyWith(_$ImportSettingsImpl value,
+          $Res Function(_$ImportSettingsImpl) then) =
+      __$$ImportSettingsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth, dynamic data});
 }
 
 /// @nodoc
-class __$$_ImportSettingsCopyWithImpl<$Res>
-    extends _$ImportSettingsCopyWithImpl<$Res, _$_ImportSettings>
-    implements _$$_ImportSettingsCopyWith<$Res> {
-  __$$_ImportSettingsCopyWithImpl(
-      _$_ImportSettings _value, $Res Function(_$_ImportSettings) _then)
+class __$$ImportSettingsImplCopyWithImpl<$Res>
+    extends _$ImportSettingsCopyWithImpl<$Res, _$ImportSettingsImpl>
+    implements _$$ImportSettingsImplCopyWith<$Res> {
+  __$$ImportSettingsImplCopyWithImpl(
+      _$ImportSettingsImpl _value, $Res Function(_$ImportSettingsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -508,7 +509,7 @@ class __$$_ImportSettingsCopyWithImpl<$Res>
     Object? auth = freezed,
     Object? data = freezed,
   }) {
-    return _then(_$_ImportSettings(
+    return _then(_$ImportSettingsImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -524,11 +525,11 @@ class __$$_ImportSettingsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ImportSettings extends _ImportSettings {
-  const _$_ImportSettings({this.auth, this.data}) : super._();
+class _$ImportSettingsImpl extends _ImportSettings {
+  const _$ImportSettingsImpl({this.auth, this.data}) : super._();
 
-  factory _$_ImportSettings.fromJson(Map<String, dynamic> json) =>
-      _$$_ImportSettingsFromJson(json);
+  factory _$ImportSettingsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ImportSettingsImplFromJson(json);
 
   @override
   final String? auth;
@@ -544,7 +545,7 @@ class _$_ImportSettings extends _ImportSettings {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ImportSettings &&
+            other is _$ImportSettingsImpl &&
             (identical(other.auth, auth) || other.auth == auth) &&
             const DeepCollectionEquality().equals(other.data, data));
   }
@@ -557,12 +558,13 @@ class _$_ImportSettings extends _ImportSettings {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ImportSettingsCopyWith<_$_ImportSettings> get copyWith =>
-      __$$_ImportSettingsCopyWithImpl<_$_ImportSettings>(this, _$identity);
+  _$$ImportSettingsImplCopyWith<_$ImportSettingsImpl> get copyWith =>
+      __$$ImportSettingsImplCopyWithImpl<_$ImportSettingsImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ImportSettingsToJson(
+    return _$$ImportSettingsImplToJson(
       this,
     );
   }
@@ -570,11 +572,11 @@ class _$_ImportSettings extends _ImportSettings {
 
 abstract class _ImportSettings extends ImportSettings {
   const factory _ImportSettings({final String? auth, final dynamic data}) =
-      _$_ImportSettings;
+      _$ImportSettingsImpl;
   const _ImportSettings._() : super._();
 
   factory _ImportSettings.fromJson(Map<String, dynamic> json) =
-      _$_ImportSettings.fromJson;
+      _$ImportSettingsImpl.fromJson;
 
   @override
   String? get auth;
@@ -582,7 +584,7 @@ abstract class _ImportSettings extends ImportSettings {
   dynamic get data;
   @override
   @JsonKey(ignore: true)
-  _$$_ImportSettingsCopyWith<_$_ImportSettings> get copyWith =>
+  _$$ImportSettingsImplCopyWith<_$ImportSettingsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -634,22 +636,22 @@ class _$ValidateAuthCopyWithImpl<$Res, $Val extends ValidateAuth>
 }
 
 /// @nodoc
-abstract class _$$_ValidateAuthCopyWith<$Res>
+abstract class _$$ValidateAuthImplCopyWith<$Res>
     implements $ValidateAuthCopyWith<$Res> {
-  factory _$$_ValidateAuthCopyWith(
-          _$_ValidateAuth value, $Res Function(_$_ValidateAuth) then) =
-      __$$_ValidateAuthCopyWithImpl<$Res>;
+  factory _$$ValidateAuthImplCopyWith(
+          _$ValidateAuthImpl value, $Res Function(_$ValidateAuthImpl) then) =
+      __$$ValidateAuthImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$_ValidateAuthCopyWithImpl<$Res>
-    extends _$ValidateAuthCopyWithImpl<$Res, _$_ValidateAuth>
-    implements _$$_ValidateAuthCopyWith<$Res> {
-  __$$_ValidateAuthCopyWithImpl(
-      _$_ValidateAuth _value, $Res Function(_$_ValidateAuth) _then)
+class __$$ValidateAuthImplCopyWithImpl<$Res>
+    extends _$ValidateAuthCopyWithImpl<$Res, _$ValidateAuthImpl>
+    implements _$$ValidateAuthImplCopyWith<$Res> {
+  __$$ValidateAuthImplCopyWithImpl(
+      _$ValidateAuthImpl _value, $Res Function(_$ValidateAuthImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -657,7 +659,7 @@ class __$$_ValidateAuthCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$_ValidateAuth(
+    return _then(_$ValidateAuthImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -669,11 +671,11 @@ class __$$_ValidateAuthCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ValidateAuth extends _ValidateAuth {
-  const _$_ValidateAuth({this.auth}) : super._();
+class _$ValidateAuthImpl extends _ValidateAuth {
+  const _$ValidateAuthImpl({this.auth}) : super._();
 
-  factory _$_ValidateAuth.fromJson(Map<String, dynamic> json) =>
-      _$$_ValidateAuthFromJson(json);
+  factory _$ValidateAuthImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ValidateAuthImplFromJson(json);
 
   @override
   final String? auth;
@@ -687,7 +689,7 @@ class _$_ValidateAuth extends _ValidateAuth {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ValidateAuth &&
+            other is _$ValidateAuthImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -698,29 +700,29 @@ class _$_ValidateAuth extends _ValidateAuth {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ValidateAuthCopyWith<_$_ValidateAuth> get copyWith =>
-      __$$_ValidateAuthCopyWithImpl<_$_ValidateAuth>(this, _$identity);
+  _$$ValidateAuthImplCopyWith<_$ValidateAuthImpl> get copyWith =>
+      __$$ValidateAuthImplCopyWithImpl<_$ValidateAuthImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ValidateAuthToJson(
+    return _$$ValidateAuthImplToJson(
       this,
     );
   }
 }
 
 abstract class _ValidateAuth extends ValidateAuth {
-  const factory _ValidateAuth({final String? auth}) = _$_ValidateAuth;
+  const factory _ValidateAuth({final String? auth}) = _$ValidateAuthImpl;
   const _ValidateAuth._() : super._();
 
   factory _ValidateAuth.fromJson(Map<String, dynamic> json) =
-      _$_ValidateAuth.fromJson;
+      _$ValidateAuthImpl.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ValidateAuthCopyWith<_$_ValidateAuth> get copyWith =>
+  _$$ValidateAuthImplCopyWith<_$ValidateAuthImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -784,22 +786,22 @@ class _$UpdateTotpCopyWithImpl<$Res, $Val extends UpdateTotp>
 }
 
 /// @nodoc
-abstract class _$$_UpdateTotpCopyWith<$Res>
+abstract class _$$UpdateTotpImplCopyWith<$Res>
     implements $UpdateTotpCopyWith<$Res> {
-  factory _$$_UpdateTotpCopyWith(
-          _$_UpdateTotp value, $Res Function(_$_UpdateTotp) then) =
-      __$$_UpdateTotpCopyWithImpl<$Res>;
+  factory _$$UpdateTotpImplCopyWith(
+          _$UpdateTotpImpl value, $Res Function(_$UpdateTotpImpl) then) =
+      __$$UpdateTotpImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth, String totpToken, bool enabled});
 }
 
 /// @nodoc
-class __$$_UpdateTotpCopyWithImpl<$Res>
-    extends _$UpdateTotpCopyWithImpl<$Res, _$_UpdateTotp>
-    implements _$$_UpdateTotpCopyWith<$Res> {
-  __$$_UpdateTotpCopyWithImpl(
-      _$_UpdateTotp _value, $Res Function(_$_UpdateTotp) _then)
+class __$$UpdateTotpImplCopyWithImpl<$Res>
+    extends _$UpdateTotpCopyWithImpl<$Res, _$UpdateTotpImpl>
+    implements _$$UpdateTotpImplCopyWith<$Res> {
+  __$$UpdateTotpImplCopyWithImpl(
+      _$UpdateTotpImpl _value, $Res Function(_$UpdateTotpImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -809,7 +811,7 @@ class __$$_UpdateTotpCopyWithImpl<$Res>
     Object? totpToken = null,
     Object? enabled = null,
   }) {
-    return _then(_$_UpdateTotp(
+    return _then(_$UpdateTotpImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -829,13 +831,13 @@ class __$$_UpdateTotpCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_UpdateTotp extends _UpdateTotp {
-  const _$_UpdateTotp(
+class _$UpdateTotpImpl extends _UpdateTotp {
+  const _$UpdateTotpImpl(
       {this.auth, required this.totpToken, required this.enabled})
       : super._();
 
-  factory _$_UpdateTotp.fromJson(Map<String, dynamic> json) =>
-      _$$_UpdateTotpFromJson(json);
+  factory _$UpdateTotpImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UpdateTotpImplFromJson(json);
 
   @override
   final String? auth;
@@ -853,7 +855,7 @@ class _$_UpdateTotp extends _UpdateTotp {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_UpdateTotp &&
+            other is _$UpdateTotpImpl &&
             (identical(other.auth, auth) || other.auth == auth) &&
             (identical(other.totpToken, totpToken) ||
                 other.totpToken == totpToken) &&
@@ -867,12 +869,12 @@ class _$_UpdateTotp extends _UpdateTotp {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_UpdateTotpCopyWith<_$_UpdateTotp> get copyWith =>
-      __$$_UpdateTotpCopyWithImpl<_$_UpdateTotp>(this, _$identity);
+  _$$UpdateTotpImplCopyWith<_$UpdateTotpImpl> get copyWith =>
+      __$$UpdateTotpImplCopyWithImpl<_$UpdateTotpImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_UpdateTotpToJson(
+    return _$$UpdateTotpImplToJson(
       this,
     );
   }
@@ -882,11 +884,11 @@ abstract class _UpdateTotp extends UpdateTotp {
   const factory _UpdateTotp(
       {final String? auth,
       required final String totpToken,
-      required final bool enabled}) = _$_UpdateTotp;
+      required final bool enabled}) = _$UpdateTotpImpl;
   const _UpdateTotp._() : super._();
 
   factory _UpdateTotp.fromJson(Map<String, dynamic> json) =
-      _$_UpdateTotp.fromJson;
+      _$UpdateTotpImpl.fromJson;
 
   @override
   String? get auth;
@@ -896,7 +898,7 @@ abstract class _UpdateTotp extends UpdateTotp {
   bool get enabled;
   @override
   @JsonKey(ignore: true)
-  _$$_UpdateTotpCopyWith<_$_UpdateTotp> get copyWith =>
+  _$$UpdateTotpImplCopyWith<_$UpdateTotpImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1004,10 +1006,11 @@ class _$RegisterCopyWithImpl<$Res, $Val extends Register>
 }
 
 /// @nodoc
-abstract class _$$_RegisterCopyWith<$Res> implements $RegisterCopyWith<$Res> {
-  factory _$$_RegisterCopyWith(
-          _$_Register value, $Res Function(_$_Register) then) =
-      __$$_RegisterCopyWithImpl<$Res>;
+abstract class _$$RegisterImplCopyWith<$Res>
+    implements $RegisterCopyWith<$Res> {
+  factory _$$RegisterImplCopyWith(
+          _$RegisterImpl value, $Res Function(_$RegisterImpl) then) =
+      __$$RegisterImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1023,11 +1026,11 @@ abstract class _$$_RegisterCopyWith<$Res> implements $RegisterCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_RegisterCopyWithImpl<$Res>
-    extends _$RegisterCopyWithImpl<$Res, _$_Register>
-    implements _$$_RegisterCopyWith<$Res> {
-  __$$_RegisterCopyWithImpl(
-      _$_Register _value, $Res Function(_$_Register) _then)
+class __$$RegisterImplCopyWithImpl<$Res>
+    extends _$RegisterCopyWithImpl<$Res, _$RegisterImpl>
+    implements _$$RegisterImplCopyWith<$Res> {
+  __$$RegisterImplCopyWithImpl(
+      _$RegisterImpl _value, $Res Function(_$RegisterImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1043,7 +1046,7 @@ class __$$_RegisterCopyWithImpl<$Res>
     Object? honeypot = freezed,
     Object? answer = freezed,
   }) {
-    return _then(_$_Register(
+    return _then(_$RegisterImpl(
       username: null == username
           ? _value.username
           : username // ignore: cast_nullable_to_non_nullable
@@ -1087,8 +1090,8 @@ class __$$_RegisterCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_Register extends _Register {
-  const _$_Register(
+class _$RegisterImpl extends _Register {
+  const _$RegisterImpl(
       {required this.username,
       required this.password,
       required this.passwordVerify,
@@ -1100,8 +1103,8 @@ class _$_Register extends _Register {
       this.answer})
       : super._();
 
-  factory _$_Register.fromJson(Map<String, dynamic> json) =>
-      _$$_RegisterFromJson(json);
+  factory _$RegisterImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RegisterImplFromJson(json);
 
   @override
   final String username;
@@ -1131,7 +1134,7 @@ class _$_Register extends _Register {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Register &&
+            other is _$RegisterImpl &&
             (identical(other.username, username) ||
                 other.username == username) &&
             (identical(other.password, password) ||
@@ -1167,12 +1170,12 @@ class _$_Register extends _Register {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RegisterCopyWith<_$_Register> get copyWith =>
-      __$$_RegisterCopyWithImpl<_$_Register>(this, _$identity);
+  _$$RegisterImplCopyWith<_$RegisterImpl> get copyWith =>
+      __$$RegisterImplCopyWithImpl<_$RegisterImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RegisterToJson(
+    return _$$RegisterImplToJson(
       this,
     );
   }
@@ -1188,10 +1191,11 @@ abstract class _Register extends Register {
       final String? captchaUuid,
       final String? captchaAnswer,
       final String? honeypot,
-      final String? answer}) = _$_Register;
+      final String? answer}) = _$RegisterImpl;
   const _Register._() : super._();
 
-  factory _Register.fromJson(Map<String, dynamic> json) = _$_Register.fromJson;
+  factory _Register.fromJson(Map<String, dynamic> json) =
+      _$RegisterImpl.fromJson;
 
   @override
   String get username;
@@ -1213,7 +1217,7 @@ abstract class _Register extends Register {
   String? get answer;
   @override
   @JsonKey(ignore: true)
-  _$$_RegisterCopyWith<_$_Register> get copyWith =>
+  _$$RegisterImplCopyWith<_$RegisterImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1275,18 +1279,21 @@ class _$LoginCopyWithImpl<$Res, $Val extends Login>
 }
 
 /// @nodoc
-abstract class _$$_LoginCopyWith<$Res> implements $LoginCopyWith<$Res> {
-  factory _$$_LoginCopyWith(_$_Login value, $Res Function(_$_Login) then) =
-      __$$_LoginCopyWithImpl<$Res>;
+abstract class _$$LoginImplCopyWith<$Res> implements $LoginCopyWith<$Res> {
+  factory _$$LoginImplCopyWith(
+          _$LoginImpl value, $Res Function(_$LoginImpl) then) =
+      __$$LoginImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String usernameOrEmail, String password, String? totp2faToken});
 }
 
 /// @nodoc
-class __$$_LoginCopyWithImpl<$Res> extends _$LoginCopyWithImpl<$Res, _$_Login>
-    implements _$$_LoginCopyWith<$Res> {
-  __$$_LoginCopyWithImpl(_$_Login _value, $Res Function(_$_Login) _then)
+class __$$LoginImplCopyWithImpl<$Res>
+    extends _$LoginCopyWithImpl<$Res, _$LoginImpl>
+    implements _$$LoginImplCopyWith<$Res> {
+  __$$LoginImplCopyWithImpl(
+      _$LoginImpl _value, $Res Function(_$LoginImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1296,7 +1303,7 @@ class __$$_LoginCopyWithImpl<$Res> extends _$LoginCopyWithImpl<$Res, _$_Login>
     Object? password = null,
     Object? totp2faToken = freezed,
   }) {
-    return _then(_$_Login(
+    return _then(_$LoginImpl(
       usernameOrEmail: null == usernameOrEmail
           ? _value.usernameOrEmail
           : usernameOrEmail // ignore: cast_nullable_to_non_nullable
@@ -1316,15 +1323,15 @@ class __$$_LoginCopyWithImpl<$Res> extends _$LoginCopyWithImpl<$Res, _$_Login>
 /// @nodoc
 
 @apiSerde
-class _$_Login extends _Login {
-  const _$_Login(
+class _$LoginImpl extends _Login {
+  const _$LoginImpl(
       {required this.usernameOrEmail,
       required this.password,
       this.totp2faToken})
       : super._();
 
-  factory _$_Login.fromJson(Map<String, dynamic> json) =>
-      _$$_LoginFromJson(json);
+  factory _$LoginImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LoginImplFromJson(json);
 
   @override
   final String usernameOrEmail;
@@ -1342,7 +1349,7 @@ class _$_Login extends _Login {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Login &&
+            other is _$LoginImpl &&
             (identical(other.usernameOrEmail, usernameOrEmail) ||
                 other.usernameOrEmail == usernameOrEmail) &&
             (identical(other.password, password) ||
@@ -1359,12 +1366,12 @@ class _$_Login extends _Login {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LoginCopyWith<_$_Login> get copyWith =>
-      __$$_LoginCopyWithImpl<_$_Login>(this, _$identity);
+  _$$LoginImplCopyWith<_$LoginImpl> get copyWith =>
+      __$$LoginImplCopyWithImpl<_$LoginImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LoginToJson(
+    return _$$LoginImplToJson(
       this,
     );
   }
@@ -1374,10 +1381,10 @@ abstract class _Login extends Login {
   const factory _Login(
       {required final String usernameOrEmail,
       required final String password,
-      final String? totp2faToken}) = _$_Login;
+      final String? totp2faToken}) = _$LoginImpl;
   const _Login._() : super._();
 
-  factory _Login.fromJson(Map<String, dynamic> json) = _$_Login.fromJson;
+  factory _Login.fromJson(Map<String, dynamic> json) = _$LoginImpl.fromJson;
 
   @override
   String get usernameOrEmail;
@@ -1387,7 +1394,7 @@ abstract class _Login extends Login {
   String? get totp2faToken;
   @override
   @JsonKey(ignore: true)
-  _$$_LoginCopyWith<_$_Login> get copyWith =>
+  _$$LoginImplCopyWith<_$LoginImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1418,27 +1425,29 @@ class _$LogoutCopyWithImpl<$Res, $Val extends Logout>
 }
 
 /// @nodoc
-abstract class _$$_LogoutCopyWith<$Res> {
-  factory _$$_LogoutCopyWith(_$_Logout value, $Res Function(_$_Logout) then) =
-      __$$_LogoutCopyWithImpl<$Res>;
+abstract class _$$LogoutImplCopyWith<$Res> {
+  factory _$$LogoutImplCopyWith(
+          _$LogoutImpl value, $Res Function(_$LogoutImpl) then) =
+      __$$LogoutImplCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$_LogoutCopyWithImpl<$Res>
-    extends _$LogoutCopyWithImpl<$Res, _$_Logout>
-    implements _$$_LogoutCopyWith<$Res> {
-  __$$_LogoutCopyWithImpl(_$_Logout _value, $Res Function(_$_Logout) _then)
+class __$$LogoutImplCopyWithImpl<$Res>
+    extends _$LogoutCopyWithImpl<$Res, _$LogoutImpl>
+    implements _$$LogoutImplCopyWith<$Res> {
+  __$$LogoutImplCopyWithImpl(
+      _$LogoutImpl _value, $Res Function(_$LogoutImpl) _then)
       : super(_value, _then);
 }
 
 /// @nodoc
 
 @apiSerde
-class _$_Logout extends _Logout {
-  const _$_Logout() : super._();
+class _$LogoutImpl extends _Logout {
+  const _$LogoutImpl() : super._();
 
-  factory _$_Logout.fromJson(Map<String, dynamic> json) =>
-      _$$_LogoutFromJson(json);
+  factory _$LogoutImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LogoutImplFromJson(json);
 
   @override
   String toString() {
@@ -1448,7 +1457,7 @@ class _$_Logout extends _Logout {
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$_Logout);
+        (other.runtimeType == runtimeType && other is _$LogoutImpl);
   }
 
   @JsonKey(ignore: true)
@@ -1457,17 +1466,17 @@ class _$_Logout extends _Logout {
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LogoutToJson(
+    return _$$LogoutImplToJson(
       this,
     );
   }
 }
 
 abstract class _Logout extends Logout {
-  const factory _Logout() = _$_Logout;
+  const factory _Logout() = _$LogoutImpl;
   const _Logout._() : super._();
 
-  factory _Logout.fromJson(Map<String, dynamic> json) = _$_Logout.fromJson;
+  factory _Logout.fromJson(Map<String, dynamic> json) = _$LogoutImpl.fromJson;
 }
 
 GetPersonDetails _$GetPersonDetailsFromJson(Map<String, dynamic> json) {
@@ -1568,11 +1577,11 @@ class _$GetPersonDetailsCopyWithImpl<$Res, $Val extends GetPersonDetails>
 }
 
 /// @nodoc
-abstract class _$$_GetPersonDetailsCopyWith<$Res>
+abstract class _$$GetPersonDetailsImplCopyWith<$Res>
     implements $GetPersonDetailsCopyWith<$Res> {
-  factory _$$_GetPersonDetailsCopyWith(
-          _$_GetPersonDetails value, $Res Function(_$_GetPersonDetails) then) =
-      __$$_GetPersonDetailsCopyWithImpl<$Res>;
+  factory _$$GetPersonDetailsImplCopyWith(_$GetPersonDetailsImpl value,
+          $Res Function(_$GetPersonDetailsImpl) then) =
+      __$$GetPersonDetailsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1587,11 +1596,11 @@ abstract class _$$_GetPersonDetailsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetPersonDetailsCopyWithImpl<$Res>
-    extends _$GetPersonDetailsCopyWithImpl<$Res, _$_GetPersonDetails>
-    implements _$$_GetPersonDetailsCopyWith<$Res> {
-  __$$_GetPersonDetailsCopyWithImpl(
-      _$_GetPersonDetails _value, $Res Function(_$_GetPersonDetails) _then)
+class __$$GetPersonDetailsImplCopyWithImpl<$Res>
+    extends _$GetPersonDetailsCopyWithImpl<$Res, _$GetPersonDetailsImpl>
+    implements _$$GetPersonDetailsImplCopyWith<$Res> {
+  __$$GetPersonDetailsImplCopyWithImpl(_$GetPersonDetailsImpl _value,
+      $Res Function(_$GetPersonDetailsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1606,7 +1615,7 @@ class __$$_GetPersonDetailsCopyWithImpl<$Res>
     Object? savedOnly = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetPersonDetails(
+    return _then(_$GetPersonDetailsImpl(
       personId: freezed == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -1646,8 +1655,8 @@ class __$$_GetPersonDetailsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetPersonDetails extends _GetPersonDetails {
-  const _$_GetPersonDetails(
+class _$GetPersonDetailsImpl extends _GetPersonDetails {
+  const _$GetPersonDetailsImpl(
       {this.personId,
       this.username,
       this.sort,
@@ -1658,8 +1667,8 @@ class _$_GetPersonDetails extends _GetPersonDetails {
       this.auth})
       : super._();
 
-  factory _$_GetPersonDetails.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPersonDetailsFromJson(json);
+  factory _$GetPersonDetailsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPersonDetailsImplFromJson(json);
 
   @override
   final int? personId;
@@ -1687,7 +1696,7 @@ class _$_GetPersonDetails extends _GetPersonDetails {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPersonDetails &&
+            other is _$GetPersonDetailsImpl &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.username, username) ||
@@ -1710,12 +1719,13 @@ class _$_GetPersonDetails extends _GetPersonDetails {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPersonDetailsCopyWith<_$_GetPersonDetails> get copyWith =>
-      __$$_GetPersonDetailsCopyWithImpl<_$_GetPersonDetails>(this, _$identity);
+  _$$GetPersonDetailsImplCopyWith<_$GetPersonDetailsImpl> get copyWith =>
+      __$$GetPersonDetailsImplCopyWithImpl<_$GetPersonDetailsImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPersonDetailsToJson(
+    return _$$GetPersonDetailsImplToJson(
       this,
     );
   }
@@ -1730,11 +1740,11 @@ abstract class _GetPersonDetails extends GetPersonDetails {
       final int? limit,
       final int? communityId,
       final bool? savedOnly,
-      final String? auth}) = _$_GetPersonDetails;
+      final String? auth}) = _$GetPersonDetailsImpl;
   const _GetPersonDetails._() : super._();
 
   factory _GetPersonDetails.fromJson(Map<String, dynamic> json) =
-      _$_GetPersonDetails.fromJson;
+      _$GetPersonDetailsImpl.fromJson;
 
   @override
   int? get personId;
@@ -1754,7 +1764,7 @@ abstract class _GetPersonDetails extends GetPersonDetails {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPersonDetailsCopyWith<_$_GetPersonDetails> get copyWith =>
+  _$$GetPersonDetailsImplCopyWith<_$GetPersonDetailsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -1835,11 +1845,11 @@ class _$GetPersonMentionsCopyWithImpl<$Res, $Val extends GetPersonMentions>
 }
 
 /// @nodoc
-abstract class _$$_GetPersonMentionsCopyWith<$Res>
+abstract class _$$GetPersonMentionsImplCopyWith<$Res>
     implements $GetPersonMentionsCopyWith<$Res> {
-  factory _$$_GetPersonMentionsCopyWith(_$_GetPersonMentions value,
-          $Res Function(_$_GetPersonMentions) then) =
-      __$$_GetPersonMentionsCopyWithImpl<$Res>;
+  factory _$$GetPersonMentionsImplCopyWith(_$GetPersonMentionsImpl value,
+          $Res Function(_$GetPersonMentionsImpl) then) =
+      __$$GetPersonMentionsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -1851,11 +1861,11 @@ abstract class _$$_GetPersonMentionsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetPersonMentionsCopyWithImpl<$Res>
-    extends _$GetPersonMentionsCopyWithImpl<$Res, _$_GetPersonMentions>
-    implements _$$_GetPersonMentionsCopyWith<$Res> {
-  __$$_GetPersonMentionsCopyWithImpl(
-      _$_GetPersonMentions _value, $Res Function(_$_GetPersonMentions) _then)
+class __$$GetPersonMentionsImplCopyWithImpl<$Res>
+    extends _$GetPersonMentionsCopyWithImpl<$Res, _$GetPersonMentionsImpl>
+    implements _$$GetPersonMentionsImplCopyWith<$Res> {
+  __$$GetPersonMentionsImplCopyWithImpl(_$GetPersonMentionsImpl _value,
+      $Res Function(_$GetPersonMentionsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1867,7 +1877,7 @@ class __$$_GetPersonMentionsCopyWithImpl<$Res>
     Object? unreadOnly = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetPersonMentions(
+    return _then(_$GetPersonMentionsImpl(
       sort: freezed == sort
           ? _value.sort
           : sort // ignore: cast_nullable_to_non_nullable
@@ -1895,13 +1905,13 @@ class __$$_GetPersonMentionsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetPersonMentions extends _GetPersonMentions {
-  const _$_GetPersonMentions(
+class _$GetPersonMentionsImpl extends _GetPersonMentions {
+  const _$GetPersonMentionsImpl(
       {this.sort, this.page, this.limit, this.unreadOnly, this.auth})
       : super._();
 
-  factory _$_GetPersonMentions.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPersonMentionsFromJson(json);
+  factory _$GetPersonMentionsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPersonMentionsImplFromJson(json);
 
   @override
   final CommentSortType? sort;
@@ -1923,7 +1933,7 @@ class _$_GetPersonMentions extends _GetPersonMentions {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPersonMentions &&
+            other is _$GetPersonMentionsImpl &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
@@ -1940,13 +1950,13 @@ class _$_GetPersonMentions extends _GetPersonMentions {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPersonMentionsCopyWith<_$_GetPersonMentions> get copyWith =>
-      __$$_GetPersonMentionsCopyWithImpl<_$_GetPersonMentions>(
+  _$$GetPersonMentionsImplCopyWith<_$GetPersonMentionsImpl> get copyWith =>
+      __$$GetPersonMentionsImplCopyWithImpl<_$GetPersonMentionsImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPersonMentionsToJson(
+    return _$$GetPersonMentionsImplToJson(
       this,
     );
   }
@@ -1958,11 +1968,11 @@ abstract class _GetPersonMentions extends GetPersonMentions {
       final int? page,
       final int? limit,
       final bool? unreadOnly,
-      final String? auth}) = _$_GetPersonMentions;
+      final String? auth}) = _$GetPersonMentionsImpl;
   const _GetPersonMentions._() : super._();
 
   factory _GetPersonMentions.fromJson(Map<String, dynamic> json) =
-      _$_GetPersonMentions.fromJson;
+      _$GetPersonMentionsImpl.fromJson;
 
   @override
   CommentSortType? get sort;
@@ -1976,7 +1986,7 @@ abstract class _GetPersonMentions extends GetPersonMentions {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPersonMentionsCopyWith<_$_GetPersonMentions> get copyWith =>
+  _$$GetPersonMentionsImplCopyWith<_$GetPersonMentionsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2042,23 +2052,25 @@ class _$MarkPersonMentionAsReadCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_MarkPersonMentionAsReadCopyWith<$Res>
+abstract class _$$MarkPersonMentionAsReadImplCopyWith<$Res>
     implements $MarkPersonMentionAsReadCopyWith<$Res> {
-  factory _$$_MarkPersonMentionAsReadCopyWith(_$_MarkPersonMentionAsRead value,
-          $Res Function(_$_MarkPersonMentionAsRead) then) =
-      __$$_MarkPersonMentionAsReadCopyWithImpl<$Res>;
+  factory _$$MarkPersonMentionAsReadImplCopyWith(
+          _$MarkPersonMentionAsReadImpl value,
+          $Res Function(_$MarkPersonMentionAsReadImpl) then) =
+      __$$MarkPersonMentionAsReadImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int personMentionId, bool read, String? auth});
 }
 
 /// @nodoc
-class __$$_MarkPersonMentionAsReadCopyWithImpl<$Res>
+class __$$MarkPersonMentionAsReadImplCopyWithImpl<$Res>
     extends _$MarkPersonMentionAsReadCopyWithImpl<$Res,
-        _$_MarkPersonMentionAsRead>
-    implements _$$_MarkPersonMentionAsReadCopyWith<$Res> {
-  __$$_MarkPersonMentionAsReadCopyWithImpl(_$_MarkPersonMentionAsRead _value,
-      $Res Function(_$_MarkPersonMentionAsRead) _then)
+        _$MarkPersonMentionAsReadImpl>
+    implements _$$MarkPersonMentionAsReadImplCopyWith<$Res> {
+  __$$MarkPersonMentionAsReadImplCopyWithImpl(
+      _$MarkPersonMentionAsReadImpl _value,
+      $Res Function(_$MarkPersonMentionAsReadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2068,7 +2080,7 @@ class __$$_MarkPersonMentionAsReadCopyWithImpl<$Res>
     Object? read = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_MarkPersonMentionAsRead(
+    return _then(_$MarkPersonMentionAsReadImpl(
       personMentionId: null == personMentionId
           ? _value.personMentionId
           : personMentionId // ignore: cast_nullable_to_non_nullable
@@ -2088,13 +2100,13 @@ class __$$_MarkPersonMentionAsReadCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_MarkPersonMentionAsRead extends _MarkPersonMentionAsRead {
-  const _$_MarkPersonMentionAsRead(
+class _$MarkPersonMentionAsReadImpl extends _MarkPersonMentionAsRead {
+  const _$MarkPersonMentionAsReadImpl(
       {required this.personMentionId, required this.read, this.auth})
       : super._();
 
-  factory _$_MarkPersonMentionAsRead.fromJson(Map<String, dynamic> json) =>
-      _$$_MarkPersonMentionAsReadFromJson(json);
+  factory _$MarkPersonMentionAsReadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MarkPersonMentionAsReadImplFromJson(json);
 
   @override
   final int personMentionId;
@@ -2112,7 +2124,7 @@ class _$_MarkPersonMentionAsRead extends _MarkPersonMentionAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MarkPersonMentionAsRead &&
+            other is _$MarkPersonMentionAsReadImpl &&
             (identical(other.personMentionId, personMentionId) ||
                 other.personMentionId == personMentionId) &&
             (identical(other.read, read) || other.read == read) &&
@@ -2126,14 +2138,13 @@ class _$_MarkPersonMentionAsRead extends _MarkPersonMentionAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MarkPersonMentionAsReadCopyWith<_$_MarkPersonMentionAsRead>
-      get copyWith =>
-          __$$_MarkPersonMentionAsReadCopyWithImpl<_$_MarkPersonMentionAsRead>(
-              this, _$identity);
+  _$$MarkPersonMentionAsReadImplCopyWith<_$MarkPersonMentionAsReadImpl>
+      get copyWith => __$$MarkPersonMentionAsReadImplCopyWithImpl<
+          _$MarkPersonMentionAsReadImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MarkPersonMentionAsReadToJson(
+    return _$$MarkPersonMentionAsReadImplToJson(
       this,
     );
   }
@@ -2143,11 +2154,11 @@ abstract class _MarkPersonMentionAsRead extends MarkPersonMentionAsRead {
   const factory _MarkPersonMentionAsRead(
       {required final int personMentionId,
       required final bool read,
-      final String? auth}) = _$_MarkPersonMentionAsRead;
+      final String? auth}) = _$MarkPersonMentionAsReadImpl;
   const _MarkPersonMentionAsRead._() : super._();
 
   factory _MarkPersonMentionAsRead.fromJson(Map<String, dynamic> json) =
-      _$_MarkPersonMentionAsRead.fromJson;
+      _$MarkPersonMentionAsReadImpl.fromJson;
 
   @override
   int get personMentionId;
@@ -2157,7 +2168,7 @@ abstract class _MarkPersonMentionAsRead extends MarkPersonMentionAsRead {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_MarkPersonMentionAsReadCopyWith<_$_MarkPersonMentionAsRead>
+  _$$MarkPersonMentionAsReadImplCopyWith<_$MarkPersonMentionAsReadImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -2238,11 +2249,11 @@ class _$GetRepliesCopyWithImpl<$Res, $Val extends GetReplies>
 }
 
 /// @nodoc
-abstract class _$$_GetRepliesCopyWith<$Res>
+abstract class _$$GetRepliesImplCopyWith<$Res>
     implements $GetRepliesCopyWith<$Res> {
-  factory _$$_GetRepliesCopyWith(
-          _$_GetReplies value, $Res Function(_$_GetReplies) then) =
-      __$$_GetRepliesCopyWithImpl<$Res>;
+  factory _$$GetRepliesImplCopyWith(
+          _$GetRepliesImpl value, $Res Function(_$GetRepliesImpl) then) =
+      __$$GetRepliesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2254,11 +2265,11 @@ abstract class _$$_GetRepliesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetRepliesCopyWithImpl<$Res>
-    extends _$GetRepliesCopyWithImpl<$Res, _$_GetReplies>
-    implements _$$_GetRepliesCopyWith<$Res> {
-  __$$_GetRepliesCopyWithImpl(
-      _$_GetReplies _value, $Res Function(_$_GetReplies) _then)
+class __$$GetRepliesImplCopyWithImpl<$Res>
+    extends _$GetRepliesCopyWithImpl<$Res, _$GetRepliesImpl>
+    implements _$$GetRepliesImplCopyWith<$Res> {
+  __$$GetRepliesImplCopyWithImpl(
+      _$GetRepliesImpl _value, $Res Function(_$GetRepliesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2270,7 +2281,7 @@ class __$$_GetRepliesCopyWithImpl<$Res>
     Object? unreadOnly = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetReplies(
+    return _then(_$GetRepliesImpl(
       sort: freezed == sort
           ? _value.sort
           : sort // ignore: cast_nullable_to_non_nullable
@@ -2298,13 +2309,13 @@ class __$$_GetRepliesCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetReplies extends _GetReplies {
-  const _$_GetReplies(
+class _$GetRepliesImpl extends _GetReplies {
+  const _$GetRepliesImpl(
       {this.sort, this.page, this.limit, this.unreadOnly, this.auth})
       : super._();
 
-  factory _$_GetReplies.fromJson(Map<String, dynamic> json) =>
-      _$$_GetRepliesFromJson(json);
+  factory _$GetRepliesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetRepliesImplFromJson(json);
 
   @override
   final CommentSortType? sort;
@@ -2326,7 +2337,7 @@ class _$_GetReplies extends _GetReplies {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetReplies &&
+            other is _$GetRepliesImpl &&
             (identical(other.sort, sort) || other.sort == sort) &&
             (identical(other.page, page) || other.page == page) &&
             (identical(other.limit, limit) || other.limit == limit) &&
@@ -2343,12 +2354,12 @@ class _$_GetReplies extends _GetReplies {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetRepliesCopyWith<_$_GetReplies> get copyWith =>
-      __$$_GetRepliesCopyWithImpl<_$_GetReplies>(this, _$identity);
+  _$$GetRepliesImplCopyWith<_$GetRepliesImpl> get copyWith =>
+      __$$GetRepliesImplCopyWithImpl<_$GetRepliesImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetRepliesToJson(
+    return _$$GetRepliesImplToJson(
       this,
     );
   }
@@ -2360,11 +2371,11 @@ abstract class _GetReplies extends GetReplies {
       final int? page,
       final int? limit,
       final bool? unreadOnly,
-      final String? auth}) = _$_GetReplies;
+      final String? auth}) = _$GetRepliesImpl;
   const _GetReplies._() : super._();
 
   factory _GetReplies.fromJson(Map<String, dynamic> json) =
-      _$_GetReplies.fromJson;
+      _$GetRepliesImpl.fromJson;
 
   @override
   CommentSortType? get sort;
@@ -2378,7 +2389,7 @@ abstract class _GetReplies extends GetReplies {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetRepliesCopyWith<_$_GetReplies> get copyWith =>
+  _$$GetRepliesImplCopyWith<_$GetRepliesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2465,10 +2476,11 @@ class _$BanPersonCopyWithImpl<$Res, $Val extends BanPerson>
 }
 
 /// @nodoc
-abstract class _$$_BanPersonCopyWith<$Res> implements $BanPersonCopyWith<$Res> {
-  factory _$$_BanPersonCopyWith(
-          _$_BanPerson value, $Res Function(_$_BanPerson) then) =
-      __$$_BanPersonCopyWithImpl<$Res>;
+abstract class _$$BanPersonImplCopyWith<$Res>
+    implements $BanPersonCopyWith<$Res> {
+  factory _$$BanPersonImplCopyWith(
+          _$BanPersonImpl value, $Res Function(_$BanPersonImpl) then) =
+      __$$BanPersonImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -2481,11 +2493,11 @@ abstract class _$$_BanPersonCopyWith<$Res> implements $BanPersonCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_BanPersonCopyWithImpl<$Res>
-    extends _$BanPersonCopyWithImpl<$Res, _$_BanPerson>
-    implements _$$_BanPersonCopyWith<$Res> {
-  __$$_BanPersonCopyWithImpl(
-      _$_BanPerson _value, $Res Function(_$_BanPerson) _then)
+class __$$BanPersonImplCopyWithImpl<$Res>
+    extends _$BanPersonCopyWithImpl<$Res, _$BanPersonImpl>
+    implements _$$BanPersonImplCopyWith<$Res> {
+  __$$BanPersonImplCopyWithImpl(
+      _$BanPersonImpl _value, $Res Function(_$BanPersonImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2498,7 +2510,7 @@ class __$$_BanPersonCopyWithImpl<$Res>
     Object? expires = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_BanPerson(
+    return _then(_$BanPersonImpl(
       personId: null == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -2530,8 +2542,8 @@ class __$$_BanPersonCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_BanPerson extends _BanPerson {
-  const _$_BanPerson(
+class _$BanPersonImpl extends _BanPerson {
+  const _$BanPersonImpl(
       {required this.personId,
       required this.ban,
       this.removeData,
@@ -2540,8 +2552,8 @@ class _$_BanPerson extends _BanPerson {
       this.auth})
       : super._();
 
-  factory _$_BanPerson.fromJson(Map<String, dynamic> json) =>
-      _$$_BanPersonFromJson(json);
+  factory _$BanPersonImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BanPersonImplFromJson(json);
 
   @override
   final int personId;
@@ -2565,7 +2577,7 @@ class _$_BanPerson extends _BanPerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BanPerson &&
+            other is _$BanPersonImpl &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.ban, ban) || other.ban == ban) &&
@@ -2584,12 +2596,12 @@ class _$_BanPerson extends _BanPerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BanPersonCopyWith<_$_BanPerson> get copyWith =>
-      __$$_BanPersonCopyWithImpl<_$_BanPerson>(this, _$identity);
+  _$$BanPersonImplCopyWith<_$BanPersonImpl> get copyWith =>
+      __$$BanPersonImplCopyWithImpl<_$BanPersonImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BanPersonToJson(
+    return _$$BanPersonImplToJson(
       this,
     );
   }
@@ -2602,11 +2614,11 @@ abstract class _BanPerson extends BanPerson {
       final bool? removeData,
       final String? reason,
       final int? expires,
-      final String? auth}) = _$_BanPerson;
+      final String? auth}) = _$BanPersonImpl;
   const _BanPerson._() : super._();
 
   factory _BanPerson.fromJson(Map<String, dynamic> json) =
-      _$_BanPerson.fromJson;
+      _$BanPersonImpl.fromJson;
 
   @override
   int get personId;
@@ -2622,7 +2634,7 @@ abstract class _BanPerson extends BanPerson {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_BanPersonCopyWith<_$_BanPerson> get copyWith =>
+  _$$BanPersonImplCopyWith<_$BanPersonImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2674,22 +2686,22 @@ class _$GetBannedPersonsCopyWithImpl<$Res, $Val extends GetBannedPersons>
 }
 
 /// @nodoc
-abstract class _$$_GetBannedPersonsCopyWith<$Res>
+abstract class _$$GetBannedPersonsImplCopyWith<$Res>
     implements $GetBannedPersonsCopyWith<$Res> {
-  factory _$$_GetBannedPersonsCopyWith(
-          _$_GetBannedPersons value, $Res Function(_$_GetBannedPersons) then) =
-      __$$_GetBannedPersonsCopyWithImpl<$Res>;
+  factory _$$GetBannedPersonsImplCopyWith(_$GetBannedPersonsImpl value,
+          $Res Function(_$GetBannedPersonsImpl) then) =
+      __$$GetBannedPersonsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$_GetBannedPersonsCopyWithImpl<$Res>
-    extends _$GetBannedPersonsCopyWithImpl<$Res, _$_GetBannedPersons>
-    implements _$$_GetBannedPersonsCopyWith<$Res> {
-  __$$_GetBannedPersonsCopyWithImpl(
-      _$_GetBannedPersons _value, $Res Function(_$_GetBannedPersons) _then)
+class __$$GetBannedPersonsImplCopyWithImpl<$Res>
+    extends _$GetBannedPersonsCopyWithImpl<$Res, _$GetBannedPersonsImpl>
+    implements _$$GetBannedPersonsImplCopyWith<$Res> {
+  __$$GetBannedPersonsImplCopyWithImpl(_$GetBannedPersonsImpl _value,
+      $Res Function(_$GetBannedPersonsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2697,7 +2709,7 @@ class __$$_GetBannedPersonsCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$_GetBannedPersons(
+    return _then(_$GetBannedPersonsImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -2709,11 +2721,11 @@ class __$$_GetBannedPersonsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetBannedPersons extends _GetBannedPersons {
-  const _$_GetBannedPersons({this.auth}) : super._();
+class _$GetBannedPersonsImpl extends _GetBannedPersons {
+  const _$GetBannedPersonsImpl({this.auth}) : super._();
 
-  factory _$_GetBannedPersons.fromJson(Map<String, dynamic> json) =>
-      _$$_GetBannedPersonsFromJson(json);
+  factory _$GetBannedPersonsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetBannedPersonsImplFromJson(json);
 
   @override
   final String? auth;
@@ -2727,7 +2739,7 @@ class _$_GetBannedPersons extends _GetBannedPersons {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetBannedPersons &&
+            other is _$GetBannedPersonsImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -2738,29 +2750,31 @@ class _$_GetBannedPersons extends _GetBannedPersons {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetBannedPersonsCopyWith<_$_GetBannedPersons> get copyWith =>
-      __$$_GetBannedPersonsCopyWithImpl<_$_GetBannedPersons>(this, _$identity);
+  _$$GetBannedPersonsImplCopyWith<_$GetBannedPersonsImpl> get copyWith =>
+      __$$GetBannedPersonsImplCopyWithImpl<_$GetBannedPersonsImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetBannedPersonsToJson(
+    return _$$GetBannedPersonsImplToJson(
       this,
     );
   }
 }
 
 abstract class _GetBannedPersons extends GetBannedPersons {
-  const factory _GetBannedPersons({final String? auth}) = _$_GetBannedPersons;
+  const factory _GetBannedPersons({final String? auth}) =
+      _$GetBannedPersonsImpl;
   const _GetBannedPersons._() : super._();
 
   factory _GetBannedPersons.fromJson(Map<String, dynamic> json) =
-      _$_GetBannedPersons.fromJson;
+      _$GetBannedPersonsImpl.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetBannedPersonsCopyWith<_$_GetBannedPersons> get copyWith =>
+  _$$GetBannedPersonsImplCopyWith<_$GetBannedPersonsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2824,22 +2838,22 @@ class _$BlockPersonCopyWithImpl<$Res, $Val extends BlockPerson>
 }
 
 /// @nodoc
-abstract class _$$_BlockPersonCopyWith<$Res>
+abstract class _$$BlockPersonImplCopyWith<$Res>
     implements $BlockPersonCopyWith<$Res> {
-  factory _$$_BlockPersonCopyWith(
-          _$_BlockPerson value, $Res Function(_$_BlockPerson) then) =
-      __$$_BlockPersonCopyWithImpl<$Res>;
+  factory _$$BlockPersonImplCopyWith(
+          _$BlockPersonImpl value, $Res Function(_$BlockPersonImpl) then) =
+      __$$BlockPersonImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int personId, bool block, String? auth});
 }
 
 /// @nodoc
-class __$$_BlockPersonCopyWithImpl<$Res>
-    extends _$BlockPersonCopyWithImpl<$Res, _$_BlockPerson>
-    implements _$$_BlockPersonCopyWith<$Res> {
-  __$$_BlockPersonCopyWithImpl(
-      _$_BlockPerson _value, $Res Function(_$_BlockPerson) _then)
+class __$$BlockPersonImplCopyWithImpl<$Res>
+    extends _$BlockPersonCopyWithImpl<$Res, _$BlockPersonImpl>
+    implements _$$BlockPersonImplCopyWith<$Res> {
+  __$$BlockPersonImplCopyWithImpl(
+      _$BlockPersonImpl _value, $Res Function(_$BlockPersonImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -2849,7 +2863,7 @@ class __$$_BlockPersonCopyWithImpl<$Res>
     Object? block = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_BlockPerson(
+    return _then(_$BlockPersonImpl(
       personId: null == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -2869,12 +2883,13 @@ class __$$_BlockPersonCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_BlockPerson extends _BlockPerson {
-  const _$_BlockPerson({required this.personId, required this.block, this.auth})
+class _$BlockPersonImpl extends _BlockPerson {
+  const _$BlockPersonImpl(
+      {required this.personId, required this.block, this.auth})
       : super._();
 
-  factory _$_BlockPerson.fromJson(Map<String, dynamic> json) =>
-      _$$_BlockPersonFromJson(json);
+  factory _$BlockPersonImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BlockPersonImplFromJson(json);
 
   @override
   final int personId;
@@ -2892,7 +2907,7 @@ class _$_BlockPerson extends _BlockPerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BlockPerson &&
+            other is _$BlockPersonImpl &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
             (identical(other.block, block) || other.block == block) &&
@@ -2906,12 +2921,12 @@ class _$_BlockPerson extends _BlockPerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BlockPersonCopyWith<_$_BlockPerson> get copyWith =>
-      __$$_BlockPersonCopyWithImpl<_$_BlockPerson>(this, _$identity);
+  _$$BlockPersonImplCopyWith<_$BlockPersonImpl> get copyWith =>
+      __$$BlockPersonImplCopyWithImpl<_$BlockPersonImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BlockPersonToJson(
+    return _$$BlockPersonImplToJson(
       this,
     );
   }
@@ -2921,11 +2936,11 @@ abstract class _BlockPerson extends BlockPerson {
   const factory _BlockPerson(
       {required final int personId,
       required final bool block,
-      final String? auth}) = _$_BlockPerson;
+      final String? auth}) = _$BlockPersonImpl;
   const _BlockPerson._() : super._();
 
   factory _BlockPerson.fromJson(Map<String, dynamic> json) =
-      _$_BlockPerson.fromJson;
+      _$BlockPersonImpl.fromJson;
 
   @override
   int get personId;
@@ -2935,7 +2950,7 @@ abstract class _BlockPerson extends BlockPerson {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_BlockPersonCopyWith<_$_BlockPerson> get copyWith =>
+  _$$BlockPersonImplCopyWith<_$BlockPersonImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -2987,22 +3002,22 @@ class _$GetCaptchaCopyWithImpl<$Res, $Val extends GetCaptcha>
 }
 
 /// @nodoc
-abstract class _$$_GetCaptchaCopyWith<$Res>
+abstract class _$$GetCaptchaImplCopyWith<$Res>
     implements $GetCaptchaCopyWith<$Res> {
-  factory _$$_GetCaptchaCopyWith(
-          _$_GetCaptcha value, $Res Function(_$_GetCaptcha) then) =
-      __$$_GetCaptchaCopyWithImpl<$Res>;
+  factory _$$GetCaptchaImplCopyWith(
+          _$GetCaptchaImpl value, $Res Function(_$GetCaptchaImpl) then) =
+      __$$GetCaptchaImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$_GetCaptchaCopyWithImpl<$Res>
-    extends _$GetCaptchaCopyWithImpl<$Res, _$_GetCaptcha>
-    implements _$$_GetCaptchaCopyWith<$Res> {
-  __$$_GetCaptchaCopyWithImpl(
-      _$_GetCaptcha _value, $Res Function(_$_GetCaptcha) _then)
+class __$$GetCaptchaImplCopyWithImpl<$Res>
+    extends _$GetCaptchaCopyWithImpl<$Res, _$GetCaptchaImpl>
+    implements _$$GetCaptchaImplCopyWith<$Res> {
+  __$$GetCaptchaImplCopyWithImpl(
+      _$GetCaptchaImpl _value, $Res Function(_$GetCaptchaImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3010,7 +3025,7 @@ class __$$_GetCaptchaCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$_GetCaptcha(
+    return _then(_$GetCaptchaImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -3022,11 +3037,11 @@ class __$$_GetCaptchaCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetCaptcha extends _GetCaptcha {
-  const _$_GetCaptcha({this.auth}) : super._();
+class _$GetCaptchaImpl extends _GetCaptcha {
+  const _$GetCaptchaImpl({this.auth}) : super._();
 
-  factory _$_GetCaptcha.fromJson(Map<String, dynamic> json) =>
-      _$$_GetCaptchaFromJson(json);
+  factory _$GetCaptchaImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetCaptchaImplFromJson(json);
 
   @override
   final String? auth;
@@ -3040,7 +3055,7 @@ class _$_GetCaptcha extends _GetCaptcha {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetCaptcha &&
+            other is _$GetCaptchaImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -3051,29 +3066,29 @@ class _$_GetCaptcha extends _GetCaptcha {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetCaptchaCopyWith<_$_GetCaptcha> get copyWith =>
-      __$$_GetCaptchaCopyWithImpl<_$_GetCaptcha>(this, _$identity);
+  _$$GetCaptchaImplCopyWith<_$GetCaptchaImpl> get copyWith =>
+      __$$GetCaptchaImplCopyWithImpl<_$GetCaptchaImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetCaptchaToJson(
+    return _$$GetCaptchaImplToJson(
       this,
     );
   }
 }
 
 abstract class _GetCaptcha extends GetCaptcha {
-  const factory _GetCaptcha({final String? auth}) = _$_GetCaptcha;
+  const factory _GetCaptcha({final String? auth}) = _$GetCaptchaImpl;
   const _GetCaptcha._() : super._();
 
   factory _GetCaptcha.fromJson(Map<String, dynamic> json) =
-      _$_GetCaptcha.fromJson;
+      _$GetCaptchaImpl.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetCaptchaCopyWith<_$_GetCaptcha> get copyWith =>
+  _$$GetCaptchaImplCopyWith<_$GetCaptchaImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3138,22 +3153,22 @@ class _$DeleteAccountCopyWithImpl<$Res, $Val extends DeleteAccount>
 }
 
 /// @nodoc
-abstract class _$$_DeleteAccountCopyWith<$Res>
+abstract class _$$DeleteAccountImplCopyWith<$Res>
     implements $DeleteAccountCopyWith<$Res> {
-  factory _$$_DeleteAccountCopyWith(
-          _$_DeleteAccount value, $Res Function(_$_DeleteAccount) then) =
-      __$$_DeleteAccountCopyWithImpl<$Res>;
+  factory _$$DeleteAccountImplCopyWith(
+          _$DeleteAccountImpl value, $Res Function(_$DeleteAccountImpl) then) =
+      __$$DeleteAccountImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String password, bool? deleteContent, String? auth});
 }
 
 /// @nodoc
-class __$$_DeleteAccountCopyWithImpl<$Res>
-    extends _$DeleteAccountCopyWithImpl<$Res, _$_DeleteAccount>
-    implements _$$_DeleteAccountCopyWith<$Res> {
-  __$$_DeleteAccountCopyWithImpl(
-      _$_DeleteAccount _value, $Res Function(_$_DeleteAccount) _then)
+class __$$DeleteAccountImplCopyWithImpl<$Res>
+    extends _$DeleteAccountCopyWithImpl<$Res, _$DeleteAccountImpl>
+    implements _$$DeleteAccountImplCopyWith<$Res> {
+  __$$DeleteAccountImplCopyWithImpl(
+      _$DeleteAccountImpl _value, $Res Function(_$DeleteAccountImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3163,7 +3178,7 @@ class __$$_DeleteAccountCopyWithImpl<$Res>
     Object? deleteContent = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_DeleteAccount(
+    return _then(_$DeleteAccountImpl(
       password: null == password
           ? _value.password
           : password // ignore: cast_nullable_to_non_nullable
@@ -3183,13 +3198,13 @@ class __$$_DeleteAccountCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_DeleteAccount extends _DeleteAccount {
-  const _$_DeleteAccount(
+class _$DeleteAccountImpl extends _DeleteAccount {
+  const _$DeleteAccountImpl(
       {required this.password, this.deleteContent, this.auth})
       : super._();
 
-  factory _$_DeleteAccount.fromJson(Map<String, dynamic> json) =>
-      _$$_DeleteAccountFromJson(json);
+  factory _$DeleteAccountImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeleteAccountImplFromJson(json);
 
   @override
   final String password;
@@ -3208,7 +3223,7 @@ class _$_DeleteAccount extends _DeleteAccount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeleteAccount &&
+            other is _$DeleteAccountImpl &&
             (identical(other.password, password) ||
                 other.password == password) &&
             (identical(other.deleteContent, deleteContent) ||
@@ -3223,12 +3238,12 @@ class _$_DeleteAccount extends _DeleteAccount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeleteAccountCopyWith<_$_DeleteAccount> get copyWith =>
-      __$$_DeleteAccountCopyWithImpl<_$_DeleteAccount>(this, _$identity);
+  _$$DeleteAccountImplCopyWith<_$DeleteAccountImpl> get copyWith =>
+      __$$DeleteAccountImplCopyWithImpl<_$DeleteAccountImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeleteAccountToJson(
+    return _$$DeleteAccountImplToJson(
       this,
     );
   }
@@ -3238,11 +3253,11 @@ abstract class _DeleteAccount extends DeleteAccount {
   const factory _DeleteAccount(
       {required final String password,
       final bool? deleteContent,
-      final String? auth}) = _$_DeleteAccount;
+      final String? auth}) = _$DeleteAccountImpl;
   const _DeleteAccount._() : super._();
 
   factory _DeleteAccount.fromJson(Map<String, dynamic> json) =
-      _$_DeleteAccount.fromJson;
+      _$DeleteAccountImpl.fromJson;
 
   @override
   String get password;
@@ -3252,7 +3267,7 @@ abstract class _DeleteAccount extends DeleteAccount {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_DeleteAccountCopyWith<_$_DeleteAccount> get copyWith =>
+  _$$DeleteAccountImplCopyWith<_$DeleteAccountImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3304,22 +3319,22 @@ class _$PasswordResetCopyWithImpl<$Res, $Val extends PasswordReset>
 }
 
 /// @nodoc
-abstract class _$$_PasswordResetCopyWith<$Res>
+abstract class _$$PasswordResetImplCopyWith<$Res>
     implements $PasswordResetCopyWith<$Res> {
-  factory _$$_PasswordResetCopyWith(
-          _$_PasswordReset value, $Res Function(_$_PasswordReset) then) =
-      __$$_PasswordResetCopyWithImpl<$Res>;
+  factory _$$PasswordResetImplCopyWith(
+          _$PasswordResetImpl value, $Res Function(_$PasswordResetImpl) then) =
+      __$$PasswordResetImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String email});
 }
 
 /// @nodoc
-class __$$_PasswordResetCopyWithImpl<$Res>
-    extends _$PasswordResetCopyWithImpl<$Res, _$_PasswordReset>
-    implements _$$_PasswordResetCopyWith<$Res> {
-  __$$_PasswordResetCopyWithImpl(
-      _$_PasswordReset _value, $Res Function(_$_PasswordReset) _then)
+class __$$PasswordResetImplCopyWithImpl<$Res>
+    extends _$PasswordResetCopyWithImpl<$Res, _$PasswordResetImpl>
+    implements _$$PasswordResetImplCopyWith<$Res> {
+  __$$PasswordResetImplCopyWithImpl(
+      _$PasswordResetImpl _value, $Res Function(_$PasswordResetImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3327,7 +3342,7 @@ class __$$_PasswordResetCopyWithImpl<$Res>
   $Res call({
     Object? email = null,
   }) {
-    return _then(_$_PasswordReset(
+    return _then(_$PasswordResetImpl(
       email: null == email
           ? _value.email
           : email // ignore: cast_nullable_to_non_nullable
@@ -3339,11 +3354,11 @@ class __$$_PasswordResetCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_PasswordReset extends _PasswordReset {
-  const _$_PasswordReset({required this.email}) : super._();
+class _$PasswordResetImpl extends _PasswordReset {
+  const _$PasswordResetImpl({required this.email}) : super._();
 
-  factory _$_PasswordReset.fromJson(Map<String, dynamic> json) =>
-      _$$_PasswordResetFromJson(json);
+  factory _$PasswordResetImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PasswordResetImplFromJson(json);
 
   @override
   final String email;
@@ -3357,7 +3372,7 @@ class _$_PasswordReset extends _PasswordReset {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PasswordReset &&
+            other is _$PasswordResetImpl &&
             (identical(other.email, email) || other.email == email));
   }
 
@@ -3368,12 +3383,12 @@ class _$_PasswordReset extends _PasswordReset {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PasswordResetCopyWith<_$_PasswordReset> get copyWith =>
-      __$$_PasswordResetCopyWithImpl<_$_PasswordReset>(this, _$identity);
+  _$$PasswordResetImplCopyWith<_$PasswordResetImpl> get copyWith =>
+      __$$PasswordResetImplCopyWithImpl<_$PasswordResetImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PasswordResetToJson(
+    return _$$PasswordResetImplToJson(
       this,
     );
   }
@@ -3381,17 +3396,17 @@ class _$_PasswordReset extends _PasswordReset {
 
 abstract class _PasswordReset extends PasswordReset {
   const factory _PasswordReset({required final String email}) =
-      _$_PasswordReset;
+      _$PasswordResetImpl;
   const _PasswordReset._() : super._();
 
   factory _PasswordReset.fromJson(Map<String, dynamic> json) =
-      _$_PasswordReset.fromJson;
+      _$PasswordResetImpl.fromJson;
 
   @override
   String get email;
   @override
   @JsonKey(ignore: true)
-  _$$_PasswordResetCopyWith<_$_PasswordReset> get copyWith =>
+  _$$PasswordResetImplCopyWith<_$PasswordResetImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3457,24 +3472,25 @@ class _$PasswordChangeAfterResetCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_PasswordChangeAfterResetCopyWith<$Res>
+abstract class _$$PasswordChangeAfterResetImplCopyWith<$Res>
     implements $PasswordChangeAfterResetCopyWith<$Res> {
-  factory _$$_PasswordChangeAfterResetCopyWith(
-          _$_PasswordChangeAfterReset value,
-          $Res Function(_$_PasswordChangeAfterReset) then) =
-      __$$_PasswordChangeAfterResetCopyWithImpl<$Res>;
+  factory _$$PasswordChangeAfterResetImplCopyWith(
+          _$PasswordChangeAfterResetImpl value,
+          $Res Function(_$PasswordChangeAfterResetImpl) then) =
+      __$$PasswordChangeAfterResetImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String token, String password, String passwordVerify});
 }
 
 /// @nodoc
-class __$$_PasswordChangeAfterResetCopyWithImpl<$Res>
+class __$$PasswordChangeAfterResetImplCopyWithImpl<$Res>
     extends _$PasswordChangeAfterResetCopyWithImpl<$Res,
-        _$_PasswordChangeAfterReset>
-    implements _$$_PasswordChangeAfterResetCopyWith<$Res> {
-  __$$_PasswordChangeAfterResetCopyWithImpl(_$_PasswordChangeAfterReset _value,
-      $Res Function(_$_PasswordChangeAfterReset) _then)
+        _$PasswordChangeAfterResetImpl>
+    implements _$$PasswordChangeAfterResetImplCopyWith<$Res> {
+  __$$PasswordChangeAfterResetImplCopyWithImpl(
+      _$PasswordChangeAfterResetImpl _value,
+      $Res Function(_$PasswordChangeAfterResetImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3484,7 +3500,7 @@ class __$$_PasswordChangeAfterResetCopyWithImpl<$Res>
     Object? password = null,
     Object? passwordVerify = null,
   }) {
-    return _then(_$_PasswordChangeAfterReset(
+    return _then(_$PasswordChangeAfterResetImpl(
       token: null == token
           ? _value.token
           : token // ignore: cast_nullable_to_non_nullable
@@ -3504,15 +3520,15 @@ class __$$_PasswordChangeAfterResetCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_PasswordChangeAfterReset extends _PasswordChangeAfterReset {
-  const _$_PasswordChangeAfterReset(
+class _$PasswordChangeAfterResetImpl extends _PasswordChangeAfterReset {
+  const _$PasswordChangeAfterResetImpl(
       {required this.token,
       required this.password,
       required this.passwordVerify})
       : super._();
 
-  factory _$_PasswordChangeAfterReset.fromJson(Map<String, dynamic> json) =>
-      _$$_PasswordChangeAfterResetFromJson(json);
+  factory _$PasswordChangeAfterResetImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PasswordChangeAfterResetImplFromJson(json);
 
   @override
   final String token;
@@ -3530,7 +3546,7 @@ class _$_PasswordChangeAfterReset extends _PasswordChangeAfterReset {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PasswordChangeAfterReset &&
+            other is _$PasswordChangeAfterResetImpl &&
             (identical(other.token, token) || other.token == token) &&
             (identical(other.password, password) ||
                 other.password == password) &&
@@ -3545,13 +3561,13 @@ class _$_PasswordChangeAfterReset extends _PasswordChangeAfterReset {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PasswordChangeAfterResetCopyWith<_$_PasswordChangeAfterReset>
-      get copyWith => __$$_PasswordChangeAfterResetCopyWithImpl<
-          _$_PasswordChangeAfterReset>(this, _$identity);
+  _$$PasswordChangeAfterResetImplCopyWith<_$PasswordChangeAfterResetImpl>
+      get copyWith => __$$PasswordChangeAfterResetImplCopyWithImpl<
+          _$PasswordChangeAfterResetImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PasswordChangeAfterResetToJson(
+    return _$$PasswordChangeAfterResetImplToJson(
       this,
     );
   }
@@ -3561,11 +3577,11 @@ abstract class _PasswordChangeAfterReset extends PasswordChangeAfterReset {
   const factory _PasswordChangeAfterReset(
       {required final String token,
       required final String password,
-      required final String passwordVerify}) = _$_PasswordChangeAfterReset;
+      required final String passwordVerify}) = _$PasswordChangeAfterResetImpl;
   const _PasswordChangeAfterReset._() : super._();
 
   factory _PasswordChangeAfterReset.fromJson(Map<String, dynamic> json) =
-      _$_PasswordChangeAfterReset.fromJson;
+      _$PasswordChangeAfterResetImpl.fromJson;
 
   @override
   String get token;
@@ -3575,7 +3591,7 @@ abstract class _PasswordChangeAfterReset extends PasswordChangeAfterReset {
   String get passwordVerify;
   @override
   @JsonKey(ignore: true)
-  _$$_PasswordChangeAfterResetCopyWith<_$_PasswordChangeAfterReset>
+  _$$PasswordChangeAfterResetImplCopyWith<_$PasswordChangeAfterResetImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -3627,22 +3643,22 @@ class _$MarkAllAsReadCopyWithImpl<$Res, $Val extends MarkAllAsRead>
 }
 
 /// @nodoc
-abstract class _$$_MarkAllAsReadCopyWith<$Res>
+abstract class _$$MarkAllAsReadImplCopyWith<$Res>
     implements $MarkAllAsReadCopyWith<$Res> {
-  factory _$$_MarkAllAsReadCopyWith(
-          _$_MarkAllAsRead value, $Res Function(_$_MarkAllAsRead) then) =
-      __$$_MarkAllAsReadCopyWithImpl<$Res>;
+  factory _$$MarkAllAsReadImplCopyWith(
+          _$MarkAllAsReadImpl value, $Res Function(_$MarkAllAsReadImpl) then) =
+      __$$MarkAllAsReadImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$_MarkAllAsReadCopyWithImpl<$Res>
-    extends _$MarkAllAsReadCopyWithImpl<$Res, _$_MarkAllAsRead>
-    implements _$$_MarkAllAsReadCopyWith<$Res> {
-  __$$_MarkAllAsReadCopyWithImpl(
-      _$_MarkAllAsRead _value, $Res Function(_$_MarkAllAsRead) _then)
+class __$$MarkAllAsReadImplCopyWithImpl<$Res>
+    extends _$MarkAllAsReadCopyWithImpl<$Res, _$MarkAllAsReadImpl>
+    implements _$$MarkAllAsReadImplCopyWith<$Res> {
+  __$$MarkAllAsReadImplCopyWithImpl(
+      _$MarkAllAsReadImpl _value, $Res Function(_$MarkAllAsReadImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -3650,7 +3666,7 @@ class __$$_MarkAllAsReadCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$_MarkAllAsRead(
+    return _then(_$MarkAllAsReadImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -3662,11 +3678,11 @@ class __$$_MarkAllAsReadCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_MarkAllAsRead extends _MarkAllAsRead {
-  const _$_MarkAllAsRead({this.auth}) : super._();
+class _$MarkAllAsReadImpl extends _MarkAllAsRead {
+  const _$MarkAllAsReadImpl({this.auth}) : super._();
 
-  factory _$_MarkAllAsRead.fromJson(Map<String, dynamic> json) =>
-      _$$_MarkAllAsReadFromJson(json);
+  factory _$MarkAllAsReadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MarkAllAsReadImplFromJson(json);
 
   @override
   final String? auth;
@@ -3680,7 +3696,7 @@ class _$_MarkAllAsRead extends _MarkAllAsRead {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MarkAllAsRead &&
+            other is _$MarkAllAsReadImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -3691,29 +3707,29 @@ class _$_MarkAllAsRead extends _MarkAllAsRead {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MarkAllAsReadCopyWith<_$_MarkAllAsRead> get copyWith =>
-      __$$_MarkAllAsReadCopyWithImpl<_$_MarkAllAsRead>(this, _$identity);
+  _$$MarkAllAsReadImplCopyWith<_$MarkAllAsReadImpl> get copyWith =>
+      __$$MarkAllAsReadImplCopyWithImpl<_$MarkAllAsReadImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MarkAllAsReadToJson(
+    return _$$MarkAllAsReadImplToJson(
       this,
     );
   }
 }
 
 abstract class _MarkAllAsRead extends MarkAllAsRead {
-  const factory _MarkAllAsRead({final String? auth}) = _$_MarkAllAsRead;
+  const factory _MarkAllAsRead({final String? auth}) = _$MarkAllAsReadImpl;
   const _MarkAllAsRead._() : super._();
 
   factory _MarkAllAsRead.fromJson(Map<String, dynamic> json) =
-      _$_MarkAllAsRead.fromJson;
+      _$MarkAllAsReadImpl.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_MarkAllAsReadCopyWith<_$_MarkAllAsRead> get copyWith =>
+  _$$MarkAllAsReadImplCopyWith<_$MarkAllAsReadImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -3754,7 +3770,9 @@ mixin _$SaveUserSettings {
       throw _privateConstructorUsedError; // Available in lemmy v0.19.0 and above
   bool? get enableKeyboardNavigation =>
       throw _privateConstructorUsedError; // Available in lemmy v0.19.0 and above
-  bool? get enableAnimatedImages => throw _privateConstructorUsedError;
+  bool? get enableAnimatedImages =>
+      throw _privateConstructorUsedError; // Available in lemmy v0.19.0 and above
+  bool? get collapseBotComments => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -3796,7 +3814,8 @@ abstract class $SaveUserSettingsCopyWith<$Res> {
       bool? infiniteScrollEnabled,
       String? postListingMode,
       bool? enableKeyboardNavigation,
-      bool? enableAnimatedImages});
+      bool? enableAnimatedImages,
+      bool? collapseBotComments});
 }
 
 /// @nodoc
@@ -3840,6 +3859,7 @@ class _$SaveUserSettingsCopyWithImpl<$Res, $Val extends SaveUserSettings>
     Object? postListingMode = freezed,
     Object? enableKeyboardNavigation = freezed,
     Object? enableAnimatedImages = freezed,
+    Object? collapseBotComments = freezed,
   }) {
     return _then(_value.copyWith(
       showNsfw: freezed == showNsfw
@@ -3954,16 +3974,20 @@ class _$SaveUserSettingsCopyWithImpl<$Res, $Val extends SaveUserSettings>
           ? _value.enableAnimatedImages
           : enableAnimatedImages // ignore: cast_nullable_to_non_nullable
               as bool?,
+      collapseBotComments: freezed == collapseBotComments
+          ? _value.collapseBotComments
+          : collapseBotComments // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ) as $Val);
   }
 }
 
 /// @nodoc
-abstract class _$$_SaveUserSettingsCopyWith<$Res>
+abstract class _$$SaveUserSettingsImplCopyWith<$Res>
     implements $SaveUserSettingsCopyWith<$Res> {
-  factory _$$_SaveUserSettingsCopyWith(
-          _$_SaveUserSettings value, $Res Function(_$_SaveUserSettings) then) =
-      __$$_SaveUserSettingsCopyWithImpl<$Res>;
+  factory _$$SaveUserSettingsImplCopyWith(_$SaveUserSettingsImpl value,
+          $Res Function(_$SaveUserSettingsImpl) then) =
+      __$$SaveUserSettingsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -3994,15 +4018,16 @@ abstract class _$$_SaveUserSettingsCopyWith<$Res>
       bool? infiniteScrollEnabled,
       String? postListingMode,
       bool? enableKeyboardNavigation,
-      bool? enableAnimatedImages});
+      bool? enableAnimatedImages,
+      bool? collapseBotComments});
 }
 
 /// @nodoc
-class __$$_SaveUserSettingsCopyWithImpl<$Res>
-    extends _$SaveUserSettingsCopyWithImpl<$Res, _$_SaveUserSettings>
-    implements _$$_SaveUserSettingsCopyWith<$Res> {
-  __$$_SaveUserSettingsCopyWithImpl(
-      _$_SaveUserSettings _value, $Res Function(_$_SaveUserSettings) _then)
+class __$$SaveUserSettingsImplCopyWithImpl<$Res>
+    extends _$SaveUserSettingsCopyWithImpl<$Res, _$SaveUserSettingsImpl>
+    implements _$$SaveUserSettingsImplCopyWith<$Res> {
+  __$$SaveUserSettingsImplCopyWithImpl(_$SaveUserSettingsImpl _value,
+      $Res Function(_$SaveUserSettingsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4036,8 +4061,9 @@ class __$$_SaveUserSettingsCopyWithImpl<$Res>
     Object? postListingMode = freezed,
     Object? enableKeyboardNavigation = freezed,
     Object? enableAnimatedImages = freezed,
+    Object? collapseBotComments = freezed,
   }) {
-    return _then(_$_SaveUserSettings(
+    return _then(_$SaveUserSettingsImpl(
       showNsfw: freezed == showNsfw
           ? _value.showNsfw
           : showNsfw // ignore: cast_nullable_to_non_nullable
@@ -4150,6 +4176,10 @@ class __$$_SaveUserSettingsCopyWithImpl<$Res>
           ? _value.enableAnimatedImages
           : enableAnimatedImages // ignore: cast_nullable_to_non_nullable
               as bool?,
+      collapseBotComments: freezed == collapseBotComments
+          ? _value.collapseBotComments
+          : collapseBotComments // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ));
   }
 }
@@ -4157,8 +4187,8 @@ class __$$_SaveUserSettingsCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_SaveUserSettings extends _SaveUserSettings {
-  const _$_SaveUserSettings(
+class _$SaveUserSettingsImpl extends _SaveUserSettings {
+  const _$SaveUserSettingsImpl(
       {this.showNsfw,
       this.blurNsfw,
       this.autoExpand,
@@ -4186,12 +4216,13 @@ class _$_SaveUserSettings extends _SaveUserSettings {
       this.infiniteScrollEnabled,
       this.postListingMode,
       this.enableKeyboardNavigation,
-      this.enableAnimatedImages})
+      this.enableAnimatedImages,
+      this.collapseBotComments})
       : _discussionLanguages = discussionLanguages,
         super._();
 
-  factory _$_SaveUserSettings.fromJson(Map<String, dynamic> json) =>
-      _$$_SaveUserSettingsFromJson(json);
+  factory _$SaveUserSettingsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SaveUserSettingsImplFromJson(json);
 
   @override
   final bool? showNsfw;
@@ -4262,17 +4293,20 @@ class _$_SaveUserSettings extends _SaveUserSettings {
 // Available in lemmy v0.19.0 and above
   @override
   final bool? enableAnimatedImages;
+// Available in lemmy v0.19.0 and above
+  @override
+  final bool? collapseBotComments;
 
   @override
   String toString() {
-    return 'SaveUserSettings(showNsfw: $showNsfw, blurNsfw: $blurNsfw, autoExpand: $autoExpand, showScores: $showScores, theme: $theme, defaultSortType: $defaultSortType, defaultListingType: $defaultListingType, interfaceLanguage: $interfaceLanguage, avatar: $avatar, banner: $banner, displayName: $displayName, email: $email, bio: $bio, matrixUserId: $matrixUserId, showAvatars: $showAvatars, sendNotificationsToEmail: $sendNotificationsToEmail, botAccount: $botAccount, showBotAccounts: $showBotAccounts, showReadPosts: $showReadPosts, showNewPostNotifs: $showNewPostNotifs, discussionLanguages: $discussionLanguages, generateTotp2fa: $generateTotp2fa, auth: $auth, openLinksInNewTab: $openLinksInNewTab, infiniteScrollEnabled: $infiniteScrollEnabled, postListingMode: $postListingMode, enableKeyboardNavigation: $enableKeyboardNavigation, enableAnimatedImages: $enableAnimatedImages)';
+    return 'SaveUserSettings(showNsfw: $showNsfw, blurNsfw: $blurNsfw, autoExpand: $autoExpand, showScores: $showScores, theme: $theme, defaultSortType: $defaultSortType, defaultListingType: $defaultListingType, interfaceLanguage: $interfaceLanguage, avatar: $avatar, banner: $banner, displayName: $displayName, email: $email, bio: $bio, matrixUserId: $matrixUserId, showAvatars: $showAvatars, sendNotificationsToEmail: $sendNotificationsToEmail, botAccount: $botAccount, showBotAccounts: $showBotAccounts, showReadPosts: $showReadPosts, showNewPostNotifs: $showNewPostNotifs, discussionLanguages: $discussionLanguages, generateTotp2fa: $generateTotp2fa, auth: $auth, openLinksInNewTab: $openLinksInNewTab, infiniteScrollEnabled: $infiniteScrollEnabled, postListingMode: $postListingMode, enableKeyboardNavigation: $enableKeyboardNavigation, enableAnimatedImages: $enableAnimatedImages, collapseBotComments: $collapseBotComments)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SaveUserSettings &&
+            other is _$SaveUserSettingsImpl &&
             (identical(other.showNsfw, showNsfw) ||
                 other.showNsfw == showNsfw) &&
             (identical(other.blurNsfw, blurNsfw) ||
@@ -4324,7 +4358,9 @@ class _$_SaveUserSettings extends _SaveUserSettings {
                     other.enableKeyboardNavigation, enableKeyboardNavigation) ||
                 other.enableKeyboardNavigation == enableKeyboardNavigation) &&
             (identical(other.enableAnimatedImages, enableAnimatedImages) ||
-                other.enableAnimatedImages == enableAnimatedImages));
+                other.enableAnimatedImages == enableAnimatedImages) &&
+            (identical(other.collapseBotComments, collapseBotComments) ||
+                other.collapseBotComments == collapseBotComments));
   }
 
   @JsonKey(ignore: true)
@@ -4358,18 +4394,20 @@ class _$_SaveUserSettings extends _SaveUserSettings {
         infiniteScrollEnabled,
         postListingMode,
         enableKeyboardNavigation,
-        enableAnimatedImages
+        enableAnimatedImages,
+        collapseBotComments
       ]);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SaveUserSettingsCopyWith<_$_SaveUserSettings> get copyWith =>
-      __$$_SaveUserSettingsCopyWithImpl<_$_SaveUserSettings>(this, _$identity);
+  _$$SaveUserSettingsImplCopyWith<_$SaveUserSettingsImpl> get copyWith =>
+      __$$SaveUserSettingsImplCopyWithImpl<_$SaveUserSettingsImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SaveUserSettingsToJson(
+    return _$$SaveUserSettingsImplToJson(
       this,
     );
   }
@@ -4404,11 +4442,12 @@ abstract class _SaveUserSettings extends SaveUserSettings {
       final bool? infiniteScrollEnabled,
       final String? postListingMode,
       final bool? enableKeyboardNavigation,
-      final bool? enableAnimatedImages}) = _$_SaveUserSettings;
+      final bool? enableAnimatedImages,
+      final bool? collapseBotComments}) = _$SaveUserSettingsImpl;
   const _SaveUserSettings._() : super._();
 
   factory _SaveUserSettings.fromJson(Map<String, dynamic> json) =
-      _$_SaveUserSettings.fromJson;
+      _$SaveUserSettingsImpl.fromJson;
 
   @override
   bool? get showNsfw;
@@ -4467,9 +4506,11 @@ abstract class _SaveUserSettings extends SaveUserSettings {
   bool? get enableKeyboardNavigation;
   @override // Available in lemmy v0.19.0 and above
   bool? get enableAnimatedImages;
+  @override // Available in lemmy v0.19.0 and above
+  bool? get collapseBotComments;
   @override
   @JsonKey(ignore: true)
-  _$$_SaveUserSettingsCopyWith<_$_SaveUserSettings> get copyWith =>
+  _$$SaveUserSettingsImplCopyWith<_$SaveUserSettingsImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4543,11 +4584,11 @@ class _$ChangePasswordCopyWithImpl<$Res, $Val extends ChangePassword>
 }
 
 /// @nodoc
-abstract class _$$_ChangePasswordCopyWith<$Res>
+abstract class _$$ChangePasswordImplCopyWith<$Res>
     implements $ChangePasswordCopyWith<$Res> {
-  factory _$$_ChangePasswordCopyWith(
-          _$_ChangePassword value, $Res Function(_$_ChangePassword) then) =
-      __$$_ChangePasswordCopyWithImpl<$Res>;
+  factory _$$ChangePasswordImplCopyWith(_$ChangePasswordImpl value,
+          $Res Function(_$ChangePasswordImpl) then) =
+      __$$ChangePasswordImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -4558,11 +4599,11 @@ abstract class _$$_ChangePasswordCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ChangePasswordCopyWithImpl<$Res>
-    extends _$ChangePasswordCopyWithImpl<$Res, _$_ChangePassword>
-    implements _$$_ChangePasswordCopyWith<$Res> {
-  __$$_ChangePasswordCopyWithImpl(
-      _$_ChangePassword _value, $Res Function(_$_ChangePassword) _then)
+class __$$ChangePasswordImplCopyWithImpl<$Res>
+    extends _$ChangePasswordCopyWithImpl<$Res, _$ChangePasswordImpl>
+    implements _$$ChangePasswordImplCopyWith<$Res> {
+  __$$ChangePasswordImplCopyWithImpl(
+      _$ChangePasswordImpl _value, $Res Function(_$ChangePasswordImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4573,7 +4614,7 @@ class __$$_ChangePasswordCopyWithImpl<$Res>
     Object? oldPassword = null,
     Object? auth = freezed,
   }) {
-    return _then(_$_ChangePassword(
+    return _then(_$ChangePasswordImpl(
       newPassword: null == newPassword
           ? _value.newPassword
           : newPassword // ignore: cast_nullable_to_non_nullable
@@ -4597,16 +4638,16 @@ class __$$_ChangePasswordCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_ChangePassword extends _ChangePassword {
-  const _$_ChangePassword(
+class _$ChangePasswordImpl extends _ChangePassword {
+  const _$ChangePasswordImpl(
       {required this.newPassword,
       required this.newPasswordVerify,
       required this.oldPassword,
       this.auth})
       : super._();
 
-  factory _$_ChangePassword.fromJson(Map<String, dynamic> json) =>
-      _$$_ChangePasswordFromJson(json);
+  factory _$ChangePasswordImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ChangePasswordImplFromJson(json);
 
   @override
   final String newPassword;
@@ -4626,7 +4667,7 @@ class _$_ChangePassword extends _ChangePassword {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ChangePassword &&
+            other is _$ChangePasswordImpl &&
             (identical(other.newPassword, newPassword) ||
                 other.newPassword == newPassword) &&
             (identical(other.newPasswordVerify, newPasswordVerify) ||
@@ -4644,12 +4685,13 @@ class _$_ChangePassword extends _ChangePassword {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ChangePasswordCopyWith<_$_ChangePassword> get copyWith =>
-      __$$_ChangePasswordCopyWithImpl<_$_ChangePassword>(this, _$identity);
+  _$$ChangePasswordImplCopyWith<_$ChangePasswordImpl> get copyWith =>
+      __$$ChangePasswordImplCopyWithImpl<_$ChangePasswordImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ChangePasswordToJson(
+    return _$$ChangePasswordImplToJson(
       this,
     );
   }
@@ -4660,11 +4702,11 @@ abstract class _ChangePassword extends ChangePassword {
       {required final String newPassword,
       required final String newPasswordVerify,
       required final String oldPassword,
-      final String? auth}) = _$_ChangePassword;
+      final String? auth}) = _$ChangePasswordImpl;
   const _ChangePassword._() : super._();
 
   factory _ChangePassword.fromJson(Map<String, dynamic> json) =
-      _$_ChangePassword.fromJson;
+      _$ChangePasswordImpl.fromJson;
 
   @override
   String get newPassword;
@@ -4676,7 +4718,7 @@ abstract class _ChangePassword extends ChangePassword {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_ChangePasswordCopyWith<_$_ChangePassword> get copyWith =>
+  _$$ChangePasswordImplCopyWith<_$ChangePasswordImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4734,22 +4776,22 @@ class _$GetReportCountCopyWithImpl<$Res, $Val extends GetReportCount>
 }
 
 /// @nodoc
-abstract class _$$_GetReportCountCopyWith<$Res>
+abstract class _$$GetReportCountImplCopyWith<$Res>
     implements $GetReportCountCopyWith<$Res> {
-  factory _$$_GetReportCountCopyWith(
-          _$_GetReportCount value, $Res Function(_$_GetReportCount) then) =
-      __$$_GetReportCountCopyWithImpl<$Res>;
+  factory _$$GetReportCountImplCopyWith(_$GetReportCountImpl value,
+          $Res Function(_$GetReportCountImpl) then) =
+      __$$GetReportCountImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int? communityId, String? auth});
 }
 
 /// @nodoc
-class __$$_GetReportCountCopyWithImpl<$Res>
-    extends _$GetReportCountCopyWithImpl<$Res, _$_GetReportCount>
-    implements _$$_GetReportCountCopyWith<$Res> {
-  __$$_GetReportCountCopyWithImpl(
-      _$_GetReportCount _value, $Res Function(_$_GetReportCount) _then)
+class __$$GetReportCountImplCopyWithImpl<$Res>
+    extends _$GetReportCountCopyWithImpl<$Res, _$GetReportCountImpl>
+    implements _$$GetReportCountImplCopyWith<$Res> {
+  __$$GetReportCountImplCopyWithImpl(
+      _$GetReportCountImpl _value, $Res Function(_$GetReportCountImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4758,7 +4800,7 @@ class __$$_GetReportCountCopyWithImpl<$Res>
     Object? communityId = freezed,
     Object? auth = freezed,
   }) {
-    return _then(_$_GetReportCount(
+    return _then(_$GetReportCountImpl(
       communityId: freezed == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -4774,11 +4816,11 @@ class __$$_GetReportCountCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetReportCount extends _GetReportCount {
-  const _$_GetReportCount({this.communityId, this.auth}) : super._();
+class _$GetReportCountImpl extends _GetReportCount {
+  const _$GetReportCountImpl({this.communityId, this.auth}) : super._();
 
-  factory _$_GetReportCount.fromJson(Map<String, dynamic> json) =>
-      _$$_GetReportCountFromJson(json);
+  factory _$GetReportCountImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetReportCountImplFromJson(json);
 
   @override
   final int? communityId;
@@ -4794,7 +4836,7 @@ class _$_GetReportCount extends _GetReportCount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetReportCount &&
+            other is _$GetReportCountImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.auth, auth) || other.auth == auth));
@@ -4807,12 +4849,13 @@ class _$_GetReportCount extends _GetReportCount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetReportCountCopyWith<_$_GetReportCount> get copyWith =>
-      __$$_GetReportCountCopyWithImpl<_$_GetReportCount>(this, _$identity);
+  _$$GetReportCountImplCopyWith<_$GetReportCountImpl> get copyWith =>
+      __$$GetReportCountImplCopyWithImpl<_$GetReportCountImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetReportCountToJson(
+    return _$$GetReportCountImplToJson(
       this,
     );
   }
@@ -4820,11 +4863,11 @@ class _$_GetReportCount extends _GetReportCount {
 
 abstract class _GetReportCount extends GetReportCount {
   const factory _GetReportCount({final int? communityId, final String? auth}) =
-      _$_GetReportCount;
+      _$GetReportCountImpl;
   const _GetReportCount._() : super._();
 
   factory _GetReportCount.fromJson(Map<String, dynamic> json) =
-      _$_GetReportCount.fromJson;
+      _$GetReportCountImpl.fromJson;
 
   @override
   int? get communityId;
@@ -4832,7 +4875,7 @@ abstract class _GetReportCount extends GetReportCount {
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetReportCountCopyWith<_$_GetReportCount> get copyWith =>
+  _$$GetReportCountImplCopyWith<_$GetReportCountImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -4884,22 +4927,22 @@ class _$GetUnreadCountCopyWithImpl<$Res, $Val extends GetUnreadCount>
 }
 
 /// @nodoc
-abstract class _$$_GetUnreadCountCopyWith<$Res>
+abstract class _$$GetUnreadCountImplCopyWith<$Res>
     implements $GetUnreadCountCopyWith<$Res> {
-  factory _$$_GetUnreadCountCopyWith(
-          _$_GetUnreadCount value, $Res Function(_$_GetUnreadCount) then) =
-      __$$_GetUnreadCountCopyWithImpl<$Res>;
+  factory _$$GetUnreadCountImplCopyWith(_$GetUnreadCountImpl value,
+          $Res Function(_$GetUnreadCountImpl) then) =
+      __$$GetUnreadCountImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? auth});
 }
 
 /// @nodoc
-class __$$_GetUnreadCountCopyWithImpl<$Res>
-    extends _$GetUnreadCountCopyWithImpl<$Res, _$_GetUnreadCount>
-    implements _$$_GetUnreadCountCopyWith<$Res> {
-  __$$_GetUnreadCountCopyWithImpl(
-      _$_GetUnreadCount _value, $Res Function(_$_GetUnreadCount) _then)
+class __$$GetUnreadCountImplCopyWithImpl<$Res>
+    extends _$GetUnreadCountCopyWithImpl<$Res, _$GetUnreadCountImpl>
+    implements _$$GetUnreadCountImplCopyWith<$Res> {
+  __$$GetUnreadCountImplCopyWithImpl(
+      _$GetUnreadCountImpl _value, $Res Function(_$GetUnreadCountImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -4907,7 +4950,7 @@ class __$$_GetUnreadCountCopyWithImpl<$Res>
   $Res call({
     Object? auth = freezed,
   }) {
-    return _then(_$_GetUnreadCount(
+    return _then(_$GetUnreadCountImpl(
       auth: freezed == auth
           ? _value.auth
           : auth // ignore: cast_nullable_to_non_nullable
@@ -4919,11 +4962,11 @@ class __$$_GetUnreadCountCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_GetUnreadCount extends _GetUnreadCount {
-  const _$_GetUnreadCount({this.auth}) : super._();
+class _$GetUnreadCountImpl extends _GetUnreadCount {
+  const _$GetUnreadCountImpl({this.auth}) : super._();
 
-  factory _$_GetUnreadCount.fromJson(Map<String, dynamic> json) =>
-      _$$_GetUnreadCountFromJson(json);
+  factory _$GetUnreadCountImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetUnreadCountImplFromJson(json);
 
   @override
   final String? auth;
@@ -4937,7 +4980,7 @@ class _$_GetUnreadCount extends _GetUnreadCount {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetUnreadCount &&
+            other is _$GetUnreadCountImpl &&
             (identical(other.auth, auth) || other.auth == auth));
   }
 
@@ -4948,29 +4991,30 @@ class _$_GetUnreadCount extends _GetUnreadCount {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetUnreadCountCopyWith<_$_GetUnreadCount> get copyWith =>
-      __$$_GetUnreadCountCopyWithImpl<_$_GetUnreadCount>(this, _$identity);
+  _$$GetUnreadCountImplCopyWith<_$GetUnreadCountImpl> get copyWith =>
+      __$$GetUnreadCountImplCopyWithImpl<_$GetUnreadCountImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetUnreadCountToJson(
+    return _$$GetUnreadCountImplToJson(
       this,
     );
   }
 }
 
 abstract class _GetUnreadCount extends GetUnreadCount {
-  const factory _GetUnreadCount({final String? auth}) = _$_GetUnreadCount;
+  const factory _GetUnreadCount({final String? auth}) = _$GetUnreadCountImpl;
   const _GetUnreadCount._() : super._();
 
   factory _GetUnreadCount.fromJson(Map<String, dynamic> json) =
-      _$_GetUnreadCount.fromJson;
+      _$GetUnreadCountImpl.fromJson;
 
   @override
   String? get auth;
   @override
   @JsonKey(ignore: true)
-  _$$_GetUnreadCountCopyWith<_$_GetUnreadCount> get copyWith =>
+  _$$GetUnreadCountImplCopyWith<_$GetUnreadCountImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -5022,22 +5066,22 @@ class _$VerifyEmailCopyWithImpl<$Res, $Val extends VerifyEmail>
 }
 
 /// @nodoc
-abstract class _$$_VerifyEmailCopyWith<$Res>
+abstract class _$$VerifyEmailImplCopyWith<$Res>
     implements $VerifyEmailCopyWith<$Res> {
-  factory _$$_VerifyEmailCopyWith(
-          _$_VerifyEmail value, $Res Function(_$_VerifyEmail) then) =
-      __$$_VerifyEmailCopyWithImpl<$Res>;
+  factory _$$VerifyEmailImplCopyWith(
+          _$VerifyEmailImpl value, $Res Function(_$VerifyEmailImpl) then) =
+      __$$VerifyEmailImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String token});
 }
 
 /// @nodoc
-class __$$_VerifyEmailCopyWithImpl<$Res>
-    extends _$VerifyEmailCopyWithImpl<$Res, _$_VerifyEmail>
-    implements _$$_VerifyEmailCopyWith<$Res> {
-  __$$_VerifyEmailCopyWithImpl(
-      _$_VerifyEmail _value, $Res Function(_$_VerifyEmail) _then)
+class __$$VerifyEmailImplCopyWithImpl<$Res>
+    extends _$VerifyEmailCopyWithImpl<$Res, _$VerifyEmailImpl>
+    implements _$$VerifyEmailImplCopyWith<$Res> {
+  __$$VerifyEmailImplCopyWithImpl(
+      _$VerifyEmailImpl _value, $Res Function(_$VerifyEmailImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -5045,7 +5089,7 @@ class __$$_VerifyEmailCopyWithImpl<$Res>
   $Res call({
     Object? token = null,
   }) {
-    return _then(_$_VerifyEmail(
+    return _then(_$VerifyEmailImpl(
       token: null == token
           ? _value.token
           : token // ignore: cast_nullable_to_non_nullable
@@ -5057,11 +5101,11 @@ class __$$_VerifyEmailCopyWithImpl<$Res>
 /// @nodoc
 
 @apiSerde
-class _$_VerifyEmail extends _VerifyEmail {
-  const _$_VerifyEmail({required this.token}) : super._();
+class _$VerifyEmailImpl extends _VerifyEmail {
+  const _$VerifyEmailImpl({required this.token}) : super._();
 
-  factory _$_VerifyEmail.fromJson(Map<String, dynamic> json) =>
-      _$$_VerifyEmailFromJson(json);
+  factory _$VerifyEmailImpl.fromJson(Map<String, dynamic> json) =>
+      _$$VerifyEmailImplFromJson(json);
 
   @override
   final String token;
@@ -5075,7 +5119,7 @@ class _$_VerifyEmail extends _VerifyEmail {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_VerifyEmail &&
+            other is _$VerifyEmailImpl &&
             (identical(other.token, token) || other.token == token));
   }
 
@@ -5086,28 +5130,28 @@ class _$_VerifyEmail extends _VerifyEmail {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_VerifyEmailCopyWith<_$_VerifyEmail> get copyWith =>
-      __$$_VerifyEmailCopyWithImpl<_$_VerifyEmail>(this, _$identity);
+  _$$VerifyEmailImplCopyWith<_$VerifyEmailImpl> get copyWith =>
+      __$$VerifyEmailImplCopyWithImpl<_$VerifyEmailImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_VerifyEmailToJson(
+    return _$$VerifyEmailImplToJson(
       this,
     );
   }
 }
 
 abstract class _VerifyEmail extends VerifyEmail {
-  const factory _VerifyEmail({required final String token}) = _$_VerifyEmail;
+  const factory _VerifyEmail({required final String token}) = _$VerifyEmailImpl;
   const _VerifyEmail._() : super._();
 
   factory _VerifyEmail.fromJson(Map<String, dynamic> json) =
-      _$_VerifyEmail.fromJson;
+      _$VerifyEmailImpl.fromJson;
 
   @override
   String get token;
   @override
   @JsonKey(ignore: true)
-  _$$_VerifyEmailCopyWith<_$_VerifyEmail> get copyWith =>
+  _$$VerifyEmailImplCopyWith<_$VerifyEmailImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/api/user/user.g.dart
+++ b/lib/src/v3/api/user/user.g.dart
@@ -6,12 +6,12 @@ part of 'user.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LeaveAdmin _$$_LeaveAdminFromJson(Map<String, dynamic> json) =>
-    _$_LeaveAdmin(
+_$LeaveAdminImpl _$$LeaveAdminImplFromJson(Map<String, dynamic> json) =>
+    _$LeaveAdminImpl(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_LeaveAdminToJson(_$_LeaveAdmin instance) {
+Map<String, dynamic> _$$LeaveAdminImplToJson(_$LeaveAdminImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -24,14 +24,14 @@ Map<String, dynamic> _$$_LeaveAdminToJson(_$_LeaveAdmin instance) {
   return val;
 }
 
-_$_GenerateTotpSecret _$$_GenerateTotpSecretFromJson(
+_$GenerateTotpSecretImpl _$$GenerateTotpSecretImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GenerateTotpSecret(
+    _$GenerateTotpSecretImpl(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GenerateTotpSecretToJson(
-    _$_GenerateTotpSecret instance) {
+Map<String, dynamic> _$$GenerateTotpSecretImplToJson(
+    _$GenerateTotpSecretImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -44,12 +44,13 @@ Map<String, dynamic> _$$_GenerateTotpSecretToJson(
   return val;
 }
 
-_$_ExportSettings _$$_ExportSettingsFromJson(Map<String, dynamic> json) =>
-    _$_ExportSettings(
+_$ExportSettingsImpl _$$ExportSettingsImplFromJson(Map<String, dynamic> json) =>
+    _$ExportSettingsImpl(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ExportSettingsToJson(_$_ExportSettings instance) {
+Map<String, dynamic> _$$ExportSettingsImplToJson(
+    _$ExportSettingsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -62,13 +63,14 @@ Map<String, dynamic> _$$_ExportSettingsToJson(_$_ExportSettings instance) {
   return val;
 }
 
-_$_ImportSettings _$$_ImportSettingsFromJson(Map<String, dynamic> json) =>
-    _$_ImportSettings(
+_$ImportSettingsImpl _$$ImportSettingsImplFromJson(Map<String, dynamic> json) =>
+    _$ImportSettingsImpl(
       auth: json['auth'] as String?,
       data: json['data'],
     );
 
-Map<String, dynamic> _$$_ImportSettingsToJson(_$_ImportSettings instance) {
+Map<String, dynamic> _$$ImportSettingsImplToJson(
+    _$ImportSettingsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -82,12 +84,12 @@ Map<String, dynamic> _$$_ImportSettingsToJson(_$_ImportSettings instance) {
   return val;
 }
 
-_$_ValidateAuth _$$_ValidateAuthFromJson(Map<String, dynamic> json) =>
-    _$_ValidateAuth(
+_$ValidateAuthImpl _$$ValidateAuthImplFromJson(Map<String, dynamic> json) =>
+    _$ValidateAuthImpl(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ValidateAuthToJson(_$_ValidateAuth instance) {
+Map<String, dynamic> _$$ValidateAuthImplToJson(_$ValidateAuthImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -100,14 +102,14 @@ Map<String, dynamic> _$$_ValidateAuthToJson(_$_ValidateAuth instance) {
   return val;
 }
 
-_$_UpdateTotp _$$_UpdateTotpFromJson(Map<String, dynamic> json) =>
-    _$_UpdateTotp(
+_$UpdateTotpImpl _$$UpdateTotpImplFromJson(Map<String, dynamic> json) =>
+    _$UpdateTotpImpl(
       auth: json['auth'] as String?,
       totpToken: json['totp_token'] as String,
       enabled: json['enabled'] as bool,
     );
 
-Map<String, dynamic> _$$_UpdateTotpToJson(_$_UpdateTotp instance) {
+Map<String, dynamic> _$$UpdateTotpImplToJson(_$UpdateTotpImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -122,7 +124,8 @@ Map<String, dynamic> _$$_UpdateTotpToJson(_$_UpdateTotp instance) {
   return val;
 }
 
-_$_Register _$$_RegisterFromJson(Map<String, dynamic> json) => _$_Register(
+_$RegisterImpl _$$RegisterImplFromJson(Map<String, dynamic> json) =>
+    _$RegisterImpl(
       username: json['username'] as String,
       password: json['password'] as String,
       passwordVerify: json['password_verify'] as String,
@@ -134,7 +137,7 @@ _$_Register _$$_RegisterFromJson(Map<String, dynamic> json) => _$_Register(
       answer: json['answer'] as String?,
     );
 
-Map<String, dynamic> _$$_RegisterToJson(_$_Register instance) {
+Map<String, dynamic> _$$RegisterImplToJson(_$RegisterImpl instance) {
   final val = <String, dynamic>{
     'username': instance.username,
     'password': instance.password,
@@ -156,13 +159,13 @@ Map<String, dynamic> _$$_RegisterToJson(_$_Register instance) {
   return val;
 }
 
-_$_Login _$$_LoginFromJson(Map<String, dynamic> json) => _$_Login(
+_$LoginImpl _$$LoginImplFromJson(Map<String, dynamic> json) => _$LoginImpl(
       usernameOrEmail: json['username_or_email'] as String,
       password: json['password'] as String,
       totp2faToken: json['totp2fa_token'] as String?,
     );
 
-Map<String, dynamic> _$$_LoginToJson(_$_Login instance) {
+Map<String, dynamic> _$$LoginImplToJson(_$LoginImpl instance) {
   final val = <String, dynamic>{
     'username_or_email': instance.usernameOrEmail,
     'password': instance.password,
@@ -178,13 +181,14 @@ Map<String, dynamic> _$$_LoginToJson(_$_Login instance) {
   return val;
 }
 
-_$_Logout _$$_LogoutFromJson(Map<String, dynamic> json) => _$_Logout();
+_$LogoutImpl _$$LogoutImplFromJson(Map<String, dynamic> json) => _$LogoutImpl();
 
-Map<String, dynamic> _$$_LogoutToJson(_$_Logout instance) =>
+Map<String, dynamic> _$$LogoutImplToJson(_$LogoutImpl instance) =>
     <String, dynamic>{};
 
-_$_GetPersonDetails _$$_GetPersonDetailsFromJson(Map<String, dynamic> json) =>
-    _$_GetPersonDetails(
+_$GetPersonDetailsImpl _$$GetPersonDetailsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GetPersonDetailsImpl(
       personId: json['person_id'] as int?,
       username: json['username'] as String?,
       sort: json['sort'] == null ? null : SortType.fromJson(json['sort']),
@@ -195,7 +199,8 @@ _$_GetPersonDetails _$$_GetPersonDetailsFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetPersonDetailsToJson(_$_GetPersonDetails instance) {
+Map<String, dynamic> _$$GetPersonDetailsImplToJson(
+    _$GetPersonDetailsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -215,8 +220,9 @@ Map<String, dynamic> _$$_GetPersonDetailsToJson(_$_GetPersonDetails instance) {
   return val;
 }
 
-_$_GetPersonMentions _$$_GetPersonMentionsFromJson(Map<String, dynamic> json) =>
-    _$_GetPersonMentions(
+_$GetPersonMentionsImpl _$$GetPersonMentionsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GetPersonMentionsImpl(
       sort:
           json['sort'] == null ? null : CommentSortType.fromJson(json['sort']),
       page: json['page'] as int?,
@@ -225,8 +231,8 @@ _$_GetPersonMentions _$$_GetPersonMentionsFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetPersonMentionsToJson(
-    _$_GetPersonMentions instance) {
+Map<String, dynamic> _$$GetPersonMentionsImplToJson(
+    _$GetPersonMentionsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -243,16 +249,16 @@ Map<String, dynamic> _$$_GetPersonMentionsToJson(
   return val;
 }
 
-_$_MarkPersonMentionAsRead _$$_MarkPersonMentionAsReadFromJson(
+_$MarkPersonMentionAsReadImpl _$$MarkPersonMentionAsReadImplFromJson(
         Map<String, dynamic> json) =>
-    _$_MarkPersonMentionAsRead(
+    _$MarkPersonMentionAsReadImpl(
       personMentionId: json['person_mention_id'] as int,
       read: json['read'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_MarkPersonMentionAsReadToJson(
-    _$_MarkPersonMentionAsRead instance) {
+Map<String, dynamic> _$$MarkPersonMentionAsReadImplToJson(
+    _$MarkPersonMentionAsReadImpl instance) {
   final val = <String, dynamic>{
     'person_mention_id': instance.personMentionId,
     'read': instance.read,
@@ -268,8 +274,8 @@ Map<String, dynamic> _$$_MarkPersonMentionAsReadToJson(
   return val;
 }
 
-_$_GetReplies _$$_GetRepliesFromJson(Map<String, dynamic> json) =>
-    _$_GetReplies(
+_$GetRepliesImpl _$$GetRepliesImplFromJson(Map<String, dynamic> json) =>
+    _$GetRepliesImpl(
       sort:
           json['sort'] == null ? null : CommentSortType.fromJson(json['sort']),
       page: json['page'] as int?,
@@ -278,7 +284,7 @@ _$_GetReplies _$$_GetRepliesFromJson(Map<String, dynamic> json) =>
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetRepliesToJson(_$_GetReplies instance) {
+Map<String, dynamic> _$$GetRepliesImplToJson(_$GetRepliesImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -295,7 +301,8 @@ Map<String, dynamic> _$$_GetRepliesToJson(_$_GetReplies instance) {
   return val;
 }
 
-_$_BanPerson _$$_BanPersonFromJson(Map<String, dynamic> json) => _$_BanPerson(
+_$BanPersonImpl _$$BanPersonImplFromJson(Map<String, dynamic> json) =>
+    _$BanPersonImpl(
       personId: json['person_id'] as int,
       ban: json['ban'] as bool,
       removeData: json['remove_data'] as bool?,
@@ -304,7 +311,7 @@ _$_BanPerson _$$_BanPersonFromJson(Map<String, dynamic> json) => _$_BanPerson(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_BanPersonToJson(_$_BanPerson instance) {
+Map<String, dynamic> _$$BanPersonImplToJson(_$BanPersonImpl instance) {
   final val = <String, dynamic>{
     'person_id': instance.personId,
     'ban': instance.ban,
@@ -323,12 +330,14 @@ Map<String, dynamic> _$$_BanPersonToJson(_$_BanPerson instance) {
   return val;
 }
 
-_$_GetBannedPersons _$$_GetBannedPersonsFromJson(Map<String, dynamic> json) =>
-    _$_GetBannedPersons(
+_$GetBannedPersonsImpl _$$GetBannedPersonsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GetBannedPersonsImpl(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetBannedPersonsToJson(_$_GetBannedPersons instance) {
+Map<String, dynamic> _$$GetBannedPersonsImplToJson(
+    _$GetBannedPersonsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -341,14 +350,14 @@ Map<String, dynamic> _$$_GetBannedPersonsToJson(_$_GetBannedPersons instance) {
   return val;
 }
 
-_$_BlockPerson _$$_BlockPersonFromJson(Map<String, dynamic> json) =>
-    _$_BlockPerson(
+_$BlockPersonImpl _$$BlockPersonImplFromJson(Map<String, dynamic> json) =>
+    _$BlockPersonImpl(
       personId: json['person_id'] as int,
       block: json['block'] as bool,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_BlockPersonToJson(_$_BlockPerson instance) {
+Map<String, dynamic> _$$BlockPersonImplToJson(_$BlockPersonImpl instance) {
   final val = <String, dynamic>{
     'person_id': instance.personId,
     'block': instance.block,
@@ -364,12 +373,12 @@ Map<String, dynamic> _$$_BlockPersonToJson(_$_BlockPerson instance) {
   return val;
 }
 
-_$_GetCaptcha _$$_GetCaptchaFromJson(Map<String, dynamic> json) =>
-    _$_GetCaptcha(
+_$GetCaptchaImpl _$$GetCaptchaImplFromJson(Map<String, dynamic> json) =>
+    _$GetCaptchaImpl(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetCaptchaToJson(_$_GetCaptcha instance) {
+Map<String, dynamic> _$$GetCaptchaImplToJson(_$GetCaptchaImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -382,14 +391,14 @@ Map<String, dynamic> _$$_GetCaptchaToJson(_$_GetCaptcha instance) {
   return val;
 }
 
-_$_DeleteAccount _$$_DeleteAccountFromJson(Map<String, dynamic> json) =>
-    _$_DeleteAccount(
+_$DeleteAccountImpl _$$DeleteAccountImplFromJson(Map<String, dynamic> json) =>
+    _$DeleteAccountImpl(
       password: json['password'] as String,
       deleteContent: json['delete_content'] as bool?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_DeleteAccountToJson(_$_DeleteAccount instance) {
+Map<String, dynamic> _$$DeleteAccountImplToJson(_$DeleteAccountImpl instance) {
   final val = <String, dynamic>{
     'password': instance.password,
   };
@@ -405,38 +414,38 @@ Map<String, dynamic> _$$_DeleteAccountToJson(_$_DeleteAccount instance) {
   return val;
 }
 
-_$_PasswordReset _$$_PasswordResetFromJson(Map<String, dynamic> json) =>
-    _$_PasswordReset(
+_$PasswordResetImpl _$$PasswordResetImplFromJson(Map<String, dynamic> json) =>
+    _$PasswordResetImpl(
       email: json['email'] as String,
     );
 
-Map<String, dynamic> _$$_PasswordResetToJson(_$_PasswordReset instance) =>
+Map<String, dynamic> _$$PasswordResetImplToJson(_$PasswordResetImpl instance) =>
     <String, dynamic>{
       'email': instance.email,
     };
 
-_$_PasswordChangeAfterReset _$$_PasswordChangeAfterResetFromJson(
+_$PasswordChangeAfterResetImpl _$$PasswordChangeAfterResetImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PasswordChangeAfterReset(
+    _$PasswordChangeAfterResetImpl(
       token: json['token'] as String,
       password: json['password'] as String,
       passwordVerify: json['password_verify'] as String,
     );
 
-Map<String, dynamic> _$$_PasswordChangeAfterResetToJson(
-        _$_PasswordChangeAfterReset instance) =>
+Map<String, dynamic> _$$PasswordChangeAfterResetImplToJson(
+        _$PasswordChangeAfterResetImpl instance) =>
     <String, dynamic>{
       'token': instance.token,
       'password': instance.password,
       'password_verify': instance.passwordVerify,
     };
 
-_$_MarkAllAsRead _$$_MarkAllAsReadFromJson(Map<String, dynamic> json) =>
-    _$_MarkAllAsRead(
+_$MarkAllAsReadImpl _$$MarkAllAsReadImplFromJson(Map<String, dynamic> json) =>
+    _$MarkAllAsReadImpl(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_MarkAllAsReadToJson(_$_MarkAllAsRead instance) {
+Map<String, dynamic> _$$MarkAllAsReadImplToJson(_$MarkAllAsReadImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -449,8 +458,9 @@ Map<String, dynamic> _$$_MarkAllAsReadToJson(_$_MarkAllAsRead instance) {
   return val;
 }
 
-_$_SaveUserSettings _$$_SaveUserSettingsFromJson(Map<String, dynamic> json) =>
-    _$_SaveUserSettings(
+_$SaveUserSettingsImpl _$$SaveUserSettingsImplFromJson(
+        Map<String, dynamic> json) =>
+    _$SaveUserSettingsImpl(
       showNsfw: json['show_nsfw'] as bool?,
       blurNsfw: json['blur_nsfw'] as bool?,
       autoExpand: json['auto_expand'] as bool?,
@@ -485,9 +495,11 @@ _$_SaveUserSettings _$$_SaveUserSettingsFromJson(Map<String, dynamic> json) =>
       postListingMode: json['post_listing_mode'] as String?,
       enableKeyboardNavigation: json['enable_keyboard_navigation'] as bool?,
       enableAnimatedImages: json['enable_animated_images'] as bool?,
+      collapseBotComments: json['collapse_bot_comments'] as bool?,
     );
 
-Map<String, dynamic> _$$_SaveUserSettingsToJson(_$_SaveUserSettings instance) {
+Map<String, dynamic> _$$SaveUserSettingsImplToJson(
+    _$SaveUserSettingsImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -525,18 +537,20 @@ Map<String, dynamic> _$$_SaveUserSettingsToJson(_$_SaveUserSettings instance) {
   writeNotNull('post_listing_mode', instance.postListingMode);
   writeNotNull('enable_keyboard_navigation', instance.enableKeyboardNavigation);
   writeNotNull('enable_animated_images', instance.enableAnimatedImages);
+  writeNotNull('collapse_bot_comments', instance.collapseBotComments);
   return val;
 }
 
-_$_ChangePassword _$$_ChangePasswordFromJson(Map<String, dynamic> json) =>
-    _$_ChangePassword(
+_$ChangePasswordImpl _$$ChangePasswordImplFromJson(Map<String, dynamic> json) =>
+    _$ChangePasswordImpl(
       newPassword: json['new_password'] as String,
       newPasswordVerify: json['new_password_verify'] as String,
       oldPassword: json['old_password'] as String,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_ChangePasswordToJson(_$_ChangePassword instance) {
+Map<String, dynamic> _$$ChangePasswordImplToJson(
+    _$ChangePasswordImpl instance) {
   final val = <String, dynamic>{
     'new_password': instance.newPassword,
     'new_password_verify': instance.newPasswordVerify,
@@ -553,13 +567,14 @@ Map<String, dynamic> _$$_ChangePasswordToJson(_$_ChangePassword instance) {
   return val;
 }
 
-_$_GetReportCount _$$_GetReportCountFromJson(Map<String, dynamic> json) =>
-    _$_GetReportCount(
+_$GetReportCountImpl _$$GetReportCountImplFromJson(Map<String, dynamic> json) =>
+    _$GetReportCountImpl(
       communityId: json['community_id'] as int?,
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetReportCountToJson(_$_GetReportCount instance) {
+Map<String, dynamic> _$$GetReportCountImplToJson(
+    _$GetReportCountImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -573,12 +588,13 @@ Map<String, dynamic> _$$_GetReportCountToJson(_$_GetReportCount instance) {
   return val;
 }
 
-_$_GetUnreadCount _$$_GetUnreadCountFromJson(Map<String, dynamic> json) =>
-    _$_GetUnreadCount(
+_$GetUnreadCountImpl _$$GetUnreadCountImplFromJson(Map<String, dynamic> json) =>
+    _$GetUnreadCountImpl(
       auth: json['auth'] as String?,
     );
 
-Map<String, dynamic> _$$_GetUnreadCountToJson(_$_GetUnreadCount instance) {
+Map<String, dynamic> _$$GetUnreadCountImplToJson(
+    _$GetUnreadCountImpl instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -591,12 +607,12 @@ Map<String, dynamic> _$$_GetUnreadCountToJson(_$_GetUnreadCount instance) {
   return val;
 }
 
-_$_VerifyEmail _$$_VerifyEmailFromJson(Map<String, dynamic> json) =>
-    _$_VerifyEmail(
+_$VerifyEmailImpl _$$VerifyEmailImplFromJson(Map<String, dynamic> json) =>
+    _$VerifyEmailImpl(
       token: json['token'] as String,
     );
 
-Map<String, dynamic> _$$_VerifyEmailToJson(_$_VerifyEmail instance) =>
+Map<String, dynamic> _$$VerifyEmailImplToJson(_$VerifyEmailImpl instance) =>
     <String, dynamic>{
       'token': instance.token,
     };

--- a/lib/src/v3/models/admin/add_admin_response.freezed.dart
+++ b/lib/src/v3/models/admin/add_admin_response.freezed.dart
@@ -62,22 +62,22 @@ class _$AddAdminResponseCopyWithImpl<$Res, $Val extends AddAdminResponse>
 }
 
 /// @nodoc
-abstract class _$$_AddAdminResponseCopyWith<$Res>
+abstract class _$$AddAdminResponseImplCopyWith<$Res>
     implements $AddAdminResponseCopyWith<$Res> {
-  factory _$$_AddAdminResponseCopyWith(
-          _$_AddAdminResponse value, $Res Function(_$_AddAdminResponse) then) =
-      __$$_AddAdminResponseCopyWithImpl<$Res>;
+  factory _$$AddAdminResponseImplCopyWith(_$AddAdminResponseImpl value,
+          $Res Function(_$AddAdminResponseImpl) then) =
+      __$$AddAdminResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<PersonView> admins});
 }
 
 /// @nodoc
-class __$$_AddAdminResponseCopyWithImpl<$Res>
-    extends _$AddAdminResponseCopyWithImpl<$Res, _$_AddAdminResponse>
-    implements _$$_AddAdminResponseCopyWith<$Res> {
-  __$$_AddAdminResponseCopyWithImpl(
-      _$_AddAdminResponse _value, $Res Function(_$_AddAdminResponse) _then)
+class __$$AddAdminResponseImplCopyWithImpl<$Res>
+    extends _$AddAdminResponseCopyWithImpl<$Res, _$AddAdminResponseImpl>
+    implements _$$AddAdminResponseImplCopyWith<$Res> {
+  __$$AddAdminResponseImplCopyWithImpl(_$AddAdminResponseImpl _value,
+      $Res Function(_$AddAdminResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -85,7 +85,7 @@ class __$$_AddAdminResponseCopyWithImpl<$Res>
   $Res call({
     Object? admins = null,
   }) {
-    return _then(_$_AddAdminResponse(
+    return _then(_$AddAdminResponseImpl(
       admins: null == admins
           ? _value._admins
           : admins // ignore: cast_nullable_to_non_nullable
@@ -97,13 +97,13 @@ class __$$_AddAdminResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AddAdminResponse extends _AddAdminResponse {
-  const _$_AddAdminResponse({required final List<PersonView> admins})
+class _$AddAdminResponseImpl extends _AddAdminResponse {
+  const _$AddAdminResponseImpl({required final List<PersonView> admins})
       : _admins = admins,
         super._();
 
-  factory _$_AddAdminResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_AddAdminResponseFromJson(json);
+  factory _$AddAdminResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AddAdminResponseImplFromJson(json);
 
   final List<PersonView> _admins;
   @override
@@ -122,7 +122,7 @@ class _$_AddAdminResponse extends _AddAdminResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AddAdminResponse &&
+            other is _$AddAdminResponseImpl &&
             const DeepCollectionEquality().equals(other._admins, _admins));
   }
 
@@ -134,12 +134,13 @@ class _$_AddAdminResponse extends _AddAdminResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AddAdminResponseCopyWith<_$_AddAdminResponse> get copyWith =>
-      __$$_AddAdminResponseCopyWithImpl<_$_AddAdminResponse>(this, _$identity);
+  _$$AddAdminResponseImplCopyWith<_$AddAdminResponseImpl> get copyWith =>
+      __$$AddAdminResponseImplCopyWithImpl<_$AddAdminResponseImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AddAdminResponseToJson(
+    return _$$AddAdminResponseImplToJson(
       this,
     );
   }
@@ -147,16 +148,16 @@ class _$_AddAdminResponse extends _AddAdminResponse {
 
 abstract class _AddAdminResponse extends AddAdminResponse {
   const factory _AddAdminResponse({required final List<PersonView> admins}) =
-      _$_AddAdminResponse;
+      _$AddAdminResponseImpl;
   const _AddAdminResponse._() : super._();
 
   factory _AddAdminResponse.fromJson(Map<String, dynamic> json) =
-      _$_AddAdminResponse.fromJson;
+      _$AddAdminResponseImpl.fromJson;
 
   @override
   List<PersonView> get admins;
   @override
   @JsonKey(ignore: true)
-  _$$_AddAdminResponseCopyWith<_$_AddAdminResponse> get copyWith =>
+  _$$AddAdminResponseImplCopyWith<_$AddAdminResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/admin/add_admin_response.g.dart
+++ b/lib/src/v3/models/admin/add_admin_response.g.dart
@@ -6,14 +6,16 @@ part of 'add_admin_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_AddAdminResponse _$$_AddAdminResponseFromJson(Map<String, dynamic> json) =>
-    _$_AddAdminResponse(
+_$AddAdminResponseImpl _$$AddAdminResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$AddAdminResponseImpl(
       admins: (json['admins'] as List<dynamic>)
           .map((e) => PersonView.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$_AddAdminResponseToJson(_$_AddAdminResponse instance) =>
+Map<String, dynamic> _$$AddAdminResponseImplToJson(
+        _$AddAdminResponseImpl instance) =>
     <String, dynamic>{
       'admins': instance.admins.map((e) => e.toJson()).toList(),
     };

--- a/lib/src/v3/models/admin/admin_purge_comment.freezed.dart
+++ b/lib/src/v3/models/admin/admin_purge_comment.freezed.dart
@@ -92,11 +92,11 @@ class _$AdminPurgeCommentCopyWithImpl<$Res, $Val extends AdminPurgeComment>
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgeCommentCopyWith<$Res>
+abstract class _$$AdminPurgeCommentImplCopyWith<$Res>
     implements $AdminPurgeCommentCopyWith<$Res> {
-  factory _$$_AdminPurgeCommentCopyWith(_$_AdminPurgeComment value,
-          $Res Function(_$_AdminPurgeComment) then) =
-      __$$_AdminPurgeCommentCopyWithImpl<$Res>;
+  factory _$$AdminPurgeCommentImplCopyWith(_$AdminPurgeCommentImpl value,
+          $Res Function(_$AdminPurgeCommentImpl) then) =
+      __$$AdminPurgeCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -108,11 +108,11 @@ abstract class _$$_AdminPurgeCommentCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgeCommentCopyWithImpl<$Res>
-    extends _$AdminPurgeCommentCopyWithImpl<$Res, _$_AdminPurgeComment>
-    implements _$$_AdminPurgeCommentCopyWith<$Res> {
-  __$$_AdminPurgeCommentCopyWithImpl(
-      _$_AdminPurgeComment _value, $Res Function(_$_AdminPurgeComment) _then)
+class __$$AdminPurgeCommentImplCopyWithImpl<$Res>
+    extends _$AdminPurgeCommentCopyWithImpl<$Res, _$AdminPurgeCommentImpl>
+    implements _$$AdminPurgeCommentImplCopyWith<$Res> {
+  __$$AdminPurgeCommentImplCopyWithImpl(_$AdminPurgeCommentImpl _value,
+      $Res Function(_$AdminPurgeCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -124,7 +124,7 @@ class __$$_AdminPurgeCommentCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? when = null,
   }) {
-    return _then(_$_AdminPurgeComment(
+    return _then(_$AdminPurgeCommentImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -152,8 +152,8 @@ class __$$_AdminPurgeCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgeComment extends _AdminPurgeComment {
-  const _$_AdminPurgeComment(
+class _$AdminPurgeCommentImpl extends _AdminPurgeComment {
+  const _$AdminPurgeCommentImpl(
       {required this.id,
       required this.adminPersonId,
       required this.postId,
@@ -161,8 +161,8 @@ class _$_AdminPurgeComment extends _AdminPurgeComment {
       @JsonKey(name: 'when_') required this.when})
       : super._();
 
-  factory _$_AdminPurgeComment.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgeCommentFromJson(json);
+  factory _$AdminPurgeCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgeCommentImplFromJson(json);
 
   @override
   final int id;
@@ -185,7 +185,7 @@ class _$_AdminPurgeComment extends _AdminPurgeComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgeComment &&
+            other is _$AdminPurgeCommentImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.adminPersonId, adminPersonId) ||
                 other.adminPersonId == adminPersonId) &&
@@ -202,13 +202,13 @@ class _$_AdminPurgeComment extends _AdminPurgeComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgeCommentCopyWith<_$_AdminPurgeComment> get copyWith =>
-      __$$_AdminPurgeCommentCopyWithImpl<_$_AdminPurgeComment>(
+  _$$AdminPurgeCommentImplCopyWith<_$AdminPurgeCommentImpl> get copyWith =>
+      __$$AdminPurgeCommentImplCopyWithImpl<_$AdminPurgeCommentImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgeCommentToJson(
+    return _$$AdminPurgeCommentImplToJson(
       this,
     );
   }
@@ -221,11 +221,11 @@ abstract class _AdminPurgeComment extends AdminPurgeComment {
           required final int postId,
           final String? reason,
           @JsonKey(name: 'when_') required final String when}) =
-      _$_AdminPurgeComment;
+      _$AdminPurgeCommentImpl;
   const _AdminPurgeComment._() : super._();
 
   factory _AdminPurgeComment.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgeComment.fromJson;
+      _$AdminPurgeCommentImpl.fromJson;
 
   @override
   int get id;
@@ -240,6 +240,6 @@ abstract class _AdminPurgeComment extends AdminPurgeComment {
   String get when;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgeCommentCopyWith<_$_AdminPurgeComment> get copyWith =>
+  _$$AdminPurgeCommentImplCopyWith<_$AdminPurgeCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/admin/admin_purge_comment.g.dart
+++ b/lib/src/v3/models/admin/admin_purge_comment.g.dart
@@ -6,8 +6,9 @@ part of 'admin_purge_comment.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_AdminPurgeComment _$$_AdminPurgeCommentFromJson(Map<String, dynamic> json) =>
-    _$_AdminPurgeComment(
+_$AdminPurgeCommentImpl _$$AdminPurgeCommentImplFromJson(
+        Map<String, dynamic> json) =>
+    _$AdminPurgeCommentImpl(
       id: json['id'] as int,
       adminPersonId: json['admin_person_id'] as int,
       postId: json['post_id'] as int,
@@ -15,8 +16,8 @@ _$_AdminPurgeComment _$$_AdminPurgeCommentFromJson(Map<String, dynamic> json) =>
       when: json['when_'] as String,
     );
 
-Map<String, dynamic> _$$_AdminPurgeCommentToJson(
-        _$_AdminPurgeComment instance) =>
+Map<String, dynamic> _$$AdminPurgeCommentImplToJson(
+        _$AdminPurgeCommentImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'admin_person_id': instance.adminPersonId,

--- a/lib/src/v3/models/admin/admin_purge_community.freezed.dart
+++ b/lib/src/v3/models/admin/admin_purge_community.freezed.dart
@@ -85,11 +85,11 @@ class _$AdminPurgeCommunityCopyWithImpl<$Res, $Val extends AdminPurgeCommunity>
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgeCommunityCopyWith<$Res>
+abstract class _$$AdminPurgeCommunityImplCopyWith<$Res>
     implements $AdminPurgeCommunityCopyWith<$Res> {
-  factory _$$_AdminPurgeCommunityCopyWith(_$_AdminPurgeCommunity value,
-          $Res Function(_$_AdminPurgeCommunity) then) =
-      __$$_AdminPurgeCommunityCopyWithImpl<$Res>;
+  factory _$$AdminPurgeCommunityImplCopyWith(_$AdminPurgeCommunityImpl value,
+          $Res Function(_$AdminPurgeCommunityImpl) then) =
+      __$$AdminPurgeCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -100,11 +100,11 @@ abstract class _$$_AdminPurgeCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgeCommunityCopyWithImpl<$Res>
-    extends _$AdminPurgeCommunityCopyWithImpl<$Res, _$_AdminPurgeCommunity>
-    implements _$$_AdminPurgeCommunityCopyWith<$Res> {
-  __$$_AdminPurgeCommunityCopyWithImpl(_$_AdminPurgeCommunity _value,
-      $Res Function(_$_AdminPurgeCommunity) _then)
+class __$$AdminPurgeCommunityImplCopyWithImpl<$Res>
+    extends _$AdminPurgeCommunityCopyWithImpl<$Res, _$AdminPurgeCommunityImpl>
+    implements _$$AdminPurgeCommunityImplCopyWith<$Res> {
+  __$$AdminPurgeCommunityImplCopyWithImpl(_$AdminPurgeCommunityImpl _value,
+      $Res Function(_$AdminPurgeCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -115,7 +115,7 @@ class __$$_AdminPurgeCommunityCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? when = null,
   }) {
-    return _then(_$_AdminPurgeCommunity(
+    return _then(_$AdminPurgeCommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -139,16 +139,16 @@ class __$$_AdminPurgeCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgeCommunity extends _AdminPurgeCommunity {
-  const _$_AdminPurgeCommunity(
+class _$AdminPurgeCommunityImpl extends _AdminPurgeCommunity {
+  const _$AdminPurgeCommunityImpl(
       {required this.id,
       required this.adminPersonId,
       this.reason,
       @JsonKey(name: 'when_') required this.when})
       : super._();
 
-  factory _$_AdminPurgeCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgeCommunityFromJson(json);
+  factory _$AdminPurgeCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgeCommunityImplFromJson(json);
 
   @override
   final int id;
@@ -169,7 +169,7 @@ class _$_AdminPurgeCommunity extends _AdminPurgeCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgeCommunity &&
+            other is _$AdminPurgeCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.adminPersonId, adminPersonId) ||
                 other.adminPersonId == adminPersonId) &&
@@ -184,13 +184,13 @@ class _$_AdminPurgeCommunity extends _AdminPurgeCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgeCommunityCopyWith<_$_AdminPurgeCommunity> get copyWith =>
-      __$$_AdminPurgeCommunityCopyWithImpl<_$_AdminPurgeCommunity>(
+  _$$AdminPurgeCommunityImplCopyWith<_$AdminPurgeCommunityImpl> get copyWith =>
+      __$$AdminPurgeCommunityImplCopyWithImpl<_$AdminPurgeCommunityImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgeCommunityToJson(
+    return _$$AdminPurgeCommunityImplToJson(
       this,
     );
   }
@@ -202,11 +202,11 @@ abstract class _AdminPurgeCommunity extends AdminPurgeCommunity {
           required final int adminPersonId,
           final String? reason,
           @JsonKey(name: 'when_') required final String when}) =
-      _$_AdminPurgeCommunity;
+      _$AdminPurgeCommunityImpl;
   const _AdminPurgeCommunity._() : super._();
 
   factory _AdminPurgeCommunity.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgeCommunity.fromJson;
+      _$AdminPurgeCommunityImpl.fromJson;
 
   @override
   int get id;
@@ -219,6 +219,6 @@ abstract class _AdminPurgeCommunity extends AdminPurgeCommunity {
   String get when;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgeCommunityCopyWith<_$_AdminPurgeCommunity> get copyWith =>
+  _$$AdminPurgeCommunityImplCopyWith<_$AdminPurgeCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/admin/admin_purge_community.g.dart
+++ b/lib/src/v3/models/admin/admin_purge_community.g.dart
@@ -6,17 +6,17 @@ part of 'admin_purge_community.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_AdminPurgeCommunity _$$_AdminPurgeCommunityFromJson(
+_$AdminPurgeCommunityImpl _$$AdminPurgeCommunityImplFromJson(
         Map<String, dynamic> json) =>
-    _$_AdminPurgeCommunity(
+    _$AdminPurgeCommunityImpl(
       id: json['id'] as int,
       adminPersonId: json['admin_person_id'] as int,
       reason: json['reason'] as String?,
       when: json['when_'] as String,
     );
 
-Map<String, dynamic> _$$_AdminPurgeCommunityToJson(
-        _$_AdminPurgeCommunity instance) =>
+Map<String, dynamic> _$$AdminPurgeCommunityImplToJson(
+        _$AdminPurgeCommunityImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'admin_person_id': instance.adminPersonId,

--- a/lib/src/v3/models/admin/admin_purge_person.freezed.dart
+++ b/lib/src/v3/models/admin/admin_purge_person.freezed.dart
@@ -85,11 +85,11 @@ class _$AdminPurgePersonCopyWithImpl<$Res, $Val extends AdminPurgePerson>
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgePersonCopyWith<$Res>
+abstract class _$$AdminPurgePersonImplCopyWith<$Res>
     implements $AdminPurgePersonCopyWith<$Res> {
-  factory _$$_AdminPurgePersonCopyWith(
-          _$_AdminPurgePerson value, $Res Function(_$_AdminPurgePerson) then) =
-      __$$_AdminPurgePersonCopyWithImpl<$Res>;
+  factory _$$AdminPurgePersonImplCopyWith(_$AdminPurgePersonImpl value,
+          $Res Function(_$AdminPurgePersonImpl) then) =
+      __$$AdminPurgePersonImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -100,11 +100,11 @@ abstract class _$$_AdminPurgePersonCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgePersonCopyWithImpl<$Res>
-    extends _$AdminPurgePersonCopyWithImpl<$Res, _$_AdminPurgePerson>
-    implements _$$_AdminPurgePersonCopyWith<$Res> {
-  __$$_AdminPurgePersonCopyWithImpl(
-      _$_AdminPurgePerson _value, $Res Function(_$_AdminPurgePerson) _then)
+class __$$AdminPurgePersonImplCopyWithImpl<$Res>
+    extends _$AdminPurgePersonCopyWithImpl<$Res, _$AdminPurgePersonImpl>
+    implements _$$AdminPurgePersonImplCopyWith<$Res> {
+  __$$AdminPurgePersonImplCopyWithImpl(_$AdminPurgePersonImpl _value,
+      $Res Function(_$AdminPurgePersonImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -115,7 +115,7 @@ class __$$_AdminPurgePersonCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? when = null,
   }) {
-    return _then(_$_AdminPurgePerson(
+    return _then(_$AdminPurgePersonImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -139,16 +139,16 @@ class __$$_AdminPurgePersonCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgePerson extends _AdminPurgePerson {
-  const _$_AdminPurgePerson(
+class _$AdminPurgePersonImpl extends _AdminPurgePerson {
+  const _$AdminPurgePersonImpl(
       {required this.id,
       required this.adminPersonId,
       this.reason,
       @JsonKey(name: 'when_') required this.when})
       : super._();
 
-  factory _$_AdminPurgePerson.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgePersonFromJson(json);
+  factory _$AdminPurgePersonImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgePersonImplFromJson(json);
 
   @override
   final int id;
@@ -169,7 +169,7 @@ class _$_AdminPurgePerson extends _AdminPurgePerson {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgePerson &&
+            other is _$AdminPurgePersonImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.adminPersonId, adminPersonId) ||
                 other.adminPersonId == adminPersonId) &&
@@ -184,12 +184,13 @@ class _$_AdminPurgePerson extends _AdminPurgePerson {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgePersonCopyWith<_$_AdminPurgePerson> get copyWith =>
-      __$$_AdminPurgePersonCopyWithImpl<_$_AdminPurgePerson>(this, _$identity);
+  _$$AdminPurgePersonImplCopyWith<_$AdminPurgePersonImpl> get copyWith =>
+      __$$AdminPurgePersonImplCopyWithImpl<_$AdminPurgePersonImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgePersonToJson(
+    return _$$AdminPurgePersonImplToJson(
       this,
     );
   }
@@ -201,11 +202,11 @@ abstract class _AdminPurgePerson extends AdminPurgePerson {
           required final int adminPersonId,
           final String? reason,
           @JsonKey(name: 'when_') required final String when}) =
-      _$_AdminPurgePerson;
+      _$AdminPurgePersonImpl;
   const _AdminPurgePerson._() : super._();
 
   factory _AdminPurgePerson.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgePerson.fromJson;
+      _$AdminPurgePersonImpl.fromJson;
 
   @override
   int get id;
@@ -218,6 +219,6 @@ abstract class _AdminPurgePerson extends AdminPurgePerson {
   String get when;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgePersonCopyWith<_$_AdminPurgePerson> get copyWith =>
+  _$$AdminPurgePersonImplCopyWith<_$AdminPurgePersonImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/admin/admin_purge_person.g.dart
+++ b/lib/src/v3/models/admin/admin_purge_person.g.dart
@@ -6,15 +6,17 @@ part of 'admin_purge_person.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_AdminPurgePerson _$$_AdminPurgePersonFromJson(Map<String, dynamic> json) =>
-    _$_AdminPurgePerson(
+_$AdminPurgePersonImpl _$$AdminPurgePersonImplFromJson(
+        Map<String, dynamic> json) =>
+    _$AdminPurgePersonImpl(
       id: json['id'] as int,
       adminPersonId: json['admin_person_id'] as int,
       reason: json['reason'] as String?,
       when: json['when_'] as String,
     );
 
-Map<String, dynamic> _$$_AdminPurgePersonToJson(_$_AdminPurgePerson instance) =>
+Map<String, dynamic> _$$AdminPurgePersonImplToJson(
+        _$AdminPurgePersonImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'admin_person_id': instance.adminPersonId,

--- a/lib/src/v3/models/admin/admin_purge_post.freezed.dart
+++ b/lib/src/v3/models/admin/admin_purge_post.freezed.dart
@@ -92,11 +92,11 @@ class _$AdminPurgePostCopyWithImpl<$Res, $Val extends AdminPurgePost>
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgePostCopyWith<$Res>
+abstract class _$$AdminPurgePostImplCopyWith<$Res>
     implements $AdminPurgePostCopyWith<$Res> {
-  factory _$$_AdminPurgePostCopyWith(
-          _$_AdminPurgePost value, $Res Function(_$_AdminPurgePost) then) =
-      __$$_AdminPurgePostCopyWithImpl<$Res>;
+  factory _$$AdminPurgePostImplCopyWith(_$AdminPurgePostImpl value,
+          $Res Function(_$AdminPurgePostImpl) then) =
+      __$$AdminPurgePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -108,11 +108,11 @@ abstract class _$$_AdminPurgePostCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgePostCopyWithImpl<$Res>
-    extends _$AdminPurgePostCopyWithImpl<$Res, _$_AdminPurgePost>
-    implements _$$_AdminPurgePostCopyWith<$Res> {
-  __$$_AdminPurgePostCopyWithImpl(
-      _$_AdminPurgePost _value, $Res Function(_$_AdminPurgePost) _then)
+class __$$AdminPurgePostImplCopyWithImpl<$Res>
+    extends _$AdminPurgePostCopyWithImpl<$Res, _$AdminPurgePostImpl>
+    implements _$$AdminPurgePostImplCopyWith<$Res> {
+  __$$AdminPurgePostImplCopyWithImpl(
+      _$AdminPurgePostImpl _value, $Res Function(_$AdminPurgePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -124,7 +124,7 @@ class __$$_AdminPurgePostCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? when = null,
   }) {
-    return _then(_$_AdminPurgePost(
+    return _then(_$AdminPurgePostImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -152,8 +152,8 @@ class __$$_AdminPurgePostCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgePost extends _AdminPurgePost {
-  const _$_AdminPurgePost(
+class _$AdminPurgePostImpl extends _AdminPurgePost {
+  const _$AdminPurgePostImpl(
       {required this.id,
       required this.adminPersonId,
       required this.communityId,
@@ -161,8 +161,8 @@ class _$_AdminPurgePost extends _AdminPurgePost {
       @JsonKey(name: 'when_') required this.when})
       : super._();
 
-  factory _$_AdminPurgePost.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgePostFromJson(json);
+  factory _$AdminPurgePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgePostImplFromJson(json);
 
   @override
   final int id;
@@ -185,7 +185,7 @@ class _$_AdminPurgePost extends _AdminPurgePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgePost &&
+            other is _$AdminPurgePostImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.adminPersonId, adminPersonId) ||
                 other.adminPersonId == adminPersonId) &&
@@ -203,12 +203,13 @@ class _$_AdminPurgePost extends _AdminPurgePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgePostCopyWith<_$_AdminPurgePost> get copyWith =>
-      __$$_AdminPurgePostCopyWithImpl<_$_AdminPurgePost>(this, _$identity);
+  _$$AdminPurgePostImplCopyWith<_$AdminPurgePostImpl> get copyWith =>
+      __$$AdminPurgePostImplCopyWithImpl<_$AdminPurgePostImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgePostToJson(
+    return _$$AdminPurgePostImplToJson(
       this,
     );
   }
@@ -216,15 +217,16 @@ class _$_AdminPurgePost extends _AdminPurgePost {
 
 abstract class _AdminPurgePost extends AdminPurgePost {
   const factory _AdminPurgePost(
-      {required final int id,
-      required final int adminPersonId,
-      required final int communityId,
-      final String? reason,
-      @JsonKey(name: 'when_') required final String when}) = _$_AdminPurgePost;
+          {required final int id,
+          required final int adminPersonId,
+          required final int communityId,
+          final String? reason,
+          @JsonKey(name: 'when_') required final String when}) =
+      _$AdminPurgePostImpl;
   const _AdminPurgePost._() : super._();
 
   factory _AdminPurgePost.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgePost.fromJson;
+      _$AdminPurgePostImpl.fromJson;
 
   @override
   int get id;
@@ -239,6 +241,6 @@ abstract class _AdminPurgePost extends AdminPurgePost {
   String get when;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgePostCopyWith<_$_AdminPurgePost> get copyWith =>
+  _$$AdminPurgePostImplCopyWith<_$AdminPurgePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/admin/admin_purge_post.g.dart
+++ b/lib/src/v3/models/admin/admin_purge_post.g.dart
@@ -6,8 +6,8 @@ part of 'admin_purge_post.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_AdminPurgePost _$$_AdminPurgePostFromJson(Map<String, dynamic> json) =>
-    _$_AdminPurgePost(
+_$AdminPurgePostImpl _$$AdminPurgePostImplFromJson(Map<String, dynamic> json) =>
+    _$AdminPurgePostImpl(
       id: json['id'] as int,
       adminPersonId: json['admin_person_id'] as int,
       communityId: json['community_id'] as int,
@@ -15,7 +15,8 @@ _$_AdminPurgePost _$$_AdminPurgePostFromJson(Map<String, dynamic> json) =>
       when: json['when_'] as String,
     );
 
-Map<String, dynamic> _$$_AdminPurgePostToJson(_$_AdminPurgePost instance) =>
+Map<String, dynamic> _$$AdminPurgePostImplToJson(
+        _$AdminPurgePostImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'admin_person_id': instance.adminPersonId,

--- a/lib/src/v3/models/admin/get_unread_registration_application_count_response.freezed.dart
+++ b/lib/src/v3/models/admin/get_unread_registration_application_count_response.freezed.dart
@@ -69,26 +69,28 @@ class _$GetUnreadRegistrationApplicationCountResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_GetUnreadRegistrationApplicationCountResponseCopyWith<$Res>
+abstract class _$$GetUnreadRegistrationApplicationCountResponseImplCopyWith<
+        $Res>
     implements $GetUnreadRegistrationApplicationCountResponseCopyWith<$Res> {
-  factory _$$_GetUnreadRegistrationApplicationCountResponseCopyWith(
-          _$_GetUnreadRegistrationApplicationCountResponse value,
-          $Res Function(_$_GetUnreadRegistrationApplicationCountResponse)
+  factory _$$GetUnreadRegistrationApplicationCountResponseImplCopyWith(
+          _$GetUnreadRegistrationApplicationCountResponseImpl value,
+          $Res Function(_$GetUnreadRegistrationApplicationCountResponseImpl)
               then) =
-      __$$_GetUnreadRegistrationApplicationCountResponseCopyWithImpl<$Res>;
+      __$$GetUnreadRegistrationApplicationCountResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int registrationApplications});
 }
 
 /// @nodoc
-class __$$_GetUnreadRegistrationApplicationCountResponseCopyWithImpl<$Res>
+class __$$GetUnreadRegistrationApplicationCountResponseImplCopyWithImpl<$Res>
     extends _$GetUnreadRegistrationApplicationCountResponseCopyWithImpl<$Res,
-        _$_GetUnreadRegistrationApplicationCountResponse>
-    implements _$$_GetUnreadRegistrationApplicationCountResponseCopyWith<$Res> {
-  __$$_GetUnreadRegistrationApplicationCountResponseCopyWithImpl(
-      _$_GetUnreadRegistrationApplicationCountResponse _value,
-      $Res Function(_$_GetUnreadRegistrationApplicationCountResponse) _then)
+        _$GetUnreadRegistrationApplicationCountResponseImpl>
+    implements
+        _$$GetUnreadRegistrationApplicationCountResponseImplCopyWith<$Res> {
+  __$$GetUnreadRegistrationApplicationCountResponseImplCopyWithImpl(
+      _$GetUnreadRegistrationApplicationCountResponseImpl _value,
+      $Res Function(_$GetUnreadRegistrationApplicationCountResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -96,7 +98,7 @@ class __$$_GetUnreadRegistrationApplicationCountResponseCopyWithImpl<$Res>
   $Res call({
     Object? registrationApplications = null,
   }) {
-    return _then(_$_GetUnreadRegistrationApplicationCountResponse(
+    return _then(_$GetUnreadRegistrationApplicationCountResponseImpl(
       registrationApplications: null == registrationApplications
           ? _value.registrationApplications
           : registrationApplications // ignore: cast_nullable_to_non_nullable
@@ -108,15 +110,15 @@ class __$$_GetUnreadRegistrationApplicationCountResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetUnreadRegistrationApplicationCountResponse
+class _$GetUnreadRegistrationApplicationCountResponseImpl
     extends _GetUnreadRegistrationApplicationCountResponse {
-  const _$_GetUnreadRegistrationApplicationCountResponse(
+  const _$GetUnreadRegistrationApplicationCountResponseImpl(
       {required this.registrationApplications})
       : super._();
 
-  factory _$_GetUnreadRegistrationApplicationCountResponse.fromJson(
+  factory _$GetUnreadRegistrationApplicationCountResponseImpl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_GetUnreadRegistrationApplicationCountResponseFromJson(json);
+      _$$GetUnreadRegistrationApplicationCountResponseImplFromJson(json);
 
   @override
   final int registrationApplications;
@@ -130,7 +132,7 @@ class _$_GetUnreadRegistrationApplicationCountResponse
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetUnreadRegistrationApplicationCountResponse &&
+            other is _$GetUnreadRegistrationApplicationCountResponseImpl &&
             (identical(
                     other.registrationApplications, registrationApplications) ||
                 other.registrationApplications == registrationApplications));
@@ -143,16 +145,16 @@ class _$_GetUnreadRegistrationApplicationCountResponse
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetUnreadRegistrationApplicationCountResponseCopyWith<
-          _$_GetUnreadRegistrationApplicationCountResponse>
+  _$$GetUnreadRegistrationApplicationCountResponseImplCopyWith<
+          _$GetUnreadRegistrationApplicationCountResponseImpl>
       get copyWith =>
-          __$$_GetUnreadRegistrationApplicationCountResponseCopyWithImpl<
-                  _$_GetUnreadRegistrationApplicationCountResponse>(
+          __$$GetUnreadRegistrationApplicationCountResponseImplCopyWithImpl<
+                  _$GetUnreadRegistrationApplicationCountResponseImpl>(
               this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetUnreadRegistrationApplicationCountResponseToJson(
+    return _$$GetUnreadRegistrationApplicationCountResponseImplToJson(
       this,
     );
   }
@@ -162,18 +164,18 @@ abstract class _GetUnreadRegistrationApplicationCountResponse
     extends GetUnreadRegistrationApplicationCountResponse {
   const factory _GetUnreadRegistrationApplicationCountResponse(
           {required final int registrationApplications}) =
-      _$_GetUnreadRegistrationApplicationCountResponse;
+      _$GetUnreadRegistrationApplicationCountResponseImpl;
   const _GetUnreadRegistrationApplicationCountResponse._() : super._();
 
   factory _GetUnreadRegistrationApplicationCountResponse.fromJson(
           Map<String, dynamic> json) =
-      _$_GetUnreadRegistrationApplicationCountResponse.fromJson;
+      _$GetUnreadRegistrationApplicationCountResponseImpl.fromJson;
 
   @override
   int get registrationApplications;
   @override
   @JsonKey(ignore: true)
-  _$$_GetUnreadRegistrationApplicationCountResponseCopyWith<
-          _$_GetUnreadRegistrationApplicationCountResponse>
+  _$$GetUnreadRegistrationApplicationCountResponseImplCopyWith<
+          _$GetUnreadRegistrationApplicationCountResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/admin/get_unread_registration_application_count_response.g.dart
+++ b/lib/src/v3/models/admin/get_unread_registration_application_count_response.g.dart
@@ -6,15 +6,15 @@ part of 'get_unread_registration_application_count_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetUnreadRegistrationApplicationCountResponse
-    _$$_GetUnreadRegistrationApplicationCountResponseFromJson(
+_$GetUnreadRegistrationApplicationCountResponseImpl
+    _$$GetUnreadRegistrationApplicationCountResponseImplFromJson(
             Map<String, dynamic> json) =>
-        _$_GetUnreadRegistrationApplicationCountResponse(
+        _$GetUnreadRegistrationApplicationCountResponseImpl(
           registrationApplications: json['registration_applications'] as int,
         );
 
-Map<String, dynamic> _$$_GetUnreadRegistrationApplicationCountResponseToJson(
-        _$_GetUnreadRegistrationApplicationCountResponse instance) =>
+Map<String, dynamic> _$$GetUnreadRegistrationApplicationCountResponseImplToJson(
+        _$GetUnreadRegistrationApplicationCountResponseImpl instance) =>
     <String, dynamic>{
       'registration_applications': instance.registrationApplications,
     };

--- a/lib/src/v3/models/admin/list_registration_applications_response.freezed.dart
+++ b/lib/src/v3/models/admin/list_registration_applications_response.freezed.dart
@@ -68,25 +68,25 @@ class _$ListRegistrationApplicationsResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ListRegistrationApplicationsResponseCopyWith<$Res>
+abstract class _$$ListRegistrationApplicationsResponseImplCopyWith<$Res>
     implements $ListRegistrationApplicationsResponseCopyWith<$Res> {
-  factory _$$_ListRegistrationApplicationsResponseCopyWith(
-          _$_ListRegistrationApplicationsResponse value,
-          $Res Function(_$_ListRegistrationApplicationsResponse) then) =
-      __$$_ListRegistrationApplicationsResponseCopyWithImpl<$Res>;
+  factory _$$ListRegistrationApplicationsResponseImplCopyWith(
+          _$ListRegistrationApplicationsResponseImpl value,
+          $Res Function(_$ListRegistrationApplicationsResponseImpl) then) =
+      __$$ListRegistrationApplicationsResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<RegistrationApplicationView> registrationApplications});
 }
 
 /// @nodoc
-class __$$_ListRegistrationApplicationsResponseCopyWithImpl<$Res>
+class __$$ListRegistrationApplicationsResponseImplCopyWithImpl<$Res>
     extends _$ListRegistrationApplicationsResponseCopyWithImpl<$Res,
-        _$_ListRegistrationApplicationsResponse>
-    implements _$$_ListRegistrationApplicationsResponseCopyWith<$Res> {
-  __$$_ListRegistrationApplicationsResponseCopyWithImpl(
-      _$_ListRegistrationApplicationsResponse _value,
-      $Res Function(_$_ListRegistrationApplicationsResponse) _then)
+        _$ListRegistrationApplicationsResponseImpl>
+    implements _$$ListRegistrationApplicationsResponseImplCopyWith<$Res> {
+  __$$ListRegistrationApplicationsResponseImplCopyWithImpl(
+      _$ListRegistrationApplicationsResponseImpl _value,
+      $Res Function(_$ListRegistrationApplicationsResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -94,7 +94,7 @@ class __$$_ListRegistrationApplicationsResponseCopyWithImpl<$Res>
   $Res call({
     Object? registrationApplications = null,
   }) {
-    return _then(_$_ListRegistrationApplicationsResponse(
+    return _then(_$ListRegistrationApplicationsResponseImpl(
       registrationApplications: null == registrationApplications
           ? _value._registrationApplications
           : registrationApplications // ignore: cast_nullable_to_non_nullable
@@ -106,17 +106,17 @@ class __$$_ListRegistrationApplicationsResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ListRegistrationApplicationsResponse
+class _$ListRegistrationApplicationsResponseImpl
     extends _ListRegistrationApplicationsResponse {
-  const _$_ListRegistrationApplicationsResponse(
+  const _$ListRegistrationApplicationsResponseImpl(
       {required final List<RegistrationApplicationView>
           registrationApplications})
       : _registrationApplications = registrationApplications,
         super._();
 
-  factory _$_ListRegistrationApplicationsResponse.fromJson(
+  factory _$ListRegistrationApplicationsResponseImpl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_ListRegistrationApplicationsResponseFromJson(json);
+      _$$ListRegistrationApplicationsResponseImplFromJson(json);
 
   final List<RegistrationApplicationView> _registrationApplications;
   @override
@@ -136,7 +136,7 @@ class _$_ListRegistrationApplicationsResponse
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListRegistrationApplicationsResponse &&
+            other is _$ListRegistrationApplicationsResponseImpl &&
             const DeepCollectionEquality().equals(
                 other._registrationApplications, _registrationApplications));
   }
@@ -149,14 +149,14 @@ class _$_ListRegistrationApplicationsResponse
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListRegistrationApplicationsResponseCopyWith<
-          _$_ListRegistrationApplicationsResponse>
-      get copyWith => __$$_ListRegistrationApplicationsResponseCopyWithImpl<
-          _$_ListRegistrationApplicationsResponse>(this, _$identity);
+  _$$ListRegistrationApplicationsResponseImplCopyWith<
+          _$ListRegistrationApplicationsResponseImpl>
+      get copyWith => __$$ListRegistrationApplicationsResponseImplCopyWithImpl<
+          _$ListRegistrationApplicationsResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListRegistrationApplicationsResponseToJson(
+    return _$$ListRegistrationApplicationsResponseImplToJson(
       this,
     );
   }
@@ -165,19 +165,20 @@ class _$_ListRegistrationApplicationsResponse
 abstract class _ListRegistrationApplicationsResponse
     extends ListRegistrationApplicationsResponse {
   const factory _ListRegistrationApplicationsResponse(
-      {required final List<RegistrationApplicationView>
-          registrationApplications}) = _$_ListRegistrationApplicationsResponse;
+          {required final List<RegistrationApplicationView>
+              registrationApplications}) =
+      _$ListRegistrationApplicationsResponseImpl;
   const _ListRegistrationApplicationsResponse._() : super._();
 
   factory _ListRegistrationApplicationsResponse.fromJson(
           Map<String, dynamic> json) =
-      _$_ListRegistrationApplicationsResponse.fromJson;
+      _$ListRegistrationApplicationsResponseImpl.fromJson;
 
   @override
   List<RegistrationApplicationView> get registrationApplications;
   @override
   @JsonKey(ignore: true)
-  _$$_ListRegistrationApplicationsResponseCopyWith<
-          _$_ListRegistrationApplicationsResponse>
+  _$$ListRegistrationApplicationsResponseImplCopyWith<
+          _$ListRegistrationApplicationsResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/admin/list_registration_applications_response.g.dart
+++ b/lib/src/v3/models/admin/list_registration_applications_response.g.dart
@@ -6,10 +6,10 @@ part of 'list_registration_applications_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ListRegistrationApplicationsResponse
-    _$$_ListRegistrationApplicationsResponseFromJson(
+_$ListRegistrationApplicationsResponseImpl
+    _$$ListRegistrationApplicationsResponseImplFromJson(
             Map<String, dynamic> json) =>
-        _$_ListRegistrationApplicationsResponse(
+        _$ListRegistrationApplicationsResponseImpl(
           registrationApplications:
               (json['registration_applications'] as List<dynamic>)
                   .map((e) => RegistrationApplicationView.fromJson(
@@ -17,8 +17,8 @@ _$_ListRegistrationApplicationsResponse
                   .toList(),
         );
 
-Map<String, dynamic> _$$_ListRegistrationApplicationsResponseToJson(
-        _$_ListRegistrationApplicationsResponse instance) =>
+Map<String, dynamic> _$$ListRegistrationApplicationsResponseImplToJson(
+        _$ListRegistrationApplicationsResponseImpl instance) =>
     <String, dynamic>{
       'registration_applications':
           instance.registrationApplications.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/models/admin/purge_item_response.freezed.dart
+++ b/lib/src/v3/models/admin/purge_item_response.freezed.dart
@@ -62,22 +62,22 @@ class _$PurgeItemResponseCopyWithImpl<$Res, $Val extends PurgeItemResponse>
 }
 
 /// @nodoc
-abstract class _$$_PurgeItemResponseCopyWith<$Res>
+abstract class _$$PurgeItemResponseImplCopyWith<$Res>
     implements $PurgeItemResponseCopyWith<$Res> {
-  factory _$$_PurgeItemResponseCopyWith(_$_PurgeItemResponse value,
-          $Res Function(_$_PurgeItemResponse) then) =
-      __$$_PurgeItemResponseCopyWithImpl<$Res>;
+  factory _$$PurgeItemResponseImplCopyWith(_$PurgeItemResponseImpl value,
+          $Res Function(_$PurgeItemResponseImpl) then) =
+      __$$PurgeItemResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool? success});
 }
 
 /// @nodoc
-class __$$_PurgeItemResponseCopyWithImpl<$Res>
-    extends _$PurgeItemResponseCopyWithImpl<$Res, _$_PurgeItemResponse>
-    implements _$$_PurgeItemResponseCopyWith<$Res> {
-  __$$_PurgeItemResponseCopyWithImpl(
-      _$_PurgeItemResponse _value, $Res Function(_$_PurgeItemResponse) _then)
+class __$$PurgeItemResponseImplCopyWithImpl<$Res>
+    extends _$PurgeItemResponseCopyWithImpl<$Res, _$PurgeItemResponseImpl>
+    implements _$$PurgeItemResponseImplCopyWith<$Res> {
+  __$$PurgeItemResponseImplCopyWithImpl(_$PurgeItemResponseImpl _value,
+      $Res Function(_$PurgeItemResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -85,7 +85,7 @@ class __$$_PurgeItemResponseCopyWithImpl<$Res>
   $Res call({
     Object? success = freezed,
   }) {
-    return _then(_$_PurgeItemResponse(
+    return _then(_$PurgeItemResponseImpl(
       success: freezed == success
           ? _value.success
           : success // ignore: cast_nullable_to_non_nullable
@@ -97,11 +97,11 @@ class __$$_PurgeItemResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PurgeItemResponse extends _PurgeItemResponse {
-  const _$_PurgeItemResponse({this.success}) : super._();
+class _$PurgeItemResponseImpl extends _PurgeItemResponse {
+  const _$PurgeItemResponseImpl({this.success}) : super._();
 
-  factory _$_PurgeItemResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_PurgeItemResponseFromJson(json);
+  factory _$PurgeItemResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PurgeItemResponseImplFromJson(json);
 
   @override
   final bool? success;
@@ -115,7 +115,7 @@ class _$_PurgeItemResponse extends _PurgeItemResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PurgeItemResponse &&
+            other is _$PurgeItemResponseImpl &&
             (identical(other.success, success) || other.success == success));
   }
 
@@ -126,13 +126,13 @@ class _$_PurgeItemResponse extends _PurgeItemResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PurgeItemResponseCopyWith<_$_PurgeItemResponse> get copyWith =>
-      __$$_PurgeItemResponseCopyWithImpl<_$_PurgeItemResponse>(
+  _$$PurgeItemResponseImplCopyWith<_$PurgeItemResponseImpl> get copyWith =>
+      __$$PurgeItemResponseImplCopyWithImpl<_$PurgeItemResponseImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PurgeItemResponseToJson(
+    return _$$PurgeItemResponseImplToJson(
       this,
     );
   }
@@ -140,16 +140,16 @@ class _$_PurgeItemResponse extends _PurgeItemResponse {
 
 abstract class _PurgeItemResponse extends PurgeItemResponse {
   const factory _PurgeItemResponse({final bool? success}) =
-      _$_PurgeItemResponse;
+      _$PurgeItemResponseImpl;
   const _PurgeItemResponse._() : super._();
 
   factory _PurgeItemResponse.fromJson(Map<String, dynamic> json) =
-      _$_PurgeItemResponse.fromJson;
+      _$PurgeItemResponseImpl.fromJson;
 
   @override
   bool? get success;
   @override
   @JsonKey(ignore: true)
-  _$$_PurgeItemResponseCopyWith<_$_PurgeItemResponse> get copyWith =>
+  _$$PurgeItemResponseImplCopyWith<_$PurgeItemResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/admin/purge_item_response.g.dart
+++ b/lib/src/v3/models/admin/purge_item_response.g.dart
@@ -6,13 +6,14 @@ part of 'purge_item_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PurgeItemResponse _$$_PurgeItemResponseFromJson(Map<String, dynamic> json) =>
-    _$_PurgeItemResponse(
+_$PurgeItemResponseImpl _$$PurgeItemResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$PurgeItemResponseImpl(
       success: json['success'] as bool?,
     );
 
-Map<String, dynamic> _$$_PurgeItemResponseToJson(
-        _$_PurgeItemResponse instance) =>
+Map<String, dynamic> _$$PurgeItemResponseImplToJson(
+        _$PurgeItemResponseImpl instance) =>
     <String, dynamic>{
       'success': instance.success,
     };

--- a/lib/src/v3/models/admin/registration_application.freezed.dart
+++ b/lib/src/v3/models/admin/registration_application.freezed.dart
@@ -100,11 +100,12 @@ class _$RegistrationApplicationCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_RegistrationApplicationCopyWith<$Res>
+abstract class _$$RegistrationApplicationImplCopyWith<$Res>
     implements $RegistrationApplicationCopyWith<$Res> {
-  factory _$$_RegistrationApplicationCopyWith(_$_RegistrationApplication value,
-          $Res Function(_$_RegistrationApplication) then) =
-      __$$_RegistrationApplicationCopyWithImpl<$Res>;
+  factory _$$RegistrationApplicationImplCopyWith(
+          _$RegistrationApplicationImpl value,
+          $Res Function(_$RegistrationApplicationImpl) then) =
+      __$$RegistrationApplicationImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -117,12 +118,13 @@ abstract class _$$_RegistrationApplicationCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_RegistrationApplicationCopyWithImpl<$Res>
+class __$$RegistrationApplicationImplCopyWithImpl<$Res>
     extends _$RegistrationApplicationCopyWithImpl<$Res,
-        _$_RegistrationApplication>
-    implements _$$_RegistrationApplicationCopyWith<$Res> {
-  __$$_RegistrationApplicationCopyWithImpl(_$_RegistrationApplication _value,
-      $Res Function(_$_RegistrationApplication) _then)
+        _$RegistrationApplicationImpl>
+    implements _$$RegistrationApplicationImplCopyWith<$Res> {
+  __$$RegistrationApplicationImplCopyWithImpl(
+      _$RegistrationApplicationImpl _value,
+      $Res Function(_$RegistrationApplicationImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -135,7 +137,7 @@ class __$$_RegistrationApplicationCopyWithImpl<$Res>
     Object? denyReason = freezed,
     Object? published = null,
   }) {
-    return _then(_$_RegistrationApplication(
+    return _then(_$RegistrationApplicationImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -167,8 +169,8 @@ class __$$_RegistrationApplicationCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_RegistrationApplication extends _RegistrationApplication {
-  const _$_RegistrationApplication(
+class _$RegistrationApplicationImpl extends _RegistrationApplication {
+  const _$RegistrationApplicationImpl(
       {required this.id,
       required this.localUserId,
       required this.answer,
@@ -177,8 +179,8 @@ class _$_RegistrationApplication extends _RegistrationApplication {
       required this.published})
       : super._();
 
-  factory _$_RegistrationApplication.fromJson(Map<String, dynamic> json) =>
-      _$$_RegistrationApplicationFromJson(json);
+  factory _$RegistrationApplicationImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RegistrationApplicationImplFromJson(json);
 
   @override
   final int id;
@@ -202,7 +204,7 @@ class _$_RegistrationApplication extends _RegistrationApplication {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_RegistrationApplication &&
+            other is _$RegistrationApplicationImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.localUserId, localUserId) ||
                 other.localUserId == localUserId) &&
@@ -222,14 +224,13 @@ class _$_RegistrationApplication extends _RegistrationApplication {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RegistrationApplicationCopyWith<_$_RegistrationApplication>
-      get copyWith =>
-          __$$_RegistrationApplicationCopyWithImpl<_$_RegistrationApplication>(
-              this, _$identity);
+  _$$RegistrationApplicationImplCopyWith<_$RegistrationApplicationImpl>
+      get copyWith => __$$RegistrationApplicationImplCopyWithImpl<
+          _$RegistrationApplicationImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RegistrationApplicationToJson(
+    return _$$RegistrationApplicationImplToJson(
       this,
     );
   }
@@ -242,11 +243,11 @@ abstract class _RegistrationApplication extends RegistrationApplication {
       required final String answer,
       final int? adminId,
       final String? denyReason,
-      required final DateTime published}) = _$_RegistrationApplication;
+      required final DateTime published}) = _$RegistrationApplicationImpl;
   const _RegistrationApplication._() : super._();
 
   factory _RegistrationApplication.fromJson(Map<String, dynamic> json) =
-      _$_RegistrationApplication.fromJson;
+      _$RegistrationApplicationImpl.fromJson;
 
   @override
   int get id;
@@ -262,6 +263,6 @@ abstract class _RegistrationApplication extends RegistrationApplication {
   DateTime get published;
   @override
   @JsonKey(ignore: true)
-  _$$_RegistrationApplicationCopyWith<_$_RegistrationApplication>
+  _$$RegistrationApplicationImplCopyWith<_$RegistrationApplicationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/admin/registration_application.g.dart
+++ b/lib/src/v3/models/admin/registration_application.g.dart
@@ -6,9 +6,9 @@ part of 'registration_application.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_RegistrationApplication _$$_RegistrationApplicationFromJson(
+_$RegistrationApplicationImpl _$$RegistrationApplicationImplFromJson(
         Map<String, dynamic> json) =>
-    _$_RegistrationApplication(
+    _$RegistrationApplicationImpl(
       id: json['id'] as int,
       localUserId: json['local_user_id'] as int,
       answer: json['answer'] as String,
@@ -17,8 +17,8 @@ _$_RegistrationApplication _$$_RegistrationApplicationFromJson(
       published: const ForceUtcDateTime().fromJson(json['published'] as String),
     );
 
-Map<String, dynamic> _$$_RegistrationApplicationToJson(
-        _$_RegistrationApplication instance) =>
+Map<String, dynamic> _$$RegistrationApplicationImplToJson(
+        _$RegistrationApplicationImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'local_user_id': instance.localUserId,

--- a/lib/src/v3/models/admin/registration_application_response.freezed.dart
+++ b/lib/src/v3/models/admin/registration_application_response.freezed.dart
@@ -78,12 +78,12 @@ class _$RegistrationApplicationResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_RegistrationApplicationResponseCopyWith<$Res>
+abstract class _$$RegistrationApplicationResponseImplCopyWith<$Res>
     implements $RegistrationApplicationResponseCopyWith<$Res> {
-  factory _$$_RegistrationApplicationResponseCopyWith(
-          _$_RegistrationApplicationResponse value,
-          $Res Function(_$_RegistrationApplicationResponse) then) =
-      __$$_RegistrationApplicationResponseCopyWithImpl<$Res>;
+  factory _$$RegistrationApplicationResponseImplCopyWith(
+          _$RegistrationApplicationResponseImpl value,
+          $Res Function(_$RegistrationApplicationResponseImpl) then) =
+      __$$RegistrationApplicationResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({RegistrationApplicationView registrationApplication});
@@ -93,13 +93,13 @@ abstract class _$$_RegistrationApplicationResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_RegistrationApplicationResponseCopyWithImpl<$Res>
+class __$$RegistrationApplicationResponseImplCopyWithImpl<$Res>
     extends _$RegistrationApplicationResponseCopyWithImpl<$Res,
-        _$_RegistrationApplicationResponse>
-    implements _$$_RegistrationApplicationResponseCopyWith<$Res> {
-  __$$_RegistrationApplicationResponseCopyWithImpl(
-      _$_RegistrationApplicationResponse _value,
-      $Res Function(_$_RegistrationApplicationResponse) _then)
+        _$RegistrationApplicationResponseImpl>
+    implements _$$RegistrationApplicationResponseImplCopyWith<$Res> {
+  __$$RegistrationApplicationResponseImplCopyWithImpl(
+      _$RegistrationApplicationResponseImpl _value,
+      $Res Function(_$RegistrationApplicationResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -107,7 +107,7 @@ class __$$_RegistrationApplicationResponseCopyWithImpl<$Res>
   $Res call({
     Object? registrationApplication = null,
   }) {
-    return _then(_$_RegistrationApplicationResponse(
+    return _then(_$RegistrationApplicationResponseImpl(
       registrationApplication: null == registrationApplication
           ? _value.registrationApplication
           : registrationApplication // ignore: cast_nullable_to_non_nullable
@@ -119,15 +119,15 @@ class __$$_RegistrationApplicationResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_RegistrationApplicationResponse
+class _$RegistrationApplicationResponseImpl
     extends _RegistrationApplicationResponse {
-  const _$_RegistrationApplicationResponse(
+  const _$RegistrationApplicationResponseImpl(
       {required this.registrationApplication})
       : super._();
 
-  factory _$_RegistrationApplicationResponse.fromJson(
+  factory _$RegistrationApplicationResponseImpl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_RegistrationApplicationResponseFromJson(json);
+      _$$RegistrationApplicationResponseImplFromJson(json);
 
   @override
   final RegistrationApplicationView registrationApplication;
@@ -141,7 +141,7 @@ class _$_RegistrationApplicationResponse
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_RegistrationApplicationResponse &&
+            other is _$RegistrationApplicationResponseImpl &&
             (identical(
                     other.registrationApplication, registrationApplication) ||
                 other.registrationApplication == registrationApplication));
@@ -154,14 +154,14 @@ class _$_RegistrationApplicationResponse
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RegistrationApplicationResponseCopyWith<
-          _$_RegistrationApplicationResponse>
-      get copyWith => __$$_RegistrationApplicationResponseCopyWithImpl<
-          _$_RegistrationApplicationResponse>(this, _$identity);
+  _$$RegistrationApplicationResponseImplCopyWith<
+          _$RegistrationApplicationResponseImpl>
+      get copyWith => __$$RegistrationApplicationResponseImplCopyWithImpl<
+          _$RegistrationApplicationResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RegistrationApplicationResponseToJson(
+    return _$$RegistrationApplicationResponseImplToJson(
       this,
     );
   }
@@ -171,17 +171,17 @@ abstract class _RegistrationApplicationResponse
     extends RegistrationApplicationResponse {
   const factory _RegistrationApplicationResponse(
       {required final RegistrationApplicationView
-          registrationApplication}) = _$_RegistrationApplicationResponse;
+          registrationApplication}) = _$RegistrationApplicationResponseImpl;
   const _RegistrationApplicationResponse._() : super._();
 
   factory _RegistrationApplicationResponse.fromJson(Map<String, dynamic> json) =
-      _$_RegistrationApplicationResponse.fromJson;
+      _$RegistrationApplicationResponseImpl.fromJson;
 
   @override
   RegistrationApplicationView get registrationApplication;
   @override
   @JsonKey(ignore: true)
-  _$$_RegistrationApplicationResponseCopyWith<
-          _$_RegistrationApplicationResponse>
+  _$$RegistrationApplicationResponseImplCopyWith<
+          _$RegistrationApplicationResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/admin/registration_application_response.g.dart
+++ b/lib/src/v3/models/admin/registration_application_response.g.dart
@@ -6,15 +6,15 @@ part of 'registration_application_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_RegistrationApplicationResponse _$$_RegistrationApplicationResponseFromJson(
-        Map<String, dynamic> json) =>
-    _$_RegistrationApplicationResponse(
-      registrationApplication: RegistrationApplicationView.fromJson(
-          json['registration_application'] as Map<String, dynamic>),
-    );
+_$RegistrationApplicationResponseImpl
+    _$$RegistrationApplicationResponseImplFromJson(Map<String, dynamic> json) =>
+        _$RegistrationApplicationResponseImpl(
+          registrationApplication: RegistrationApplicationView.fromJson(
+              json['registration_application'] as Map<String, dynamic>),
+        );
 
-Map<String, dynamic> _$$_RegistrationApplicationResponseToJson(
-        _$_RegistrationApplicationResponse instance) =>
+Map<String, dynamic> _$$RegistrationApplicationResponseImplToJson(
+        _$RegistrationApplicationResponseImpl instance) =>
     <String, dynamic>{
       'registration_application': instance.registrationApplication.toJson(),
     };

--- a/lib/src/v3/models/comment/comment.freezed.dart
+++ b/lib/src/v3/models/comment/comment.freezed.dart
@@ -145,10 +145,10 @@ class _$CommentCopyWithImpl<$Res, $Val extends Comment>
 }
 
 /// @nodoc
-abstract class _$$_CommentCopyWith<$Res> implements $CommentCopyWith<$Res> {
-  factory _$$_CommentCopyWith(
-          _$_Comment value, $Res Function(_$_Comment) then) =
-      __$$_CommentCopyWithImpl<$Res>;
+abstract class _$$CommentImplCopyWith<$Res> implements $CommentCopyWith<$Res> {
+  factory _$$CommentImplCopyWith(
+          _$CommentImpl value, $Res Function(_$CommentImpl) then) =
+      __$$CommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -168,10 +168,11 @@ abstract class _$$_CommentCopyWith<$Res> implements $CommentCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_CommentCopyWithImpl<$Res>
-    extends _$CommentCopyWithImpl<$Res, _$_Comment>
-    implements _$$_CommentCopyWith<$Res> {
-  __$$_CommentCopyWithImpl(_$_Comment _value, $Res Function(_$_Comment) _then)
+class __$$CommentImplCopyWithImpl<$Res>
+    extends _$CommentCopyWithImpl<$Res, _$CommentImpl>
+    implements _$$CommentImplCopyWith<$Res> {
+  __$$CommentImplCopyWithImpl(
+      _$CommentImpl _value, $Res Function(_$CommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -191,7 +192,7 @@ class __$$_CommentCopyWithImpl<$Res>
     Object? distinguished = null,
     Object? languageId = null,
   }) {
-    return _then(_$_Comment(
+    return _then(_$CommentImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -251,8 +252,8 @@ class __$$_CommentCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_Comment extends _Comment {
-  const _$_Comment(
+class _$CommentImpl extends _Comment {
+  const _$CommentImpl(
       {required this.id,
       required this.creatorId,
       required this.postId,
@@ -268,8 +269,8 @@ class _$_Comment extends _Comment {
       required this.languageId})
       : super._();
 
-  factory _$_Comment.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentFromJson(json);
+  factory _$CommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentImplFromJson(json);
 
   @override
   final int id;
@@ -307,7 +308,7 @@ class _$_Comment extends _Comment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Comment &&
+            other is _$CommentImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -348,12 +349,12 @@ class _$_Comment extends _Comment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentCopyWith<_$_Comment> get copyWith =>
-      __$$_CommentCopyWithImpl<_$_Comment>(this, _$identity);
+  _$$CommentImplCopyWith<_$CommentImpl> get copyWith =>
+      __$$CommentImplCopyWithImpl<_$CommentImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentToJson(
+    return _$$CommentImplToJson(
       this,
     );
   }
@@ -373,10 +374,10 @@ abstract class _Comment extends Comment {
       required final bool local,
       required final String path,
       required final bool distinguished,
-      required final int languageId}) = _$_Comment;
+      required final int languageId}) = _$CommentImpl;
   const _Comment._() : super._();
 
-  factory _Comment.fromJson(Map<String, dynamic> json) = _$_Comment.fromJson;
+  factory _Comment.fromJson(Map<String, dynamic> json) = _$CommentImpl.fromJson;
 
   @override
   int get id;
@@ -406,6 +407,6 @@ abstract class _Comment extends Comment {
   int get languageId;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentCopyWith<_$_Comment> get copyWith =>
+  _$$CommentImplCopyWith<_$CommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/comment/comment.g.dart
+++ b/lib/src/v3/models/comment/comment.g.dart
@@ -6,7 +6,8 @@ part of 'comment.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Comment _$$_CommentFromJson(Map<String, dynamic> json) => _$_Comment(
+_$CommentImpl _$$CommentImplFromJson(Map<String, dynamic> json) =>
+    _$CommentImpl(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       postId: json['post_id'] as int,
@@ -23,7 +24,7 @@ _$_Comment _$$_CommentFromJson(Map<String, dynamic> json) => _$_Comment(
       languageId: json['language_id'] as int,
     );
 
-Map<String, dynamic> _$$_CommentToJson(_$_Comment instance) =>
+Map<String, dynamic> _$$CommentImplToJson(_$CommentImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,

--- a/lib/src/v3/models/comment/comment_aggregates.dart
+++ b/lib/src/v3/models/comment/comment_aggregates.dart
@@ -10,7 +10,7 @@ part 'comment_aggregates.g.dart';
 class CommentAggregates with _$CommentAggregates {
   @modelSerde
   const factory CommentAggregates({
-    required int id,
+    @deprecated int? id,
     required int commentId,
     required int score,
     required int upvotes,

--- a/lib/src/v3/models/comment/comment_aggregates.freezed.dart
+++ b/lib/src/v3/models/comment/comment_aggregates.freezed.dart
@@ -20,7 +20,8 @@ CommentAggregates _$CommentAggregatesFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$CommentAggregates {
-  int get id => throw _privateConstructorUsedError;
+  @deprecated
+  int? get id => throw _privateConstructorUsedError;
   int get commentId => throw _privateConstructorUsedError;
   int get score => throw _privateConstructorUsedError;
   int get upvotes => throw _privateConstructorUsedError;
@@ -43,7 +44,7 @@ abstract class $CommentAggregatesCopyWith<$Res> {
       _$CommentAggregatesCopyWithImpl<$Res, CommentAggregates>;
   @useResult
   $Res call(
-      {int id,
+      {@deprecated int? id,
       int commentId,
       int score,
       int upvotes,
@@ -66,7 +67,7 @@ class _$CommentAggregatesCopyWithImpl<$Res, $Val extends CommentAggregates>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? commentId = null,
     Object? score = null,
     Object? upvotes = null,
@@ -76,10 +77,10 @@ class _$CommentAggregatesCopyWithImpl<$Res, $Val extends CommentAggregates>
     Object? hotRank = freezed,
   }) {
     return _then(_value.copyWith(
-      id: null == id
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -113,15 +114,15 @@ class _$CommentAggregatesCopyWithImpl<$Res, $Val extends CommentAggregates>
 }
 
 /// @nodoc
-abstract class _$$_CommentAggregatesCopyWith<$Res>
+abstract class _$$CommentAggregatesImplCopyWith<$Res>
     implements $CommentAggregatesCopyWith<$Res> {
-  factory _$$_CommentAggregatesCopyWith(_$_CommentAggregates value,
-          $Res Function(_$_CommentAggregates) then) =
-      __$$_CommentAggregatesCopyWithImpl<$Res>;
+  factory _$$CommentAggregatesImplCopyWith(_$CommentAggregatesImpl value,
+          $Res Function(_$CommentAggregatesImpl) then) =
+      __$$CommentAggregatesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
-      {int id,
+      {@deprecated int? id,
       int commentId,
       int score,
       int upvotes,
@@ -132,17 +133,17 @@ abstract class _$$_CommentAggregatesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentAggregatesCopyWithImpl<$Res>
-    extends _$CommentAggregatesCopyWithImpl<$Res, _$_CommentAggregates>
-    implements _$$_CommentAggregatesCopyWith<$Res> {
-  __$$_CommentAggregatesCopyWithImpl(
-      _$_CommentAggregates _value, $Res Function(_$_CommentAggregates) _then)
+class __$$CommentAggregatesImplCopyWithImpl<$Res>
+    extends _$CommentAggregatesCopyWithImpl<$Res, _$CommentAggregatesImpl>
+    implements _$$CommentAggregatesImplCopyWith<$Res> {
+  __$$CommentAggregatesImplCopyWithImpl(_$CommentAggregatesImpl _value,
+      $Res Function(_$CommentAggregatesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? commentId = null,
     Object? score = null,
     Object? upvotes = null,
@@ -151,11 +152,11 @@ class __$$_CommentAggregatesCopyWithImpl<$Res>
     Object? childCount = null,
     Object? hotRank = freezed,
   }) {
-    return _then(_$_CommentAggregates(
-      id: null == id
+    return _then(_$CommentAggregatesImpl(
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       commentId: null == commentId
           ? _value.commentId
           : commentId // ignore: cast_nullable_to_non_nullable
@@ -191,9 +192,9 @@ class __$$_CommentAggregatesCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentAggregates extends _CommentAggregates {
-  const _$_CommentAggregates(
-      {required this.id,
+class _$CommentAggregatesImpl extends _CommentAggregates {
+  const _$CommentAggregatesImpl(
+      {@deprecated this.id,
       required this.commentId,
       required this.score,
       required this.upvotes,
@@ -203,11 +204,12 @@ class _$_CommentAggregates extends _CommentAggregates {
       @deprecated this.hotRank})
       : super._();
 
-  factory _$_CommentAggregates.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentAggregatesFromJson(json);
+  factory _$CommentAggregatesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentAggregatesImplFromJson(json);
 
   @override
-  final int id;
+  @deprecated
+  final int? id;
   @override
   final int commentId;
   @override
@@ -233,7 +235,7 @@ class _$_CommentAggregates extends _CommentAggregates {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentAggregates &&
+            other is _$CommentAggregatesImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.commentId, commentId) ||
                 other.commentId == commentId) &&
@@ -256,13 +258,13 @@ class _$_CommentAggregates extends _CommentAggregates {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentAggregatesCopyWith<_$_CommentAggregates> get copyWith =>
-      __$$_CommentAggregatesCopyWithImpl<_$_CommentAggregates>(
+  _$$CommentAggregatesImplCopyWith<_$CommentAggregatesImpl> get copyWith =>
+      __$$CommentAggregatesImplCopyWithImpl<_$CommentAggregatesImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentAggregatesToJson(
+    return _$$CommentAggregatesImplToJson(
       this,
     );
   }
@@ -270,21 +272,22 @@ class _$_CommentAggregates extends _CommentAggregates {
 
 abstract class _CommentAggregates extends CommentAggregates {
   const factory _CommentAggregates(
-      {required final int id,
+      {@deprecated final int? id,
       required final int commentId,
       required final int score,
       required final int upvotes,
       required final int downvotes,
       required final DateTime published,
       required final int childCount,
-      @deprecated final int? hotRank}) = _$_CommentAggregates;
+      @deprecated final int? hotRank}) = _$CommentAggregatesImpl;
   const _CommentAggregates._() : super._();
 
   factory _CommentAggregates.fromJson(Map<String, dynamic> json) =
-      _$_CommentAggregates.fromJson;
+      _$CommentAggregatesImpl.fromJson;
 
   @override
-  int get id;
+  @deprecated
+  int? get id;
   @override
   int get commentId;
   @override
@@ -302,6 +305,6 @@ abstract class _CommentAggregates extends CommentAggregates {
   int? get hotRank;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentAggregatesCopyWith<_$_CommentAggregates> get copyWith =>
+  _$$CommentAggregatesImplCopyWith<_$CommentAggregatesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/comment/comment_aggregates.g.dart
+++ b/lib/src/v3/models/comment/comment_aggregates.g.dart
@@ -6,9 +6,10 @@ part of 'comment_aggregates.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommentAggregates _$$_CommentAggregatesFromJson(Map<String, dynamic> json) =>
-    _$_CommentAggregates(
-      id: json['id'] as int,
+_$CommentAggregatesImpl _$$CommentAggregatesImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CommentAggregatesImpl(
+      id: json['id'] as int?,
       commentId: json['comment_id'] as int,
       score: json['score'] as int,
       upvotes: json['upvotes'] as int,
@@ -18,8 +19,8 @@ _$_CommentAggregates _$$_CommentAggregatesFromJson(Map<String, dynamic> json) =>
       hotRank: json['hot_rank'] as int?,
     );
 
-Map<String, dynamic> _$$_CommentAggregatesToJson(
-        _$_CommentAggregates instance) =>
+Map<String, dynamic> _$$CommentAggregatesImplToJson(
+        _$CommentAggregatesImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'comment_id': instance.commentId,

--- a/lib/src/v3/models/comment/comment_reply.freezed.dart
+++ b/lib/src/v3/models/comment/comment_reply.freezed.dart
@@ -87,11 +87,11 @@ class _$CommentReplyCopyWithImpl<$Res, $Val extends CommentReply>
 }
 
 /// @nodoc
-abstract class _$$_CommentReplyCopyWith<$Res>
+abstract class _$$CommentReplyImplCopyWith<$Res>
     implements $CommentReplyCopyWith<$Res> {
-  factory _$$_CommentReplyCopyWith(
-          _$_CommentReply value, $Res Function(_$_CommentReply) then) =
-      __$$_CommentReplyCopyWithImpl<$Res>;
+  factory _$$CommentReplyImplCopyWith(
+          _$CommentReplyImpl value, $Res Function(_$CommentReplyImpl) then) =
+      __$$CommentReplyImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -99,11 +99,11 @@ abstract class _$$_CommentReplyCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentReplyCopyWithImpl<$Res>
-    extends _$CommentReplyCopyWithImpl<$Res, _$_CommentReply>
-    implements _$$_CommentReplyCopyWith<$Res> {
-  __$$_CommentReplyCopyWithImpl(
-      _$_CommentReply _value, $Res Function(_$_CommentReply) _then)
+class __$$CommentReplyImplCopyWithImpl<$Res>
+    extends _$CommentReplyCopyWithImpl<$Res, _$CommentReplyImpl>
+    implements _$$CommentReplyImplCopyWith<$Res> {
+  __$$CommentReplyImplCopyWithImpl(
+      _$CommentReplyImpl _value, $Res Function(_$CommentReplyImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -115,7 +115,7 @@ class __$$_CommentReplyCopyWithImpl<$Res>
     Object? read = null,
     Object? published = null,
   }) {
-    return _then(_$_CommentReply(
+    return _then(_$CommentReplyImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -143,8 +143,8 @@ class __$$_CommentReplyCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentReply extends _CommentReply {
-  const _$_CommentReply(
+class _$CommentReplyImpl extends _CommentReply {
+  const _$CommentReplyImpl(
       {required this.id,
       required this.recipientId,
       required this.commentId,
@@ -152,8 +152,8 @@ class _$_CommentReply extends _CommentReply {
       required this.published})
       : super._();
 
-  factory _$_CommentReply.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentReplyFromJson(json);
+  factory _$CommentReplyImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentReplyImplFromJson(json);
 
   @override
   final int id;
@@ -175,7 +175,7 @@ class _$_CommentReply extends _CommentReply {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentReply &&
+            other is _$CommentReplyImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.recipientId, recipientId) ||
                 other.recipientId == recipientId) &&
@@ -194,12 +194,12 @@ class _$_CommentReply extends _CommentReply {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentReplyCopyWith<_$_CommentReply> get copyWith =>
-      __$$_CommentReplyCopyWithImpl<_$_CommentReply>(this, _$identity);
+  _$$CommentReplyImplCopyWith<_$CommentReplyImpl> get copyWith =>
+      __$$CommentReplyImplCopyWithImpl<_$CommentReplyImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentReplyToJson(
+    return _$$CommentReplyImplToJson(
       this,
     );
   }
@@ -211,11 +211,11 @@ abstract class _CommentReply extends CommentReply {
       required final int recipientId,
       required final int commentId,
       required final bool read,
-      required final DateTime published}) = _$_CommentReply;
+      required final DateTime published}) = _$CommentReplyImpl;
   const _CommentReply._() : super._();
 
   factory _CommentReply.fromJson(Map<String, dynamic> json) =
-      _$_CommentReply.fromJson;
+      _$CommentReplyImpl.fromJson;
 
   @override
   int get id;
@@ -229,6 +229,6 @@ abstract class _CommentReply extends CommentReply {
   DateTime get published;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentReplyCopyWith<_$_CommentReply> get copyWith =>
+  _$$CommentReplyImplCopyWith<_$CommentReplyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/comment/comment_reply.g.dart
+++ b/lib/src/v3/models/comment/comment_reply.g.dart
@@ -6,8 +6,8 @@ part of 'comment_reply.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommentReply _$$_CommentReplyFromJson(Map<String, dynamic> json) =>
-    _$_CommentReply(
+_$CommentReplyImpl _$$CommentReplyImplFromJson(Map<String, dynamic> json) =>
+    _$CommentReplyImpl(
       id: json['id'] as int,
       recipientId: json['recipient_id'] as int,
       commentId: json['comment_id'] as int,
@@ -15,7 +15,7 @@ _$_CommentReply _$$_CommentReplyFromJson(Map<String, dynamic> json) =>
       published: const ForceUtcDateTime().fromJson(json['published'] as String),
     );
 
-Map<String, dynamic> _$$_CommentReplyToJson(_$_CommentReply instance) =>
+Map<String, dynamic> _$$CommentReplyImplToJson(_$CommentReplyImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'recipient_id': instance.recipientId,

--- a/lib/src/v3/models/comment/comment_reply_response.freezed.dart
+++ b/lib/src/v3/models/comment/comment_reply_response.freezed.dart
@@ -73,11 +73,11 @@ class _$CommentReplyResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_CommentReplyResponseCopyWith<$Res>
+abstract class _$$CommentReplyResponseImplCopyWith<$Res>
     implements $CommentReplyResponseCopyWith<$Res> {
-  factory _$$_CommentReplyResponseCopyWith(_$_CommentReplyResponse value,
-          $Res Function(_$_CommentReplyResponse) then) =
-      __$$_CommentReplyResponseCopyWithImpl<$Res>;
+  factory _$$CommentReplyResponseImplCopyWith(_$CommentReplyResponseImpl value,
+          $Res Function(_$CommentReplyResponseImpl) then) =
+      __$$CommentReplyResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CommentReplyView commentReplyView});
@@ -87,11 +87,11 @@ abstract class _$$_CommentReplyResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentReplyResponseCopyWithImpl<$Res>
-    extends _$CommentReplyResponseCopyWithImpl<$Res, _$_CommentReplyResponse>
-    implements _$$_CommentReplyResponseCopyWith<$Res> {
-  __$$_CommentReplyResponseCopyWithImpl(_$_CommentReplyResponse _value,
-      $Res Function(_$_CommentReplyResponse) _then)
+class __$$CommentReplyResponseImplCopyWithImpl<$Res>
+    extends _$CommentReplyResponseCopyWithImpl<$Res, _$CommentReplyResponseImpl>
+    implements _$$CommentReplyResponseImplCopyWith<$Res> {
+  __$$CommentReplyResponseImplCopyWithImpl(_$CommentReplyResponseImpl _value,
+      $Res Function(_$CommentReplyResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -99,7 +99,7 @@ class __$$_CommentReplyResponseCopyWithImpl<$Res>
   $Res call({
     Object? commentReplyView = null,
   }) {
-    return _then(_$_CommentReplyResponse(
+    return _then(_$CommentReplyResponseImpl(
       commentReplyView: null == commentReplyView
           ? _value.commentReplyView
           : commentReplyView // ignore: cast_nullable_to_non_nullable
@@ -111,11 +111,12 @@ class __$$_CommentReplyResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentReplyResponse extends _CommentReplyResponse {
-  const _$_CommentReplyResponse({required this.commentReplyView}) : super._();
+class _$CommentReplyResponseImpl extends _CommentReplyResponse {
+  const _$CommentReplyResponseImpl({required this.commentReplyView})
+      : super._();
 
-  factory _$_CommentReplyResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentReplyResponseFromJson(json);
+  factory _$CommentReplyResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentReplyResponseImplFromJson(json);
 
   @override
   final CommentReplyView commentReplyView;
@@ -129,7 +130,7 @@ class _$_CommentReplyResponse extends _CommentReplyResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentReplyResponse &&
+            other is _$CommentReplyResponseImpl &&
             (identical(other.commentReplyView, commentReplyView) ||
                 other.commentReplyView == commentReplyView));
   }
@@ -141,13 +142,14 @@ class _$_CommentReplyResponse extends _CommentReplyResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentReplyResponseCopyWith<_$_CommentReplyResponse> get copyWith =>
-      __$$_CommentReplyResponseCopyWithImpl<_$_CommentReplyResponse>(
-          this, _$identity);
+  _$$CommentReplyResponseImplCopyWith<_$CommentReplyResponseImpl>
+      get copyWith =>
+          __$$CommentReplyResponseImplCopyWithImpl<_$CommentReplyResponseImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentReplyResponseToJson(
+    return _$$CommentReplyResponseImplToJson(
       this,
     );
   }
@@ -156,16 +158,16 @@ class _$_CommentReplyResponse extends _CommentReplyResponse {
 abstract class _CommentReplyResponse extends CommentReplyResponse {
   const factory _CommentReplyResponse(
           {required final CommentReplyView commentReplyView}) =
-      _$_CommentReplyResponse;
+      _$CommentReplyResponseImpl;
   const _CommentReplyResponse._() : super._();
 
   factory _CommentReplyResponse.fromJson(Map<String, dynamic> json) =
-      _$_CommentReplyResponse.fromJson;
+      _$CommentReplyResponseImpl.fromJson;
 
   @override
   CommentReplyView get commentReplyView;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentReplyResponseCopyWith<_$_CommentReplyResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$CommentReplyResponseImplCopyWith<_$CommentReplyResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/comment/comment_reply_response.g.dart
+++ b/lib/src/v3/models/comment/comment_reply_response.g.dart
@@ -6,15 +6,15 @@ part of 'comment_reply_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommentReplyResponse _$$_CommentReplyResponseFromJson(
+_$CommentReplyResponseImpl _$$CommentReplyResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CommentReplyResponse(
+    _$CommentReplyResponseImpl(
       commentReplyView: CommentReplyView.fromJson(
           json['comment_reply_view'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_CommentReplyResponseToJson(
-        _$_CommentReplyResponse instance) =>
+Map<String, dynamic> _$$CommentReplyResponseImplToJson(
+        _$CommentReplyResponseImpl instance) =>
     <String, dynamic>{
       'comment_reply_view': instance.commentReplyView.toJson(),
     };

--- a/lib/src/v3/models/comment/comment_report.freezed.dart
+++ b/lib/src/v3/models/comment/comment_report.freezed.dart
@@ -119,11 +119,11 @@ class _$CommentReportCopyWithImpl<$Res, $Val extends CommentReport>
 }
 
 /// @nodoc
-abstract class _$$_CommentReportCopyWith<$Res>
+abstract class _$$CommentReportImplCopyWith<$Res>
     implements $CommentReportCopyWith<$Res> {
-  factory _$$_CommentReportCopyWith(
-          _$_CommentReport value, $Res Function(_$_CommentReport) then) =
-      __$$_CommentReportCopyWithImpl<$Res>;
+  factory _$$CommentReportImplCopyWith(
+          _$CommentReportImpl value, $Res Function(_$CommentReportImpl) then) =
+      __$$CommentReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -139,11 +139,11 @@ abstract class _$$_CommentReportCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentReportCopyWithImpl<$Res>
-    extends _$CommentReportCopyWithImpl<$Res, _$_CommentReport>
-    implements _$$_CommentReportCopyWith<$Res> {
-  __$$_CommentReportCopyWithImpl(
-      _$_CommentReport _value, $Res Function(_$_CommentReport) _then)
+class __$$CommentReportImplCopyWithImpl<$Res>
+    extends _$CommentReportCopyWithImpl<$Res, _$CommentReportImpl>
+    implements _$$CommentReportImplCopyWith<$Res> {
+  __$$CommentReportImplCopyWithImpl(
+      _$CommentReportImpl _value, $Res Function(_$CommentReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -159,7 +159,7 @@ class __$$_CommentReportCopyWithImpl<$Res>
     Object? published = null,
     Object? updated = freezed,
   }) {
-    return _then(_$_CommentReport(
+    return _then(_$CommentReportImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -203,8 +203,8 @@ class __$$_CommentReportCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentReport extends _CommentReport {
-  const _$_CommentReport(
+class _$CommentReportImpl extends _CommentReport {
+  const _$CommentReportImpl(
       {required this.id,
       required this.creatorId,
       required this.commentId,
@@ -216,8 +216,8 @@ class _$_CommentReport extends _CommentReport {
       this.updated})
       : super._();
 
-  factory _$_CommentReport.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentReportFromJson(json);
+  factory _$CommentReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentReportImplFromJson(json);
 
   @override
   final int id;
@@ -247,7 +247,7 @@ class _$_CommentReport extends _CommentReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentReport &&
+            other is _$CommentReportImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -273,12 +273,12 @@ class _$_CommentReport extends _CommentReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentReportCopyWith<_$_CommentReport> get copyWith =>
-      __$$_CommentReportCopyWithImpl<_$_CommentReport>(this, _$identity);
+  _$$CommentReportImplCopyWith<_$CommentReportImpl> get copyWith =>
+      __$$CommentReportImplCopyWithImpl<_$CommentReportImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentReportToJson(
+    return _$$CommentReportImplToJson(
       this,
     );
   }
@@ -294,11 +294,11 @@ abstract class _CommentReport extends CommentReport {
       required final bool resolved,
       final int? resolverId,
       required final DateTime published,
-      final DateTime? updated}) = _$_CommentReport;
+      final DateTime? updated}) = _$CommentReportImpl;
   const _CommentReport._() : super._();
 
   factory _CommentReport.fromJson(Map<String, dynamic> json) =
-      _$_CommentReport.fromJson;
+      _$CommentReportImpl.fromJson;
 
   @override
   int get id;
@@ -320,6 +320,6 @@ abstract class _CommentReport extends CommentReport {
   DateTime? get updated;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentReportCopyWith<_$_CommentReport> get copyWith =>
+  _$$CommentReportImplCopyWith<_$CommentReportImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/comment/comment_report.g.dart
+++ b/lib/src/v3/models/comment/comment_report.g.dart
@@ -6,8 +6,8 @@ part of 'comment_report.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommentReport _$$_CommentReportFromJson(Map<String, dynamic> json) =>
-    _$_CommentReport(
+_$CommentReportImpl _$$CommentReportImplFromJson(Map<String, dynamic> json) =>
+    _$CommentReportImpl(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       commentId: json['comment_id'] as int,
@@ -20,7 +20,7 @@ _$_CommentReport _$$_CommentReportFromJson(Map<String, dynamic> json) =>
           json['updated'], const ForceUtcDateTime().fromJson),
     );
 
-Map<String, dynamic> _$$_CommentReportToJson(_$_CommentReport instance) =>
+Map<String, dynamic> _$$CommentReportImplToJson(_$CommentReportImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,

--- a/lib/src/v3/models/comment/comment_report_response.freezed.dart
+++ b/lib/src/v3/models/comment/comment_report_response.freezed.dart
@@ -74,11 +74,12 @@ class _$CommentReportResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_CommentReportResponseCopyWith<$Res>
+abstract class _$$CommentReportResponseImplCopyWith<$Res>
     implements $CommentReportResponseCopyWith<$Res> {
-  factory _$$_CommentReportResponseCopyWith(_$_CommentReportResponse value,
-          $Res Function(_$_CommentReportResponse) then) =
-      __$$_CommentReportResponseCopyWithImpl<$Res>;
+  factory _$$CommentReportResponseImplCopyWith(
+          _$CommentReportResponseImpl value,
+          $Res Function(_$CommentReportResponseImpl) then) =
+      __$$CommentReportResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CommentReportView commentReportView});
@@ -88,11 +89,12 @@ abstract class _$$_CommentReportResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentReportResponseCopyWithImpl<$Res>
-    extends _$CommentReportResponseCopyWithImpl<$Res, _$_CommentReportResponse>
-    implements _$$_CommentReportResponseCopyWith<$Res> {
-  __$$_CommentReportResponseCopyWithImpl(_$_CommentReportResponse _value,
-      $Res Function(_$_CommentReportResponse) _then)
+class __$$CommentReportResponseImplCopyWithImpl<$Res>
+    extends _$CommentReportResponseCopyWithImpl<$Res,
+        _$CommentReportResponseImpl>
+    implements _$$CommentReportResponseImplCopyWith<$Res> {
+  __$$CommentReportResponseImplCopyWithImpl(_$CommentReportResponseImpl _value,
+      $Res Function(_$CommentReportResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -100,7 +102,7 @@ class __$$_CommentReportResponseCopyWithImpl<$Res>
   $Res call({
     Object? commentReportView = null,
   }) {
-    return _then(_$_CommentReportResponse(
+    return _then(_$CommentReportResponseImpl(
       commentReportView: null == commentReportView
           ? _value.commentReportView
           : commentReportView // ignore: cast_nullable_to_non_nullable
@@ -112,11 +114,12 @@ class __$$_CommentReportResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentReportResponse extends _CommentReportResponse {
-  const _$_CommentReportResponse({required this.commentReportView}) : super._();
+class _$CommentReportResponseImpl extends _CommentReportResponse {
+  const _$CommentReportResponseImpl({required this.commentReportView})
+      : super._();
 
-  factory _$_CommentReportResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentReportResponseFromJson(json);
+  factory _$CommentReportResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentReportResponseImplFromJson(json);
 
   @override
   final CommentReportView commentReportView;
@@ -130,7 +133,7 @@ class _$_CommentReportResponse extends _CommentReportResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentReportResponse &&
+            other is _$CommentReportResponseImpl &&
             (identical(other.commentReportView, commentReportView) ||
                 other.commentReportView == commentReportView));
   }
@@ -142,13 +145,13 @@ class _$_CommentReportResponse extends _CommentReportResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentReportResponseCopyWith<_$_CommentReportResponse> get copyWith =>
-      __$$_CommentReportResponseCopyWithImpl<_$_CommentReportResponse>(
-          this, _$identity);
+  _$$CommentReportResponseImplCopyWith<_$CommentReportResponseImpl>
+      get copyWith => __$$CommentReportResponseImplCopyWithImpl<
+          _$CommentReportResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentReportResponseToJson(
+    return _$$CommentReportResponseImplToJson(
       this,
     );
   }
@@ -157,16 +160,16 @@ class _$_CommentReportResponse extends _CommentReportResponse {
 abstract class _CommentReportResponse extends CommentReportResponse {
   const factory _CommentReportResponse(
           {required final CommentReportView commentReportView}) =
-      _$_CommentReportResponse;
+      _$CommentReportResponseImpl;
   const _CommentReportResponse._() : super._();
 
   factory _CommentReportResponse.fromJson(Map<String, dynamic> json) =
-      _$_CommentReportResponse.fromJson;
+      _$CommentReportResponseImpl.fromJson;
 
   @override
   CommentReportView get commentReportView;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentReportResponseCopyWith<_$_CommentReportResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$CommentReportResponseImplCopyWith<_$CommentReportResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/comment/comment_report_response.g.dart
+++ b/lib/src/v3/models/comment/comment_report_response.g.dart
@@ -6,15 +6,15 @@ part of 'comment_report_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommentReportResponse _$$_CommentReportResponseFromJson(
+_$CommentReportResponseImpl _$$CommentReportResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CommentReportResponse(
+    _$CommentReportResponseImpl(
       commentReportView: CommentReportView.fromJson(
           json['comment_report_view'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_CommentReportResponseToJson(
-        _$_CommentReportResponse instance) =>
+Map<String, dynamic> _$$CommentReportResponseImplToJson(
+        _$CommentReportResponseImpl instance) =>
     <String, dynamic>{
       'comment_report_view': instance.commentReportView.toJson(),
     };

--- a/lib/src/v3/models/comment/comment_response.freezed.dart
+++ b/lib/src/v3/models/comment/comment_response.freezed.dart
@@ -88,11 +88,11 @@ class _$CommentResponseCopyWithImpl<$Res, $Val extends CommentResponse>
 }
 
 /// @nodoc
-abstract class _$$_CommentResponseCopyWith<$Res>
+abstract class _$$CommentResponseImplCopyWith<$Res>
     implements $CommentResponseCopyWith<$Res> {
-  factory _$$_CommentResponseCopyWith(
-          _$_CommentResponse value, $Res Function(_$_CommentResponse) then) =
-      __$$_CommentResponseCopyWithImpl<$Res>;
+  factory _$$CommentResponseImplCopyWith(_$CommentResponseImpl value,
+          $Res Function(_$CommentResponseImpl) then) =
+      __$$CommentResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -105,11 +105,11 @@ abstract class _$$_CommentResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentResponseCopyWithImpl<$Res>
-    extends _$CommentResponseCopyWithImpl<$Res, _$_CommentResponse>
-    implements _$$_CommentResponseCopyWith<$Res> {
-  __$$_CommentResponseCopyWithImpl(
-      _$_CommentResponse _value, $Res Function(_$_CommentResponse) _then)
+class __$$CommentResponseImplCopyWithImpl<$Res>
+    extends _$CommentResponseCopyWithImpl<$Res, _$CommentResponseImpl>
+    implements _$$CommentResponseImplCopyWith<$Res> {
+  __$$CommentResponseImplCopyWithImpl(
+      _$CommentResponseImpl _value, $Res Function(_$CommentResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -119,7 +119,7 @@ class __$$_CommentResponseCopyWithImpl<$Res>
     Object? recipientIds = null,
     Object? formId = freezed,
   }) {
-    return _then(_$_CommentResponse(
+    return _then(_$CommentResponseImpl(
       commentView: null == commentView
           ? _value.commentView
           : commentView // ignore: cast_nullable_to_non_nullable
@@ -139,16 +139,16 @@ class __$$_CommentResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentResponse extends _CommentResponse {
-  const _$_CommentResponse(
+class _$CommentResponseImpl extends _CommentResponse {
+  const _$CommentResponseImpl(
       {required this.commentView,
       required final List<int> recipientIds,
       @deprecated this.formId})
       : _recipientIds = recipientIds,
         super._();
 
-  factory _$_CommentResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentResponseFromJson(json);
+  factory _$CommentResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentResponseImplFromJson(json);
 
   @override
   final CommentView commentView;
@@ -173,7 +173,7 @@ class _$_CommentResponse extends _CommentResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentResponse &&
+            other is _$CommentResponseImpl &&
             (identical(other.commentView, commentView) ||
                 other.commentView == commentView) &&
             const DeepCollectionEquality()
@@ -189,12 +189,13 @@ class _$_CommentResponse extends _CommentResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentResponseCopyWith<_$_CommentResponse> get copyWith =>
-      __$$_CommentResponseCopyWithImpl<_$_CommentResponse>(this, _$identity);
+  _$$CommentResponseImplCopyWith<_$CommentResponseImpl> get copyWith =>
+      __$$CommentResponseImplCopyWithImpl<_$CommentResponseImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentResponseToJson(
+    return _$$CommentResponseImplToJson(
       this,
     );
   }
@@ -204,11 +205,11 @@ abstract class _CommentResponse extends CommentResponse {
   const factory _CommentResponse(
       {required final CommentView commentView,
       required final List<int> recipientIds,
-      @deprecated final String? formId}) = _$_CommentResponse;
+      @deprecated final String? formId}) = _$CommentResponseImpl;
   const _CommentResponse._() : super._();
 
   factory _CommentResponse.fromJson(Map<String, dynamic> json) =
-      _$_CommentResponse.fromJson;
+      _$CommentResponseImpl.fromJson;
 
   @override
   CommentView get commentView;
@@ -219,6 +220,6 @@ abstract class _CommentResponse extends CommentResponse {
   String? get formId;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentResponseCopyWith<_$_CommentResponse> get copyWith =>
+  _$$CommentResponseImplCopyWith<_$CommentResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/comment/comment_response.g.dart
+++ b/lib/src/v3/models/comment/comment_response.g.dart
@@ -6,8 +6,9 @@ part of 'comment_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommentResponse _$$_CommentResponseFromJson(Map<String, dynamic> json) =>
-    _$_CommentResponse(
+_$CommentResponseImpl _$$CommentResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CommentResponseImpl(
       commentView:
           CommentView.fromJson(json['comment_view'] as Map<String, dynamic>),
       recipientIds: (json['recipient_ids'] as List<dynamic>)
@@ -16,7 +17,8 @@ _$_CommentResponse _$$_CommentResponseFromJson(Map<String, dynamic> json) =>
       formId: json['form_id'] as String?,
     );
 
-Map<String, dynamic> _$$_CommentResponseToJson(_$_CommentResponse instance) =>
+Map<String, dynamic> _$$CommentResponseImplToJson(
+        _$CommentResponseImpl instance) =>
     <String, dynamic>{
       'comment_view': instance.commentView.toJson(),
       'recipient_ids': instance.recipientIds,

--- a/lib/src/v3/models/comment/get_comments_response.freezed.dart
+++ b/lib/src/v3/models/comment/get_comments_response.freezed.dart
@@ -62,22 +62,22 @@ class _$GetCommentsResponseCopyWithImpl<$Res, $Val extends GetCommentsResponse>
 }
 
 /// @nodoc
-abstract class _$$_GetCommentsResponseCopyWith<$Res>
+abstract class _$$GetCommentsResponseImplCopyWith<$Res>
     implements $GetCommentsResponseCopyWith<$Res> {
-  factory _$$_GetCommentsResponseCopyWith(_$_GetCommentsResponse value,
-          $Res Function(_$_GetCommentsResponse) then) =
-      __$$_GetCommentsResponseCopyWithImpl<$Res>;
+  factory _$$GetCommentsResponseImplCopyWith(_$GetCommentsResponseImpl value,
+          $Res Function(_$GetCommentsResponseImpl) then) =
+      __$$GetCommentsResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<CommentView> comments});
 }
 
 /// @nodoc
-class __$$_GetCommentsResponseCopyWithImpl<$Res>
-    extends _$GetCommentsResponseCopyWithImpl<$Res, _$_GetCommentsResponse>
-    implements _$$_GetCommentsResponseCopyWith<$Res> {
-  __$$_GetCommentsResponseCopyWithImpl(_$_GetCommentsResponse _value,
-      $Res Function(_$_GetCommentsResponse) _then)
+class __$$GetCommentsResponseImplCopyWithImpl<$Res>
+    extends _$GetCommentsResponseCopyWithImpl<$Res, _$GetCommentsResponseImpl>
+    implements _$$GetCommentsResponseImplCopyWith<$Res> {
+  __$$GetCommentsResponseImplCopyWithImpl(_$GetCommentsResponseImpl _value,
+      $Res Function(_$GetCommentsResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -85,7 +85,7 @@ class __$$_GetCommentsResponseCopyWithImpl<$Res>
   $Res call({
     Object? comments = null,
   }) {
-    return _then(_$_GetCommentsResponse(
+    return _then(_$GetCommentsResponseImpl(
       comments: null == comments
           ? _value._comments
           : comments // ignore: cast_nullable_to_non_nullable
@@ -97,13 +97,13 @@ class __$$_GetCommentsResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetCommentsResponse extends _GetCommentsResponse {
-  const _$_GetCommentsResponse({required final List<CommentView> comments})
+class _$GetCommentsResponseImpl extends _GetCommentsResponse {
+  const _$GetCommentsResponseImpl({required final List<CommentView> comments})
       : _comments = comments,
         super._();
 
-  factory _$_GetCommentsResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetCommentsResponseFromJson(json);
+  factory _$GetCommentsResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetCommentsResponseImplFromJson(json);
 
   final List<CommentView> _comments;
   @override
@@ -122,7 +122,7 @@ class _$_GetCommentsResponse extends _GetCommentsResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetCommentsResponse &&
+            other is _$GetCommentsResponseImpl &&
             const DeepCollectionEquality().equals(other._comments, _comments));
   }
 
@@ -134,13 +134,13 @@ class _$_GetCommentsResponse extends _GetCommentsResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetCommentsResponseCopyWith<_$_GetCommentsResponse> get copyWith =>
-      __$$_GetCommentsResponseCopyWithImpl<_$_GetCommentsResponse>(
+  _$$GetCommentsResponseImplCopyWith<_$GetCommentsResponseImpl> get copyWith =>
+      __$$GetCommentsResponseImplCopyWithImpl<_$GetCommentsResponseImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetCommentsResponseToJson(
+    return _$$GetCommentsResponseImplToJson(
       this,
     );
   }
@@ -148,16 +148,16 @@ class _$_GetCommentsResponse extends _GetCommentsResponse {
 
 abstract class _GetCommentsResponse extends GetCommentsResponse {
   const factory _GetCommentsResponse(
-      {required final List<CommentView> comments}) = _$_GetCommentsResponse;
+      {required final List<CommentView> comments}) = _$GetCommentsResponseImpl;
   const _GetCommentsResponse._() : super._();
 
   factory _GetCommentsResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetCommentsResponse.fromJson;
+      _$GetCommentsResponseImpl.fromJson;
 
   @override
   List<CommentView> get comments;
   @override
   @JsonKey(ignore: true)
-  _$$_GetCommentsResponseCopyWith<_$_GetCommentsResponse> get copyWith =>
+  _$$GetCommentsResponseImplCopyWith<_$GetCommentsResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/comment/get_comments_response.g.dart
+++ b/lib/src/v3/models/comment/get_comments_response.g.dart
@@ -6,16 +6,16 @@ part of 'get_comments_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetCommentsResponse _$$_GetCommentsResponseFromJson(
+_$GetCommentsResponseImpl _$$GetCommentsResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GetCommentsResponse(
+    _$GetCommentsResponseImpl(
       comments: (json['comments'] as List<dynamic>)
           .map((e) => CommentView.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$_GetCommentsResponseToJson(
-        _$_GetCommentsResponse instance) =>
+Map<String, dynamic> _$$GetCommentsResponseImplToJson(
+        _$GetCommentsResponseImpl instance) =>
     <String, dynamic>{
       'comments': instance.comments.map((e) => e.toJson()).toList(),
     };

--- a/lib/src/v3/models/comment/list_comment_reports_response.freezed.dart
+++ b/lib/src/v3/models/comment/list_comment_reports_response.freezed.dart
@@ -66,25 +66,25 @@ class _$ListCommentReportsResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ListCommentReportsResponseCopyWith<$Res>
+abstract class _$$ListCommentReportsResponseImplCopyWith<$Res>
     implements $ListCommentReportsResponseCopyWith<$Res> {
-  factory _$$_ListCommentReportsResponseCopyWith(
-          _$_ListCommentReportsResponse value,
-          $Res Function(_$_ListCommentReportsResponse) then) =
-      __$$_ListCommentReportsResponseCopyWithImpl<$Res>;
+  factory _$$ListCommentReportsResponseImplCopyWith(
+          _$ListCommentReportsResponseImpl value,
+          $Res Function(_$ListCommentReportsResponseImpl) then) =
+      __$$ListCommentReportsResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<CommentReportView> commentReports});
 }
 
 /// @nodoc
-class __$$_ListCommentReportsResponseCopyWithImpl<$Res>
+class __$$ListCommentReportsResponseImplCopyWithImpl<$Res>
     extends _$ListCommentReportsResponseCopyWithImpl<$Res,
-        _$_ListCommentReportsResponse>
-    implements _$$_ListCommentReportsResponseCopyWith<$Res> {
-  __$$_ListCommentReportsResponseCopyWithImpl(
-      _$_ListCommentReportsResponse _value,
-      $Res Function(_$_ListCommentReportsResponse) _then)
+        _$ListCommentReportsResponseImpl>
+    implements _$$ListCommentReportsResponseImplCopyWith<$Res> {
+  __$$ListCommentReportsResponseImplCopyWithImpl(
+      _$ListCommentReportsResponseImpl _value,
+      $Res Function(_$ListCommentReportsResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -92,7 +92,7 @@ class __$$_ListCommentReportsResponseCopyWithImpl<$Res>
   $Res call({
     Object? commentReports = null,
   }) {
-    return _then(_$_ListCommentReportsResponse(
+    return _then(_$ListCommentReportsResponseImpl(
       commentReports: null == commentReports
           ? _value._commentReports
           : commentReports // ignore: cast_nullable_to_non_nullable
@@ -104,14 +104,15 @@ class __$$_ListCommentReportsResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ListCommentReportsResponse extends _ListCommentReportsResponse {
-  const _$_ListCommentReportsResponse(
+class _$ListCommentReportsResponseImpl extends _ListCommentReportsResponse {
+  const _$ListCommentReportsResponseImpl(
       {required final List<CommentReportView> commentReports})
       : _commentReports = commentReports,
         super._();
 
-  factory _$_ListCommentReportsResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_ListCommentReportsResponseFromJson(json);
+  factory _$ListCommentReportsResponseImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$ListCommentReportsResponseImplFromJson(json);
 
   final List<CommentReportView> _commentReports;
   @override
@@ -130,7 +131,7 @@ class _$_ListCommentReportsResponse extends _ListCommentReportsResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListCommentReportsResponse &&
+            other is _$ListCommentReportsResponseImpl &&
             const DeepCollectionEquality()
                 .equals(other._commentReports, _commentReports));
   }
@@ -143,13 +144,13 @@ class _$_ListCommentReportsResponse extends _ListCommentReportsResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListCommentReportsResponseCopyWith<_$_ListCommentReportsResponse>
-      get copyWith => __$$_ListCommentReportsResponseCopyWithImpl<
-          _$_ListCommentReportsResponse>(this, _$identity);
+  _$$ListCommentReportsResponseImplCopyWith<_$ListCommentReportsResponseImpl>
+      get copyWith => __$$ListCommentReportsResponseImplCopyWithImpl<
+          _$ListCommentReportsResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListCommentReportsResponseToJson(
+    return _$$ListCommentReportsResponseImplToJson(
       this,
     );
   }
@@ -158,16 +159,16 @@ class _$_ListCommentReportsResponse extends _ListCommentReportsResponse {
 abstract class _ListCommentReportsResponse extends ListCommentReportsResponse {
   const factory _ListCommentReportsResponse(
           {required final List<CommentReportView> commentReports}) =
-      _$_ListCommentReportsResponse;
+      _$ListCommentReportsResponseImpl;
   const _ListCommentReportsResponse._() : super._();
 
   factory _ListCommentReportsResponse.fromJson(Map<String, dynamic> json) =
-      _$_ListCommentReportsResponse.fromJson;
+      _$ListCommentReportsResponseImpl.fromJson;
 
   @override
   List<CommentReportView> get commentReports;
   @override
   @JsonKey(ignore: true)
-  _$$_ListCommentReportsResponseCopyWith<_$_ListCommentReportsResponse>
+  _$$ListCommentReportsResponseImplCopyWith<_$ListCommentReportsResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/comment/list_comment_reports_response.g.dart
+++ b/lib/src/v3/models/comment/list_comment_reports_response.g.dart
@@ -6,16 +6,16 @@ part of 'list_comment_reports_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ListCommentReportsResponse _$$_ListCommentReportsResponseFromJson(
+_$ListCommentReportsResponseImpl _$$ListCommentReportsResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ListCommentReportsResponse(
+    _$ListCommentReportsResponseImpl(
       commentReports: (json['comment_reports'] as List<dynamic>)
           .map((e) => CommentReportView.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$_ListCommentReportsResponseToJson(
-        _$_ListCommentReportsResponse instance) =>
+Map<String, dynamic> _$$ListCommentReportsResponseImplToJson(
+        _$ListCommentReportsResponseImpl instance) =>
     <String, dynamic>{
       'comment_reports':
           instance.commentReports.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/models/community/add_mod_to_community_response.freezed.dart
+++ b/lib/src/v3/models/community/add_mod_to_community_response.freezed.dart
@@ -65,25 +65,25 @@ class _$AddModToCommunityResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_AddModToCommunityResponseCopyWith<$Res>
+abstract class _$$AddModToCommunityResponseImplCopyWith<$Res>
     implements $AddModToCommunityResponseCopyWith<$Res> {
-  factory _$$_AddModToCommunityResponseCopyWith(
-          _$_AddModToCommunityResponse value,
-          $Res Function(_$_AddModToCommunityResponse) then) =
-      __$$_AddModToCommunityResponseCopyWithImpl<$Res>;
+  factory _$$AddModToCommunityResponseImplCopyWith(
+          _$AddModToCommunityResponseImpl value,
+          $Res Function(_$AddModToCommunityResponseImpl) then) =
+      __$$AddModToCommunityResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<CommunityModeratorView> moderators});
 }
 
 /// @nodoc
-class __$$_AddModToCommunityResponseCopyWithImpl<$Res>
+class __$$AddModToCommunityResponseImplCopyWithImpl<$Res>
     extends _$AddModToCommunityResponseCopyWithImpl<$Res,
-        _$_AddModToCommunityResponse>
-    implements _$$_AddModToCommunityResponseCopyWith<$Res> {
-  __$$_AddModToCommunityResponseCopyWithImpl(
-      _$_AddModToCommunityResponse _value,
-      $Res Function(_$_AddModToCommunityResponse) _then)
+        _$AddModToCommunityResponseImpl>
+    implements _$$AddModToCommunityResponseImplCopyWith<$Res> {
+  __$$AddModToCommunityResponseImplCopyWithImpl(
+      _$AddModToCommunityResponseImpl _value,
+      $Res Function(_$AddModToCommunityResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -91,7 +91,7 @@ class __$$_AddModToCommunityResponseCopyWithImpl<$Res>
   $Res call({
     Object? moderators = null,
   }) {
-    return _then(_$_AddModToCommunityResponse(
+    return _then(_$AddModToCommunityResponseImpl(
       moderators: null == moderators
           ? _value._moderators
           : moderators // ignore: cast_nullable_to_non_nullable
@@ -103,14 +103,14 @@ class __$$_AddModToCommunityResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AddModToCommunityResponse extends _AddModToCommunityResponse {
-  const _$_AddModToCommunityResponse(
+class _$AddModToCommunityResponseImpl extends _AddModToCommunityResponse {
+  const _$AddModToCommunityResponseImpl(
       {required final List<CommunityModeratorView> moderators})
       : _moderators = moderators,
         super._();
 
-  factory _$_AddModToCommunityResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_AddModToCommunityResponseFromJson(json);
+  factory _$AddModToCommunityResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AddModToCommunityResponseImplFromJson(json);
 
   final List<CommunityModeratorView> _moderators;
   @override
@@ -129,7 +129,7 @@ class _$_AddModToCommunityResponse extends _AddModToCommunityResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AddModToCommunityResponse &&
+            other is _$AddModToCommunityResponseImpl &&
             const DeepCollectionEquality()
                 .equals(other._moderators, _moderators));
   }
@@ -142,13 +142,13 @@ class _$_AddModToCommunityResponse extends _AddModToCommunityResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AddModToCommunityResponseCopyWith<_$_AddModToCommunityResponse>
-      get copyWith => __$$_AddModToCommunityResponseCopyWithImpl<
-          _$_AddModToCommunityResponse>(this, _$identity);
+  _$$AddModToCommunityResponseImplCopyWith<_$AddModToCommunityResponseImpl>
+      get copyWith => __$$AddModToCommunityResponseImplCopyWithImpl<
+          _$AddModToCommunityResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AddModToCommunityResponseToJson(
+    return _$$AddModToCommunityResponseImplToJson(
       this,
     );
   }
@@ -157,16 +157,16 @@ class _$_AddModToCommunityResponse extends _AddModToCommunityResponse {
 abstract class _AddModToCommunityResponse extends AddModToCommunityResponse {
   const factory _AddModToCommunityResponse(
           {required final List<CommunityModeratorView> moderators}) =
-      _$_AddModToCommunityResponse;
+      _$AddModToCommunityResponseImpl;
   const _AddModToCommunityResponse._() : super._();
 
   factory _AddModToCommunityResponse.fromJson(Map<String, dynamic> json) =
-      _$_AddModToCommunityResponse.fromJson;
+      _$AddModToCommunityResponseImpl.fromJson;
 
   @override
   List<CommunityModeratorView> get moderators;
   @override
   @JsonKey(ignore: true)
-  _$$_AddModToCommunityResponseCopyWith<_$_AddModToCommunityResponse>
+  _$$AddModToCommunityResponseImplCopyWith<_$AddModToCommunityResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/community/add_mod_to_community_response.g.dart
+++ b/lib/src/v3/models/community/add_mod_to_community_response.g.dart
@@ -6,17 +6,17 @@ part of 'add_mod_to_community_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_AddModToCommunityResponse _$$_AddModToCommunityResponseFromJson(
+_$AddModToCommunityResponseImpl _$$AddModToCommunityResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_AddModToCommunityResponse(
+    _$AddModToCommunityResponseImpl(
       moderators: (json['moderators'] as List<dynamic>)
           .map(
               (e) => CommunityModeratorView.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$_AddModToCommunityResponseToJson(
-        _$_AddModToCommunityResponse instance) =>
+Map<String, dynamic> _$$AddModToCommunityResponseImplToJson(
+        _$AddModToCommunityResponseImpl instance) =>
     <String, dynamic>{
       'moderators': instance.moderators.map((e) => e.toJson()).toList(),
     };

--- a/lib/src/v3/models/community/ban_from_community_response.freezed.dart
+++ b/lib/src/v3/models/community/ban_from_community_response.freezed.dart
@@ -80,12 +80,12 @@ class _$BanFromCommunityResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_BanFromCommunityResponseCopyWith<$Res>
+abstract class _$$BanFromCommunityResponseImplCopyWith<$Res>
     implements $BanFromCommunityResponseCopyWith<$Res> {
-  factory _$$_BanFromCommunityResponseCopyWith(
-          _$_BanFromCommunityResponse value,
-          $Res Function(_$_BanFromCommunityResponse) then) =
-      __$$_BanFromCommunityResponseCopyWithImpl<$Res>;
+  factory _$$BanFromCommunityResponseImplCopyWith(
+          _$BanFromCommunityResponseImpl value,
+          $Res Function(_$BanFromCommunityResponseImpl) then) =
+      __$$BanFromCommunityResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonView personView, bool banned});
@@ -95,12 +95,13 @@ abstract class _$$_BanFromCommunityResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_BanFromCommunityResponseCopyWithImpl<$Res>
+class __$$BanFromCommunityResponseImplCopyWithImpl<$Res>
     extends _$BanFromCommunityResponseCopyWithImpl<$Res,
-        _$_BanFromCommunityResponse>
-    implements _$$_BanFromCommunityResponseCopyWith<$Res> {
-  __$$_BanFromCommunityResponseCopyWithImpl(_$_BanFromCommunityResponse _value,
-      $Res Function(_$_BanFromCommunityResponse) _then)
+        _$BanFromCommunityResponseImpl>
+    implements _$$BanFromCommunityResponseImplCopyWith<$Res> {
+  __$$BanFromCommunityResponseImplCopyWithImpl(
+      _$BanFromCommunityResponseImpl _value,
+      $Res Function(_$BanFromCommunityResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -109,7 +110,7 @@ class __$$_BanFromCommunityResponseCopyWithImpl<$Res>
     Object? personView = null,
     Object? banned = null,
   }) {
-    return _then(_$_BanFromCommunityResponse(
+    return _then(_$BanFromCommunityResponseImpl(
       personView: null == personView
           ? _value.personView
           : personView // ignore: cast_nullable_to_non_nullable
@@ -125,13 +126,13 @@ class __$$_BanFromCommunityResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_BanFromCommunityResponse extends _BanFromCommunityResponse {
-  const _$_BanFromCommunityResponse(
+class _$BanFromCommunityResponseImpl extends _BanFromCommunityResponse {
+  const _$BanFromCommunityResponseImpl(
       {required this.personView, required this.banned})
       : super._();
 
-  factory _$_BanFromCommunityResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_BanFromCommunityResponseFromJson(json);
+  factory _$BanFromCommunityResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BanFromCommunityResponseImplFromJson(json);
 
   @override
   final PersonView personView;
@@ -147,7 +148,7 @@ class _$_BanFromCommunityResponse extends _BanFromCommunityResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BanFromCommunityResponse &&
+            other is _$BanFromCommunityResponseImpl &&
             (identical(other.personView, personView) ||
                 other.personView == personView) &&
             (identical(other.banned, banned) || other.banned == banned));
@@ -160,13 +161,13 @@ class _$_BanFromCommunityResponse extends _BanFromCommunityResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BanFromCommunityResponseCopyWith<_$_BanFromCommunityResponse>
-      get copyWith => __$$_BanFromCommunityResponseCopyWithImpl<
-          _$_BanFromCommunityResponse>(this, _$identity);
+  _$$BanFromCommunityResponseImplCopyWith<_$BanFromCommunityResponseImpl>
+      get copyWith => __$$BanFromCommunityResponseImplCopyWithImpl<
+          _$BanFromCommunityResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BanFromCommunityResponseToJson(
+    return _$$BanFromCommunityResponseImplToJson(
       this,
     );
   }
@@ -175,11 +176,11 @@ class _$_BanFromCommunityResponse extends _BanFromCommunityResponse {
 abstract class _BanFromCommunityResponse extends BanFromCommunityResponse {
   const factory _BanFromCommunityResponse(
       {required final PersonView personView,
-      required final bool banned}) = _$_BanFromCommunityResponse;
+      required final bool banned}) = _$BanFromCommunityResponseImpl;
   const _BanFromCommunityResponse._() : super._();
 
   factory _BanFromCommunityResponse.fromJson(Map<String, dynamic> json) =
-      _$_BanFromCommunityResponse.fromJson;
+      _$BanFromCommunityResponseImpl.fromJson;
 
   @override
   PersonView get personView;
@@ -187,6 +188,6 @@ abstract class _BanFromCommunityResponse extends BanFromCommunityResponse {
   bool get banned;
   @override
   @JsonKey(ignore: true)
-  _$$_BanFromCommunityResponseCopyWith<_$_BanFromCommunityResponse>
+  _$$BanFromCommunityResponseImplCopyWith<_$BanFromCommunityResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/community/ban_from_community_response.g.dart
+++ b/lib/src/v3/models/community/ban_from_community_response.g.dart
@@ -6,16 +6,16 @@ part of 'ban_from_community_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_BanFromCommunityResponse _$$_BanFromCommunityResponseFromJson(
+_$BanFromCommunityResponseImpl _$$BanFromCommunityResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_BanFromCommunityResponse(
+    _$BanFromCommunityResponseImpl(
       personView:
           PersonView.fromJson(json['person_view'] as Map<String, dynamic>),
       banned: json['banned'] as bool,
     );
 
-Map<String, dynamic> _$$_BanFromCommunityResponseToJson(
-        _$_BanFromCommunityResponse instance) =>
+Map<String, dynamic> _$$BanFromCommunityResponseImplToJson(
+        _$BanFromCommunityResponseImpl instance) =>
     <String, dynamic>{
       'person_view': instance.personView.toJson(),
       'banned': instance.banned,

--- a/lib/src/v3/models/community/block_community_response.freezed.dart
+++ b/lib/src/v3/models/community/block_community_response.freezed.dart
@@ -80,11 +80,12 @@ class _$BlockCommunityResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_BlockCommunityResponseCopyWith<$Res>
+abstract class _$$BlockCommunityResponseImplCopyWith<$Res>
     implements $BlockCommunityResponseCopyWith<$Res> {
-  factory _$$_BlockCommunityResponseCopyWith(_$_BlockCommunityResponse value,
-          $Res Function(_$_BlockCommunityResponse) then) =
-      __$$_BlockCommunityResponseCopyWithImpl<$Res>;
+  factory _$$BlockCommunityResponseImplCopyWith(
+          _$BlockCommunityResponseImpl value,
+          $Res Function(_$BlockCommunityResponseImpl) then) =
+      __$$BlockCommunityResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CommunityView communityView, bool blocked});
@@ -94,12 +95,13 @@ abstract class _$$_BlockCommunityResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_BlockCommunityResponseCopyWithImpl<$Res>
+class __$$BlockCommunityResponseImplCopyWithImpl<$Res>
     extends _$BlockCommunityResponseCopyWithImpl<$Res,
-        _$_BlockCommunityResponse>
-    implements _$$_BlockCommunityResponseCopyWith<$Res> {
-  __$$_BlockCommunityResponseCopyWithImpl(_$_BlockCommunityResponse _value,
-      $Res Function(_$_BlockCommunityResponse) _then)
+        _$BlockCommunityResponseImpl>
+    implements _$$BlockCommunityResponseImplCopyWith<$Res> {
+  __$$BlockCommunityResponseImplCopyWithImpl(
+      _$BlockCommunityResponseImpl _value,
+      $Res Function(_$BlockCommunityResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -108,7 +110,7 @@ class __$$_BlockCommunityResponseCopyWithImpl<$Res>
     Object? communityView = null,
     Object? blocked = null,
   }) {
-    return _then(_$_BlockCommunityResponse(
+    return _then(_$BlockCommunityResponseImpl(
       communityView: null == communityView
           ? _value.communityView
           : communityView // ignore: cast_nullable_to_non_nullable
@@ -124,13 +126,13 @@ class __$$_BlockCommunityResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_BlockCommunityResponse extends _BlockCommunityResponse {
-  const _$_BlockCommunityResponse(
+class _$BlockCommunityResponseImpl extends _BlockCommunityResponse {
+  const _$BlockCommunityResponseImpl(
       {required this.communityView, required this.blocked})
       : super._();
 
-  factory _$_BlockCommunityResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_BlockCommunityResponseFromJson(json);
+  factory _$BlockCommunityResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BlockCommunityResponseImplFromJson(json);
 
   @override
   final CommunityView communityView;
@@ -146,7 +148,7 @@ class _$_BlockCommunityResponse extends _BlockCommunityResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BlockCommunityResponse &&
+            other is _$BlockCommunityResponseImpl &&
             (identical(other.communityView, communityView) ||
                 other.communityView == communityView) &&
             (identical(other.blocked, blocked) || other.blocked == blocked));
@@ -159,13 +161,13 @@ class _$_BlockCommunityResponse extends _BlockCommunityResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BlockCommunityResponseCopyWith<_$_BlockCommunityResponse> get copyWith =>
-      __$$_BlockCommunityResponseCopyWithImpl<_$_BlockCommunityResponse>(
-          this, _$identity);
+  _$$BlockCommunityResponseImplCopyWith<_$BlockCommunityResponseImpl>
+      get copyWith => __$$BlockCommunityResponseImplCopyWithImpl<
+          _$BlockCommunityResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BlockCommunityResponseToJson(
+    return _$$BlockCommunityResponseImplToJson(
       this,
     );
   }
@@ -174,11 +176,11 @@ class _$_BlockCommunityResponse extends _BlockCommunityResponse {
 abstract class _BlockCommunityResponse extends BlockCommunityResponse {
   const factory _BlockCommunityResponse(
       {required final CommunityView communityView,
-      required final bool blocked}) = _$_BlockCommunityResponse;
+      required final bool blocked}) = _$BlockCommunityResponseImpl;
   const _BlockCommunityResponse._() : super._();
 
   factory _BlockCommunityResponse.fromJson(Map<String, dynamic> json) =
-      _$_BlockCommunityResponse.fromJson;
+      _$BlockCommunityResponseImpl.fromJson;
 
   @override
   CommunityView get communityView;
@@ -186,6 +188,6 @@ abstract class _BlockCommunityResponse extends BlockCommunityResponse {
   bool get blocked;
   @override
   @JsonKey(ignore: true)
-  _$$_BlockCommunityResponseCopyWith<_$_BlockCommunityResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$BlockCommunityResponseImplCopyWith<_$BlockCommunityResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/community/block_community_response.g.dart
+++ b/lib/src/v3/models/community/block_community_response.g.dart
@@ -6,16 +6,16 @@ part of 'block_community_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_BlockCommunityResponse _$$_BlockCommunityResponseFromJson(
+_$BlockCommunityResponseImpl _$$BlockCommunityResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_BlockCommunityResponse(
+    _$BlockCommunityResponseImpl(
       communityView: CommunityView.fromJson(
           json['community_view'] as Map<String, dynamic>),
       blocked: json['blocked'] as bool,
     );
 
-Map<String, dynamic> _$$_BlockCommunityResponseToJson(
-        _$_BlockCommunityResponse instance) =>
+Map<String, dynamic> _$$BlockCommunityResponseImplToJson(
+        _$BlockCommunityResponseImpl instance) =>
     <String, dynamic>{
       'community_view': instance.communityView.toJson(),
       'blocked': instance.blocked,

--- a/lib/src/v3/models/community/community.freezed.dart
+++ b/lib/src/v3/models/community/community.freezed.dart
@@ -183,10 +183,11 @@ class _$CommunityCopyWithImpl<$Res, $Val extends Community>
 }
 
 /// @nodoc
-abstract class _$$_CommunityCopyWith<$Res> implements $CommunityCopyWith<$Res> {
-  factory _$$_CommunityCopyWith(
-          _$_Community value, $Res Function(_$_Community) then) =
-      __$$_CommunityCopyWithImpl<$Res>;
+abstract class _$$CommunityImplCopyWith<$Res>
+    implements $CommunityCopyWith<$Res> {
+  factory _$$CommunityImplCopyWith(
+          _$CommunityImpl value, $Res Function(_$CommunityImpl) then) =
+      __$$CommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -211,11 +212,11 @@ abstract class _$$_CommunityCopyWith<$Res> implements $CommunityCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_CommunityCopyWithImpl<$Res>
-    extends _$CommunityCopyWithImpl<$Res, _$_Community>
-    implements _$$_CommunityCopyWith<$Res> {
-  __$$_CommunityCopyWithImpl(
-      _$_Community _value, $Res Function(_$_Community) _then)
+class __$$CommunityImplCopyWithImpl<$Res>
+    extends _$CommunityCopyWithImpl<$Res, _$CommunityImpl>
+    implements _$$CommunityImplCopyWith<$Res> {
+  __$$CommunityImplCopyWithImpl(
+      _$CommunityImpl _value, $Res Function(_$CommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -240,7 +241,7 @@ class __$$_CommunityCopyWithImpl<$Res>
     Object? postingRestrictedToMods = null,
     Object? instanceId = null,
   }) {
-    return _then(_$_Community(
+    return _then(_$CommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -320,8 +321,8 @@ class __$$_CommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_Community extends _Community {
-  const _$_Community(
+class _$CommunityImpl extends _Community {
+  const _$CommunityImpl(
       {required this.id,
       required this.name,
       required this.title,
@@ -342,8 +343,8 @@ class _$_Community extends _Community {
       required this.instanceId})
       : super._();
 
-  factory _$_Community.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityFromJson(json);
+  factory _$CommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityImplFromJson(json);
 
   @override
   final int id;
@@ -393,7 +394,7 @@ class _$_Community extends _Community {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Community &&
+            other is _$CommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.title, title) || other.title == title) &&
@@ -447,12 +448,12 @@ class _$_Community extends _Community {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityCopyWith<_$_Community> get copyWith =>
-      __$$_CommunityCopyWithImpl<_$_Community>(this, _$identity);
+  _$$CommunityImplCopyWith<_$CommunityImpl> get copyWith =>
+      __$$CommunityImplCopyWithImpl<_$CommunityImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityToJson(
+    return _$$CommunityImplToJson(
       this,
     );
   }
@@ -477,11 +478,11 @@ abstract class _Community extends Community {
       @deprecated final String? inboxUrl,
       required final bool hidden,
       required final bool postingRestrictedToMods,
-      required final int instanceId}) = _$_Community;
+      required final int instanceId}) = _$CommunityImpl;
   const _Community._() : super._();
 
   factory _Community.fromJson(Map<String, dynamic> json) =
-      _$_Community.fromJson;
+      _$CommunityImpl.fromJson;
 
   @override
   int get id;
@@ -523,6 +524,6 @@ abstract class _Community extends Community {
   int get instanceId;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityCopyWith<_$_Community> get copyWith =>
+  _$$CommunityImplCopyWith<_$CommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/community/community.g.dart
+++ b/lib/src/v3/models/community/community.g.dart
@@ -6,7 +6,8 @@ part of 'community.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Community _$$_CommunityFromJson(Map<String, dynamic> json) => _$_Community(
+_$CommunityImpl _$$CommunityImplFromJson(Map<String, dynamic> json) =>
+    _$CommunityImpl(
       id: json['id'] as int,
       name: json['name'] as String,
       title: json['title'] as String,
@@ -28,7 +29,7 @@ _$_Community _$$_CommunityFromJson(Map<String, dynamic> json) => _$_Community(
       instanceId: json['instance_id'] as int,
     );
 
-Map<String, dynamic> _$$_CommunityToJson(_$_Community instance) =>
+Map<String, dynamic> _$$CommunityImplToJson(_$CommunityImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'name': instance.name,

--- a/lib/src/v3/models/community/community_aggregates.dart
+++ b/lib/src/v3/models/community/community_aggregates.dart
@@ -10,7 +10,7 @@ part 'community_aggregates.g.dart';
 class CommunityAggregates with _$CommunityAggregates {
   @modelSerde
   const factory CommunityAggregates({
-    required int id,
+    @deprecated int? id,
     required int communityId,
     required int subscribers,
     required int posts,

--- a/lib/src/v3/models/community/community_aggregates.freezed.dart
+++ b/lib/src/v3/models/community/community_aggregates.freezed.dart
@@ -20,7 +20,8 @@ CommunityAggregates _$CommunityAggregatesFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$CommunityAggregates {
-  int get id => throw _privateConstructorUsedError;
+  @deprecated
+  int? get id => throw _privateConstructorUsedError;
   int get communityId => throw _privateConstructorUsedError;
   int get subscribers => throw _privateConstructorUsedError;
   int get posts => throw _privateConstructorUsedError;
@@ -46,7 +47,7 @@ abstract class $CommunityAggregatesCopyWith<$Res> {
       _$CommunityAggregatesCopyWithImpl<$Res, CommunityAggregates>;
   @useResult
   $Res call(
-      {int id,
+      {@deprecated int? id,
       int communityId,
       int subscribers,
       int posts,
@@ -72,7 +73,7 @@ class _$CommunityAggregatesCopyWithImpl<$Res, $Val extends CommunityAggregates>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? communityId = null,
     Object? subscribers = null,
     Object? posts = null,
@@ -85,10 +86,10 @@ class _$CommunityAggregatesCopyWithImpl<$Res, $Val extends CommunityAggregates>
     Object? hotRank = freezed,
   }) {
     return _then(_value.copyWith(
-      id: null == id
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -134,15 +135,15 @@ class _$CommunityAggregatesCopyWithImpl<$Res, $Val extends CommunityAggregates>
 }
 
 /// @nodoc
-abstract class _$$_CommunityAggregatesCopyWith<$Res>
+abstract class _$$CommunityAggregatesImplCopyWith<$Res>
     implements $CommunityAggregatesCopyWith<$Res> {
-  factory _$$_CommunityAggregatesCopyWith(_$_CommunityAggregates value,
-          $Res Function(_$_CommunityAggregates) then) =
-      __$$_CommunityAggregatesCopyWithImpl<$Res>;
+  factory _$$CommunityAggregatesImplCopyWith(_$CommunityAggregatesImpl value,
+          $Res Function(_$CommunityAggregatesImpl) then) =
+      __$$CommunityAggregatesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
-      {int id,
+      {@deprecated int? id,
       int communityId,
       int subscribers,
       int posts,
@@ -156,17 +157,17 @@ abstract class _$$_CommunityAggregatesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunityAggregatesCopyWithImpl<$Res>
-    extends _$CommunityAggregatesCopyWithImpl<$Res, _$_CommunityAggregates>
-    implements _$$_CommunityAggregatesCopyWith<$Res> {
-  __$$_CommunityAggregatesCopyWithImpl(_$_CommunityAggregates _value,
-      $Res Function(_$_CommunityAggregates) _then)
+class __$$CommunityAggregatesImplCopyWithImpl<$Res>
+    extends _$CommunityAggregatesCopyWithImpl<$Res, _$CommunityAggregatesImpl>
+    implements _$$CommunityAggregatesImplCopyWith<$Res> {
+  __$$CommunityAggregatesImplCopyWithImpl(_$CommunityAggregatesImpl _value,
+      $Res Function(_$CommunityAggregatesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? communityId = null,
     Object? subscribers = null,
     Object? posts = null,
@@ -178,11 +179,11 @@ class __$$_CommunityAggregatesCopyWithImpl<$Res>
     Object? usersActiveHalfYear = null,
     Object? hotRank = freezed,
   }) {
-    return _then(_$_CommunityAggregates(
-      id: null == id
+    return _then(_$CommunityAggregatesImpl(
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       communityId: null == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -230,9 +231,9 @@ class __$$_CommunityAggregatesCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunityAggregates extends _CommunityAggregates {
-  const _$_CommunityAggregates(
-      {required this.id,
+class _$CommunityAggregatesImpl extends _CommunityAggregates {
+  const _$CommunityAggregatesImpl(
+      {@deprecated this.id,
       required this.communityId,
       required this.subscribers,
       required this.posts,
@@ -245,11 +246,12 @@ class _$_CommunityAggregates extends _CommunityAggregates {
       @deprecated this.hotRank})
       : super._();
 
-  factory _$_CommunityAggregates.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityAggregatesFromJson(json);
+  factory _$CommunityAggregatesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityAggregatesImplFromJson(json);
 
   @override
-  final int id;
+  @deprecated
+  final int? id;
   @override
   final int communityId;
   @override
@@ -281,7 +283,7 @@ class _$_CommunityAggregates extends _CommunityAggregates {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunityAggregates &&
+            other is _$CommunityAggregatesImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
@@ -322,13 +324,13 @@ class _$_CommunityAggregates extends _CommunityAggregates {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityAggregatesCopyWith<_$_CommunityAggregates> get copyWith =>
-      __$$_CommunityAggregatesCopyWithImpl<_$_CommunityAggregates>(
+  _$$CommunityAggregatesImplCopyWith<_$CommunityAggregatesImpl> get copyWith =>
+      __$$CommunityAggregatesImplCopyWithImpl<_$CommunityAggregatesImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityAggregatesToJson(
+    return _$$CommunityAggregatesImplToJson(
       this,
     );
   }
@@ -336,7 +338,7 @@ class _$_CommunityAggregates extends _CommunityAggregates {
 
 abstract class _CommunityAggregates extends CommunityAggregates {
   const factory _CommunityAggregates(
-      {required final int id,
+      {@deprecated final int? id,
       required final int communityId,
       required final int subscribers,
       required final int posts,
@@ -346,14 +348,15 @@ abstract class _CommunityAggregates extends CommunityAggregates {
       required final int usersActiveWeek,
       required final int usersActiveMonth,
       required final int usersActiveHalfYear,
-      @deprecated final int? hotRank}) = _$_CommunityAggregates;
+      @deprecated final int? hotRank}) = _$CommunityAggregatesImpl;
   const _CommunityAggregates._() : super._();
 
   factory _CommunityAggregates.fromJson(Map<String, dynamic> json) =
-      _$_CommunityAggregates.fromJson;
+      _$CommunityAggregatesImpl.fromJson;
 
   @override
-  int get id;
+  @deprecated
+  int? get id;
   @override
   int get communityId;
   @override
@@ -377,6 +380,6 @@ abstract class _CommunityAggregates extends CommunityAggregates {
   int? get hotRank;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityAggregatesCopyWith<_$_CommunityAggregates> get copyWith =>
+  _$$CommunityAggregatesImplCopyWith<_$CommunityAggregatesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/community/community_aggregates.g.dart
+++ b/lib/src/v3/models/community/community_aggregates.g.dart
@@ -6,10 +6,10 @@ part of 'community_aggregates.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommunityAggregates _$$_CommunityAggregatesFromJson(
+_$CommunityAggregatesImpl _$$CommunityAggregatesImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CommunityAggregates(
-      id: json['id'] as int,
+    _$CommunityAggregatesImpl(
+      id: json['id'] as int?,
       communityId: json['community_id'] as int,
       subscribers: json['subscribers'] as int,
       posts: json['posts'] as int,
@@ -22,8 +22,8 @@ _$_CommunityAggregates _$$_CommunityAggregatesFromJson(
       hotRank: json['hot_rank'] as int?,
     );
 
-Map<String, dynamic> _$$_CommunityAggregatesToJson(
-        _$_CommunityAggregates instance) =>
+Map<String, dynamic> _$$CommunityAggregatesImplToJson(
+        _$CommunityAggregatesImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'community_id': instance.communityId,

--- a/lib/src/v3/models/community/community_response.freezed.dart
+++ b/lib/src/v3/models/community/community_response.freezed.dart
@@ -78,11 +78,11 @@ class _$CommunityResponseCopyWithImpl<$Res, $Val extends CommunityResponse>
 }
 
 /// @nodoc
-abstract class _$$_CommunityResponseCopyWith<$Res>
+abstract class _$$CommunityResponseImplCopyWith<$Res>
     implements $CommunityResponseCopyWith<$Res> {
-  factory _$$_CommunityResponseCopyWith(_$_CommunityResponse value,
-          $Res Function(_$_CommunityResponse) then) =
-      __$$_CommunityResponseCopyWithImpl<$Res>;
+  factory _$$CommunityResponseImplCopyWith(_$CommunityResponseImpl value,
+          $Res Function(_$CommunityResponseImpl) then) =
+      __$$CommunityResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CommunityView communityView, List<int> discussionLanguages});
@@ -92,11 +92,11 @@ abstract class _$$_CommunityResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunityResponseCopyWithImpl<$Res>
-    extends _$CommunityResponseCopyWithImpl<$Res, _$_CommunityResponse>
-    implements _$$_CommunityResponseCopyWith<$Res> {
-  __$$_CommunityResponseCopyWithImpl(
-      _$_CommunityResponse _value, $Res Function(_$_CommunityResponse) _then)
+class __$$CommunityResponseImplCopyWithImpl<$Res>
+    extends _$CommunityResponseCopyWithImpl<$Res, _$CommunityResponseImpl>
+    implements _$$CommunityResponseImplCopyWith<$Res> {
+  __$$CommunityResponseImplCopyWithImpl(_$CommunityResponseImpl _value,
+      $Res Function(_$CommunityResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -105,7 +105,7 @@ class __$$_CommunityResponseCopyWithImpl<$Res>
     Object? communityView = null,
     Object? discussionLanguages = null,
   }) {
-    return _then(_$_CommunityResponse(
+    return _then(_$CommunityResponseImpl(
       communityView: null == communityView
           ? _value.communityView
           : communityView // ignore: cast_nullable_to_non_nullable
@@ -121,15 +121,15 @@ class __$$_CommunityResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunityResponse extends _CommunityResponse {
-  const _$_CommunityResponse(
+class _$CommunityResponseImpl extends _CommunityResponse {
+  const _$CommunityResponseImpl(
       {required this.communityView,
       required final List<int> discussionLanguages})
       : _discussionLanguages = discussionLanguages,
         super._();
 
-  factory _$_CommunityResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityResponseFromJson(json);
+  factory _$CommunityResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityResponseImplFromJson(json);
 
   @override
   final CommunityView communityView;
@@ -151,7 +151,7 @@ class _$_CommunityResponse extends _CommunityResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunityResponse &&
+            other is _$CommunityResponseImpl &&
             (identical(other.communityView, communityView) ||
                 other.communityView == communityView) &&
             const DeepCollectionEquality()
@@ -166,13 +166,13 @@ class _$_CommunityResponse extends _CommunityResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityResponseCopyWith<_$_CommunityResponse> get copyWith =>
-      __$$_CommunityResponseCopyWithImpl<_$_CommunityResponse>(
+  _$$CommunityResponseImplCopyWith<_$CommunityResponseImpl> get copyWith =>
+      __$$CommunityResponseImplCopyWithImpl<_$CommunityResponseImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityResponseToJson(
+    return _$$CommunityResponseImplToJson(
       this,
     );
   }
@@ -181,11 +181,11 @@ class _$_CommunityResponse extends _CommunityResponse {
 abstract class _CommunityResponse extends CommunityResponse {
   const factory _CommunityResponse(
       {required final CommunityView communityView,
-      required final List<int> discussionLanguages}) = _$_CommunityResponse;
+      required final List<int> discussionLanguages}) = _$CommunityResponseImpl;
   const _CommunityResponse._() : super._();
 
   factory _CommunityResponse.fromJson(Map<String, dynamic> json) =
-      _$_CommunityResponse.fromJson;
+      _$CommunityResponseImpl.fromJson;
 
   @override
   CommunityView get communityView;
@@ -193,6 +193,6 @@ abstract class _CommunityResponse extends CommunityResponse {
   List<int> get discussionLanguages;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityResponseCopyWith<_$_CommunityResponse> get copyWith =>
+  _$$CommunityResponseImplCopyWith<_$CommunityResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/community/community_response.g.dart
+++ b/lib/src/v3/models/community/community_response.g.dart
@@ -6,8 +6,9 @@ part of 'community_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommunityResponse _$$_CommunityResponseFromJson(Map<String, dynamic> json) =>
-    _$_CommunityResponse(
+_$CommunityResponseImpl _$$CommunityResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CommunityResponseImpl(
       communityView: CommunityView.fromJson(
           json['community_view'] as Map<String, dynamic>),
       discussionLanguages: (json['discussion_languages'] as List<dynamic>)
@@ -15,8 +16,8 @@ _$_CommunityResponse _$$_CommunityResponseFromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
-Map<String, dynamic> _$$_CommunityResponseToJson(
-        _$_CommunityResponse instance) =>
+Map<String, dynamic> _$$CommunityResponseImplToJson(
+        _$CommunityResponseImpl instance) =>
     <String, dynamic>{
       'community_view': instance.communityView.toJson(),
       'discussion_languages': instance.discussionLanguages,

--- a/lib/src/v3/models/community/get_community_response.freezed.dart
+++ b/lib/src/v3/models/community/get_community_response.freezed.dart
@@ -109,11 +109,11 @@ class _$GetCommunityResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_GetCommunityResponseCopyWith<$Res>
+abstract class _$$GetCommunityResponseImplCopyWith<$Res>
     implements $GetCommunityResponseCopyWith<$Res> {
-  factory _$$_GetCommunityResponseCopyWith(_$_GetCommunityResponse value,
-          $Res Function(_$_GetCommunityResponse) then) =
-      __$$_GetCommunityResponseCopyWithImpl<$Res>;
+  factory _$$GetCommunityResponseImplCopyWith(_$GetCommunityResponseImpl value,
+          $Res Function(_$GetCommunityResponseImpl) then) =
+      __$$GetCommunityResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -129,11 +129,11 @@ abstract class _$$_GetCommunityResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetCommunityResponseCopyWithImpl<$Res>
-    extends _$GetCommunityResponseCopyWithImpl<$Res, _$_GetCommunityResponse>
-    implements _$$_GetCommunityResponseCopyWith<$Res> {
-  __$$_GetCommunityResponseCopyWithImpl(_$_GetCommunityResponse _value,
-      $Res Function(_$_GetCommunityResponse) _then)
+class __$$GetCommunityResponseImplCopyWithImpl<$Res>
+    extends _$GetCommunityResponseCopyWithImpl<$Res, _$GetCommunityResponseImpl>
+    implements _$$GetCommunityResponseImplCopyWith<$Res> {
+  __$$GetCommunityResponseImplCopyWithImpl(_$GetCommunityResponseImpl _value,
+      $Res Function(_$GetCommunityResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -144,7 +144,7 @@ class __$$_GetCommunityResponseCopyWithImpl<$Res>
     Object? moderators = null,
     Object? discussionLanguages = null,
   }) {
-    return _then(_$_GetCommunityResponse(
+    return _then(_$GetCommunityResponseImpl(
       communityView: null == communityView
           ? _value.communityView
           : communityView // ignore: cast_nullable_to_non_nullable
@@ -168,8 +168,8 @@ class __$$_GetCommunityResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetCommunityResponse extends _GetCommunityResponse {
-  const _$_GetCommunityResponse(
+class _$GetCommunityResponseImpl extends _GetCommunityResponse {
+  const _$GetCommunityResponseImpl(
       {required this.communityView,
       this.site,
       required final List<CommunityModeratorView> moderators,
@@ -178,8 +178,8 @@ class _$_GetCommunityResponse extends _GetCommunityResponse {
         _discussionLanguages = discussionLanguages,
         super._();
 
-  factory _$_GetCommunityResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetCommunityResponseFromJson(json);
+  factory _$GetCommunityResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetCommunityResponseImplFromJson(json);
 
   @override
   final CommunityView communityView;
@@ -211,7 +211,7 @@ class _$_GetCommunityResponse extends _GetCommunityResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetCommunityResponse &&
+            other is _$GetCommunityResponseImpl &&
             (identical(other.communityView, communityView) ||
                 other.communityView == communityView) &&
             (identical(other.site, site) || other.site == site) &&
@@ -233,13 +233,14 @@ class _$_GetCommunityResponse extends _GetCommunityResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetCommunityResponseCopyWith<_$_GetCommunityResponse> get copyWith =>
-      __$$_GetCommunityResponseCopyWithImpl<_$_GetCommunityResponse>(
-          this, _$identity);
+  _$$GetCommunityResponseImplCopyWith<_$GetCommunityResponseImpl>
+      get copyWith =>
+          __$$GetCommunityResponseImplCopyWithImpl<_$GetCommunityResponseImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetCommunityResponseToJson(
+    return _$$GetCommunityResponseImplToJson(
       this,
     );
   }
@@ -247,14 +248,15 @@ class _$_GetCommunityResponse extends _GetCommunityResponse {
 
 abstract class _GetCommunityResponse extends GetCommunityResponse {
   const factory _GetCommunityResponse(
-      {required final CommunityView communityView,
-      final Site? site,
-      required final List<CommunityModeratorView> moderators,
-      required final List<int> discussionLanguages}) = _$_GetCommunityResponse;
+          {required final CommunityView communityView,
+          final Site? site,
+          required final List<CommunityModeratorView> moderators,
+          required final List<int> discussionLanguages}) =
+      _$GetCommunityResponseImpl;
   const _GetCommunityResponse._() : super._();
 
   factory _GetCommunityResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetCommunityResponse.fromJson;
+      _$GetCommunityResponseImpl.fromJson;
 
   @override
   CommunityView get communityView;
@@ -266,6 +268,6 @@ abstract class _GetCommunityResponse extends GetCommunityResponse {
   List<int> get discussionLanguages;
   @override
   @JsonKey(ignore: true)
-  _$$_GetCommunityResponseCopyWith<_$_GetCommunityResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$GetCommunityResponseImplCopyWith<_$GetCommunityResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/community/get_community_response.g.dart
+++ b/lib/src/v3/models/community/get_community_response.g.dart
@@ -6,9 +6,9 @@ part of 'get_community_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetCommunityResponse _$$_GetCommunityResponseFromJson(
+_$GetCommunityResponseImpl _$$GetCommunityResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GetCommunityResponse(
+    _$GetCommunityResponseImpl(
       communityView: CommunityView.fromJson(
           json['community_view'] as Map<String, dynamic>),
       site: json['site'] == null
@@ -23,8 +23,8 @@ _$_GetCommunityResponse _$$_GetCommunityResponseFromJson(
           .toList(),
     );
 
-Map<String, dynamic> _$$_GetCommunityResponseToJson(
-        _$_GetCommunityResponse instance) =>
+Map<String, dynamic> _$$GetCommunityResponseImplToJson(
+        _$GetCommunityResponseImpl instance) =>
     <String, dynamic>{
       'community_view': instance.communityView.toJson(),
       'site': instance.site?.toJson(),

--- a/lib/src/v3/models/community/hide_community_response.freezed.dart
+++ b/lib/src/v3/models/community/hide_community_response.freezed.dart
@@ -95,11 +95,12 @@ class _$HideCommunityResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_HideCommunityResponseCopyWith<$Res>
+abstract class _$$HideCommunityResponseImplCopyWith<$Res>
     implements $HideCommunityResponseCopyWith<$Res> {
-  factory _$$_HideCommunityResponseCopyWith(_$_HideCommunityResponse value,
-          $Res Function(_$_HideCommunityResponse) then) =
-      __$$_HideCommunityResponseCopyWithImpl<$Res>;
+  factory _$$HideCommunityResponseImplCopyWith(
+          _$HideCommunityResponseImpl value,
+          $Res Function(_$HideCommunityResponseImpl) then) =
+      __$$HideCommunityResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -112,11 +113,12 @@ abstract class _$$_HideCommunityResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_HideCommunityResponseCopyWithImpl<$Res>
-    extends _$HideCommunityResponseCopyWithImpl<$Res, _$_HideCommunityResponse>
-    implements _$$_HideCommunityResponseCopyWith<$Res> {
-  __$$_HideCommunityResponseCopyWithImpl(_$_HideCommunityResponse _value,
-      $Res Function(_$_HideCommunityResponse) _then)
+class __$$HideCommunityResponseImplCopyWithImpl<$Res>
+    extends _$HideCommunityResponseCopyWithImpl<$Res,
+        _$HideCommunityResponseImpl>
+    implements _$$HideCommunityResponseImplCopyWith<$Res> {
+  __$$HideCommunityResponseImplCopyWithImpl(_$HideCommunityResponseImpl _value,
+      $Res Function(_$HideCommunityResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -126,7 +128,7 @@ class __$$_HideCommunityResponseCopyWithImpl<$Res>
     Object? discussionLanguages = freezed,
     Object? success = freezed,
   }) {
-    return _then(_$_HideCommunityResponse(
+    return _then(_$HideCommunityResponseImpl(
       communityView: freezed == communityView
           ? _value.communityView
           : communityView // ignore: cast_nullable_to_non_nullable
@@ -146,16 +148,16 @@ class __$$_HideCommunityResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_HideCommunityResponse extends _HideCommunityResponse {
-  const _$_HideCommunityResponse(
+class _$HideCommunityResponseImpl extends _HideCommunityResponse {
+  const _$HideCommunityResponseImpl(
       {@deprecated this.communityView,
       @deprecated final List<int>? discussionLanguages,
       this.success})
       : _discussionLanguages = discussionLanguages,
         super._();
 
-  factory _$_HideCommunityResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_HideCommunityResponseFromJson(json);
+  factory _$HideCommunityResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$HideCommunityResponseImplFromJson(json);
 
   @override
   @deprecated
@@ -184,7 +186,7 @@ class _$_HideCommunityResponse extends _HideCommunityResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_HideCommunityResponse &&
+            other is _$HideCommunityResponseImpl &&
             (identical(other.communityView, communityView) ||
                 other.communityView == communityView) &&
             const DeepCollectionEquality()
@@ -200,13 +202,13 @@ class _$_HideCommunityResponse extends _HideCommunityResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_HideCommunityResponseCopyWith<_$_HideCommunityResponse> get copyWith =>
-      __$$_HideCommunityResponseCopyWithImpl<_$_HideCommunityResponse>(
-          this, _$identity);
+  _$$HideCommunityResponseImplCopyWith<_$HideCommunityResponseImpl>
+      get copyWith => __$$HideCommunityResponseImplCopyWithImpl<
+          _$HideCommunityResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_HideCommunityResponseToJson(
+    return _$$HideCommunityResponseImplToJson(
       this,
     );
   }
@@ -216,11 +218,11 @@ abstract class _HideCommunityResponse extends HideCommunityResponse {
   const factory _HideCommunityResponse(
       {@deprecated final CommunityView? communityView,
       @deprecated final List<int>? discussionLanguages,
-      final bool? success}) = _$_HideCommunityResponse;
+      final bool? success}) = _$HideCommunityResponseImpl;
   const _HideCommunityResponse._() : super._();
 
   factory _HideCommunityResponse.fromJson(Map<String, dynamic> json) =
-      _$_HideCommunityResponse.fromJson;
+      _$HideCommunityResponseImpl.fromJson;
 
   @override
   @deprecated
@@ -232,6 +234,6 @@ abstract class _HideCommunityResponse extends HideCommunityResponse {
   bool? get success;
   @override
   @JsonKey(ignore: true)
-  _$$_HideCommunityResponseCopyWith<_$_HideCommunityResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$HideCommunityResponseImplCopyWith<_$HideCommunityResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/community/hide_community_response.g.dart
+++ b/lib/src/v3/models/community/hide_community_response.g.dart
@@ -6,9 +6,9 @@ part of 'hide_community_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_HideCommunityResponse _$$_HideCommunityResponseFromJson(
+_$HideCommunityResponseImpl _$$HideCommunityResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_HideCommunityResponse(
+    _$HideCommunityResponseImpl(
       communityView: json['community_view'] == null
           ? null
           : CommunityView.fromJson(
@@ -19,8 +19,8 @@ _$_HideCommunityResponse _$$_HideCommunityResponseFromJson(
       success: json['success'] as bool?,
     );
 
-Map<String, dynamic> _$$_HideCommunityResponseToJson(
-        _$_HideCommunityResponse instance) =>
+Map<String, dynamic> _$$HideCommunityResponseImplToJson(
+        _$HideCommunityResponseImpl instance) =>
     <String, dynamic>{
       'community_view': instance.communityView?.toJson(),
       'discussion_languages': instance.discussionLanguages,

--- a/lib/src/v3/models/community/list_communities_response.freezed.dart
+++ b/lib/src/v3/models/community/list_communities_response.freezed.dart
@@ -64,23 +64,25 @@ class _$ListCommunitiesResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ListCommunitiesResponseCopyWith<$Res>
+abstract class _$$ListCommunitiesResponseImplCopyWith<$Res>
     implements $ListCommunitiesResponseCopyWith<$Res> {
-  factory _$$_ListCommunitiesResponseCopyWith(_$_ListCommunitiesResponse value,
-          $Res Function(_$_ListCommunitiesResponse) then) =
-      __$$_ListCommunitiesResponseCopyWithImpl<$Res>;
+  factory _$$ListCommunitiesResponseImplCopyWith(
+          _$ListCommunitiesResponseImpl value,
+          $Res Function(_$ListCommunitiesResponseImpl) then) =
+      __$$ListCommunitiesResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<CommunityView> communities});
 }
 
 /// @nodoc
-class __$$_ListCommunitiesResponseCopyWithImpl<$Res>
+class __$$ListCommunitiesResponseImplCopyWithImpl<$Res>
     extends _$ListCommunitiesResponseCopyWithImpl<$Res,
-        _$_ListCommunitiesResponse>
-    implements _$$_ListCommunitiesResponseCopyWith<$Res> {
-  __$$_ListCommunitiesResponseCopyWithImpl(_$_ListCommunitiesResponse _value,
-      $Res Function(_$_ListCommunitiesResponse) _then)
+        _$ListCommunitiesResponseImpl>
+    implements _$$ListCommunitiesResponseImplCopyWith<$Res> {
+  __$$ListCommunitiesResponseImplCopyWithImpl(
+      _$ListCommunitiesResponseImpl _value,
+      $Res Function(_$ListCommunitiesResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -88,7 +90,7 @@ class __$$_ListCommunitiesResponseCopyWithImpl<$Res>
   $Res call({
     Object? communities = null,
   }) {
-    return _then(_$_ListCommunitiesResponse(
+    return _then(_$ListCommunitiesResponseImpl(
       communities: null == communities
           ? _value._communities
           : communities // ignore: cast_nullable_to_non_nullable
@@ -100,14 +102,14 @@ class __$$_ListCommunitiesResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ListCommunitiesResponse extends _ListCommunitiesResponse {
-  const _$_ListCommunitiesResponse(
+class _$ListCommunitiesResponseImpl extends _ListCommunitiesResponse {
+  const _$ListCommunitiesResponseImpl(
       {required final List<CommunityView> communities})
       : _communities = communities,
         super._();
 
-  factory _$_ListCommunitiesResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_ListCommunitiesResponseFromJson(json);
+  factory _$ListCommunitiesResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ListCommunitiesResponseImplFromJson(json);
 
   final List<CommunityView> _communities;
   @override
@@ -126,7 +128,7 @@ class _$_ListCommunitiesResponse extends _ListCommunitiesResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListCommunitiesResponse &&
+            other is _$ListCommunitiesResponseImpl &&
             const DeepCollectionEquality()
                 .equals(other._communities, _communities));
   }
@@ -139,14 +141,13 @@ class _$_ListCommunitiesResponse extends _ListCommunitiesResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListCommunitiesResponseCopyWith<_$_ListCommunitiesResponse>
-      get copyWith =>
-          __$$_ListCommunitiesResponseCopyWithImpl<_$_ListCommunitiesResponse>(
-              this, _$identity);
+  _$$ListCommunitiesResponseImplCopyWith<_$ListCommunitiesResponseImpl>
+      get copyWith => __$$ListCommunitiesResponseImplCopyWithImpl<
+          _$ListCommunitiesResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListCommunitiesResponseToJson(
+    return _$$ListCommunitiesResponseImplToJson(
       this,
     );
   }
@@ -155,16 +156,16 @@ class _$_ListCommunitiesResponse extends _ListCommunitiesResponse {
 abstract class _ListCommunitiesResponse extends ListCommunitiesResponse {
   const factory _ListCommunitiesResponse(
           {required final List<CommunityView> communities}) =
-      _$_ListCommunitiesResponse;
+      _$ListCommunitiesResponseImpl;
   const _ListCommunitiesResponse._() : super._();
 
   factory _ListCommunitiesResponse.fromJson(Map<String, dynamic> json) =
-      _$_ListCommunitiesResponse.fromJson;
+      _$ListCommunitiesResponseImpl.fromJson;
 
   @override
   List<CommunityView> get communities;
   @override
   @JsonKey(ignore: true)
-  _$$_ListCommunitiesResponseCopyWith<_$_ListCommunitiesResponse>
+  _$$ListCommunitiesResponseImplCopyWith<_$ListCommunitiesResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/community/list_communities_response.g.dart
+++ b/lib/src/v3/models/community/list_communities_response.g.dart
@@ -6,16 +6,16 @@ part of 'list_communities_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ListCommunitiesResponse _$$_ListCommunitiesResponseFromJson(
+_$ListCommunitiesResponseImpl _$$ListCommunitiesResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ListCommunitiesResponse(
+    _$ListCommunitiesResponseImpl(
       communities: (json['communities'] as List<dynamic>)
           .map((e) => CommunityView.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$_ListCommunitiesResponseToJson(
-        _$_ListCommunitiesResponse instance) =>
+Map<String, dynamic> _$$ListCommunitiesResponseImplToJson(
+        _$ListCommunitiesResponseImpl instance) =>
     <String, dynamic>{
       'communities': instance.communities.map((e) => e.toJson()).toList(),
     };

--- a/lib/src/v3/models/custom_emoji/custom_emoji.freezed.dart
+++ b/lib/src/v3/models/custom_emoji/custom_emoji.freezed.dart
@@ -112,11 +112,11 @@ class _$CustomEmojiCopyWithImpl<$Res, $Val extends CustomEmoji>
 }
 
 /// @nodoc
-abstract class _$$_CustomEmojiCopyWith<$Res>
+abstract class _$$CustomEmojiImplCopyWith<$Res>
     implements $CustomEmojiCopyWith<$Res> {
-  factory _$$_CustomEmojiCopyWith(
-          _$_CustomEmoji value, $Res Function(_$_CustomEmoji) then) =
-      __$$_CustomEmojiCopyWithImpl<$Res>;
+  factory _$$CustomEmojiImplCopyWith(
+          _$CustomEmojiImpl value, $Res Function(_$CustomEmojiImpl) then) =
+      __$$CustomEmojiImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -131,11 +131,11 @@ abstract class _$$_CustomEmojiCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CustomEmojiCopyWithImpl<$Res>
-    extends _$CustomEmojiCopyWithImpl<$Res, _$_CustomEmoji>
-    implements _$$_CustomEmojiCopyWith<$Res> {
-  __$$_CustomEmojiCopyWithImpl(
-      _$_CustomEmoji _value, $Res Function(_$_CustomEmoji) _then)
+class __$$CustomEmojiImplCopyWithImpl<$Res>
+    extends _$CustomEmojiCopyWithImpl<$Res, _$CustomEmojiImpl>
+    implements _$$CustomEmojiImplCopyWith<$Res> {
+  __$$CustomEmojiImplCopyWithImpl(
+      _$CustomEmojiImpl _value, $Res Function(_$CustomEmojiImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -150,7 +150,7 @@ class __$$_CustomEmojiCopyWithImpl<$Res>
     Object? published = null,
     Object? updated = freezed,
   }) {
-    return _then(_$_CustomEmoji(
+    return _then(_$CustomEmojiImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -190,8 +190,8 @@ class __$$_CustomEmojiCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CustomEmoji extends _CustomEmoji {
-  const _$_CustomEmoji(
+class _$CustomEmojiImpl extends _CustomEmoji {
+  const _$CustomEmojiImpl(
       {required this.id,
       required this.localSiteId,
       required this.shortcode,
@@ -202,8 +202,8 @@ class _$_CustomEmoji extends _CustomEmoji {
       this.updated})
       : super._();
 
-  factory _$_CustomEmoji.fromJson(Map<String, dynamic> json) =>
-      _$$_CustomEmojiFromJson(json);
+  factory _$CustomEmojiImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CustomEmojiImplFromJson(json);
 
   @override
   final int id;
@@ -231,7 +231,7 @@ class _$_CustomEmoji extends _CustomEmoji {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CustomEmoji &&
+            other is _$CustomEmojiImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.localSiteId, localSiteId) ||
                 other.localSiteId == localSiteId) &&
@@ -255,12 +255,12 @@ class _$_CustomEmoji extends _CustomEmoji {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CustomEmojiCopyWith<_$_CustomEmoji> get copyWith =>
-      __$$_CustomEmojiCopyWithImpl<_$_CustomEmoji>(this, _$identity);
+  _$$CustomEmojiImplCopyWith<_$CustomEmojiImpl> get copyWith =>
+      __$$CustomEmojiImplCopyWithImpl<_$CustomEmojiImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CustomEmojiToJson(
+    return _$$CustomEmojiImplToJson(
       this,
     );
   }
@@ -275,11 +275,11 @@ abstract class _CustomEmoji extends CustomEmoji {
       required final String altText,
       required final String category,
       required final DateTime published,
-      final DateTime? updated}) = _$_CustomEmoji;
+      final DateTime? updated}) = _$CustomEmojiImpl;
   const _CustomEmoji._() : super._();
 
   factory _CustomEmoji.fromJson(Map<String, dynamic> json) =
-      _$_CustomEmoji.fromJson;
+      _$CustomEmojiImpl.fromJson;
 
   @override
   int get id;
@@ -299,6 +299,6 @@ abstract class _CustomEmoji extends CustomEmoji {
   DateTime? get updated;
   @override
   @JsonKey(ignore: true)
-  _$$_CustomEmojiCopyWith<_$_CustomEmoji> get copyWith =>
+  _$$CustomEmojiImplCopyWith<_$CustomEmojiImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/custom_emoji/custom_emoji.g.dart
+++ b/lib/src/v3/models/custom_emoji/custom_emoji.g.dart
@@ -6,8 +6,8 @@ part of 'custom_emoji.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CustomEmoji _$$_CustomEmojiFromJson(Map<String, dynamic> json) =>
-    _$_CustomEmoji(
+_$CustomEmojiImpl _$$CustomEmojiImplFromJson(Map<String, dynamic> json) =>
+    _$CustomEmojiImpl(
       id: json['id'] as int,
       localSiteId: json['local_site_id'] as int,
       shortcode: json['shortcode'] as String,
@@ -19,7 +19,7 @@ _$_CustomEmoji _$$_CustomEmojiFromJson(Map<String, dynamic> json) =>
           json['updated'], const ForceUtcDateTime().fromJson),
     );
 
-Map<String, dynamic> _$$_CustomEmojiToJson(_$_CustomEmoji instance) =>
+Map<String, dynamic> _$$CustomEmojiImplToJson(_$CustomEmojiImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'local_site_id': instance.localSiteId,

--- a/lib/src/v3/models/custom_emoji/custom_emoji_keyword.dart
+++ b/lib/src/v3/models/custom_emoji/custom_emoji_keyword.dart
@@ -9,7 +9,7 @@ part 'custom_emoji_keyword.g.dart';
 class CustomEmojiKeyword with _$CustomEmojiKeyword {
   @modelSerde
   const factory CustomEmojiKeyword({
-    required int id,
+    @deprecated int? id,
     required int customEmojiId,
     required String keyword,
   }) = _CustomEmojiKeyword;

--- a/lib/src/v3/models/custom_emoji/custom_emoji_keyword.freezed.dart
+++ b/lib/src/v3/models/custom_emoji/custom_emoji_keyword.freezed.dart
@@ -20,7 +20,8 @@ CustomEmojiKeyword _$CustomEmojiKeywordFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$CustomEmojiKeyword {
-  int get id => throw _privateConstructorUsedError;
+  @deprecated
+  int? get id => throw _privateConstructorUsedError;
   int get customEmojiId => throw _privateConstructorUsedError;
   String get keyword => throw _privateConstructorUsedError;
 
@@ -36,7 +37,7 @@ abstract class $CustomEmojiKeywordCopyWith<$Res> {
           CustomEmojiKeyword value, $Res Function(CustomEmojiKeyword) then) =
       _$CustomEmojiKeywordCopyWithImpl<$Res, CustomEmojiKeyword>;
   @useResult
-  $Res call({int id, int customEmojiId, String keyword});
+  $Res call({@deprecated int? id, int customEmojiId, String keyword});
 }
 
 /// @nodoc
@@ -52,15 +53,15 @@ class _$CustomEmojiKeywordCopyWithImpl<$Res, $Val extends CustomEmojiKeyword>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? customEmojiId = null,
     Object? keyword = null,
   }) {
     return _then(_value.copyWith(
-      id: null == id
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       customEmojiId: null == customEmojiId
           ? _value.customEmojiId
           : customEmojiId // ignore: cast_nullable_to_non_nullable
@@ -74,36 +75,36 @@ class _$CustomEmojiKeywordCopyWithImpl<$Res, $Val extends CustomEmojiKeyword>
 }
 
 /// @nodoc
-abstract class _$$_CustomEmojiKeywordCopyWith<$Res>
+abstract class _$$CustomEmojiKeywordImplCopyWith<$Res>
     implements $CustomEmojiKeywordCopyWith<$Res> {
-  factory _$$_CustomEmojiKeywordCopyWith(_$_CustomEmojiKeyword value,
-          $Res Function(_$_CustomEmojiKeyword) then) =
-      __$$_CustomEmojiKeywordCopyWithImpl<$Res>;
+  factory _$$CustomEmojiKeywordImplCopyWith(_$CustomEmojiKeywordImpl value,
+          $Res Function(_$CustomEmojiKeywordImpl) then) =
+      __$$CustomEmojiKeywordImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({int id, int customEmojiId, String keyword});
+  $Res call({@deprecated int? id, int customEmojiId, String keyword});
 }
 
 /// @nodoc
-class __$$_CustomEmojiKeywordCopyWithImpl<$Res>
-    extends _$CustomEmojiKeywordCopyWithImpl<$Res, _$_CustomEmojiKeyword>
-    implements _$$_CustomEmojiKeywordCopyWith<$Res> {
-  __$$_CustomEmojiKeywordCopyWithImpl(
-      _$_CustomEmojiKeyword _value, $Res Function(_$_CustomEmojiKeyword) _then)
+class __$$CustomEmojiKeywordImplCopyWithImpl<$Res>
+    extends _$CustomEmojiKeywordCopyWithImpl<$Res, _$CustomEmojiKeywordImpl>
+    implements _$$CustomEmojiKeywordImplCopyWith<$Res> {
+  __$$CustomEmojiKeywordImplCopyWithImpl(_$CustomEmojiKeywordImpl _value,
+      $Res Function(_$CustomEmojiKeywordImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? customEmojiId = null,
     Object? keyword = null,
   }) {
-    return _then(_$_CustomEmojiKeyword(
-      id: null == id
+    return _then(_$CustomEmojiKeywordImpl(
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       customEmojiId: null == customEmojiId
           ? _value.customEmojiId
           : customEmojiId // ignore: cast_nullable_to_non_nullable
@@ -119,16 +120,17 @@ class __$$_CustomEmojiKeywordCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CustomEmojiKeyword extends _CustomEmojiKeyword {
-  const _$_CustomEmojiKeyword(
-      {required this.id, required this.customEmojiId, required this.keyword})
+class _$CustomEmojiKeywordImpl extends _CustomEmojiKeyword {
+  const _$CustomEmojiKeywordImpl(
+      {@deprecated this.id, required this.customEmojiId, required this.keyword})
       : super._();
 
-  factory _$_CustomEmojiKeyword.fromJson(Map<String, dynamic> json) =>
-      _$$_CustomEmojiKeywordFromJson(json);
+  factory _$CustomEmojiKeywordImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CustomEmojiKeywordImplFromJson(json);
 
   @override
-  final int id;
+  @deprecated
+  final int? id;
   @override
   final int customEmojiId;
   @override
@@ -143,7 +145,7 @@ class _$_CustomEmojiKeyword extends _CustomEmojiKeyword {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CustomEmojiKeyword &&
+            other is _$CustomEmojiKeywordImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.customEmojiId, customEmojiId) ||
                 other.customEmojiId == customEmojiId) &&
@@ -157,13 +159,13 @@ class _$_CustomEmojiKeyword extends _CustomEmojiKeyword {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CustomEmojiKeywordCopyWith<_$_CustomEmojiKeyword> get copyWith =>
-      __$$_CustomEmojiKeywordCopyWithImpl<_$_CustomEmojiKeyword>(
+  _$$CustomEmojiKeywordImplCopyWith<_$CustomEmojiKeywordImpl> get copyWith =>
+      __$$CustomEmojiKeywordImplCopyWithImpl<_$CustomEmojiKeywordImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CustomEmojiKeywordToJson(
+    return _$$CustomEmojiKeywordImplToJson(
       this,
     );
   }
@@ -171,22 +173,23 @@ class _$_CustomEmojiKeyword extends _CustomEmojiKeyword {
 
 abstract class _CustomEmojiKeyword extends CustomEmojiKeyword {
   const factory _CustomEmojiKeyword(
-      {required final int id,
+      {@deprecated final int? id,
       required final int customEmojiId,
-      required final String keyword}) = _$_CustomEmojiKeyword;
+      required final String keyword}) = _$CustomEmojiKeywordImpl;
   const _CustomEmojiKeyword._() : super._();
 
   factory _CustomEmojiKeyword.fromJson(Map<String, dynamic> json) =
-      _$_CustomEmojiKeyword.fromJson;
+      _$CustomEmojiKeywordImpl.fromJson;
 
   @override
-  int get id;
+  @deprecated
+  int? get id;
   @override
   int get customEmojiId;
   @override
   String get keyword;
   @override
   @JsonKey(ignore: true)
-  _$$_CustomEmojiKeywordCopyWith<_$_CustomEmojiKeyword> get copyWith =>
+  _$$CustomEmojiKeywordImplCopyWith<_$CustomEmojiKeywordImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/custom_emoji/custom_emoji_keyword.g.dart
+++ b/lib/src/v3/models/custom_emoji/custom_emoji_keyword.g.dart
@@ -6,16 +6,16 @@ part of 'custom_emoji_keyword.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CustomEmojiKeyword _$$_CustomEmojiKeywordFromJson(
+_$CustomEmojiKeywordImpl _$$CustomEmojiKeywordImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CustomEmojiKeyword(
-      id: json['id'] as int,
+    _$CustomEmojiKeywordImpl(
+      id: json['id'] as int?,
       customEmojiId: json['custom_emoji_id'] as int,
       keyword: json['keyword'] as String,
     );
 
-Map<String, dynamic> _$$_CustomEmojiKeywordToJson(
-        _$_CustomEmojiKeyword instance) =>
+Map<String, dynamic> _$$CustomEmojiKeywordImplToJson(
+        _$CustomEmojiKeywordImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'custom_emoji_id': instance.customEmojiId,

--- a/lib/src/v3/models/custom_emoji/custom_emoji_response.freezed.dart
+++ b/lib/src/v3/models/custom_emoji/custom_emoji_response.freezed.dart
@@ -72,11 +72,11 @@ class _$CustomEmojiResponseCopyWithImpl<$Res, $Val extends CustomEmojiResponse>
 }
 
 /// @nodoc
-abstract class _$$_CustomEmojiResponseCopyWith<$Res>
+abstract class _$$CustomEmojiResponseImplCopyWith<$Res>
     implements $CustomEmojiResponseCopyWith<$Res> {
-  factory _$$_CustomEmojiResponseCopyWith(_$_CustomEmojiResponse value,
-          $Res Function(_$_CustomEmojiResponse) then) =
-      __$$_CustomEmojiResponseCopyWithImpl<$Res>;
+  factory _$$CustomEmojiResponseImplCopyWith(_$CustomEmojiResponseImpl value,
+          $Res Function(_$CustomEmojiResponseImpl) then) =
+      __$$CustomEmojiResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CustomEmojiView customEmoji});
@@ -86,11 +86,11 @@ abstract class _$$_CustomEmojiResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CustomEmojiResponseCopyWithImpl<$Res>
-    extends _$CustomEmojiResponseCopyWithImpl<$Res, _$_CustomEmojiResponse>
-    implements _$$_CustomEmojiResponseCopyWith<$Res> {
-  __$$_CustomEmojiResponseCopyWithImpl(_$_CustomEmojiResponse _value,
-      $Res Function(_$_CustomEmojiResponse) _then)
+class __$$CustomEmojiResponseImplCopyWithImpl<$Res>
+    extends _$CustomEmojiResponseCopyWithImpl<$Res, _$CustomEmojiResponseImpl>
+    implements _$$CustomEmojiResponseImplCopyWith<$Res> {
+  __$$CustomEmojiResponseImplCopyWithImpl(_$CustomEmojiResponseImpl _value,
+      $Res Function(_$CustomEmojiResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -98,7 +98,7 @@ class __$$_CustomEmojiResponseCopyWithImpl<$Res>
   $Res call({
     Object? customEmoji = null,
   }) {
-    return _then(_$_CustomEmojiResponse(
+    return _then(_$CustomEmojiResponseImpl(
       customEmoji: null == customEmoji
           ? _value.customEmoji
           : customEmoji // ignore: cast_nullable_to_non_nullable
@@ -110,11 +110,11 @@ class __$$_CustomEmojiResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CustomEmojiResponse extends _CustomEmojiResponse {
-  const _$_CustomEmojiResponse({required this.customEmoji}) : super._();
+class _$CustomEmojiResponseImpl extends _CustomEmojiResponse {
+  const _$CustomEmojiResponseImpl({required this.customEmoji}) : super._();
 
-  factory _$_CustomEmojiResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_CustomEmojiResponseFromJson(json);
+  factory _$CustomEmojiResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CustomEmojiResponseImplFromJson(json);
 
   @override
   final CustomEmojiView customEmoji;
@@ -128,7 +128,7 @@ class _$_CustomEmojiResponse extends _CustomEmojiResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CustomEmojiResponse &&
+            other is _$CustomEmojiResponseImpl &&
             (identical(other.customEmoji, customEmoji) ||
                 other.customEmoji == customEmoji));
   }
@@ -140,13 +140,13 @@ class _$_CustomEmojiResponse extends _CustomEmojiResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CustomEmojiResponseCopyWith<_$_CustomEmojiResponse> get copyWith =>
-      __$$_CustomEmojiResponseCopyWithImpl<_$_CustomEmojiResponse>(
+  _$$CustomEmojiResponseImplCopyWith<_$CustomEmojiResponseImpl> get copyWith =>
+      __$$CustomEmojiResponseImplCopyWithImpl<_$CustomEmojiResponseImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CustomEmojiResponseToJson(
+    return _$$CustomEmojiResponseImplToJson(
       this,
     );
   }
@@ -154,16 +154,16 @@ class _$_CustomEmojiResponse extends _CustomEmojiResponse {
 
 abstract class _CustomEmojiResponse extends CustomEmojiResponse {
   const factory _CustomEmojiResponse(
-      {required final CustomEmojiView customEmoji}) = _$_CustomEmojiResponse;
+      {required final CustomEmojiView customEmoji}) = _$CustomEmojiResponseImpl;
   const _CustomEmojiResponse._() : super._();
 
   factory _CustomEmojiResponse.fromJson(Map<String, dynamic> json) =
-      _$_CustomEmojiResponse.fromJson;
+      _$CustomEmojiResponseImpl.fromJson;
 
   @override
   CustomEmojiView get customEmoji;
   @override
   @JsonKey(ignore: true)
-  _$$_CustomEmojiResponseCopyWith<_$_CustomEmojiResponse> get copyWith =>
+  _$$CustomEmojiResponseImplCopyWith<_$CustomEmojiResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/custom_emoji/custom_emoji_response.g.dart
+++ b/lib/src/v3/models/custom_emoji/custom_emoji_response.g.dart
@@ -6,15 +6,15 @@ part of 'custom_emoji_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CustomEmojiResponse _$$_CustomEmojiResponseFromJson(
+_$CustomEmojiResponseImpl _$$CustomEmojiResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CustomEmojiResponse(
+    _$CustomEmojiResponseImpl(
       customEmoji: CustomEmojiView.fromJson(
           json['custom_emoji'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_CustomEmojiResponseToJson(
-        _$_CustomEmojiResponse instance) =>
+Map<String, dynamic> _$$CustomEmojiResponseImplToJson(
+        _$CustomEmojiResponseImpl instance) =>
     <String, dynamic>{
       'custom_emoji': instance.customEmoji.toJson(),
     };

--- a/lib/src/v3/models/custom_emoji/delete_custom_emoji_response.freezed.dart
+++ b/lib/src/v3/models/custom_emoji/delete_custom_emoji_response.freezed.dart
@@ -71,25 +71,25 @@ class _$DeleteCustomEmojiResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_DeleteCustomEmojiResponseCopyWith<$Res>
+abstract class _$$DeleteCustomEmojiResponseImplCopyWith<$Res>
     implements $DeleteCustomEmojiResponseCopyWith<$Res> {
-  factory _$$_DeleteCustomEmojiResponseCopyWith(
-          _$_DeleteCustomEmojiResponse value,
-          $Res Function(_$_DeleteCustomEmojiResponse) then) =
-      __$$_DeleteCustomEmojiResponseCopyWithImpl<$Res>;
+  factory _$$DeleteCustomEmojiResponseImplCopyWith(
+          _$DeleteCustomEmojiResponseImpl value,
+          $Res Function(_$DeleteCustomEmojiResponseImpl) then) =
+      __$$DeleteCustomEmojiResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({@deprecated int? id, bool? success});
 }
 
 /// @nodoc
-class __$$_DeleteCustomEmojiResponseCopyWithImpl<$Res>
+class __$$DeleteCustomEmojiResponseImplCopyWithImpl<$Res>
     extends _$DeleteCustomEmojiResponseCopyWithImpl<$Res,
-        _$_DeleteCustomEmojiResponse>
-    implements _$$_DeleteCustomEmojiResponseCopyWith<$Res> {
-  __$$_DeleteCustomEmojiResponseCopyWithImpl(
-      _$_DeleteCustomEmojiResponse _value,
-      $Res Function(_$_DeleteCustomEmojiResponse) _then)
+        _$DeleteCustomEmojiResponseImpl>
+    implements _$$DeleteCustomEmojiResponseImplCopyWith<$Res> {
+  __$$DeleteCustomEmojiResponseImplCopyWithImpl(
+      _$DeleteCustomEmojiResponseImpl _value,
+      $Res Function(_$DeleteCustomEmojiResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -98,7 +98,7 @@ class __$$_DeleteCustomEmojiResponseCopyWithImpl<$Res>
     Object? id = freezed,
     Object? success = freezed,
   }) {
-    return _then(_$_DeleteCustomEmojiResponse(
+    return _then(_$DeleteCustomEmojiResponseImpl(
       id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -114,12 +114,12 @@ class __$$_DeleteCustomEmojiResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_DeleteCustomEmojiResponse extends _DeleteCustomEmojiResponse {
-  const _$_DeleteCustomEmojiResponse({@deprecated this.id, this.success})
+class _$DeleteCustomEmojiResponseImpl extends _DeleteCustomEmojiResponse {
+  const _$DeleteCustomEmojiResponseImpl({@deprecated this.id, this.success})
       : super._();
 
-  factory _$_DeleteCustomEmojiResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_DeleteCustomEmojiResponseFromJson(json);
+  factory _$DeleteCustomEmojiResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeleteCustomEmojiResponseImplFromJson(json);
 
   @override
   @deprecated
@@ -136,7 +136,7 @@ class _$_DeleteCustomEmojiResponse extends _DeleteCustomEmojiResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeleteCustomEmojiResponse &&
+            other is _$DeleteCustomEmojiResponseImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.success, success) || other.success == success));
   }
@@ -148,13 +148,13 @@ class _$_DeleteCustomEmojiResponse extends _DeleteCustomEmojiResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeleteCustomEmojiResponseCopyWith<_$_DeleteCustomEmojiResponse>
-      get copyWith => __$$_DeleteCustomEmojiResponseCopyWithImpl<
-          _$_DeleteCustomEmojiResponse>(this, _$identity);
+  _$$DeleteCustomEmojiResponseImplCopyWith<_$DeleteCustomEmojiResponseImpl>
+      get copyWith => __$$DeleteCustomEmojiResponseImplCopyWithImpl<
+          _$DeleteCustomEmojiResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeleteCustomEmojiResponseToJson(
+    return _$$DeleteCustomEmojiResponseImplToJson(
       this,
     );
   }
@@ -163,11 +163,11 @@ class _$_DeleteCustomEmojiResponse extends _DeleteCustomEmojiResponse {
 abstract class _DeleteCustomEmojiResponse extends DeleteCustomEmojiResponse {
   const factory _DeleteCustomEmojiResponse(
       {@deprecated final int? id,
-      final bool? success}) = _$_DeleteCustomEmojiResponse;
+      final bool? success}) = _$DeleteCustomEmojiResponseImpl;
   const _DeleteCustomEmojiResponse._() : super._();
 
   factory _DeleteCustomEmojiResponse.fromJson(Map<String, dynamic> json) =
-      _$_DeleteCustomEmojiResponse.fromJson;
+      _$DeleteCustomEmojiResponseImpl.fromJson;
 
   @override
   @deprecated
@@ -176,6 +176,6 @@ abstract class _DeleteCustomEmojiResponse extends DeleteCustomEmojiResponse {
   bool? get success;
   @override
   @JsonKey(ignore: true)
-  _$$_DeleteCustomEmojiResponseCopyWith<_$_DeleteCustomEmojiResponse>
+  _$$DeleteCustomEmojiResponseImplCopyWith<_$DeleteCustomEmojiResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/custom_emoji/delete_custom_emoji_response.g.dart
+++ b/lib/src/v3/models/custom_emoji/delete_custom_emoji_response.g.dart
@@ -6,15 +6,15 @@ part of 'delete_custom_emoji_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_DeleteCustomEmojiResponse _$$_DeleteCustomEmojiResponseFromJson(
+_$DeleteCustomEmojiResponseImpl _$$DeleteCustomEmojiResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_DeleteCustomEmojiResponse(
+    _$DeleteCustomEmojiResponseImpl(
       id: json['id'] as int?,
       success: json['success'] as bool?,
     );
 
-Map<String, dynamic> _$$_DeleteCustomEmojiResponseToJson(
-        _$_DeleteCustomEmojiResponse instance) =>
+Map<String, dynamic> _$$DeleteCustomEmojiResponseImplToJson(
+        _$DeleteCustomEmojiResponseImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'success': instance.success,

--- a/lib/src/v3/models/federated_instances/federated_instances.dart
+++ b/lib/src/v3/models/federated_instances/federated_instances.dart
@@ -10,9 +10,9 @@ part 'federated_instances.g.dart';
 class FederatedInstances with _$FederatedInstances {
   @modelSerde
   const factory FederatedInstances({
-    required List<Instance> linked,
-    required List<Instance> allowed,
-    required List<Instance> blocked,
+    required List<InstanceWithFederationState> linked,
+    required List<InstanceWithFederationState> allowed,
+    required List<InstanceWithFederationState> blocked,
   }) = _FederatedInstances;
 
   const FederatedInstances._();

--- a/lib/src/v3/models/federated_instances/federated_instances.freezed.dart
+++ b/lib/src/v3/models/federated_instances/federated_instances.freezed.dart
@@ -20,9 +20,12 @@ FederatedInstances _$FederatedInstancesFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$FederatedInstances {
-  List<Instance> get linked => throw _privateConstructorUsedError;
-  List<Instance> get allowed => throw _privateConstructorUsedError;
-  List<Instance> get blocked => throw _privateConstructorUsedError;
+  List<InstanceWithFederationState> get linked =>
+      throw _privateConstructorUsedError;
+  List<InstanceWithFederationState> get allowed =>
+      throw _privateConstructorUsedError;
+  List<InstanceWithFederationState> get blocked =>
+      throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -37,7 +40,9 @@ abstract class $FederatedInstancesCopyWith<$Res> {
       _$FederatedInstancesCopyWithImpl<$Res, FederatedInstances>;
   @useResult
   $Res call(
-      {List<Instance> linked, List<Instance> allowed, List<Instance> blocked});
+      {List<InstanceWithFederationState> linked,
+      List<InstanceWithFederationState> allowed,
+      List<InstanceWithFederationState> blocked});
 }
 
 /// @nodoc
@@ -61,37 +66,39 @@ class _$FederatedInstancesCopyWithImpl<$Res, $Val extends FederatedInstances>
       linked: null == linked
           ? _value.linked
           : linked // ignore: cast_nullable_to_non_nullable
-              as List<Instance>,
+              as List<InstanceWithFederationState>,
       allowed: null == allowed
           ? _value.allowed
           : allowed // ignore: cast_nullable_to_non_nullable
-              as List<Instance>,
+              as List<InstanceWithFederationState>,
       blocked: null == blocked
           ? _value.blocked
           : blocked // ignore: cast_nullable_to_non_nullable
-              as List<Instance>,
+              as List<InstanceWithFederationState>,
     ) as $Val);
   }
 }
 
 /// @nodoc
-abstract class _$$_FederatedInstancesCopyWith<$Res>
+abstract class _$$FederatedInstancesImplCopyWith<$Res>
     implements $FederatedInstancesCopyWith<$Res> {
-  factory _$$_FederatedInstancesCopyWith(_$_FederatedInstances value,
-          $Res Function(_$_FederatedInstances) then) =
-      __$$_FederatedInstancesCopyWithImpl<$Res>;
+  factory _$$FederatedInstancesImplCopyWith(_$FederatedInstancesImpl value,
+          $Res Function(_$FederatedInstancesImpl) then) =
+      __$$FederatedInstancesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
-      {List<Instance> linked, List<Instance> allowed, List<Instance> blocked});
+      {List<InstanceWithFederationState> linked,
+      List<InstanceWithFederationState> allowed,
+      List<InstanceWithFederationState> blocked});
 }
 
 /// @nodoc
-class __$$_FederatedInstancesCopyWithImpl<$Res>
-    extends _$FederatedInstancesCopyWithImpl<$Res, _$_FederatedInstances>
-    implements _$$_FederatedInstancesCopyWith<$Res> {
-  __$$_FederatedInstancesCopyWithImpl(
-      _$_FederatedInstances _value, $Res Function(_$_FederatedInstances) _then)
+class __$$FederatedInstancesImplCopyWithImpl<$Res>
+    extends _$FederatedInstancesCopyWithImpl<$Res, _$FederatedInstancesImpl>
+    implements _$$FederatedInstancesImplCopyWith<$Res> {
+  __$$FederatedInstancesImplCopyWithImpl(_$FederatedInstancesImpl _value,
+      $Res Function(_$FederatedInstancesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -101,19 +108,19 @@ class __$$_FederatedInstancesCopyWithImpl<$Res>
     Object? allowed = null,
     Object? blocked = null,
   }) {
-    return _then(_$_FederatedInstances(
+    return _then(_$FederatedInstancesImpl(
       linked: null == linked
           ? _value._linked
           : linked // ignore: cast_nullable_to_non_nullable
-              as List<Instance>,
+              as List<InstanceWithFederationState>,
       allowed: null == allowed
           ? _value._allowed
           : allowed // ignore: cast_nullable_to_non_nullable
-              as List<Instance>,
+              as List<InstanceWithFederationState>,
       blocked: null == blocked
           ? _value._blocked
           : blocked // ignore: cast_nullable_to_non_nullable
-              as List<Instance>,
+              as List<InstanceWithFederationState>,
     ));
   }
 }
@@ -121,38 +128,38 @@ class __$$_FederatedInstancesCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_FederatedInstances extends _FederatedInstances {
-  const _$_FederatedInstances(
-      {required final List<Instance> linked,
-      required final List<Instance> allowed,
-      required final List<Instance> blocked})
+class _$FederatedInstancesImpl extends _FederatedInstances {
+  const _$FederatedInstancesImpl(
+      {required final List<InstanceWithFederationState> linked,
+      required final List<InstanceWithFederationState> allowed,
+      required final List<InstanceWithFederationState> blocked})
       : _linked = linked,
         _allowed = allowed,
         _blocked = blocked,
         super._();
 
-  factory _$_FederatedInstances.fromJson(Map<String, dynamic> json) =>
-      _$$_FederatedInstancesFromJson(json);
+  factory _$FederatedInstancesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FederatedInstancesImplFromJson(json);
 
-  final List<Instance> _linked;
+  final List<InstanceWithFederationState> _linked;
   @override
-  List<Instance> get linked {
+  List<InstanceWithFederationState> get linked {
     if (_linked is EqualUnmodifiableListView) return _linked;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_linked);
   }
 
-  final List<Instance> _allowed;
+  final List<InstanceWithFederationState> _allowed;
   @override
-  List<Instance> get allowed {
+  List<InstanceWithFederationState> get allowed {
     if (_allowed is EqualUnmodifiableListView) return _allowed;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_allowed);
   }
 
-  final List<Instance> _blocked;
+  final List<InstanceWithFederationState> _blocked;
   @override
-  List<Instance> get blocked {
+  List<InstanceWithFederationState> get blocked {
     if (_blocked is EqualUnmodifiableListView) return _blocked;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_blocked);
@@ -167,7 +174,7 @@ class _$_FederatedInstances extends _FederatedInstances {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FederatedInstances &&
+            other is _$FederatedInstancesImpl &&
             const DeepCollectionEquality().equals(other._linked, _linked) &&
             const DeepCollectionEquality().equals(other._allowed, _allowed) &&
             const DeepCollectionEquality().equals(other._blocked, _blocked));
@@ -184,13 +191,13 @@ class _$_FederatedInstances extends _FederatedInstances {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FederatedInstancesCopyWith<_$_FederatedInstances> get copyWith =>
-      __$$_FederatedInstancesCopyWithImpl<_$_FederatedInstances>(
+  _$$FederatedInstancesImplCopyWith<_$FederatedInstancesImpl> get copyWith =>
+      __$$FederatedInstancesImplCopyWithImpl<_$FederatedInstancesImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FederatedInstancesToJson(
+    return _$$FederatedInstancesImplToJson(
       this,
     );
   }
@@ -198,22 +205,23 @@ class _$_FederatedInstances extends _FederatedInstances {
 
 abstract class _FederatedInstances extends FederatedInstances {
   const factory _FederatedInstances(
-      {required final List<Instance> linked,
-      required final List<Instance> allowed,
-      required final List<Instance> blocked}) = _$_FederatedInstances;
+          {required final List<InstanceWithFederationState> linked,
+          required final List<InstanceWithFederationState> allowed,
+          required final List<InstanceWithFederationState> blocked}) =
+      _$FederatedInstancesImpl;
   const _FederatedInstances._() : super._();
 
   factory _FederatedInstances.fromJson(Map<String, dynamic> json) =
-      _$_FederatedInstances.fromJson;
+      _$FederatedInstancesImpl.fromJson;
 
   @override
-  List<Instance> get linked;
+  List<InstanceWithFederationState> get linked;
   @override
-  List<Instance> get allowed;
+  List<InstanceWithFederationState> get allowed;
   @override
-  List<Instance> get blocked;
+  List<InstanceWithFederationState> get blocked;
   @override
   @JsonKey(ignore: true)
-  _$$_FederatedInstancesCopyWith<_$_FederatedInstances> get copyWith =>
+  _$$FederatedInstancesImplCopyWith<_$FederatedInstancesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/federated_instances/federated_instances.g.dart
+++ b/lib/src/v3/models/federated_instances/federated_instances.g.dart
@@ -6,22 +6,25 @@ part of 'federated_instances.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_FederatedInstances _$$_FederatedInstancesFromJson(
+_$FederatedInstancesImpl _$$FederatedInstancesImplFromJson(
         Map<String, dynamic> json) =>
-    _$_FederatedInstances(
+    _$FederatedInstancesImpl(
       linked: (json['linked'] as List<dynamic>)
-          .map((e) => Instance.fromJson(e as Map<String, dynamic>))
+          .map((e) =>
+              InstanceWithFederationState.fromJson(e as Map<String, dynamic>))
           .toList(),
       allowed: (json['allowed'] as List<dynamic>)
-          .map((e) => Instance.fromJson(e as Map<String, dynamic>))
+          .map((e) =>
+              InstanceWithFederationState.fromJson(e as Map<String, dynamic>))
           .toList(),
       blocked: (json['blocked'] as List<dynamic>)
-          .map((e) => Instance.fromJson(e as Map<String, dynamic>))
+          .map((e) =>
+              InstanceWithFederationState.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$_FederatedInstancesToJson(
-        _$_FederatedInstances instance) =>
+Map<String, dynamic> _$$FederatedInstancesImplToJson(
+        _$FederatedInstancesImpl instance) =>
     <String, dynamic>{
       'linked': instance.linked.map((e) => e.toJson()).toList(),
       'allowed': instance.allowed.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/models/federated_instances/get_federated_instances_response.freezed.dart
+++ b/lib/src/v3/models/federated_instances/get_federated_instances_response.freezed.dart
@@ -82,12 +82,12 @@ class _$GetFederatedInstancesResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_GetFederatedInstancesResponseCopyWith<$Res>
+abstract class _$$GetFederatedInstancesResponseImplCopyWith<$Res>
     implements $GetFederatedInstancesResponseCopyWith<$Res> {
-  factory _$$_GetFederatedInstancesResponseCopyWith(
-          _$_GetFederatedInstancesResponse value,
-          $Res Function(_$_GetFederatedInstancesResponse) then) =
-      __$$_GetFederatedInstancesResponseCopyWithImpl<$Res>;
+  factory _$$GetFederatedInstancesResponseImplCopyWith(
+          _$GetFederatedInstancesResponseImpl value,
+          $Res Function(_$GetFederatedInstancesResponseImpl) then) =
+      __$$GetFederatedInstancesResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({FederatedInstances? federatedInstances});
@@ -97,13 +97,13 @@ abstract class _$$_GetFederatedInstancesResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetFederatedInstancesResponseCopyWithImpl<$Res>
+class __$$GetFederatedInstancesResponseImplCopyWithImpl<$Res>
     extends _$GetFederatedInstancesResponseCopyWithImpl<$Res,
-        _$_GetFederatedInstancesResponse>
-    implements _$$_GetFederatedInstancesResponseCopyWith<$Res> {
-  __$$_GetFederatedInstancesResponseCopyWithImpl(
-      _$_GetFederatedInstancesResponse _value,
-      $Res Function(_$_GetFederatedInstancesResponse) _then)
+        _$GetFederatedInstancesResponseImpl>
+    implements _$$GetFederatedInstancesResponseImplCopyWith<$Res> {
+  __$$GetFederatedInstancesResponseImplCopyWithImpl(
+      _$GetFederatedInstancesResponseImpl _value,
+      $Res Function(_$GetFederatedInstancesResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -111,7 +111,7 @@ class __$$_GetFederatedInstancesResponseCopyWithImpl<$Res>
   $Res call({
     Object? federatedInstances = freezed,
   }) {
-    return _then(_$_GetFederatedInstancesResponse(
+    return _then(_$GetFederatedInstancesResponseImpl(
       federatedInstances: freezed == federatedInstances
           ? _value.federatedInstances
           : federatedInstances // ignore: cast_nullable_to_non_nullable
@@ -123,12 +123,14 @@ class __$$_GetFederatedInstancesResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetFederatedInstancesResponse extends _GetFederatedInstancesResponse {
-  const _$_GetFederatedInstancesResponse({this.federatedInstances}) : super._();
+class _$GetFederatedInstancesResponseImpl
+    extends _GetFederatedInstancesResponse {
+  const _$GetFederatedInstancesResponseImpl({this.federatedInstances})
+      : super._();
 
-  factory _$_GetFederatedInstancesResponse.fromJson(
+  factory _$GetFederatedInstancesResponseImpl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_GetFederatedInstancesResponseFromJson(json);
+      _$$GetFederatedInstancesResponseImplFromJson(json);
 
   @override
   final FederatedInstances? federatedInstances;
@@ -142,7 +144,7 @@ class _$_GetFederatedInstancesResponse extends _GetFederatedInstancesResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetFederatedInstancesResponse &&
+            other is _$GetFederatedInstancesResponseImpl &&
             (identical(other.federatedInstances, federatedInstances) ||
                 other.federatedInstances == federatedInstances));
   }
@@ -154,13 +156,14 @@ class _$_GetFederatedInstancesResponse extends _GetFederatedInstancesResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetFederatedInstancesResponseCopyWith<_$_GetFederatedInstancesResponse>
-      get copyWith => __$$_GetFederatedInstancesResponseCopyWithImpl<
-          _$_GetFederatedInstancesResponse>(this, _$identity);
+  _$$GetFederatedInstancesResponseImplCopyWith<
+          _$GetFederatedInstancesResponseImpl>
+      get copyWith => __$$GetFederatedInstancesResponseImplCopyWithImpl<
+          _$GetFederatedInstancesResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetFederatedInstancesResponseToJson(
+    return _$$GetFederatedInstancesResponseImplToJson(
       this,
     );
   }
@@ -170,16 +173,17 @@ abstract class _GetFederatedInstancesResponse
     extends GetFederatedInstancesResponse {
   const factory _GetFederatedInstancesResponse(
           {final FederatedInstances? federatedInstances}) =
-      _$_GetFederatedInstancesResponse;
+      _$GetFederatedInstancesResponseImpl;
   const _GetFederatedInstancesResponse._() : super._();
 
   factory _GetFederatedInstancesResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetFederatedInstancesResponse.fromJson;
+      _$GetFederatedInstancesResponseImpl.fromJson;
 
   @override
   FederatedInstances? get federatedInstances;
   @override
   @JsonKey(ignore: true)
-  _$$_GetFederatedInstancesResponseCopyWith<_$_GetFederatedInstancesResponse>
+  _$$GetFederatedInstancesResponseImplCopyWith<
+          _$GetFederatedInstancesResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/federated_instances/get_federated_instances_response.g.dart
+++ b/lib/src/v3/models/federated_instances/get_federated_instances_response.g.dart
@@ -6,17 +6,17 @@ part of 'get_federated_instances_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetFederatedInstancesResponse _$$_GetFederatedInstancesResponseFromJson(
-        Map<String, dynamic> json) =>
-    _$_GetFederatedInstancesResponse(
-      federatedInstances: json['federated_instances'] == null
-          ? null
-          : FederatedInstances.fromJson(
-              json['federated_instances'] as Map<String, dynamic>),
-    );
+_$GetFederatedInstancesResponseImpl
+    _$$GetFederatedInstancesResponseImplFromJson(Map<String, dynamic> json) =>
+        _$GetFederatedInstancesResponseImpl(
+          federatedInstances: json['federated_instances'] == null
+              ? null
+              : FederatedInstances.fromJson(
+                  json['federated_instances'] as Map<String, dynamic>),
+        );
 
-Map<String, dynamic> _$$_GetFederatedInstancesResponseToJson(
-        _$_GetFederatedInstancesResponse instance) =>
+Map<String, dynamic> _$$GetFederatedInstancesResponseImplToJson(
+        _$GetFederatedInstancesResponseImpl instance) =>
     <String, dynamic>{
       'federated_instances': instance.federatedInstances?.toJson(),
     };

--- a/lib/src/v3/models/federated_instances/instance.freezed.dart
+++ b/lib/src/v3/models/federated_instances/instance.freezed.dart
@@ -97,10 +97,11 @@ class _$InstanceCopyWithImpl<$Res, $Val extends Instance>
 }
 
 /// @nodoc
-abstract class _$$_InstanceCopyWith<$Res> implements $InstanceCopyWith<$Res> {
-  factory _$$_InstanceCopyWith(
-          _$_Instance value, $Res Function(_$_Instance) then) =
-      __$$_InstanceCopyWithImpl<$Res>;
+abstract class _$$InstanceImplCopyWith<$Res>
+    implements $InstanceCopyWith<$Res> {
+  factory _$$InstanceImplCopyWith(
+          _$InstanceImpl value, $Res Function(_$InstanceImpl) then) =
+      __$$InstanceImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -113,11 +114,11 @@ abstract class _$$_InstanceCopyWith<$Res> implements $InstanceCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_InstanceCopyWithImpl<$Res>
-    extends _$InstanceCopyWithImpl<$Res, _$_Instance>
-    implements _$$_InstanceCopyWith<$Res> {
-  __$$_InstanceCopyWithImpl(
-      _$_Instance _value, $Res Function(_$_Instance) _then)
+class __$$InstanceImplCopyWithImpl<$Res>
+    extends _$InstanceCopyWithImpl<$Res, _$InstanceImpl>
+    implements _$$InstanceImplCopyWith<$Res> {
+  __$$InstanceImplCopyWithImpl(
+      _$InstanceImpl _value, $Res Function(_$InstanceImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -130,7 +131,7 @@ class __$$_InstanceCopyWithImpl<$Res>
     Object? software = freezed,
     Object? version = freezed,
   }) {
-    return _then(_$_Instance(
+    return _then(_$InstanceImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -162,8 +163,8 @@ class __$$_InstanceCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_Instance extends _Instance {
-  const _$_Instance(
+class _$InstanceImpl extends _Instance {
+  const _$InstanceImpl(
       {required this.id,
       required this.domain,
       required this.published,
@@ -172,8 +173,8 @@ class _$_Instance extends _Instance {
       this.version})
       : super._();
 
-  factory _$_Instance.fromJson(Map<String, dynamic> json) =>
-      _$$_InstanceFromJson(json);
+  factory _$InstanceImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InstanceImplFromJson(json);
 
   @override
   final int id;
@@ -197,7 +198,7 @@ class _$_Instance extends _Instance {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Instance &&
+            other is _$InstanceImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.domain, domain) || other.domain == domain) &&
             (identical(other.published, published) ||
@@ -216,12 +217,12 @@ class _$_Instance extends _Instance {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_InstanceCopyWith<_$_Instance> get copyWith =>
-      __$$_InstanceCopyWithImpl<_$_Instance>(this, _$identity);
+  _$$InstanceImplCopyWith<_$InstanceImpl> get copyWith =>
+      __$$InstanceImplCopyWithImpl<_$InstanceImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_InstanceToJson(
+    return _$$InstanceImplToJson(
       this,
     );
   }
@@ -234,10 +235,11 @@ abstract class _Instance extends Instance {
       required final DateTime published,
       final DateTime? updated,
       final String? software,
-      final String? version}) = _$_Instance;
+      final String? version}) = _$InstanceImpl;
   const _Instance._() : super._();
 
-  factory _Instance.fromJson(Map<String, dynamic> json) = _$_Instance.fromJson;
+  factory _Instance.fromJson(Map<String, dynamic> json) =
+      _$InstanceImpl.fromJson;
 
   @override
   int get id;
@@ -253,6 +255,6 @@ abstract class _Instance extends Instance {
   String? get version;
   @override
   @JsonKey(ignore: true)
-  _$$_InstanceCopyWith<_$_Instance> get copyWith =>
+  _$$InstanceImplCopyWith<_$InstanceImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/federated_instances/instance.g.dart
+++ b/lib/src/v3/models/federated_instances/instance.g.dart
@@ -6,7 +6,8 @@ part of 'instance.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Instance _$$_InstanceFromJson(Map<String, dynamic> json) => _$_Instance(
+_$InstanceImpl _$$InstanceImplFromJson(Map<String, dynamic> json) =>
+    _$InstanceImpl(
       id: json['id'] as int,
       domain: json['domain'] as String,
       published: const ForceUtcDateTime().fromJson(json['published'] as String),
@@ -16,7 +17,7 @@ _$_Instance _$$_InstanceFromJson(Map<String, dynamic> json) => _$_Instance(
       version: json['version'] as String?,
     );
 
-Map<String, dynamic> _$$_InstanceToJson(_$_Instance instance) =>
+Map<String, dynamic> _$$InstanceImplToJson(_$InstanceImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'domain': instance.domain,

--- a/lib/src/v3/models/federated_instances/instance_with_federation_state.dart
+++ b/lib/src/v3/models/federated_instances/instance_with_federation_state.dart
@@ -1,0 +1,27 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../utils/force_utc_datetime.dart';
+import '../../../utils/serde.dart';
+import '../models.dart';
+
+part 'instance_with_federation_state.freezed.dart';
+part 'instance_with_federation_state.g.dart';
+
+@freezed
+class InstanceWithFederationState with _$InstanceWithFederationState {
+  @modelSerde
+  const factory InstanceWithFederationState({
+    required int id,
+    required String domain,
+    required DateTime published,
+    DateTime? updated,
+    String? software,
+    String? version,
+    ReadableFederationState?
+        federationState, // Only available in lemmy v0.19.0 and above
+  }) = _InstanceWithFederationState;
+
+  const InstanceWithFederationState._();
+  factory InstanceWithFederationState.fromJson(Map<String, dynamic> json) =>
+      _$InstanceWithFederationStateFromJson(json);
+}

--- a/lib/src/v3/models/federated_instances/instance_with_federation_state.freezed.dart
+++ b/lib/src/v3/models/federated_instances/instance_with_federation_state.freezed.dart
@@ -1,0 +1,312 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'instance_with_federation_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+InstanceWithFederationState _$InstanceWithFederationStateFromJson(
+    Map<String, dynamic> json) {
+  return _InstanceWithFederationState.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InstanceWithFederationState {
+  int get id => throw _privateConstructorUsedError;
+  String get domain => throw _privateConstructorUsedError;
+  DateTime get published => throw _privateConstructorUsedError;
+  DateTime? get updated => throw _privateConstructorUsedError;
+  String? get software => throw _privateConstructorUsedError;
+  String? get version => throw _privateConstructorUsedError;
+  ReadableFederationState? get federationState =>
+      throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InstanceWithFederationStateCopyWith<InstanceWithFederationState>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InstanceWithFederationStateCopyWith<$Res> {
+  factory $InstanceWithFederationStateCopyWith(
+          InstanceWithFederationState value,
+          $Res Function(InstanceWithFederationState) then) =
+      _$InstanceWithFederationStateCopyWithImpl<$Res,
+          InstanceWithFederationState>;
+  @useResult
+  $Res call(
+      {int id,
+      String domain,
+      DateTime published,
+      DateTime? updated,
+      String? software,
+      String? version,
+      ReadableFederationState? federationState});
+
+  $ReadableFederationStateCopyWith<$Res>? get federationState;
+}
+
+/// @nodoc
+class _$InstanceWithFederationStateCopyWithImpl<$Res,
+        $Val extends InstanceWithFederationState>
+    implements $InstanceWithFederationStateCopyWith<$Res> {
+  _$InstanceWithFederationStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? domain = null,
+    Object? published = null,
+    Object? updated = freezed,
+    Object? software = freezed,
+    Object? version = freezed,
+    Object? federationState = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      domain: null == domain
+          ? _value.domain
+          : domain // ignore: cast_nullable_to_non_nullable
+              as String,
+      published: null == published
+          ? _value.published
+          : published // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updated: freezed == updated
+          ? _value.updated
+          : updated // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      software: freezed == software
+          ? _value.software
+          : software // ignore: cast_nullable_to_non_nullable
+              as String?,
+      version: freezed == version
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as String?,
+      federationState: freezed == federationState
+          ? _value.federationState
+          : federationState // ignore: cast_nullable_to_non_nullable
+              as ReadableFederationState?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $ReadableFederationStateCopyWith<$Res>? get federationState {
+    if (_value.federationState == null) {
+      return null;
+    }
+
+    return $ReadableFederationStateCopyWith<$Res>(_value.federationState!,
+        (value) {
+      return _then(_value.copyWith(federationState: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$InstanceWithFederationStateImplCopyWith<$Res>
+    implements $InstanceWithFederationStateCopyWith<$Res> {
+  factory _$$InstanceWithFederationStateImplCopyWith(
+          _$InstanceWithFederationStateImpl value,
+          $Res Function(_$InstanceWithFederationStateImpl) then) =
+      __$$InstanceWithFederationStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int id,
+      String domain,
+      DateTime published,
+      DateTime? updated,
+      String? software,
+      String? version,
+      ReadableFederationState? federationState});
+
+  @override
+  $ReadableFederationStateCopyWith<$Res>? get federationState;
+}
+
+/// @nodoc
+class __$$InstanceWithFederationStateImplCopyWithImpl<$Res>
+    extends _$InstanceWithFederationStateCopyWithImpl<$Res,
+        _$InstanceWithFederationStateImpl>
+    implements _$$InstanceWithFederationStateImplCopyWith<$Res> {
+  __$$InstanceWithFederationStateImplCopyWithImpl(
+      _$InstanceWithFederationStateImpl _value,
+      $Res Function(_$InstanceWithFederationStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? domain = null,
+    Object? published = null,
+    Object? updated = freezed,
+    Object? software = freezed,
+    Object? version = freezed,
+    Object? federationState = freezed,
+  }) {
+    return _then(_$InstanceWithFederationStateImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      domain: null == domain
+          ? _value.domain
+          : domain // ignore: cast_nullable_to_non_nullable
+              as String,
+      published: null == published
+          ? _value.published
+          : published // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updated: freezed == updated
+          ? _value.updated
+          : updated // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      software: freezed == software
+          ? _value.software
+          : software // ignore: cast_nullable_to_non_nullable
+              as String?,
+      version: freezed == version
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as String?,
+      federationState: freezed == federationState
+          ? _value.federationState
+          : federationState // ignore: cast_nullable_to_non_nullable
+              as ReadableFederationState?,
+    ));
+  }
+}
+
+/// @nodoc
+
+@modelSerde
+class _$InstanceWithFederationStateImpl extends _InstanceWithFederationState {
+  const _$InstanceWithFederationStateImpl(
+      {required this.id,
+      required this.domain,
+      required this.published,
+      this.updated,
+      this.software,
+      this.version,
+      this.federationState})
+      : super._();
+
+  factory _$InstanceWithFederationStateImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$InstanceWithFederationStateImplFromJson(json);
+
+  @override
+  final int id;
+  @override
+  final String domain;
+  @override
+  final DateTime published;
+  @override
+  final DateTime? updated;
+  @override
+  final String? software;
+  @override
+  final String? version;
+  @override
+  final ReadableFederationState? federationState;
+
+  @override
+  String toString() {
+    return 'InstanceWithFederationState(id: $id, domain: $domain, published: $published, updated: $updated, software: $software, version: $version, federationState: $federationState)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InstanceWithFederationStateImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.domain, domain) || other.domain == domain) &&
+            (identical(other.published, published) ||
+                other.published == published) &&
+            (identical(other.updated, updated) || other.updated == updated) &&
+            (identical(other.software, software) ||
+                other.software == software) &&
+            (identical(other.version, version) || other.version == version) &&
+            (identical(other.federationState, federationState) ||
+                other.federationState == federationState));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, domain, published, updated,
+      software, version, federationState);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InstanceWithFederationStateImplCopyWith<_$InstanceWithFederationStateImpl>
+      get copyWith => __$$InstanceWithFederationStateImplCopyWithImpl<
+          _$InstanceWithFederationStateImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InstanceWithFederationStateImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InstanceWithFederationState
+    extends InstanceWithFederationState {
+  const factory _InstanceWithFederationState(
+          {required final int id,
+          required final String domain,
+          required final DateTime published,
+          final DateTime? updated,
+          final String? software,
+          final String? version,
+          final ReadableFederationState? federationState}) =
+      _$InstanceWithFederationStateImpl;
+  const _InstanceWithFederationState._() : super._();
+
+  factory _InstanceWithFederationState.fromJson(Map<String, dynamic> json) =
+      _$InstanceWithFederationStateImpl.fromJson;
+
+  @override
+  int get id;
+  @override
+  String get domain;
+  @override
+  DateTime get published;
+  @override
+  DateTime? get updated;
+  @override
+  String? get software;
+  @override
+  String? get version;
+  @override
+  ReadableFederationState? get federationState;
+  @override
+  @JsonKey(ignore: true)
+  _$$InstanceWithFederationStateImplCopyWith<_$InstanceWithFederationStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/src/v3/models/federated_instances/instance_with_federation_state.g.dart
+++ b/lib/src/v3/models/federated_instances/instance_with_federation_state.g.dart
@@ -1,0 +1,48 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'instance_with_federation_state.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InstanceWithFederationStateImpl _$$InstanceWithFederationStateImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InstanceWithFederationStateImpl(
+      id: json['id'] as int,
+      domain: json['domain'] as String,
+      published: const ForceUtcDateTime().fromJson(json['published'] as String),
+      updated: _$JsonConverterFromJson<String, DateTime>(
+          json['updated'], const ForceUtcDateTime().fromJson),
+      software: json['software'] as String?,
+      version: json['version'] as String?,
+      federationState: json['federation_state'] == null
+          ? null
+          : ReadableFederationState.fromJson(
+              json['federation_state'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$InstanceWithFederationStateImplToJson(
+        _$InstanceWithFederationStateImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'domain': instance.domain,
+      'published': const ForceUtcDateTime().toJson(instance.published),
+      'updated': _$JsonConverterToJson<String, DateTime>(
+          instance.updated, const ForceUtcDateTime().toJson),
+      'software': instance.software,
+      'version': instance.version,
+      'federation_state': instance.federationState?.toJson(),
+    };
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) =>
+    json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) =>
+    value == null ? null : toJson(value);

--- a/lib/src/v3/models/federated_instances/readable_federation_state.dart
+++ b/lib/src/v3/models/federated_instances/readable_federation_state.dart
@@ -11,11 +11,11 @@ class ReadableFederationState with _$ReadableFederationState {
   @modelSerde
   const factory ReadableFederationState({
     required int instanceId,
-    required int lastSuccessfulId,
-    required DateTime lastSuccessfulPublishedTime,
+    int? lastSuccessfulId,
+    DateTime? lastSuccessfulPublishedTime,
     required int failCount,
-    required DateTime lastRetry,
-    required DateTime nextRetry,
+    DateTime? lastRetry,
+    DateTime? nextRetry,
   }) = _ReadableFederationState;
 
   const ReadableFederationState._();

--- a/lib/src/v3/models/federated_instances/readable_federation_state.dart
+++ b/lib/src/v3/models/federated_instances/readable_federation_state.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../utils/force_utc_datetime.dart';
+import '../../../utils/serde.dart';
+
+part 'readable_federation_state.freezed.dart';
+part 'readable_federation_state.g.dart';
+
+@freezed
+class ReadableFederationState with _$ReadableFederationState {
+  @modelSerde
+  const factory ReadableFederationState({
+    required int instanceId,
+    required int lastSuccessfulId,
+    required DateTime lastSuccessfulPublishedTime,
+    required int failCount,
+    required DateTime lastRetry,
+    required DateTime nextRetry,
+  }) = _ReadableFederationState;
+
+  const ReadableFederationState._();
+  factory ReadableFederationState.fromJson(Map<String, dynamic> json) =>
+      _$ReadableFederationStateFromJson(json);
+}

--- a/lib/src/v3/models/federated_instances/readable_federation_state.freezed.dart
+++ b/lib/src/v3/models/federated_instances/readable_federation_state.freezed.dart
@@ -22,12 +22,12 @@ ReadableFederationState _$ReadableFederationStateFromJson(
 /// @nodoc
 mixin _$ReadableFederationState {
   int get instanceId => throw _privateConstructorUsedError;
-  int get lastSuccessfulId => throw _privateConstructorUsedError;
-  DateTime get lastSuccessfulPublishedTime =>
+  int? get lastSuccessfulId => throw _privateConstructorUsedError;
+  DateTime? get lastSuccessfulPublishedTime =>
       throw _privateConstructorUsedError;
   int get failCount => throw _privateConstructorUsedError;
-  DateTime get lastRetry => throw _privateConstructorUsedError;
-  DateTime get nextRetry => throw _privateConstructorUsedError;
+  DateTime? get lastRetry => throw _privateConstructorUsedError;
+  DateTime? get nextRetry => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -43,11 +43,11 @@ abstract class $ReadableFederationStateCopyWith<$Res> {
   @useResult
   $Res call(
       {int instanceId,
-      int lastSuccessfulId,
-      DateTime lastSuccessfulPublishedTime,
+      int? lastSuccessfulId,
+      DateTime? lastSuccessfulPublishedTime,
       int failCount,
-      DateTime lastRetry,
-      DateTime nextRetry});
+      DateTime? lastRetry,
+      DateTime? nextRetry});
 }
 
 /// @nodoc
@@ -65,37 +65,37 @@ class _$ReadableFederationStateCopyWithImpl<$Res,
   @override
   $Res call({
     Object? instanceId = null,
-    Object? lastSuccessfulId = null,
-    Object? lastSuccessfulPublishedTime = null,
+    Object? lastSuccessfulId = freezed,
+    Object? lastSuccessfulPublishedTime = freezed,
     Object? failCount = null,
-    Object? lastRetry = null,
-    Object? nextRetry = null,
+    Object? lastRetry = freezed,
+    Object? nextRetry = freezed,
   }) {
     return _then(_value.copyWith(
       instanceId: null == instanceId
           ? _value.instanceId
           : instanceId // ignore: cast_nullable_to_non_nullable
               as int,
-      lastSuccessfulId: null == lastSuccessfulId
+      lastSuccessfulId: freezed == lastSuccessfulId
           ? _value.lastSuccessfulId
           : lastSuccessfulId // ignore: cast_nullable_to_non_nullable
-              as int,
-      lastSuccessfulPublishedTime: null == lastSuccessfulPublishedTime
+              as int?,
+      lastSuccessfulPublishedTime: freezed == lastSuccessfulPublishedTime
           ? _value.lastSuccessfulPublishedTime
           : lastSuccessfulPublishedTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
+              as DateTime?,
       failCount: null == failCount
           ? _value.failCount
           : failCount // ignore: cast_nullable_to_non_nullable
               as int,
-      lastRetry: null == lastRetry
+      lastRetry: freezed == lastRetry
           ? _value.lastRetry
           : lastRetry // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      nextRetry: null == nextRetry
+              as DateTime?,
+      nextRetry: freezed == nextRetry
           ? _value.nextRetry
           : nextRetry // ignore: cast_nullable_to_non_nullable
-              as DateTime,
+              as DateTime?,
     ) as $Val);
   }
 }
@@ -111,11 +111,11 @@ abstract class _$$ReadableFederationStateImplCopyWith<$Res>
   @useResult
   $Res call(
       {int instanceId,
-      int lastSuccessfulId,
-      DateTime lastSuccessfulPublishedTime,
+      int? lastSuccessfulId,
+      DateTime? lastSuccessfulPublishedTime,
       int failCount,
-      DateTime lastRetry,
-      DateTime nextRetry});
+      DateTime? lastRetry,
+      DateTime? nextRetry});
 }
 
 /// @nodoc
@@ -132,37 +132,37 @@ class __$$ReadableFederationStateImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? instanceId = null,
-    Object? lastSuccessfulId = null,
-    Object? lastSuccessfulPublishedTime = null,
+    Object? lastSuccessfulId = freezed,
+    Object? lastSuccessfulPublishedTime = freezed,
     Object? failCount = null,
-    Object? lastRetry = null,
-    Object? nextRetry = null,
+    Object? lastRetry = freezed,
+    Object? nextRetry = freezed,
   }) {
     return _then(_$ReadableFederationStateImpl(
       instanceId: null == instanceId
           ? _value.instanceId
           : instanceId // ignore: cast_nullable_to_non_nullable
               as int,
-      lastSuccessfulId: null == lastSuccessfulId
+      lastSuccessfulId: freezed == lastSuccessfulId
           ? _value.lastSuccessfulId
           : lastSuccessfulId // ignore: cast_nullable_to_non_nullable
-              as int,
-      lastSuccessfulPublishedTime: null == lastSuccessfulPublishedTime
+              as int?,
+      lastSuccessfulPublishedTime: freezed == lastSuccessfulPublishedTime
           ? _value.lastSuccessfulPublishedTime
           : lastSuccessfulPublishedTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
+              as DateTime?,
       failCount: null == failCount
           ? _value.failCount
           : failCount // ignore: cast_nullable_to_non_nullable
               as int,
-      lastRetry: null == lastRetry
+      lastRetry: freezed == lastRetry
           ? _value.lastRetry
           : lastRetry // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      nextRetry: null == nextRetry
+              as DateTime?,
+      nextRetry: freezed == nextRetry
           ? _value.nextRetry
           : nextRetry // ignore: cast_nullable_to_non_nullable
-              as DateTime,
+              as DateTime?,
     ));
   }
 }
@@ -173,11 +173,11 @@ class __$$ReadableFederationStateImplCopyWithImpl<$Res>
 class _$ReadableFederationStateImpl extends _ReadableFederationState {
   const _$ReadableFederationStateImpl(
       {required this.instanceId,
-      required this.lastSuccessfulId,
-      required this.lastSuccessfulPublishedTime,
+      this.lastSuccessfulId,
+      this.lastSuccessfulPublishedTime,
       required this.failCount,
-      required this.lastRetry,
-      required this.nextRetry})
+      this.lastRetry,
+      this.nextRetry})
       : super._();
 
   factory _$ReadableFederationStateImpl.fromJson(Map<String, dynamic> json) =>
@@ -186,15 +186,15 @@ class _$ReadableFederationStateImpl extends _ReadableFederationState {
   @override
   final int instanceId;
   @override
-  final int lastSuccessfulId;
+  final int? lastSuccessfulId;
   @override
-  final DateTime lastSuccessfulPublishedTime;
+  final DateTime? lastSuccessfulPublishedTime;
   @override
   final int failCount;
   @override
-  final DateTime lastRetry;
+  final DateTime? lastRetry;
   @override
-  final DateTime nextRetry;
+  final DateTime? nextRetry;
 
   @override
   String toString() {
@@ -245,11 +245,11 @@ class _$ReadableFederationStateImpl extends _ReadableFederationState {
 abstract class _ReadableFederationState extends ReadableFederationState {
   const factory _ReadableFederationState(
       {required final int instanceId,
-      required final int lastSuccessfulId,
-      required final DateTime lastSuccessfulPublishedTime,
+      final int? lastSuccessfulId,
+      final DateTime? lastSuccessfulPublishedTime,
       required final int failCount,
-      required final DateTime lastRetry,
-      required final DateTime nextRetry}) = _$ReadableFederationStateImpl;
+      final DateTime? lastRetry,
+      final DateTime? nextRetry}) = _$ReadableFederationStateImpl;
   const _ReadableFederationState._() : super._();
 
   factory _ReadableFederationState.fromJson(Map<String, dynamic> json) =
@@ -258,15 +258,15 @@ abstract class _ReadableFederationState extends ReadableFederationState {
   @override
   int get instanceId;
   @override
-  int get lastSuccessfulId;
+  int? get lastSuccessfulId;
   @override
-  DateTime get lastSuccessfulPublishedTime;
+  DateTime? get lastSuccessfulPublishedTime;
   @override
   int get failCount;
   @override
-  DateTime get lastRetry;
+  DateTime? get lastRetry;
   @override
-  DateTime get nextRetry;
+  DateTime? get nextRetry;
   @override
   @JsonKey(ignore: true)
   _$$ReadableFederationStateImplCopyWith<_$ReadableFederationStateImpl>

--- a/lib/src/v3/models/federated_instances/readable_federation_state.freezed.dart
+++ b/lib/src/v3/models/federated_instances/readable_federation_state.freezed.dart
@@ -1,0 +1,274 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'readable_federation_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+ReadableFederationState _$ReadableFederationStateFromJson(
+    Map<String, dynamic> json) {
+  return _ReadableFederationState.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ReadableFederationState {
+  int get instanceId => throw _privateConstructorUsedError;
+  int get lastSuccessfulId => throw _privateConstructorUsedError;
+  DateTime get lastSuccessfulPublishedTime =>
+      throw _privateConstructorUsedError;
+  int get failCount => throw _privateConstructorUsedError;
+  DateTime get lastRetry => throw _privateConstructorUsedError;
+  DateTime get nextRetry => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ReadableFederationStateCopyWith<ReadableFederationState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReadableFederationStateCopyWith<$Res> {
+  factory $ReadableFederationStateCopyWith(ReadableFederationState value,
+          $Res Function(ReadableFederationState) then) =
+      _$ReadableFederationStateCopyWithImpl<$Res, ReadableFederationState>;
+  @useResult
+  $Res call(
+      {int instanceId,
+      int lastSuccessfulId,
+      DateTime lastSuccessfulPublishedTime,
+      int failCount,
+      DateTime lastRetry,
+      DateTime nextRetry});
+}
+
+/// @nodoc
+class _$ReadableFederationStateCopyWithImpl<$Res,
+        $Val extends ReadableFederationState>
+    implements $ReadableFederationStateCopyWith<$Res> {
+  _$ReadableFederationStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? instanceId = null,
+    Object? lastSuccessfulId = null,
+    Object? lastSuccessfulPublishedTime = null,
+    Object? failCount = null,
+    Object? lastRetry = null,
+    Object? nextRetry = null,
+  }) {
+    return _then(_value.copyWith(
+      instanceId: null == instanceId
+          ? _value.instanceId
+          : instanceId // ignore: cast_nullable_to_non_nullable
+              as int,
+      lastSuccessfulId: null == lastSuccessfulId
+          ? _value.lastSuccessfulId
+          : lastSuccessfulId // ignore: cast_nullable_to_non_nullable
+              as int,
+      lastSuccessfulPublishedTime: null == lastSuccessfulPublishedTime
+          ? _value.lastSuccessfulPublishedTime
+          : lastSuccessfulPublishedTime // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      failCount: null == failCount
+          ? _value.failCount
+          : failCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      lastRetry: null == lastRetry
+          ? _value.lastRetry
+          : lastRetry // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      nextRetry: null == nextRetry
+          ? _value.nextRetry
+          : nextRetry // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ReadableFederationStateImplCopyWith<$Res>
+    implements $ReadableFederationStateCopyWith<$Res> {
+  factory _$$ReadableFederationStateImplCopyWith(
+          _$ReadableFederationStateImpl value,
+          $Res Function(_$ReadableFederationStateImpl) then) =
+      __$$ReadableFederationStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {int instanceId,
+      int lastSuccessfulId,
+      DateTime lastSuccessfulPublishedTime,
+      int failCount,
+      DateTime lastRetry,
+      DateTime nextRetry});
+}
+
+/// @nodoc
+class __$$ReadableFederationStateImplCopyWithImpl<$Res>
+    extends _$ReadableFederationStateCopyWithImpl<$Res,
+        _$ReadableFederationStateImpl>
+    implements _$$ReadableFederationStateImplCopyWith<$Res> {
+  __$$ReadableFederationStateImplCopyWithImpl(
+      _$ReadableFederationStateImpl _value,
+      $Res Function(_$ReadableFederationStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? instanceId = null,
+    Object? lastSuccessfulId = null,
+    Object? lastSuccessfulPublishedTime = null,
+    Object? failCount = null,
+    Object? lastRetry = null,
+    Object? nextRetry = null,
+  }) {
+    return _then(_$ReadableFederationStateImpl(
+      instanceId: null == instanceId
+          ? _value.instanceId
+          : instanceId // ignore: cast_nullable_to_non_nullable
+              as int,
+      lastSuccessfulId: null == lastSuccessfulId
+          ? _value.lastSuccessfulId
+          : lastSuccessfulId // ignore: cast_nullable_to_non_nullable
+              as int,
+      lastSuccessfulPublishedTime: null == lastSuccessfulPublishedTime
+          ? _value.lastSuccessfulPublishedTime
+          : lastSuccessfulPublishedTime // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      failCount: null == failCount
+          ? _value.failCount
+          : failCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      lastRetry: null == lastRetry
+          ? _value.lastRetry
+          : lastRetry // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      nextRetry: null == nextRetry
+          ? _value.nextRetry
+          : nextRetry // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+
+@modelSerde
+class _$ReadableFederationStateImpl extends _ReadableFederationState {
+  const _$ReadableFederationStateImpl(
+      {required this.instanceId,
+      required this.lastSuccessfulId,
+      required this.lastSuccessfulPublishedTime,
+      required this.failCount,
+      required this.lastRetry,
+      required this.nextRetry})
+      : super._();
+
+  factory _$ReadableFederationStateImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ReadableFederationStateImplFromJson(json);
+
+  @override
+  final int instanceId;
+  @override
+  final int lastSuccessfulId;
+  @override
+  final DateTime lastSuccessfulPublishedTime;
+  @override
+  final int failCount;
+  @override
+  final DateTime lastRetry;
+  @override
+  final DateTime nextRetry;
+
+  @override
+  String toString() {
+    return 'ReadableFederationState(instanceId: $instanceId, lastSuccessfulId: $lastSuccessfulId, lastSuccessfulPublishedTime: $lastSuccessfulPublishedTime, failCount: $failCount, lastRetry: $lastRetry, nextRetry: $nextRetry)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReadableFederationStateImpl &&
+            (identical(other.instanceId, instanceId) ||
+                other.instanceId == instanceId) &&
+            (identical(other.lastSuccessfulId, lastSuccessfulId) ||
+                other.lastSuccessfulId == lastSuccessfulId) &&
+            (identical(other.lastSuccessfulPublishedTime,
+                    lastSuccessfulPublishedTime) ||
+                other.lastSuccessfulPublishedTime ==
+                    lastSuccessfulPublishedTime) &&
+            (identical(other.failCount, failCount) ||
+                other.failCount == failCount) &&
+            (identical(other.lastRetry, lastRetry) ||
+                other.lastRetry == lastRetry) &&
+            (identical(other.nextRetry, nextRetry) ||
+                other.nextRetry == nextRetry));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, instanceId, lastSuccessfulId,
+      lastSuccessfulPublishedTime, failCount, lastRetry, nextRetry);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReadableFederationStateImplCopyWith<_$ReadableFederationStateImpl>
+      get copyWith => __$$ReadableFederationStateImplCopyWithImpl<
+          _$ReadableFederationStateImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ReadableFederationStateImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ReadableFederationState extends ReadableFederationState {
+  const factory _ReadableFederationState(
+      {required final int instanceId,
+      required final int lastSuccessfulId,
+      required final DateTime lastSuccessfulPublishedTime,
+      required final int failCount,
+      required final DateTime lastRetry,
+      required final DateTime nextRetry}) = _$ReadableFederationStateImpl;
+  const _ReadableFederationState._() : super._();
+
+  factory _ReadableFederationState.fromJson(Map<String, dynamic> json) =
+      _$ReadableFederationStateImpl.fromJson;
+
+  @override
+  int get instanceId;
+  @override
+  int get lastSuccessfulId;
+  @override
+  DateTime get lastSuccessfulPublishedTime;
+  @override
+  int get failCount;
+  @override
+  DateTime get lastRetry;
+  @override
+  DateTime get nextRetry;
+  @override
+  @JsonKey(ignore: true)
+  _$$ReadableFederationStateImplCopyWith<_$ReadableFederationStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/src/v3/models/federated_instances/readable_federation_state.g.dart
+++ b/lib/src/v3/models/federated_instances/readable_federation_state.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'readable_federation_state.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ReadableFederationStateImpl _$$ReadableFederationStateImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ReadableFederationStateImpl(
+      instanceId: json['instance_id'] as int,
+      lastSuccessfulId: json['last_successful_id'] as int,
+      lastSuccessfulPublishedTime: const ForceUtcDateTime()
+          .fromJson(json['last_successful_published_time'] as String),
+      failCount: json['fail_count'] as int,
+      lastRetry:
+          const ForceUtcDateTime().fromJson(json['last_retry'] as String),
+      nextRetry:
+          const ForceUtcDateTime().fromJson(json['next_retry'] as String),
+    );
+
+Map<String, dynamic> _$$ReadableFederationStateImplToJson(
+        _$ReadableFederationStateImpl instance) =>
+    <String, dynamic>{
+      'instance_id': instance.instanceId,
+      'last_successful_id': instance.lastSuccessfulId,
+      'last_successful_published_time':
+          const ForceUtcDateTime().toJson(instance.lastSuccessfulPublishedTime),
+      'fail_count': instance.failCount,
+      'last_retry': const ForceUtcDateTime().toJson(instance.lastRetry),
+      'next_retry': const ForceUtcDateTime().toJson(instance.nextRetry),
+    };

--- a/lib/src/v3/models/federated_instances/readable_federation_state.g.dart
+++ b/lib/src/v3/models/federated_instances/readable_federation_state.g.dart
@@ -10,14 +10,15 @@ _$ReadableFederationStateImpl _$$ReadableFederationStateImplFromJson(
         Map<String, dynamic> json) =>
     _$ReadableFederationStateImpl(
       instanceId: json['instance_id'] as int,
-      lastSuccessfulId: json['last_successful_id'] as int,
-      lastSuccessfulPublishedTime: const ForceUtcDateTime()
-          .fromJson(json['last_successful_published_time'] as String),
+      lastSuccessfulId: json['last_successful_id'] as int?,
+      lastSuccessfulPublishedTime: _$JsonConverterFromJson<String, DateTime>(
+          json['last_successful_published_time'],
+          const ForceUtcDateTime().fromJson),
       failCount: json['fail_count'] as int,
-      lastRetry:
-          const ForceUtcDateTime().fromJson(json['last_retry'] as String),
-      nextRetry:
-          const ForceUtcDateTime().fromJson(json['next_retry'] as String),
+      lastRetry: _$JsonConverterFromJson<String, DateTime>(
+          json['last_retry'], const ForceUtcDateTime().fromJson),
+      nextRetry: _$JsonConverterFromJson<String, DateTime>(
+          json['next_retry'], const ForceUtcDateTime().fromJson),
     );
 
 Map<String, dynamic> _$$ReadableFederationStateImplToJson(
@@ -25,9 +26,24 @@ Map<String, dynamic> _$$ReadableFederationStateImplToJson(
     <String, dynamic>{
       'instance_id': instance.instanceId,
       'last_successful_id': instance.lastSuccessfulId,
-      'last_successful_published_time':
-          const ForceUtcDateTime().toJson(instance.lastSuccessfulPublishedTime),
+      'last_successful_published_time': _$JsonConverterToJson<String, DateTime>(
+          instance.lastSuccessfulPublishedTime,
+          const ForceUtcDateTime().toJson),
       'fail_count': instance.failCount,
-      'last_retry': const ForceUtcDateTime().toJson(instance.lastRetry),
-      'next_retry': const ForceUtcDateTime().toJson(instance.nextRetry),
+      'last_retry': _$JsonConverterToJson<String, DateTime>(
+          instance.lastRetry, const ForceUtcDateTime().toJson),
+      'next_retry': _$JsonConverterToJson<String, DateTime>(
+          instance.nextRetry, const ForceUtcDateTime().toJson),
     };
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) =>
+    json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) =>
+    value == null ? null : toJson(value);

--- a/lib/src/v3/models/language/language.freezed.dart
+++ b/lib/src/v3/models/language/language.freezed.dart
@@ -73,21 +73,22 @@ class _$LanguageCopyWithImpl<$Res, $Val extends Language>
 }
 
 /// @nodoc
-abstract class _$$_LanguageCopyWith<$Res> implements $LanguageCopyWith<$Res> {
-  factory _$$_LanguageCopyWith(
-          _$_Language value, $Res Function(_$_Language) then) =
-      __$$_LanguageCopyWithImpl<$Res>;
+abstract class _$$LanguageImplCopyWith<$Res>
+    implements $LanguageCopyWith<$Res> {
+  factory _$$LanguageImplCopyWith(
+          _$LanguageImpl value, $Res Function(_$LanguageImpl) then) =
+      __$$LanguageImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int id, String code, String name});
 }
 
 /// @nodoc
-class __$$_LanguageCopyWithImpl<$Res>
-    extends _$LanguageCopyWithImpl<$Res, _$_Language>
-    implements _$$_LanguageCopyWith<$Res> {
-  __$$_LanguageCopyWithImpl(
-      _$_Language _value, $Res Function(_$_Language) _then)
+class __$$LanguageImplCopyWithImpl<$Res>
+    extends _$LanguageCopyWithImpl<$Res, _$LanguageImpl>
+    implements _$$LanguageImplCopyWith<$Res> {
+  __$$LanguageImplCopyWithImpl(
+      _$LanguageImpl _value, $Res Function(_$LanguageImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -97,7 +98,7 @@ class __$$_LanguageCopyWithImpl<$Res>
     Object? code = null,
     Object? name = null,
   }) {
-    return _then(_$_Language(
+    return _then(_$LanguageImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -117,12 +118,13 @@ class __$$_LanguageCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_Language extends _Language {
-  const _$_Language({required this.id, required this.code, required this.name})
+class _$LanguageImpl extends _Language {
+  const _$LanguageImpl(
+      {required this.id, required this.code, required this.name})
       : super._();
 
-  factory _$_Language.fromJson(Map<String, dynamic> json) =>
-      _$$_LanguageFromJson(json);
+  factory _$LanguageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LanguageImplFromJson(json);
 
   @override
   final int id;
@@ -140,7 +142,7 @@ class _$_Language extends _Language {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Language &&
+            other is _$LanguageImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.code, code) || other.code == code) &&
             (identical(other.name, name) || other.name == name));
@@ -153,12 +155,12 @@ class _$_Language extends _Language {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LanguageCopyWith<_$_Language> get copyWith =>
-      __$$_LanguageCopyWithImpl<_$_Language>(this, _$identity);
+  _$$LanguageImplCopyWith<_$LanguageImpl> get copyWith =>
+      __$$LanguageImplCopyWithImpl<_$LanguageImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LanguageToJson(
+    return _$$LanguageImplToJson(
       this,
     );
   }
@@ -168,10 +170,11 @@ abstract class _Language extends Language {
   const factory _Language(
       {required final int id,
       required final String code,
-      required final String name}) = _$_Language;
+      required final String name}) = _$LanguageImpl;
   const _Language._() : super._();
 
-  factory _Language.fromJson(Map<String, dynamic> json) = _$_Language.fromJson;
+  factory _Language.fromJson(Map<String, dynamic> json) =
+      _$LanguageImpl.fromJson;
 
   @override
   int get id;
@@ -181,6 +184,6 @@ abstract class _Language extends Language {
   String get name;
   @override
   @JsonKey(ignore: true)
-  _$$_LanguageCopyWith<_$_Language> get copyWith =>
+  _$$LanguageImplCopyWith<_$LanguageImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/language/language.g.dart
+++ b/lib/src/v3/models/language/language.g.dart
@@ -6,13 +6,14 @@ part of 'language.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Language _$$_LanguageFromJson(Map<String, dynamic> json) => _$_Language(
+_$LanguageImpl _$$LanguageImplFromJson(Map<String, dynamic> json) =>
+    _$LanguageImpl(
       id: json['id'] as int,
       code: json['code'] as String,
       name: json['name'] as String,
     );
 
-Map<String, dynamic> _$$_LanguageToJson(_$_Language instance) =>
+Map<String, dynamic> _$$LanguageImplToJson(_$LanguageImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'code': instance.code,

--- a/lib/src/v3/models/local_user/local_user.dart
+++ b/lib/src/v3/models/local_user/local_user.dart
@@ -37,6 +37,7 @@ class LocalUser with _$LocalUser {
     bool? totp2faEnabled, // Only available in lemmy v0.19.0 and above
     bool? enableKeyboardNavigation, // Only available in lemmy v0.19.0 and above
     bool? enableAnimatedImages, // Only available in lemmy v0.19.0 and above
+    bool? collapseBotComments, // Only available in lemmy v0.19.0 and above
   }) = _LocalUser;
 
   const LocalUser._();

--- a/lib/src/v3/models/local_user/local_user.freezed.dart
+++ b/lib/src/v3/models/local_user/local_user.freezed.dart
@@ -54,7 +54,9 @@ mixin _$LocalUser {
       throw _privateConstructorUsedError; // Only available in lemmy v0.19.0 and above
   bool? get enableKeyboardNavigation =>
       throw _privateConstructorUsedError; // Only available in lemmy v0.19.0 and above
-  bool? get enableAnimatedImages => throw _privateConstructorUsedError;
+  bool? get enableAnimatedImages =>
+      throw _privateConstructorUsedError; // Only available in lemmy v0.19.0 and above
+  bool? get collapseBotComments => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -94,7 +96,8 @@ abstract class $LocalUserCopyWith<$Res> {
       String? postListingMode,
       bool? totp2faEnabled,
       bool? enableKeyboardNavigation,
-      bool? enableAnimatedImages});
+      bool? enableAnimatedImages,
+      bool? collapseBotComments});
 }
 
 /// @nodoc
@@ -137,6 +140,7 @@ class _$LocalUserCopyWithImpl<$Res, $Val extends LocalUser>
     Object? totp2faEnabled = freezed,
     Object? enableKeyboardNavigation = freezed,
     Object? enableAnimatedImages = freezed,
+    Object? collapseBotComments = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -247,15 +251,20 @@ class _$LocalUserCopyWithImpl<$Res, $Val extends LocalUser>
           ? _value.enableAnimatedImages
           : enableAnimatedImages // ignore: cast_nullable_to_non_nullable
               as bool?,
+      collapseBotComments: freezed == collapseBotComments
+          ? _value.collapseBotComments
+          : collapseBotComments // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ) as $Val);
   }
 }
 
 /// @nodoc
-abstract class _$$_LocalUserCopyWith<$Res> implements $LocalUserCopyWith<$Res> {
-  factory _$$_LocalUserCopyWith(
-          _$_LocalUser value, $Res Function(_$_LocalUser) then) =
-      __$$_LocalUserCopyWithImpl<$Res>;
+abstract class _$$LocalUserImplCopyWith<$Res>
+    implements $LocalUserCopyWith<$Res> {
+  factory _$$LocalUserImplCopyWith(
+          _$LocalUserImpl value, $Res Function(_$LocalUserImpl) then) =
+      __$$LocalUserImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -285,15 +294,16 @@ abstract class _$$_LocalUserCopyWith<$Res> implements $LocalUserCopyWith<$Res> {
       String? postListingMode,
       bool? totp2faEnabled,
       bool? enableKeyboardNavigation,
-      bool? enableAnimatedImages});
+      bool? enableAnimatedImages,
+      bool? collapseBotComments});
 }
 
 /// @nodoc
-class __$$_LocalUserCopyWithImpl<$Res>
-    extends _$LocalUserCopyWithImpl<$Res, _$_LocalUser>
-    implements _$$_LocalUserCopyWith<$Res> {
-  __$$_LocalUserCopyWithImpl(
-      _$_LocalUser _value, $Res Function(_$_LocalUser) _then)
+class __$$LocalUserImplCopyWithImpl<$Res>
+    extends _$LocalUserCopyWithImpl<$Res, _$LocalUserImpl>
+    implements _$$LocalUserImplCopyWith<$Res> {
+  __$$LocalUserImplCopyWithImpl(
+      _$LocalUserImpl _value, $Res Function(_$LocalUserImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -326,8 +336,9 @@ class __$$_LocalUserCopyWithImpl<$Res>
     Object? totp2faEnabled = freezed,
     Object? enableKeyboardNavigation = freezed,
     Object? enableAnimatedImages = freezed,
+    Object? collapseBotComments = freezed,
   }) {
-    return _then(_$_LocalUser(
+    return _then(_$LocalUserImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -436,6 +447,10 @@ class __$$_LocalUserCopyWithImpl<$Res>
           ? _value.enableAnimatedImages
           : enableAnimatedImages // ignore: cast_nullable_to_non_nullable
               as bool?,
+      collapseBotComments: freezed == collapseBotComments
+          ? _value.collapseBotComments
+          : collapseBotComments // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ));
   }
 }
@@ -443,8 +458,8 @@ class __$$_LocalUserCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_LocalUser extends _LocalUser {
-  const _$_LocalUser(
+class _$LocalUserImpl extends _LocalUser {
+  const _$LocalUserImpl(
       {required this.id,
       required this.personId,
       this.email,
@@ -471,11 +486,12 @@ class _$_LocalUser extends _LocalUser {
       this.postListingMode,
       this.totp2faEnabled,
       this.enableKeyboardNavigation,
-      this.enableAnimatedImages})
+      this.enableAnimatedImages,
+      this.collapseBotComments})
       : super._();
 
-  factory _$_LocalUser.fromJson(Map<String, dynamic> json) =>
-      _$$_LocalUserFromJson(json);
+  factory _$LocalUserImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LocalUserImplFromJson(json);
 
   @override
   final int id;
@@ -539,17 +555,20 @@ class _$_LocalUser extends _LocalUser {
 // Only available in lemmy v0.19.0 and above
   @override
   final bool? enableAnimatedImages;
+// Only available in lemmy v0.19.0 and above
+  @override
+  final bool? collapseBotComments;
 
   @override
   String toString() {
-    return 'LocalUser(id: $id, personId: $personId, email: $email, showNsfw: $showNsfw, blurNsfw: $blurNsfw, autoExpand: $autoExpand, theme: $theme, defaultSortType: $defaultSortType, defaultListingType: $defaultListingType, interfaceLanguage: $interfaceLanguage, showAvatars: $showAvatars, sendNotificationsToEmail: $sendNotificationsToEmail, validatorTime: $validatorTime, showScores: $showScores, showBotAccounts: $showBotAccounts, showReadPosts: $showReadPosts, showNewPostNotifs: $showNewPostNotifs, emailVerified: $emailVerified, acceptedApplication: $acceptedApplication, totp2faUrl: $totp2faUrl, openLinksInNewTab: $openLinksInNewTab, infiniteScrollEnabled: $infiniteScrollEnabled, admin: $admin, postListingMode: $postListingMode, totp2faEnabled: $totp2faEnabled, enableKeyboardNavigation: $enableKeyboardNavigation, enableAnimatedImages: $enableAnimatedImages)';
+    return 'LocalUser(id: $id, personId: $personId, email: $email, showNsfw: $showNsfw, blurNsfw: $blurNsfw, autoExpand: $autoExpand, theme: $theme, defaultSortType: $defaultSortType, defaultListingType: $defaultListingType, interfaceLanguage: $interfaceLanguage, showAvatars: $showAvatars, sendNotificationsToEmail: $sendNotificationsToEmail, validatorTime: $validatorTime, showScores: $showScores, showBotAccounts: $showBotAccounts, showReadPosts: $showReadPosts, showNewPostNotifs: $showNewPostNotifs, emailVerified: $emailVerified, acceptedApplication: $acceptedApplication, totp2faUrl: $totp2faUrl, openLinksInNewTab: $openLinksInNewTab, infiniteScrollEnabled: $infiniteScrollEnabled, admin: $admin, postListingMode: $postListingMode, totp2faEnabled: $totp2faEnabled, enableKeyboardNavigation: $enableKeyboardNavigation, enableAnimatedImages: $enableAnimatedImages, collapseBotComments: $collapseBotComments)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LocalUser &&
+            other is _$LocalUserImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
@@ -601,7 +620,9 @@ class _$_LocalUser extends _LocalUser {
                     other.enableKeyboardNavigation, enableKeyboardNavigation) ||
                 other.enableKeyboardNavigation == enableKeyboardNavigation) &&
             (identical(other.enableAnimatedImages, enableAnimatedImages) ||
-                other.enableAnimatedImages == enableAnimatedImages));
+                other.enableAnimatedImages == enableAnimatedImages) &&
+            (identical(other.collapseBotComments, collapseBotComments) ||
+                other.collapseBotComments == collapseBotComments));
   }
 
   @JsonKey(ignore: true)
@@ -634,18 +655,19 @@ class _$_LocalUser extends _LocalUser {
         postListingMode,
         totp2faEnabled,
         enableKeyboardNavigation,
-        enableAnimatedImages
+        enableAnimatedImages,
+        collapseBotComments
       ]);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LocalUserCopyWith<_$_LocalUser> get copyWith =>
-      __$$_LocalUserCopyWithImpl<_$_LocalUser>(this, _$identity);
+  _$$LocalUserImplCopyWith<_$LocalUserImpl> get copyWith =>
+      __$$LocalUserImplCopyWithImpl<_$LocalUserImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LocalUserToJson(
+    return _$$LocalUserImplToJson(
       this,
     );
   }
@@ -679,11 +701,12 @@ abstract class _LocalUser extends LocalUser {
       final String? postListingMode,
       final bool? totp2faEnabled,
       final bool? enableKeyboardNavigation,
-      final bool? enableAnimatedImages}) = _$_LocalUser;
+      final bool? enableAnimatedImages,
+      final bool? collapseBotComments}) = _$LocalUserImpl;
   const _LocalUser._() : super._();
 
   factory _LocalUser.fromJson(Map<String, dynamic> json) =
-      _$_LocalUser.fromJson;
+      _$LocalUserImpl.fromJson;
 
   @override
   int get id;
@@ -742,8 +765,10 @@ abstract class _LocalUser extends LocalUser {
   bool? get enableKeyboardNavigation;
   @override // Only available in lemmy v0.19.0 and above
   bool? get enableAnimatedImages;
+  @override // Only available in lemmy v0.19.0 and above
+  bool? get collapseBotComments;
   @override
   @JsonKey(ignore: true)
-  _$$_LocalUserCopyWith<_$_LocalUser> get copyWith =>
+  _$$LocalUserImplCopyWith<_$LocalUserImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/local_user/local_user.g.dart
+++ b/lib/src/v3/models/local_user/local_user.g.dart
@@ -6,7 +6,8 @@ part of 'local_user.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LocalUser _$$_LocalUserFromJson(Map<String, dynamic> json) => _$_LocalUser(
+_$LocalUserImpl _$$LocalUserImplFromJson(Map<String, dynamic> json) =>
+    _$LocalUserImpl(
       id: json['id'] as int,
       personId: json['person_id'] as int,
       email: json['email'] as String?,
@@ -34,9 +35,10 @@ _$_LocalUser _$$_LocalUserFromJson(Map<String, dynamic> json) => _$_LocalUser(
       totp2faEnabled: json['totp2fa_enabled'] as bool?,
       enableKeyboardNavigation: json['enable_keyboard_navigation'] as bool?,
       enableAnimatedImages: json['enable_animated_images'] as bool?,
+      collapseBotComments: json['collapse_bot_comments'] as bool?,
     );
 
-Map<String, dynamic> _$$_LocalUserToJson(_$_LocalUser instance) =>
+Map<String, dynamic> _$$LocalUserImplToJson(_$LocalUserImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'person_id': instance.personId,
@@ -65,4 +67,5 @@ Map<String, dynamic> _$$_LocalUserToJson(_$_LocalUser instance) =>
       'totp2fa_enabled': instance.totp2faEnabled,
       'enable_keyboard_navigation': instance.enableKeyboardNavigation,
       'enable_animated_images': instance.enableAnimatedImages,
+      'collapse_bot_comments': instance.collapseBotComments,
     };

--- a/lib/src/v3/models/mod/mod_add_community.freezed.dart
+++ b/lib/src/v3/models/mod/mod_add_community.freezed.dart
@@ -99,11 +99,11 @@ class _$ModAddCommunityCopyWithImpl<$Res, $Val extends ModAddCommunity>
 }
 
 /// @nodoc
-abstract class _$$_ModAddCommunityCopyWith<$Res>
+abstract class _$$ModAddCommunityImplCopyWith<$Res>
     implements $ModAddCommunityCopyWith<$Res> {
-  factory _$$_ModAddCommunityCopyWith(
-          _$_ModAddCommunity value, $Res Function(_$_ModAddCommunity) then) =
-      __$$_ModAddCommunityCopyWithImpl<$Res>;
+  factory _$$ModAddCommunityImplCopyWith(_$ModAddCommunityImpl value,
+          $Res Function(_$ModAddCommunityImpl) then) =
+      __$$ModAddCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -116,11 +116,11 @@ abstract class _$$_ModAddCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModAddCommunityCopyWithImpl<$Res>
-    extends _$ModAddCommunityCopyWithImpl<$Res, _$_ModAddCommunity>
-    implements _$$_ModAddCommunityCopyWith<$Res> {
-  __$$_ModAddCommunityCopyWithImpl(
-      _$_ModAddCommunity _value, $Res Function(_$_ModAddCommunity) _then)
+class __$$ModAddCommunityImplCopyWithImpl<$Res>
+    extends _$ModAddCommunityCopyWithImpl<$Res, _$ModAddCommunityImpl>
+    implements _$$ModAddCommunityImplCopyWith<$Res> {
+  __$$ModAddCommunityImplCopyWithImpl(
+      _$ModAddCommunityImpl _value, $Res Function(_$ModAddCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -133,7 +133,7 @@ class __$$_ModAddCommunityCopyWithImpl<$Res>
     Object? removed = null,
     Object? when = null,
   }) {
-    return _then(_$_ModAddCommunity(
+    return _then(_$ModAddCommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -165,8 +165,8 @@ class __$$_ModAddCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModAddCommunity extends _ModAddCommunity {
-  const _$_ModAddCommunity(
+class _$ModAddCommunityImpl extends _ModAddCommunity {
+  const _$ModAddCommunityImpl(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -175,8 +175,8 @@ class _$_ModAddCommunity extends _ModAddCommunity {
       @JsonKey(name: 'when_') required this.when})
       : super._();
 
-  factory _$_ModAddCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_ModAddCommunityFromJson(json);
+  factory _$ModAddCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModAddCommunityImplFromJson(json);
 
   @override
   final int id;
@@ -201,7 +201,7 @@ class _$_ModAddCommunity extends _ModAddCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModAddCommunity &&
+            other is _$ModAddCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -221,12 +221,13 @@ class _$_ModAddCommunity extends _ModAddCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModAddCommunityCopyWith<_$_ModAddCommunity> get copyWith =>
-      __$$_ModAddCommunityCopyWithImpl<_$_ModAddCommunity>(this, _$identity);
+  _$$ModAddCommunityImplCopyWith<_$ModAddCommunityImpl> get copyWith =>
+      __$$ModAddCommunityImplCopyWithImpl<_$ModAddCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModAddCommunityToJson(
+    return _$$ModAddCommunityImplToJson(
       this,
     );
   }
@@ -234,16 +235,17 @@ class _$_ModAddCommunity extends _ModAddCommunity {
 
 abstract class _ModAddCommunity extends ModAddCommunity {
   const factory _ModAddCommunity(
-      {required final int id,
-      required final int modPersonId,
-      required final int otherPersonId,
-      required final int communityId,
-      required final bool removed,
-      @JsonKey(name: 'when_') required final String when}) = _$_ModAddCommunity;
+          {required final int id,
+          required final int modPersonId,
+          required final int otherPersonId,
+          required final int communityId,
+          required final bool removed,
+          @JsonKey(name: 'when_') required final String when}) =
+      _$ModAddCommunityImpl;
   const _ModAddCommunity._() : super._();
 
   factory _ModAddCommunity.fromJson(Map<String, dynamic> json) =
-      _$_ModAddCommunity.fromJson;
+      _$ModAddCommunityImpl.fromJson;
 
   @override
   int get id;
@@ -260,6 +262,6 @@ abstract class _ModAddCommunity extends ModAddCommunity {
   String get when;
   @override
   @JsonKey(ignore: true)
-  _$$_ModAddCommunityCopyWith<_$_ModAddCommunity> get copyWith =>
+  _$$ModAddCommunityImplCopyWith<_$ModAddCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/mod/mod_add_community.g.dart
+++ b/lib/src/v3/models/mod/mod_add_community.g.dart
@@ -6,8 +6,9 @@ part of 'mod_add_community.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModAddCommunity _$$_ModAddCommunityFromJson(Map<String, dynamic> json) =>
-    _$_ModAddCommunity(
+_$ModAddCommunityImpl _$$ModAddCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ModAddCommunityImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       otherPersonId: json['other_person_id'] as int,
@@ -16,7 +17,8 @@ _$_ModAddCommunity _$$_ModAddCommunityFromJson(Map<String, dynamic> json) =>
       when: json['when_'] as String,
     );
 
-Map<String, dynamic> _$$_ModAddCommunityToJson(_$_ModAddCommunity instance) =>
+Map<String, dynamic> _$$ModAddCommunityImplToJson(
+        _$ModAddCommunityImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,

--- a/lib/src/v3/models/mod/mod_ban_from_community.freezed.dart
+++ b/lib/src/v3/models/mod/mod_ban_from_community.freezed.dart
@@ -113,11 +113,11 @@ class _$ModBanFromCommunityCopyWithImpl<$Res, $Val extends ModBanFromCommunity>
 }
 
 /// @nodoc
-abstract class _$$_ModBanFromCommunityCopyWith<$Res>
+abstract class _$$ModBanFromCommunityImplCopyWith<$Res>
     implements $ModBanFromCommunityCopyWith<$Res> {
-  factory _$$_ModBanFromCommunityCopyWith(_$_ModBanFromCommunity value,
-          $Res Function(_$_ModBanFromCommunity) then) =
-      __$$_ModBanFromCommunityCopyWithImpl<$Res>;
+  factory _$$ModBanFromCommunityImplCopyWith(_$ModBanFromCommunityImpl value,
+          $Res Function(_$ModBanFromCommunityImpl) then) =
+      __$$ModBanFromCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -132,11 +132,11 @@ abstract class _$$_ModBanFromCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModBanFromCommunityCopyWithImpl<$Res>
-    extends _$ModBanFromCommunityCopyWithImpl<$Res, _$_ModBanFromCommunity>
-    implements _$$_ModBanFromCommunityCopyWith<$Res> {
-  __$$_ModBanFromCommunityCopyWithImpl(_$_ModBanFromCommunity _value,
-      $Res Function(_$_ModBanFromCommunity) _then)
+class __$$ModBanFromCommunityImplCopyWithImpl<$Res>
+    extends _$ModBanFromCommunityCopyWithImpl<$Res, _$ModBanFromCommunityImpl>
+    implements _$$ModBanFromCommunityImplCopyWith<$Res> {
+  __$$ModBanFromCommunityImplCopyWithImpl(_$ModBanFromCommunityImpl _value,
+      $Res Function(_$ModBanFromCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -151,7 +151,7 @@ class __$$_ModBanFromCommunityCopyWithImpl<$Res>
     Object? expires = freezed,
     Object? when = null,
   }) {
-    return _then(_$_ModBanFromCommunity(
+    return _then(_$ModBanFromCommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -191,8 +191,8 @@ class __$$_ModBanFromCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModBanFromCommunity extends _ModBanFromCommunity {
-  const _$_ModBanFromCommunity(
+class _$ModBanFromCommunityImpl extends _ModBanFromCommunity {
+  const _$ModBanFromCommunityImpl(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -203,8 +203,8 @@ class _$_ModBanFromCommunity extends _ModBanFromCommunity {
       @JsonKey(name: 'when_') required this.when})
       : super._();
 
-  factory _$_ModBanFromCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_ModBanFromCommunityFromJson(json);
+  factory _$ModBanFromCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModBanFromCommunityImplFromJson(json);
 
   @override
   final int id;
@@ -233,7 +233,7 @@ class _$_ModBanFromCommunity extends _ModBanFromCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModBanFromCommunity &&
+            other is _$ModBanFromCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -255,13 +255,13 @@ class _$_ModBanFromCommunity extends _ModBanFromCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModBanFromCommunityCopyWith<_$_ModBanFromCommunity> get copyWith =>
-      __$$_ModBanFromCommunityCopyWithImpl<_$_ModBanFromCommunity>(
+  _$$ModBanFromCommunityImplCopyWith<_$ModBanFromCommunityImpl> get copyWith =>
+      __$$ModBanFromCommunityImplCopyWithImpl<_$ModBanFromCommunityImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModBanFromCommunityToJson(
+    return _$$ModBanFromCommunityImplToJson(
       this,
     );
   }
@@ -277,11 +277,11 @@ abstract class _ModBanFromCommunity extends ModBanFromCommunity {
           required final bool banned,
           final int? expires,
           @JsonKey(name: 'when_') required final String when}) =
-      _$_ModBanFromCommunity;
+      _$ModBanFromCommunityImpl;
   const _ModBanFromCommunity._() : super._();
 
   factory _ModBanFromCommunity.fromJson(Map<String, dynamic> json) =
-      _$_ModBanFromCommunity.fromJson;
+      _$ModBanFromCommunityImpl.fromJson;
 
   @override
   int get id;
@@ -302,6 +302,6 @@ abstract class _ModBanFromCommunity extends ModBanFromCommunity {
   String get when;
   @override
   @JsonKey(ignore: true)
-  _$$_ModBanFromCommunityCopyWith<_$_ModBanFromCommunity> get copyWith =>
+  _$$ModBanFromCommunityImplCopyWith<_$ModBanFromCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/mod/mod_ban_from_community.g.dart
+++ b/lib/src/v3/models/mod/mod_ban_from_community.g.dart
@@ -6,9 +6,9 @@ part of 'mod_ban_from_community.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModBanFromCommunity _$$_ModBanFromCommunityFromJson(
+_$ModBanFromCommunityImpl _$$ModBanFromCommunityImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModBanFromCommunity(
+    _$ModBanFromCommunityImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       otherPersonId: json['other_person_id'] as int,
@@ -19,8 +19,8 @@ _$_ModBanFromCommunity _$$_ModBanFromCommunityFromJson(
       when: json['when_'] as String,
     );
 
-Map<String, dynamic> _$$_ModBanFromCommunityToJson(
-        _$_ModBanFromCommunity instance) =>
+Map<String, dynamic> _$$ModBanFromCommunityImplToJson(
+        _$ModBanFromCommunityImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,

--- a/lib/src/v3/models/mod/mod_feature_post.freezed.dart
+++ b/lib/src/v3/models/mod/mod_feature_post.freezed.dart
@@ -99,11 +99,11 @@ class _$ModFeaturePostCopyWithImpl<$Res, $Val extends ModFeaturePost>
 }
 
 /// @nodoc
-abstract class _$$_ModFeaturePostCopyWith<$Res>
+abstract class _$$ModFeaturePostImplCopyWith<$Res>
     implements $ModFeaturePostCopyWith<$Res> {
-  factory _$$_ModFeaturePostCopyWith(
-          _$_ModFeaturePost value, $Res Function(_$_ModFeaturePost) then) =
-      __$$_ModFeaturePostCopyWithImpl<$Res>;
+  factory _$$ModFeaturePostImplCopyWith(_$ModFeaturePostImpl value,
+          $Res Function(_$ModFeaturePostImpl) then) =
+      __$$ModFeaturePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -116,11 +116,11 @@ abstract class _$$_ModFeaturePostCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModFeaturePostCopyWithImpl<$Res>
-    extends _$ModFeaturePostCopyWithImpl<$Res, _$_ModFeaturePost>
-    implements _$$_ModFeaturePostCopyWith<$Res> {
-  __$$_ModFeaturePostCopyWithImpl(
-      _$_ModFeaturePost _value, $Res Function(_$_ModFeaturePost) _then)
+class __$$ModFeaturePostImplCopyWithImpl<$Res>
+    extends _$ModFeaturePostCopyWithImpl<$Res, _$ModFeaturePostImpl>
+    implements _$$ModFeaturePostImplCopyWith<$Res> {
+  __$$ModFeaturePostImplCopyWithImpl(
+      _$ModFeaturePostImpl _value, $Res Function(_$ModFeaturePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -133,7 +133,7 @@ class __$$_ModFeaturePostCopyWithImpl<$Res>
     Object? when = null,
     Object? isFeaturedCommunity = null,
   }) {
-    return _then(_$_ModFeaturePost(
+    return _then(_$ModFeaturePostImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -165,8 +165,8 @@ class __$$_ModFeaturePostCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModFeaturePost extends _ModFeaturePost {
-  const _$_ModFeaturePost(
+class _$ModFeaturePostImpl extends _ModFeaturePost {
+  const _$ModFeaturePostImpl(
       {required this.id,
       required this.modPersonId,
       required this.postId,
@@ -175,8 +175,8 @@ class _$_ModFeaturePost extends _ModFeaturePost {
       required this.isFeaturedCommunity})
       : super._();
 
-  factory _$_ModFeaturePost.fromJson(Map<String, dynamic> json) =>
-      _$$_ModFeaturePostFromJson(json);
+  factory _$ModFeaturePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModFeaturePostImplFromJson(json);
 
   @override
   final int id;
@@ -201,7 +201,7 @@ class _$_ModFeaturePost extends _ModFeaturePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModFeaturePost &&
+            other is _$ModFeaturePostImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -221,12 +221,13 @@ class _$_ModFeaturePost extends _ModFeaturePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModFeaturePostCopyWith<_$_ModFeaturePost> get copyWith =>
-      __$$_ModFeaturePostCopyWithImpl<_$_ModFeaturePost>(this, _$identity);
+  _$$ModFeaturePostImplCopyWith<_$ModFeaturePostImpl> get copyWith =>
+      __$$ModFeaturePostImplCopyWithImpl<_$ModFeaturePostImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModFeaturePostToJson(
+    return _$$ModFeaturePostImplToJson(
       this,
     );
   }
@@ -239,11 +240,11 @@ abstract class _ModFeaturePost extends ModFeaturePost {
       required final int postId,
       required final bool featured,
       @JsonKey(name: 'when_') required final String when,
-      required final bool isFeaturedCommunity}) = _$_ModFeaturePost;
+      required final bool isFeaturedCommunity}) = _$ModFeaturePostImpl;
   const _ModFeaturePost._() : super._();
 
   factory _ModFeaturePost.fromJson(Map<String, dynamic> json) =
-      _$_ModFeaturePost.fromJson;
+      _$ModFeaturePostImpl.fromJson;
 
   @override
   int get id;
@@ -260,6 +261,6 @@ abstract class _ModFeaturePost extends ModFeaturePost {
   bool get isFeaturedCommunity;
   @override
   @JsonKey(ignore: true)
-  _$$_ModFeaturePostCopyWith<_$_ModFeaturePost> get copyWith =>
+  _$$ModFeaturePostImplCopyWith<_$ModFeaturePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/mod/mod_feature_post.g.dart
+++ b/lib/src/v3/models/mod/mod_feature_post.g.dart
@@ -6,8 +6,8 @@ part of 'mod_feature_post.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModFeaturePost _$$_ModFeaturePostFromJson(Map<String, dynamic> json) =>
-    _$_ModFeaturePost(
+_$ModFeaturePostImpl _$$ModFeaturePostImplFromJson(Map<String, dynamic> json) =>
+    _$ModFeaturePostImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       postId: json['post_id'] as int,
@@ -16,7 +16,8 @@ _$_ModFeaturePost _$$_ModFeaturePostFromJson(Map<String, dynamic> json) =>
       isFeaturedCommunity: json['is_featured_community'] as bool,
     );
 
-Map<String, dynamic> _$$_ModFeaturePostToJson(_$_ModFeaturePost instance) =>
+Map<String, dynamic> _$$ModFeaturePostImplToJson(
+        _$ModFeaturePostImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,

--- a/lib/src/v3/models/mod/mod_hide_community.freezed.dart
+++ b/lib/src/v3/models/mod/mod_hide_community.freezed.dart
@@ -99,11 +99,11 @@ class _$ModHideCommunityCopyWithImpl<$Res, $Val extends ModHideCommunity>
 }
 
 /// @nodoc
-abstract class _$$_ModHideCommunityCopyWith<$Res>
+abstract class _$$ModHideCommunityImplCopyWith<$Res>
     implements $ModHideCommunityCopyWith<$Res> {
-  factory _$$_ModHideCommunityCopyWith(
-          _$_ModHideCommunity value, $Res Function(_$_ModHideCommunity) then) =
-      __$$_ModHideCommunityCopyWithImpl<$Res>;
+  factory _$$ModHideCommunityImplCopyWith(_$ModHideCommunityImpl value,
+          $Res Function(_$ModHideCommunityImpl) then) =
+      __$$ModHideCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -116,11 +116,11 @@ abstract class _$$_ModHideCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModHideCommunityCopyWithImpl<$Res>
-    extends _$ModHideCommunityCopyWithImpl<$Res, _$_ModHideCommunity>
-    implements _$$_ModHideCommunityCopyWith<$Res> {
-  __$$_ModHideCommunityCopyWithImpl(
-      _$_ModHideCommunity _value, $Res Function(_$_ModHideCommunity) _then)
+class __$$ModHideCommunityImplCopyWithImpl<$Res>
+    extends _$ModHideCommunityCopyWithImpl<$Res, _$ModHideCommunityImpl>
+    implements _$$ModHideCommunityImplCopyWith<$Res> {
+  __$$ModHideCommunityImplCopyWithImpl(_$ModHideCommunityImpl _value,
+      $Res Function(_$ModHideCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -133,7 +133,7 @@ class __$$_ModHideCommunityCopyWithImpl<$Res>
     Object? reason = freezed,
     Object? hidden = null,
   }) {
-    return _then(_$_ModHideCommunity(
+    return _then(_$ModHideCommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -165,8 +165,8 @@ class __$$_ModHideCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModHideCommunity extends _ModHideCommunity {
-  const _$_ModHideCommunity(
+class _$ModHideCommunityImpl extends _ModHideCommunity {
+  const _$ModHideCommunityImpl(
       {required this.id,
       required this.communityId,
       required this.modPersonId,
@@ -175,8 +175,8 @@ class _$_ModHideCommunity extends _ModHideCommunity {
       required this.hidden})
       : super._();
 
-  factory _$_ModHideCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_ModHideCommunityFromJson(json);
+  factory _$ModHideCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModHideCommunityImplFromJson(json);
 
   @override
   final int id;
@@ -201,7 +201,7 @@ class _$_ModHideCommunity extends _ModHideCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModHideCommunity &&
+            other is _$ModHideCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
@@ -220,12 +220,13 @@ class _$_ModHideCommunity extends _ModHideCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModHideCommunityCopyWith<_$_ModHideCommunity> get copyWith =>
-      __$$_ModHideCommunityCopyWithImpl<_$_ModHideCommunity>(this, _$identity);
+  _$$ModHideCommunityImplCopyWith<_$ModHideCommunityImpl> get copyWith =>
+      __$$ModHideCommunityImplCopyWithImpl<_$ModHideCommunityImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModHideCommunityToJson(
+    return _$$ModHideCommunityImplToJson(
       this,
     );
   }
@@ -238,11 +239,11 @@ abstract class _ModHideCommunity extends ModHideCommunity {
       required final int modPersonId,
       @JsonKey(name: 'when_') required final String when,
       final String? reason,
-      required final bool hidden}) = _$_ModHideCommunity;
+      required final bool hidden}) = _$ModHideCommunityImpl;
   const _ModHideCommunity._() : super._();
 
   factory _ModHideCommunity.fromJson(Map<String, dynamic> json) =
-      _$_ModHideCommunity.fromJson;
+      _$ModHideCommunityImpl.fromJson;
 
   @override
   int get id;
@@ -259,6 +260,6 @@ abstract class _ModHideCommunity extends ModHideCommunity {
   bool get hidden;
   @override
   @JsonKey(ignore: true)
-  _$$_ModHideCommunityCopyWith<_$_ModHideCommunity> get copyWith =>
+  _$$ModHideCommunityImplCopyWith<_$ModHideCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/mod/mod_hide_community.g.dart
+++ b/lib/src/v3/models/mod/mod_hide_community.g.dart
@@ -6,8 +6,9 @@ part of 'mod_hide_community.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModHideCommunity _$$_ModHideCommunityFromJson(Map<String, dynamic> json) =>
-    _$_ModHideCommunity(
+_$ModHideCommunityImpl _$$ModHideCommunityImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ModHideCommunityImpl(
       id: json['id'] as int,
       communityId: json['community_id'] as int,
       modPersonId: json['mod_person_id'] as int,
@@ -16,7 +17,8 @@ _$_ModHideCommunity _$$_ModHideCommunityFromJson(Map<String, dynamic> json) =>
       hidden: json['hidden'] as bool,
     );
 
-Map<String, dynamic> _$$_ModHideCommunityToJson(_$_ModHideCommunity instance) =>
+Map<String, dynamic> _$$ModHideCommunityImplToJson(
+        _$ModHideCommunityImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'community_id': instance.communityId,

--- a/lib/src/v3/models/mod/mod_lock_post.freezed.dart
+++ b/lib/src/v3/models/mod/mod_lock_post.freezed.dart
@@ -92,11 +92,11 @@ class _$ModLockPostCopyWithImpl<$Res, $Val extends ModLockPost>
 }
 
 /// @nodoc
-abstract class _$$_ModLockPostCopyWith<$Res>
+abstract class _$$ModLockPostImplCopyWith<$Res>
     implements $ModLockPostCopyWith<$Res> {
-  factory _$$_ModLockPostCopyWith(
-          _$_ModLockPost value, $Res Function(_$_ModLockPost) then) =
-      __$$_ModLockPostCopyWithImpl<$Res>;
+  factory _$$ModLockPostImplCopyWith(
+          _$ModLockPostImpl value, $Res Function(_$ModLockPostImpl) then) =
+      __$$ModLockPostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -108,11 +108,11 @@ abstract class _$$_ModLockPostCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModLockPostCopyWithImpl<$Res>
-    extends _$ModLockPostCopyWithImpl<$Res, _$_ModLockPost>
-    implements _$$_ModLockPostCopyWith<$Res> {
-  __$$_ModLockPostCopyWithImpl(
-      _$_ModLockPost _value, $Res Function(_$_ModLockPost) _then)
+class __$$ModLockPostImplCopyWithImpl<$Res>
+    extends _$ModLockPostCopyWithImpl<$Res, _$ModLockPostImpl>
+    implements _$$ModLockPostImplCopyWith<$Res> {
+  __$$ModLockPostImplCopyWithImpl(
+      _$ModLockPostImpl _value, $Res Function(_$ModLockPostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -124,7 +124,7 @@ class __$$_ModLockPostCopyWithImpl<$Res>
     Object? locked = null,
     Object? when = null,
   }) {
-    return _then(_$_ModLockPost(
+    return _then(_$ModLockPostImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -152,8 +152,8 @@ class __$$_ModLockPostCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModLockPost extends _ModLockPost {
-  const _$_ModLockPost(
+class _$ModLockPostImpl extends _ModLockPost {
+  const _$ModLockPostImpl(
       {required this.id,
       required this.modPersonId,
       required this.postId,
@@ -161,8 +161,8 @@ class _$_ModLockPost extends _ModLockPost {
       @JsonKey(name: 'when_') required this.when})
       : super._();
 
-  factory _$_ModLockPost.fromJson(Map<String, dynamic> json) =>
-      _$$_ModLockPostFromJson(json);
+  factory _$ModLockPostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModLockPostImplFromJson(json);
 
   @override
   final int id;
@@ -185,7 +185,7 @@ class _$_ModLockPost extends _ModLockPost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModLockPost &&
+            other is _$ModLockPostImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -202,12 +202,12 @@ class _$_ModLockPost extends _ModLockPost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModLockPostCopyWith<_$_ModLockPost> get copyWith =>
-      __$$_ModLockPostCopyWithImpl<_$_ModLockPost>(this, _$identity);
+  _$$ModLockPostImplCopyWith<_$ModLockPostImpl> get copyWith =>
+      __$$ModLockPostImplCopyWithImpl<_$ModLockPostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModLockPostToJson(
+    return _$$ModLockPostImplToJson(
       this,
     );
   }
@@ -219,11 +219,11 @@ abstract class _ModLockPost extends ModLockPost {
       required final int modPersonId,
       required final int postId,
       required final bool locked,
-      @JsonKey(name: 'when_') required final String when}) = _$_ModLockPost;
+      @JsonKey(name: 'when_') required final String when}) = _$ModLockPostImpl;
   const _ModLockPost._() : super._();
 
   factory _ModLockPost.fromJson(Map<String, dynamic> json) =
-      _$_ModLockPost.fromJson;
+      _$ModLockPostImpl.fromJson;
 
   @override
   int get id;
@@ -238,6 +238,6 @@ abstract class _ModLockPost extends ModLockPost {
   String get when;
   @override
   @JsonKey(ignore: true)
-  _$$_ModLockPostCopyWith<_$_ModLockPost> get copyWith =>
+  _$$ModLockPostImplCopyWith<_$ModLockPostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/mod/mod_lock_post.g.dart
+++ b/lib/src/v3/models/mod/mod_lock_post.g.dart
@@ -6,8 +6,8 @@ part of 'mod_lock_post.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModLockPost _$$_ModLockPostFromJson(Map<String, dynamic> json) =>
-    _$_ModLockPost(
+_$ModLockPostImpl _$$ModLockPostImplFromJson(Map<String, dynamic> json) =>
+    _$ModLockPostImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       postId: json['post_id'] as int,
@@ -15,7 +15,7 @@ _$_ModLockPost _$$_ModLockPostFromJson(Map<String, dynamic> json) =>
       when: json['when_'] as String,
     );
 
-Map<String, dynamic> _$$_ModLockPostToJson(_$_ModLockPost instance) =>
+Map<String, dynamic> _$$ModLockPostImplToJson(_$ModLockPostImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,

--- a/lib/src/v3/models/mod/mod_remove_comment.freezed.dart
+++ b/lib/src/v3/models/mod/mod_remove_comment.freezed.dart
@@ -99,11 +99,11 @@ class _$ModRemoveCommentCopyWithImpl<$Res, $Val extends ModRemoveComment>
 }
 
 /// @nodoc
-abstract class _$$_ModRemoveCommentCopyWith<$Res>
+abstract class _$$ModRemoveCommentImplCopyWith<$Res>
     implements $ModRemoveCommentCopyWith<$Res> {
-  factory _$$_ModRemoveCommentCopyWith(
-          _$_ModRemoveComment value, $Res Function(_$_ModRemoveComment) then) =
-      __$$_ModRemoveCommentCopyWithImpl<$Res>;
+  factory _$$ModRemoveCommentImplCopyWith(_$ModRemoveCommentImpl value,
+          $Res Function(_$ModRemoveCommentImpl) then) =
+      __$$ModRemoveCommentImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -116,11 +116,11 @@ abstract class _$$_ModRemoveCommentCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModRemoveCommentCopyWithImpl<$Res>
-    extends _$ModRemoveCommentCopyWithImpl<$Res, _$_ModRemoveComment>
-    implements _$$_ModRemoveCommentCopyWith<$Res> {
-  __$$_ModRemoveCommentCopyWithImpl(
-      _$_ModRemoveComment _value, $Res Function(_$_ModRemoveComment) _then)
+class __$$ModRemoveCommentImplCopyWithImpl<$Res>
+    extends _$ModRemoveCommentCopyWithImpl<$Res, _$ModRemoveCommentImpl>
+    implements _$$ModRemoveCommentImplCopyWith<$Res> {
+  __$$ModRemoveCommentImplCopyWithImpl(_$ModRemoveCommentImpl _value,
+      $Res Function(_$ModRemoveCommentImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -133,7 +133,7 @@ class __$$_ModRemoveCommentCopyWithImpl<$Res>
     Object? removed = null,
     Object? when = null,
   }) {
-    return _then(_$_ModRemoveComment(
+    return _then(_$ModRemoveCommentImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -165,8 +165,8 @@ class __$$_ModRemoveCommentCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModRemoveComment extends _ModRemoveComment {
-  const _$_ModRemoveComment(
+class _$ModRemoveCommentImpl extends _ModRemoveComment {
+  const _$ModRemoveCommentImpl(
       {required this.id,
       required this.modPersonId,
       required this.commentId,
@@ -175,8 +175,8 @@ class _$_ModRemoveComment extends _ModRemoveComment {
       @JsonKey(name: 'when_') required this.when})
       : super._();
 
-  factory _$_ModRemoveComment.fromJson(Map<String, dynamic> json) =>
-      _$$_ModRemoveCommentFromJson(json);
+  factory _$ModRemoveCommentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModRemoveCommentImplFromJson(json);
 
   @override
   final int id;
@@ -201,7 +201,7 @@ class _$_ModRemoveComment extends _ModRemoveComment {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModRemoveComment &&
+            other is _$ModRemoveCommentImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -220,12 +220,13 @@ class _$_ModRemoveComment extends _ModRemoveComment {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModRemoveCommentCopyWith<_$_ModRemoveComment> get copyWith =>
-      __$$_ModRemoveCommentCopyWithImpl<_$_ModRemoveComment>(this, _$identity);
+  _$$ModRemoveCommentImplCopyWith<_$ModRemoveCommentImpl> get copyWith =>
+      __$$ModRemoveCommentImplCopyWithImpl<_$ModRemoveCommentImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModRemoveCommentToJson(
+    return _$$ModRemoveCommentImplToJson(
       this,
     );
   }
@@ -239,11 +240,11 @@ abstract class _ModRemoveComment extends ModRemoveComment {
           final String? reason,
           required final bool removed,
           @JsonKey(name: 'when_') required final String when}) =
-      _$_ModRemoveComment;
+      _$ModRemoveCommentImpl;
   const _ModRemoveComment._() : super._();
 
   factory _ModRemoveComment.fromJson(Map<String, dynamic> json) =
-      _$_ModRemoveComment.fromJson;
+      _$ModRemoveCommentImpl.fromJson;
 
   @override
   int get id;
@@ -260,6 +261,6 @@ abstract class _ModRemoveComment extends ModRemoveComment {
   String get when;
   @override
   @JsonKey(ignore: true)
-  _$$_ModRemoveCommentCopyWith<_$_ModRemoveComment> get copyWith =>
+  _$$ModRemoveCommentImplCopyWith<_$ModRemoveCommentImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/mod/mod_remove_comment.g.dart
+++ b/lib/src/v3/models/mod/mod_remove_comment.g.dart
@@ -6,8 +6,9 @@ part of 'mod_remove_comment.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModRemoveComment _$$_ModRemoveCommentFromJson(Map<String, dynamic> json) =>
-    _$_ModRemoveComment(
+_$ModRemoveCommentImpl _$$ModRemoveCommentImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ModRemoveCommentImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       commentId: json['comment_id'] as int,
@@ -16,7 +17,8 @@ _$_ModRemoveComment _$$_ModRemoveCommentFromJson(Map<String, dynamic> json) =>
       when: json['when_'] as String,
     );
 
-Map<String, dynamic> _$$_ModRemoveCommentToJson(_$_ModRemoveComment instance) =>
+Map<String, dynamic> _$$ModRemoveCommentImplToJson(
+        _$ModRemoveCommentImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,

--- a/lib/src/v3/models/mod/mod_remove_community.freezed.dart
+++ b/lib/src/v3/models/mod/mod_remove_community.freezed.dart
@@ -107,11 +107,11 @@ class _$ModRemoveCommunityCopyWithImpl<$Res, $Val extends ModRemoveCommunity>
 }
 
 /// @nodoc
-abstract class _$$_ModRemoveCommunityCopyWith<$Res>
+abstract class _$$ModRemoveCommunityImplCopyWith<$Res>
     implements $ModRemoveCommunityCopyWith<$Res> {
-  factory _$$_ModRemoveCommunityCopyWith(_$_ModRemoveCommunity value,
-          $Res Function(_$_ModRemoveCommunity) then) =
-      __$$_ModRemoveCommunityCopyWithImpl<$Res>;
+  factory _$$ModRemoveCommunityImplCopyWith(_$ModRemoveCommunityImpl value,
+          $Res Function(_$ModRemoveCommunityImpl) then) =
+      __$$ModRemoveCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -125,11 +125,11 @@ abstract class _$$_ModRemoveCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModRemoveCommunityCopyWithImpl<$Res>
-    extends _$ModRemoveCommunityCopyWithImpl<$Res, _$_ModRemoveCommunity>
-    implements _$$_ModRemoveCommunityCopyWith<$Res> {
-  __$$_ModRemoveCommunityCopyWithImpl(
-      _$_ModRemoveCommunity _value, $Res Function(_$_ModRemoveCommunity) _then)
+class __$$ModRemoveCommunityImplCopyWithImpl<$Res>
+    extends _$ModRemoveCommunityCopyWithImpl<$Res, _$ModRemoveCommunityImpl>
+    implements _$$ModRemoveCommunityImplCopyWith<$Res> {
+  __$$ModRemoveCommunityImplCopyWithImpl(_$ModRemoveCommunityImpl _value,
+      $Res Function(_$ModRemoveCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -143,7 +143,7 @@ class __$$_ModRemoveCommunityCopyWithImpl<$Res>
     Object? expires = freezed,
     Object? when = null,
   }) {
-    return _then(_$_ModRemoveCommunity(
+    return _then(_$ModRemoveCommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -179,8 +179,8 @@ class __$$_ModRemoveCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModRemoveCommunity extends _ModRemoveCommunity {
-  const _$_ModRemoveCommunity(
+class _$ModRemoveCommunityImpl extends _ModRemoveCommunity {
+  const _$ModRemoveCommunityImpl(
       {required this.id,
       required this.modPersonId,
       required this.communityId,
@@ -190,8 +190,8 @@ class _$_ModRemoveCommunity extends _ModRemoveCommunity {
       @JsonKey(name: 'when_') required this.when})
       : super._();
 
-  factory _$_ModRemoveCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_ModRemoveCommunityFromJson(json);
+  factory _$ModRemoveCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModRemoveCommunityImplFromJson(json);
 
   @override
   final int id;
@@ -219,7 +219,7 @@ class _$_ModRemoveCommunity extends _ModRemoveCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModRemoveCommunity &&
+            other is _$ModRemoveCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -239,13 +239,13 @@ class _$_ModRemoveCommunity extends _ModRemoveCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModRemoveCommunityCopyWith<_$_ModRemoveCommunity> get copyWith =>
-      __$$_ModRemoveCommunityCopyWithImpl<_$_ModRemoveCommunity>(
+  _$$ModRemoveCommunityImplCopyWith<_$ModRemoveCommunityImpl> get copyWith =>
+      __$$ModRemoveCommunityImplCopyWithImpl<_$ModRemoveCommunityImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModRemoveCommunityToJson(
+    return _$$ModRemoveCommunityImplToJson(
       this,
     );
   }
@@ -260,11 +260,11 @@ abstract class _ModRemoveCommunity extends ModRemoveCommunity {
           required final bool removed,
           @deprecated final int? expires,
           @JsonKey(name: 'when_') required final String when}) =
-      _$_ModRemoveCommunity;
+      _$ModRemoveCommunityImpl;
   const _ModRemoveCommunity._() : super._();
 
   factory _ModRemoveCommunity.fromJson(Map<String, dynamic> json) =
-      _$_ModRemoveCommunity.fromJson;
+      _$ModRemoveCommunityImpl.fromJson;
 
   @override
   int get id;
@@ -284,6 +284,6 @@ abstract class _ModRemoveCommunity extends ModRemoveCommunity {
   String get when;
   @override
   @JsonKey(ignore: true)
-  _$$_ModRemoveCommunityCopyWith<_$_ModRemoveCommunity> get copyWith =>
+  _$$ModRemoveCommunityImplCopyWith<_$ModRemoveCommunityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/mod/mod_remove_community.g.dart
+++ b/lib/src/v3/models/mod/mod_remove_community.g.dart
@@ -6,9 +6,9 @@ part of 'mod_remove_community.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModRemoveCommunity _$$_ModRemoveCommunityFromJson(
+_$ModRemoveCommunityImpl _$$ModRemoveCommunityImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModRemoveCommunity(
+    _$ModRemoveCommunityImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       communityId: json['community_id'] as int,
@@ -18,8 +18,8 @@ _$_ModRemoveCommunity _$$_ModRemoveCommunityFromJson(
       when: json['when_'] as String,
     );
 
-Map<String, dynamic> _$$_ModRemoveCommunityToJson(
-        _$_ModRemoveCommunity instance) =>
+Map<String, dynamic> _$$ModRemoveCommunityImplToJson(
+        _$ModRemoveCommunityImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,

--- a/lib/src/v3/models/mod/mod_remove_post.freezed.dart
+++ b/lib/src/v3/models/mod/mod_remove_post.freezed.dart
@@ -99,11 +99,11 @@ class _$ModRemovePostCopyWithImpl<$Res, $Val extends ModRemovePost>
 }
 
 /// @nodoc
-abstract class _$$_ModRemovePostCopyWith<$Res>
+abstract class _$$ModRemovePostImplCopyWith<$Res>
     implements $ModRemovePostCopyWith<$Res> {
-  factory _$$_ModRemovePostCopyWith(
-          _$_ModRemovePost value, $Res Function(_$_ModRemovePost) then) =
-      __$$_ModRemovePostCopyWithImpl<$Res>;
+  factory _$$ModRemovePostImplCopyWith(
+          _$ModRemovePostImpl value, $Res Function(_$ModRemovePostImpl) then) =
+      __$$ModRemovePostImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -116,11 +116,11 @@ abstract class _$$_ModRemovePostCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModRemovePostCopyWithImpl<$Res>
-    extends _$ModRemovePostCopyWithImpl<$Res, _$_ModRemovePost>
-    implements _$$_ModRemovePostCopyWith<$Res> {
-  __$$_ModRemovePostCopyWithImpl(
-      _$_ModRemovePost _value, $Res Function(_$_ModRemovePost) _then)
+class __$$ModRemovePostImplCopyWithImpl<$Res>
+    extends _$ModRemovePostCopyWithImpl<$Res, _$ModRemovePostImpl>
+    implements _$$ModRemovePostImplCopyWith<$Res> {
+  __$$ModRemovePostImplCopyWithImpl(
+      _$ModRemovePostImpl _value, $Res Function(_$ModRemovePostImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -133,7 +133,7 @@ class __$$_ModRemovePostCopyWithImpl<$Res>
     Object? removed = null,
     Object? when = null,
   }) {
-    return _then(_$_ModRemovePost(
+    return _then(_$ModRemovePostImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -165,8 +165,8 @@ class __$$_ModRemovePostCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModRemovePost extends _ModRemovePost {
-  const _$_ModRemovePost(
+class _$ModRemovePostImpl extends _ModRemovePost {
+  const _$ModRemovePostImpl(
       {required this.id,
       required this.modPersonId,
       required this.postId,
@@ -175,8 +175,8 @@ class _$_ModRemovePost extends _ModRemovePost {
       @JsonKey(name: 'when_') required this.when})
       : super._();
 
-  factory _$_ModRemovePost.fromJson(Map<String, dynamic> json) =>
-      _$$_ModRemovePostFromJson(json);
+  factory _$ModRemovePostImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModRemovePostImplFromJson(json);
 
   @override
   final int id;
@@ -201,7 +201,7 @@ class _$_ModRemovePost extends _ModRemovePost {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModRemovePost &&
+            other is _$ModRemovePostImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -219,12 +219,12 @@ class _$_ModRemovePost extends _ModRemovePost {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModRemovePostCopyWith<_$_ModRemovePost> get copyWith =>
-      __$$_ModRemovePostCopyWithImpl<_$_ModRemovePost>(this, _$identity);
+  _$$ModRemovePostImplCopyWith<_$ModRemovePostImpl> get copyWith =>
+      __$$ModRemovePostImplCopyWithImpl<_$ModRemovePostImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModRemovePostToJson(
+    return _$$ModRemovePostImplToJson(
       this,
     );
   }
@@ -232,16 +232,17 @@ class _$_ModRemovePost extends _ModRemovePost {
 
 abstract class _ModRemovePost extends ModRemovePost {
   const factory _ModRemovePost(
-      {required final int id,
-      required final int modPersonId,
-      required final int postId,
-      final String? reason,
-      required final bool removed,
-      @JsonKey(name: 'when_') required final String when}) = _$_ModRemovePost;
+          {required final int id,
+          required final int modPersonId,
+          required final int postId,
+          final String? reason,
+          required final bool removed,
+          @JsonKey(name: 'when_') required final String when}) =
+      _$ModRemovePostImpl;
   const _ModRemovePost._() : super._();
 
   factory _ModRemovePost.fromJson(Map<String, dynamic> json) =
-      _$_ModRemovePost.fromJson;
+      _$ModRemovePostImpl.fromJson;
 
   @override
   int get id;
@@ -258,6 +259,6 @@ abstract class _ModRemovePost extends ModRemovePost {
   String get when;
   @override
   @JsonKey(ignore: true)
-  _$$_ModRemovePostCopyWith<_$_ModRemovePost> get copyWith =>
+  _$$ModRemovePostImplCopyWith<_$ModRemovePostImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/mod/mod_remove_post.g.dart
+++ b/lib/src/v3/models/mod/mod_remove_post.g.dart
@@ -6,8 +6,8 @@ part of 'mod_remove_post.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModRemovePost _$$_ModRemovePostFromJson(Map<String, dynamic> json) =>
-    _$_ModRemovePost(
+_$ModRemovePostImpl _$$ModRemovePostImplFromJson(Map<String, dynamic> json) =>
+    _$ModRemovePostImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       postId: json['post_id'] as int,
@@ -16,7 +16,7 @@ _$_ModRemovePost _$$_ModRemovePostFromJson(Map<String, dynamic> json) =>
       when: json['when_'] as String,
     );
 
-Map<String, dynamic> _$$_ModRemovePostToJson(_$_ModRemovePost instance) =>
+Map<String, dynamic> _$$ModRemovePostImplToJson(_$ModRemovePostImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,

--- a/lib/src/v3/models/mod/mod_transfer_community.freezed.dart
+++ b/lib/src/v3/models/mod/mod_transfer_community.freezed.dart
@@ -93,11 +93,11 @@ class _$ModTransferCommunityCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ModTransferCommunityCopyWith<$Res>
+abstract class _$$ModTransferCommunityImplCopyWith<$Res>
     implements $ModTransferCommunityCopyWith<$Res> {
-  factory _$$_ModTransferCommunityCopyWith(_$_ModTransferCommunity value,
-          $Res Function(_$_ModTransferCommunity) then) =
-      __$$_ModTransferCommunityCopyWithImpl<$Res>;
+  factory _$$ModTransferCommunityImplCopyWith(_$ModTransferCommunityImpl value,
+          $Res Function(_$ModTransferCommunityImpl) then) =
+      __$$ModTransferCommunityImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -109,11 +109,11 @@ abstract class _$$_ModTransferCommunityCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModTransferCommunityCopyWithImpl<$Res>
-    extends _$ModTransferCommunityCopyWithImpl<$Res, _$_ModTransferCommunity>
-    implements _$$_ModTransferCommunityCopyWith<$Res> {
-  __$$_ModTransferCommunityCopyWithImpl(_$_ModTransferCommunity _value,
-      $Res Function(_$_ModTransferCommunity) _then)
+class __$$ModTransferCommunityImplCopyWithImpl<$Res>
+    extends _$ModTransferCommunityCopyWithImpl<$Res, _$ModTransferCommunityImpl>
+    implements _$$ModTransferCommunityImplCopyWith<$Res> {
+  __$$ModTransferCommunityImplCopyWithImpl(_$ModTransferCommunityImpl _value,
+      $Res Function(_$ModTransferCommunityImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -125,7 +125,7 @@ class __$$_ModTransferCommunityCopyWithImpl<$Res>
     Object? communityId = null,
     Object? when = null,
   }) {
-    return _then(_$_ModTransferCommunity(
+    return _then(_$ModTransferCommunityImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -153,8 +153,8 @@ class __$$_ModTransferCommunityCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModTransferCommunity extends _ModTransferCommunity {
-  const _$_ModTransferCommunity(
+class _$ModTransferCommunityImpl extends _ModTransferCommunity {
+  const _$ModTransferCommunityImpl(
       {required this.id,
       required this.modPersonId,
       required this.otherPersonId,
@@ -162,8 +162,8 @@ class _$_ModTransferCommunity extends _ModTransferCommunity {
       @JsonKey(name: 'when_') required this.when})
       : super._();
 
-  factory _$_ModTransferCommunity.fromJson(Map<String, dynamic> json) =>
-      _$$_ModTransferCommunityFromJson(json);
+  factory _$ModTransferCommunityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModTransferCommunityImplFromJson(json);
 
   @override
   final int id;
@@ -186,7 +186,7 @@ class _$_ModTransferCommunity extends _ModTransferCommunity {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModTransferCommunity &&
+            other is _$ModTransferCommunityImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.modPersonId, modPersonId) ||
                 other.modPersonId == modPersonId) &&
@@ -205,13 +205,14 @@ class _$_ModTransferCommunity extends _ModTransferCommunity {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModTransferCommunityCopyWith<_$_ModTransferCommunity> get copyWith =>
-      __$$_ModTransferCommunityCopyWithImpl<_$_ModTransferCommunity>(
-          this, _$identity);
+  _$$ModTransferCommunityImplCopyWith<_$ModTransferCommunityImpl>
+      get copyWith =>
+          __$$ModTransferCommunityImplCopyWithImpl<_$ModTransferCommunityImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModTransferCommunityToJson(
+    return _$$ModTransferCommunityImplToJson(
       this,
     );
   }
@@ -224,11 +225,11 @@ abstract class _ModTransferCommunity extends ModTransferCommunity {
           required final int otherPersonId,
           required final int communityId,
           @JsonKey(name: 'when_') required final String when}) =
-      _$_ModTransferCommunity;
+      _$ModTransferCommunityImpl;
   const _ModTransferCommunity._() : super._();
 
   factory _ModTransferCommunity.fromJson(Map<String, dynamic> json) =
-      _$_ModTransferCommunity.fromJson;
+      _$ModTransferCommunityImpl.fromJson;
 
   @override
   int get id;
@@ -243,6 +244,6 @@ abstract class _ModTransferCommunity extends ModTransferCommunity {
   String get when;
   @override
   @JsonKey(ignore: true)
-  _$$_ModTransferCommunityCopyWith<_$_ModTransferCommunity> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ModTransferCommunityImplCopyWith<_$ModTransferCommunityImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/mod/mod_transfer_community.g.dart
+++ b/lib/src/v3/models/mod/mod_transfer_community.g.dart
@@ -6,9 +6,9 @@ part of 'mod_transfer_community.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModTransferCommunity _$$_ModTransferCommunityFromJson(
+_$ModTransferCommunityImpl _$$ModTransferCommunityImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModTransferCommunity(
+    _$ModTransferCommunityImpl(
       id: json['id'] as int,
       modPersonId: json['mod_person_id'] as int,
       otherPersonId: json['other_person_id'] as int,
@@ -16,8 +16,8 @@ _$_ModTransferCommunity _$$_ModTransferCommunityFromJson(
       when: json['when_'] as String,
     );
 
-Map<String, dynamic> _$$_ModTransferCommunityToJson(
-        _$_ModTransferCommunity instance) =>
+Map<String, dynamic> _$$ModTransferCommunityImplToJson(
+        _$ModTransferCommunityImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mod_person_id': instance.modPersonId,

--- a/lib/src/v3/models/models.dart
+++ b/lib/src/v3/models/models.dart
@@ -33,6 +33,8 @@ export 'custom_emoji/delete_custom_emoji_response.dart';
 export 'federated_instances/federated_instances.dart';
 export 'federated_instances/get_federated_instances_response.dart';
 export 'federated_instances/instance.dart';
+export 'federated_instances/instance_with_federation_state.dart';
+export 'federated_instances/readable_federation_state.dart';
 export 'language/language.dart';
 export 'local_user/local_user.dart';
 export 'mod/mod_add.dart';

--- a/lib/src/v3/models/modlog/get_modlog_response.freezed.dart
+++ b/lib/src/v3/models/modlog/get_modlog_response.freezed.dart
@@ -173,11 +173,11 @@ class _$GetModlogResponseCopyWithImpl<$Res, $Val extends GetModlogResponse>
 }
 
 /// @nodoc
-abstract class _$$_GetModlogResponseCopyWith<$Res>
+abstract class _$$GetModlogResponseImplCopyWith<$Res>
     implements $GetModlogResponseCopyWith<$Res> {
-  factory _$$_GetModlogResponseCopyWith(_$_GetModlogResponse value,
-          $Res Function(_$_GetModlogResponse) then) =
-      __$$_GetModlogResponseCopyWithImpl<$Res>;
+  factory _$$GetModlogResponseImplCopyWith(_$GetModlogResponseImpl value,
+          $Res Function(_$GetModlogResponseImpl) then) =
+      __$$GetModlogResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -199,11 +199,11 @@ abstract class _$$_GetModlogResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetModlogResponseCopyWithImpl<$Res>
-    extends _$GetModlogResponseCopyWithImpl<$Res, _$_GetModlogResponse>
-    implements _$$_GetModlogResponseCopyWith<$Res> {
-  __$$_GetModlogResponseCopyWithImpl(
-      _$_GetModlogResponse _value, $Res Function(_$_GetModlogResponse) _then)
+class __$$GetModlogResponseImplCopyWithImpl<$Res>
+    extends _$GetModlogResponseCopyWithImpl<$Res, _$GetModlogResponseImpl>
+    implements _$$GetModlogResponseImplCopyWith<$Res> {
+  __$$GetModlogResponseImplCopyWithImpl(_$GetModlogResponseImpl _value,
+      $Res Function(_$GetModlogResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -225,7 +225,7 @@ class __$$_GetModlogResponseCopyWithImpl<$Res>
     Object? adminPurgedComments = null,
     Object? hiddenCommunities = null,
   }) {
-    return _then(_$_GetModlogResponse(
+    return _then(_$GetModlogResponseImpl(
       removedPosts: null == removedPosts
           ? _value._removedPosts
           : removedPosts // ignore: cast_nullable_to_non_nullable
@@ -293,8 +293,8 @@ class __$$_GetModlogResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetModlogResponse extends _GetModlogResponse {
-  const _$_GetModlogResponse(
+class _$GetModlogResponseImpl extends _GetModlogResponse {
+  const _$GetModlogResponseImpl(
       {required final List<ModRemovePostView> removedPosts,
       required final List<ModLockPostView> lockedPosts,
       required final List<ModFeaturePostView> featuredPosts,
@@ -327,8 +327,8 @@ class _$_GetModlogResponse extends _GetModlogResponse {
         _hiddenCommunities = hiddenCommunities,
         super._();
 
-  factory _$_GetModlogResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetModlogResponseFromJson(json);
+  factory _$GetModlogResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetModlogResponseImplFromJson(json);
 
   final List<ModRemovePostView> _removedPosts;
   @override
@@ -468,7 +468,7 @@ class _$_GetModlogResponse extends _GetModlogResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetModlogResponse &&
+            other is _$GetModlogResponseImpl &&
             const DeepCollectionEquality()
                 .equals(other._removedPosts, _removedPosts) &&
             const DeepCollectionEquality()
@@ -522,13 +522,13 @@ class _$_GetModlogResponse extends _GetModlogResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetModlogResponseCopyWith<_$_GetModlogResponse> get copyWith =>
-      __$$_GetModlogResponseCopyWithImpl<_$_GetModlogResponse>(
+  _$$GetModlogResponseImplCopyWith<_$GetModlogResponseImpl> get copyWith =>
+      __$$GetModlogResponseImplCopyWithImpl<_$GetModlogResponseImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetModlogResponseToJson(
+    return _$$GetModlogResponseImplToJson(
       this,
     );
   }
@@ -551,11 +551,11 @@ abstract class _GetModlogResponse extends GetModlogResponse {
           required final List<AdminPurgePostView> adminPurgedPosts,
           required final List<AdminPurgeCommentView> adminPurgedComments,
           required final List<ModHideCommunityView> hiddenCommunities}) =
-      _$_GetModlogResponse;
+      _$GetModlogResponseImpl;
   const _GetModlogResponse._() : super._();
 
   factory _GetModlogResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetModlogResponse.fromJson;
+      _$GetModlogResponseImpl.fromJson;
 
   @override
   List<ModRemovePostView> get removedPosts;
@@ -589,6 +589,6 @@ abstract class _GetModlogResponse extends GetModlogResponse {
   List<ModHideCommunityView> get hiddenCommunities;
   @override
   @JsonKey(ignore: true)
-  _$$_GetModlogResponseCopyWith<_$_GetModlogResponse> get copyWith =>
+  _$$GetModlogResponseImplCopyWith<_$GetModlogResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/modlog/get_modlog_response.g.dart
+++ b/lib/src/v3/models/modlog/get_modlog_response.g.dart
@@ -6,8 +6,9 @@ part of 'get_modlog_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetModlogResponse _$$_GetModlogResponseFromJson(Map<String, dynamic> json) =>
-    _$_GetModlogResponse(
+_$GetModlogResponseImpl _$$GetModlogResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GetModlogResponseImpl(
       removedPosts: (json['removed_posts'] as List<dynamic>)
           .map((e) => ModRemovePostView.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -61,8 +62,8 @@ _$_GetModlogResponse _$$_GetModlogResponseFromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
-Map<String, dynamic> _$$_GetModlogResponseToJson(
-        _$_GetModlogResponse instance) =>
+Map<String, dynamic> _$$GetModlogResponseImplToJson(
+        _$GetModlogResponseImpl instance) =>
     <String, dynamic>{
       'removed_posts': instance.removedPosts.map((e) => e.toJson()).toList(),
       'locked_posts': instance.lockedPosts.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/models/my_user_info/my_user_info.freezed.dart
+++ b/lib/src/v3/models/my_user_info/my_user_info.freezed.dart
@@ -118,11 +118,11 @@ class _$MyUserInfoCopyWithImpl<$Res, $Val extends MyUserInfo>
 }
 
 /// @nodoc
-abstract class _$$_MyUserInfoCopyWith<$Res>
+abstract class _$$MyUserInfoImplCopyWith<$Res>
     implements $MyUserInfoCopyWith<$Res> {
-  factory _$$_MyUserInfoCopyWith(
-          _$_MyUserInfo value, $Res Function(_$_MyUserInfo) then) =
-      __$$_MyUserInfoCopyWithImpl<$Res>;
+  factory _$$MyUserInfoImplCopyWith(
+          _$MyUserInfoImpl value, $Res Function(_$MyUserInfoImpl) then) =
+      __$$MyUserInfoImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -139,11 +139,11 @@ abstract class _$$_MyUserInfoCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_MyUserInfoCopyWithImpl<$Res>
-    extends _$MyUserInfoCopyWithImpl<$Res, _$_MyUserInfo>
-    implements _$$_MyUserInfoCopyWith<$Res> {
-  __$$_MyUserInfoCopyWithImpl(
-      _$_MyUserInfo _value, $Res Function(_$_MyUserInfo) _then)
+class __$$MyUserInfoImplCopyWithImpl<$Res>
+    extends _$MyUserInfoCopyWithImpl<$Res, _$MyUserInfoImpl>
+    implements _$$MyUserInfoImplCopyWith<$Res> {
+  __$$MyUserInfoImplCopyWithImpl(
+      _$MyUserInfoImpl _value, $Res Function(_$MyUserInfoImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -157,7 +157,7 @@ class __$$_MyUserInfoCopyWithImpl<$Res>
     Object? personBlocks = null,
     Object? discussionLanguages = null,
   }) {
-    return _then(_$_MyUserInfo(
+    return _then(_$MyUserInfoImpl(
       localUserView: null == localUserView
           ? _value.localUserView
           : localUserView // ignore: cast_nullable_to_non_nullable
@@ -193,8 +193,8 @@ class __$$_MyUserInfoCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_MyUserInfo extends _MyUserInfo {
-  const _$_MyUserInfo(
+class _$MyUserInfoImpl extends _MyUserInfo {
+  const _$MyUserInfoImpl(
       {required this.localUserView,
       required final List<CommunityFollowerView> follows,
       required final List<CommunityModeratorView> moderates,
@@ -210,8 +210,8 @@ class _$_MyUserInfo extends _MyUserInfo {
         _discussionLanguages = discussionLanguages,
         super._();
 
-  factory _$_MyUserInfo.fromJson(Map<String, dynamic> json) =>
-      _$$_MyUserInfoFromJson(json);
+  factory _$MyUserInfoImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MyUserInfoImplFromJson(json);
 
   @override
   final LocalUserView localUserView;
@@ -277,7 +277,7 @@ class _$_MyUserInfo extends _MyUserInfo {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MyUserInfo &&
+            other is _$MyUserInfoImpl &&
             (identical(other.localUserView, localUserView) ||
                 other.localUserView == localUserView) &&
             const DeepCollectionEquality().equals(other._follows, _follows) &&
@@ -308,12 +308,12 @@ class _$_MyUserInfo extends _MyUserInfo {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MyUserInfoCopyWith<_$_MyUserInfo> get copyWith =>
-      __$$_MyUserInfoCopyWithImpl<_$_MyUserInfo>(this, _$identity);
+  _$$MyUserInfoImplCopyWith<_$MyUserInfoImpl> get copyWith =>
+      __$$MyUserInfoImplCopyWithImpl<_$MyUserInfoImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MyUserInfoToJson(
+    return _$$MyUserInfoImplToJson(
       this,
     );
   }
@@ -327,11 +327,11 @@ abstract class _MyUserInfo extends MyUserInfo {
       required final List<CommunityBlockView> communityBlocks,
       final List<InstanceBlockView>? instanceBlocks,
       required final List<PersonBlockView> personBlocks,
-      required final List<int> discussionLanguages}) = _$_MyUserInfo;
+      required final List<int> discussionLanguages}) = _$MyUserInfoImpl;
   const _MyUserInfo._() : super._();
 
   factory _MyUserInfo.fromJson(Map<String, dynamic> json) =
-      _$_MyUserInfo.fromJson;
+      _$MyUserInfoImpl.fromJson;
 
   @override
   LocalUserView get localUserView;
@@ -349,6 +349,6 @@ abstract class _MyUserInfo extends MyUserInfo {
   List<int> get discussionLanguages;
   @override
   @JsonKey(ignore: true)
-  _$$_MyUserInfoCopyWith<_$_MyUserInfo> get copyWith =>
+  _$$MyUserInfoImplCopyWith<_$MyUserInfoImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/my_user_info/my_user_info.g.dart
+++ b/lib/src/v3/models/my_user_info/my_user_info.g.dart
@@ -6,8 +6,8 @@ part of 'my_user_info.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_MyUserInfo _$$_MyUserInfoFromJson(Map<String, dynamic> json) =>
-    _$_MyUserInfo(
+_$MyUserInfoImpl _$$MyUserInfoImplFromJson(Map<String, dynamic> json) =>
+    _$MyUserInfoImpl(
       localUserView: LocalUserView.fromJson(
           json['local_user_view'] as Map<String, dynamic>),
       follows: (json['follows'] as List<dynamic>)
@@ -31,7 +31,7 @@ _$_MyUserInfo _$$_MyUserInfoFromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
-Map<String, dynamic> _$$_MyUserInfoToJson(_$_MyUserInfo instance) =>
+Map<String, dynamic> _$$MyUserInfoImplToJson(_$MyUserInfoImpl instance) =>
     <String, dynamic>{
       'local_user_view': instance.localUserView.toJson(),
       'follows': instance.follows.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/models/person/person_aggregates.dart
+++ b/lib/src/v3/models/person/person_aggregates.dart
@@ -9,7 +9,7 @@ part 'person_aggregates.g.dart';
 class PersonAggregates with _$PersonAggregates {
   @modelSerde
   const factory PersonAggregates({
-    required int id,
+    @deprecated int? id,
     required int personId,
     required int postCount,
     @deprecated int? postScore,

--- a/lib/src/v3/models/person/person_aggregates.freezed.dart
+++ b/lib/src/v3/models/person/person_aggregates.freezed.dart
@@ -20,7 +20,8 @@ PersonAggregates _$PersonAggregatesFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$PersonAggregates {
-  int get id => throw _privateConstructorUsedError;
+  @deprecated
+  int? get id => throw _privateConstructorUsedError;
   int get personId => throw _privateConstructorUsedError;
   int get postCount => throw _privateConstructorUsedError;
   @deprecated
@@ -42,7 +43,7 @@ abstract class $PersonAggregatesCopyWith<$Res> {
       _$PersonAggregatesCopyWithImpl<$Res, PersonAggregates>;
   @useResult
   $Res call(
-      {int id,
+      {@deprecated int? id,
       int personId,
       int postCount,
       @deprecated int? postScore,
@@ -63,7 +64,7 @@ class _$PersonAggregatesCopyWithImpl<$Res, $Val extends PersonAggregates>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? personId = null,
     Object? postCount = null,
     Object? postScore = freezed,
@@ -71,10 +72,10 @@ class _$PersonAggregatesCopyWithImpl<$Res, $Val extends PersonAggregates>
     Object? commentScore = freezed,
   }) {
     return _then(_value.copyWith(
-      id: null == id
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       personId: null == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -100,15 +101,15 @@ class _$PersonAggregatesCopyWithImpl<$Res, $Val extends PersonAggregates>
 }
 
 /// @nodoc
-abstract class _$$_PersonAggregatesCopyWith<$Res>
+abstract class _$$PersonAggregatesImplCopyWith<$Res>
     implements $PersonAggregatesCopyWith<$Res> {
-  factory _$$_PersonAggregatesCopyWith(
-          _$_PersonAggregates value, $Res Function(_$_PersonAggregates) then) =
-      __$$_PersonAggregatesCopyWithImpl<$Res>;
+  factory _$$PersonAggregatesImplCopyWith(_$PersonAggregatesImpl value,
+          $Res Function(_$PersonAggregatesImpl) then) =
+      __$$PersonAggregatesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
-      {int id,
+      {@deprecated int? id,
       int personId,
       int postCount,
       @deprecated int? postScore,
@@ -117,28 +118,28 @@ abstract class _$$_PersonAggregatesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PersonAggregatesCopyWithImpl<$Res>
-    extends _$PersonAggregatesCopyWithImpl<$Res, _$_PersonAggregates>
-    implements _$$_PersonAggregatesCopyWith<$Res> {
-  __$$_PersonAggregatesCopyWithImpl(
-      _$_PersonAggregates _value, $Res Function(_$_PersonAggregates) _then)
+class __$$PersonAggregatesImplCopyWithImpl<$Res>
+    extends _$PersonAggregatesCopyWithImpl<$Res, _$PersonAggregatesImpl>
+    implements _$$PersonAggregatesImplCopyWith<$Res> {
+  __$$PersonAggregatesImplCopyWithImpl(_$PersonAggregatesImpl _value,
+      $Res Function(_$PersonAggregatesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? personId = null,
     Object? postCount = null,
     Object? postScore = freezed,
     Object? commentCount = null,
     Object? commentScore = freezed,
   }) {
-    return _then(_$_PersonAggregates(
-      id: null == id
+    return _then(_$PersonAggregatesImpl(
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       personId: null == personId
           ? _value.personId
           : personId // ignore: cast_nullable_to_non_nullable
@@ -166,9 +167,9 @@ class __$$_PersonAggregatesCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PersonAggregates extends _PersonAggregates {
-  const _$_PersonAggregates(
-      {required this.id,
+class _$PersonAggregatesImpl extends _PersonAggregates {
+  const _$PersonAggregatesImpl(
+      {@deprecated this.id,
       required this.personId,
       required this.postCount,
       @deprecated this.postScore,
@@ -176,11 +177,12 @@ class _$_PersonAggregates extends _PersonAggregates {
       @deprecated this.commentScore})
       : super._();
 
-  factory _$_PersonAggregates.fromJson(Map<String, dynamic> json) =>
-      _$$_PersonAggregatesFromJson(json);
+  factory _$PersonAggregatesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonAggregatesImplFromJson(json);
 
   @override
-  final int id;
+  @deprecated
+  final int? id;
   @override
   final int personId;
   @override
@@ -203,7 +205,7 @@ class _$_PersonAggregates extends _PersonAggregates {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PersonAggregates &&
+            other is _$PersonAggregatesImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.personId, personId) ||
                 other.personId == personId) &&
@@ -225,12 +227,13 @@ class _$_PersonAggregates extends _PersonAggregates {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PersonAggregatesCopyWith<_$_PersonAggregates> get copyWith =>
-      __$$_PersonAggregatesCopyWithImpl<_$_PersonAggregates>(this, _$identity);
+  _$$PersonAggregatesImplCopyWith<_$PersonAggregatesImpl> get copyWith =>
+      __$$PersonAggregatesImplCopyWithImpl<_$PersonAggregatesImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PersonAggregatesToJson(
+    return _$$PersonAggregatesImplToJson(
       this,
     );
   }
@@ -238,19 +241,20 @@ class _$_PersonAggregates extends _PersonAggregates {
 
 abstract class _PersonAggregates extends PersonAggregates {
   const factory _PersonAggregates(
-      {required final int id,
+      {@deprecated final int? id,
       required final int personId,
       required final int postCount,
       @deprecated final int? postScore,
       required final int commentCount,
-      @deprecated final int? commentScore}) = _$_PersonAggregates;
+      @deprecated final int? commentScore}) = _$PersonAggregatesImpl;
   const _PersonAggregates._() : super._();
 
   factory _PersonAggregates.fromJson(Map<String, dynamic> json) =
-      _$_PersonAggregates.fromJson;
+      _$PersonAggregatesImpl.fromJson;
 
   @override
-  int get id;
+  @deprecated
+  int? get id;
   @override
   int get personId;
   @override
@@ -265,6 +269,6 @@ abstract class _PersonAggregates extends PersonAggregates {
   int? get commentScore;
   @override
   @JsonKey(ignore: true)
-  _$$_PersonAggregatesCopyWith<_$_PersonAggregates> get copyWith =>
+  _$$PersonAggregatesImplCopyWith<_$PersonAggregatesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/person/person_aggregates.g.dart
+++ b/lib/src/v3/models/person/person_aggregates.g.dart
@@ -6,9 +6,10 @@ part of 'person_aggregates.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PersonAggregates _$$_PersonAggregatesFromJson(Map<String, dynamic> json) =>
-    _$_PersonAggregates(
-      id: json['id'] as int,
+_$PersonAggregatesImpl _$$PersonAggregatesImplFromJson(
+        Map<String, dynamic> json) =>
+    _$PersonAggregatesImpl(
+      id: json['id'] as int?,
       personId: json['person_id'] as int,
       postCount: json['post_count'] as int,
       postScore: json['post_score'] as int?,
@@ -16,7 +17,8 @@ _$_PersonAggregates _$$_PersonAggregatesFromJson(Map<String, dynamic> json) =>
       commentScore: json['comment_score'] as int?,
     );
 
-Map<String, dynamic> _$$_PersonAggregatesToJson(_$_PersonAggregates instance) =>
+Map<String, dynamic> _$$PersonAggregatesImplToJson(
+        _$PersonAggregatesImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'person_id': instance.personId,

--- a/lib/src/v3/models/person/person_mention.freezed.dart
+++ b/lib/src/v3/models/person/person_mention.freezed.dart
@@ -87,11 +87,11 @@ class _$PersonMentionCopyWithImpl<$Res, $Val extends PersonMention>
 }
 
 /// @nodoc
-abstract class _$$_PersonMentionCopyWith<$Res>
+abstract class _$$PersonMentionImplCopyWith<$Res>
     implements $PersonMentionCopyWith<$Res> {
-  factory _$$_PersonMentionCopyWith(
-          _$_PersonMention value, $Res Function(_$_PersonMention) then) =
-      __$$_PersonMentionCopyWithImpl<$Res>;
+  factory _$$PersonMentionImplCopyWith(
+          _$PersonMentionImpl value, $Res Function(_$PersonMentionImpl) then) =
+      __$$PersonMentionImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -99,11 +99,11 @@ abstract class _$$_PersonMentionCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PersonMentionCopyWithImpl<$Res>
-    extends _$PersonMentionCopyWithImpl<$Res, _$_PersonMention>
-    implements _$$_PersonMentionCopyWith<$Res> {
-  __$$_PersonMentionCopyWithImpl(
-      _$_PersonMention _value, $Res Function(_$_PersonMention) _then)
+class __$$PersonMentionImplCopyWithImpl<$Res>
+    extends _$PersonMentionCopyWithImpl<$Res, _$PersonMentionImpl>
+    implements _$$PersonMentionImplCopyWith<$Res> {
+  __$$PersonMentionImplCopyWithImpl(
+      _$PersonMentionImpl _value, $Res Function(_$PersonMentionImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -115,7 +115,7 @@ class __$$_PersonMentionCopyWithImpl<$Res>
     Object? read = null,
     Object? published = null,
   }) {
-    return _then(_$_PersonMention(
+    return _then(_$PersonMentionImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -143,8 +143,8 @@ class __$$_PersonMentionCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PersonMention extends _PersonMention {
-  const _$_PersonMention(
+class _$PersonMentionImpl extends _PersonMention {
+  const _$PersonMentionImpl(
       {required this.id,
       required this.recipientId,
       required this.commentId,
@@ -152,8 +152,8 @@ class _$_PersonMention extends _PersonMention {
       required this.published})
       : super._();
 
-  factory _$_PersonMention.fromJson(Map<String, dynamic> json) =>
-      _$$_PersonMentionFromJson(json);
+  factory _$PersonMentionImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonMentionImplFromJson(json);
 
   @override
   final int id;
@@ -175,7 +175,7 @@ class _$_PersonMention extends _PersonMention {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PersonMention &&
+            other is _$PersonMentionImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.recipientId, recipientId) ||
                 other.recipientId == recipientId) &&
@@ -194,12 +194,12 @@ class _$_PersonMention extends _PersonMention {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PersonMentionCopyWith<_$_PersonMention> get copyWith =>
-      __$$_PersonMentionCopyWithImpl<_$_PersonMention>(this, _$identity);
+  _$$PersonMentionImplCopyWith<_$PersonMentionImpl> get copyWith =>
+      __$$PersonMentionImplCopyWithImpl<_$PersonMentionImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PersonMentionToJson(
+    return _$$PersonMentionImplToJson(
       this,
     );
   }
@@ -211,11 +211,11 @@ abstract class _PersonMention extends PersonMention {
       required final int recipientId,
       required final int commentId,
       required final bool read,
-      required final DateTime published}) = _$_PersonMention;
+      required final DateTime published}) = _$PersonMentionImpl;
   const _PersonMention._() : super._();
 
   factory _PersonMention.fromJson(Map<String, dynamic> json) =
-      _$_PersonMention.fromJson;
+      _$PersonMentionImpl.fromJson;
 
   @override
   int get id;
@@ -229,6 +229,6 @@ abstract class _PersonMention extends PersonMention {
   DateTime get published;
   @override
   @JsonKey(ignore: true)
-  _$$_PersonMentionCopyWith<_$_PersonMention> get copyWith =>
+  _$$PersonMentionImplCopyWith<_$PersonMentionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/person/person_mention.g.dart
+++ b/lib/src/v3/models/person/person_mention.g.dart
@@ -6,8 +6,8 @@ part of 'person_mention.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PersonMention _$$_PersonMentionFromJson(Map<String, dynamic> json) =>
-    _$_PersonMention(
+_$PersonMentionImpl _$$PersonMentionImplFromJson(Map<String, dynamic> json) =>
+    _$PersonMentionImpl(
       id: json['id'] as int,
       recipientId: json['recipient_id'] as int,
       commentId: json['comment_id'] as int,
@@ -15,7 +15,7 @@ _$_PersonMention _$$_PersonMentionFromJson(Map<String, dynamic> json) =>
       published: const ForceUtcDateTime().fromJson(json['published'] as String),
     );
 
-Map<String, dynamic> _$$_PersonMentionToJson(_$_PersonMention instance) =>
+Map<String, dynamic> _$$PersonMentionImplToJson(_$PersonMentionImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'recipient_id': instance.recipientId,

--- a/lib/src/v3/models/post/get_post_response.freezed.dart
+++ b/lib/src/v3/models/post/get_post_response.freezed.dart
@@ -104,11 +104,11 @@ class _$GetPostResponseCopyWithImpl<$Res, $Val extends GetPostResponse>
 }
 
 /// @nodoc
-abstract class _$$_GetPostResponseCopyWith<$Res>
+abstract class _$$GetPostResponseImplCopyWith<$Res>
     implements $GetPostResponseCopyWith<$Res> {
-  factory _$$_GetPostResponseCopyWith(
-          _$_GetPostResponse value, $Res Function(_$_GetPostResponse) then) =
-      __$$_GetPostResponseCopyWithImpl<$Res>;
+  factory _$$GetPostResponseImplCopyWith(_$GetPostResponseImpl value,
+          $Res Function(_$GetPostResponseImpl) then) =
+      __$$GetPostResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -124,11 +124,11 @@ abstract class _$$_GetPostResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetPostResponseCopyWithImpl<$Res>
-    extends _$GetPostResponseCopyWithImpl<$Res, _$_GetPostResponse>
-    implements _$$_GetPostResponseCopyWith<$Res> {
-  __$$_GetPostResponseCopyWithImpl(
-      _$_GetPostResponse _value, $Res Function(_$_GetPostResponse) _then)
+class __$$GetPostResponseImplCopyWithImpl<$Res>
+    extends _$GetPostResponseCopyWithImpl<$Res, _$GetPostResponseImpl>
+    implements _$$GetPostResponseImplCopyWith<$Res> {
+  __$$GetPostResponseImplCopyWithImpl(
+      _$GetPostResponseImpl _value, $Res Function(_$GetPostResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -139,7 +139,7 @@ class __$$_GetPostResponseCopyWithImpl<$Res>
     Object? moderators = null,
     Object? crossPosts = null,
   }) {
-    return _then(_$_GetPostResponse(
+    return _then(_$GetPostResponseImpl(
       postView: null == postView
           ? _value.postView
           : postView // ignore: cast_nullable_to_non_nullable
@@ -163,8 +163,8 @@ class __$$_GetPostResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetPostResponse extends _GetPostResponse {
-  const _$_GetPostResponse(
+class _$GetPostResponseImpl extends _GetPostResponse {
+  const _$GetPostResponseImpl(
       {required this.postView,
       required this.communityView,
       required final List<CommunityModeratorView> moderators,
@@ -173,8 +173,8 @@ class _$_GetPostResponse extends _GetPostResponse {
         _crossPosts = crossPosts,
         super._();
 
-  factory _$_GetPostResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPostResponseFromJson(json);
+  factory _$GetPostResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPostResponseImplFromJson(json);
 
   @override
   final PostView postView;
@@ -205,7 +205,7 @@ class _$_GetPostResponse extends _GetPostResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPostResponse &&
+            other is _$GetPostResponseImpl &&
             (identical(other.postView, postView) ||
                 other.postView == postView) &&
             (identical(other.communityView, communityView) ||
@@ -228,12 +228,13 @@ class _$_GetPostResponse extends _GetPostResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPostResponseCopyWith<_$_GetPostResponse> get copyWith =>
-      __$$_GetPostResponseCopyWithImpl<_$_GetPostResponse>(this, _$identity);
+  _$$GetPostResponseImplCopyWith<_$GetPostResponseImpl> get copyWith =>
+      __$$GetPostResponseImplCopyWithImpl<_$GetPostResponseImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPostResponseToJson(
+    return _$$GetPostResponseImplToJson(
       this,
     );
   }
@@ -244,11 +245,11 @@ abstract class _GetPostResponse extends GetPostResponse {
       {required final PostView postView,
       required final CommunityView communityView,
       required final List<CommunityModeratorView> moderators,
-      required final List<PostView> crossPosts}) = _$_GetPostResponse;
+      required final List<PostView> crossPosts}) = _$GetPostResponseImpl;
   const _GetPostResponse._() : super._();
 
   factory _GetPostResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetPostResponse.fromJson;
+      _$GetPostResponseImpl.fromJson;
 
   @override
   PostView get postView;
@@ -260,6 +261,6 @@ abstract class _GetPostResponse extends GetPostResponse {
   List<PostView> get crossPosts;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPostResponseCopyWith<_$_GetPostResponse> get copyWith =>
+  _$$GetPostResponseImplCopyWith<_$GetPostResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/post/get_post_response.g.dart
+++ b/lib/src/v3/models/post/get_post_response.g.dart
@@ -6,8 +6,9 @@ part of 'get_post_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetPostResponse _$$_GetPostResponseFromJson(Map<String, dynamic> json) =>
-    _$_GetPostResponse(
+_$GetPostResponseImpl _$$GetPostResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GetPostResponseImpl(
       postView: PostView.fromJson(json['post_view'] as Map<String, dynamic>),
       communityView: CommunityView.fromJson(
           json['community_view'] as Map<String, dynamic>),
@@ -20,7 +21,8 @@ _$_GetPostResponse _$$_GetPostResponseFromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
-Map<String, dynamic> _$$_GetPostResponseToJson(_$_GetPostResponse instance) =>
+Map<String, dynamic> _$$GetPostResponseImplToJson(
+        _$GetPostResponseImpl instance) =>
     <String, dynamic>{
       'post_view': instance.postView.toJson(),
       'community_view': instance.communityView.toJson(),

--- a/lib/src/v3/models/post/get_posts_response.freezed.dart
+++ b/lib/src/v3/models/post/get_posts_response.freezed.dart
@@ -68,22 +68,22 @@ class _$GetPostsResponseCopyWithImpl<$Res, $Val extends GetPostsResponse>
 }
 
 /// @nodoc
-abstract class _$$_GetPostsResponseCopyWith<$Res>
+abstract class _$$GetPostsResponseImplCopyWith<$Res>
     implements $GetPostsResponseCopyWith<$Res> {
-  factory _$$_GetPostsResponseCopyWith(
-          _$_GetPostsResponse value, $Res Function(_$_GetPostsResponse) then) =
-      __$$_GetPostsResponseCopyWithImpl<$Res>;
+  factory _$$GetPostsResponseImplCopyWith(_$GetPostsResponseImpl value,
+          $Res Function(_$GetPostsResponseImpl) then) =
+      __$$GetPostsResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<PostView> posts, String? nextPage});
 }
 
 /// @nodoc
-class __$$_GetPostsResponseCopyWithImpl<$Res>
-    extends _$GetPostsResponseCopyWithImpl<$Res, _$_GetPostsResponse>
-    implements _$$_GetPostsResponseCopyWith<$Res> {
-  __$$_GetPostsResponseCopyWithImpl(
-      _$_GetPostsResponse _value, $Res Function(_$_GetPostsResponse) _then)
+class __$$GetPostsResponseImplCopyWithImpl<$Res>
+    extends _$GetPostsResponseCopyWithImpl<$Res, _$GetPostsResponseImpl>
+    implements _$$GetPostsResponseImplCopyWith<$Res> {
+  __$$GetPostsResponseImplCopyWithImpl(_$GetPostsResponseImpl _value,
+      $Res Function(_$GetPostsResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -92,7 +92,7 @@ class __$$_GetPostsResponseCopyWithImpl<$Res>
     Object? posts = null,
     Object? nextPage = freezed,
   }) {
-    return _then(_$_GetPostsResponse(
+    return _then(_$GetPostsResponseImpl(
       posts: null == posts
           ? _value._posts
           : posts // ignore: cast_nullable_to_non_nullable
@@ -108,14 +108,14 @@ class __$$_GetPostsResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetPostsResponse extends _GetPostsResponse {
-  const _$_GetPostsResponse(
+class _$GetPostsResponseImpl extends _GetPostsResponse {
+  const _$GetPostsResponseImpl(
       {required final List<PostView> posts, this.nextPage})
       : _posts = posts,
         super._();
 
-  factory _$_GetPostsResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPostsResponseFromJson(json);
+  factory _$GetPostsResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPostsResponseImplFromJson(json);
 
   final List<PostView> _posts;
   @override
@@ -137,7 +137,7 @@ class _$_GetPostsResponse extends _GetPostsResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPostsResponse &&
+            other is _$GetPostsResponseImpl &&
             const DeepCollectionEquality().equals(other._posts, _posts) &&
             (identical(other.nextPage, nextPage) ||
                 other.nextPage == nextPage));
@@ -151,12 +151,13 @@ class _$_GetPostsResponse extends _GetPostsResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPostsResponseCopyWith<_$_GetPostsResponse> get copyWith =>
-      __$$_GetPostsResponseCopyWithImpl<_$_GetPostsResponse>(this, _$identity);
+  _$$GetPostsResponseImplCopyWith<_$GetPostsResponseImpl> get copyWith =>
+      __$$GetPostsResponseImplCopyWithImpl<_$GetPostsResponseImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPostsResponseToJson(
+    return _$$GetPostsResponseImplToJson(
       this,
     );
   }
@@ -165,11 +166,11 @@ class _$_GetPostsResponse extends _GetPostsResponse {
 abstract class _GetPostsResponse extends GetPostsResponse {
   const factory _GetPostsResponse(
       {required final List<PostView> posts,
-      final String? nextPage}) = _$_GetPostsResponse;
+      final String? nextPage}) = _$GetPostsResponseImpl;
   const _GetPostsResponse._() : super._();
 
   factory _GetPostsResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetPostsResponse.fromJson;
+      _$GetPostsResponseImpl.fromJson;
 
   @override
   List<PostView> get posts;
@@ -177,6 +178,6 @@ abstract class _GetPostsResponse extends GetPostsResponse {
   String? get nextPage;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPostsResponseCopyWith<_$_GetPostsResponse> get copyWith =>
+  _$$GetPostsResponseImplCopyWith<_$GetPostsResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/post/get_posts_response.g.dart
+++ b/lib/src/v3/models/post/get_posts_response.g.dart
@@ -6,15 +6,17 @@ part of 'get_posts_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetPostsResponse _$$_GetPostsResponseFromJson(Map<String, dynamic> json) =>
-    _$_GetPostsResponse(
+_$GetPostsResponseImpl _$$GetPostsResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GetPostsResponseImpl(
       posts: (json['posts'] as List<dynamic>)
           .map((e) => PostView.fromJson(e as Map<String, dynamic>))
           .toList(),
       nextPage: json['next_page'] as String?,
     );
 
-Map<String, dynamic> _$$_GetPostsResponseToJson(_$_GetPostsResponse instance) =>
+Map<String, dynamic> _$$GetPostsResponseImplToJson(
+        _$GetPostsResponseImpl instance) =>
     <String, dynamic>{
       'posts': instance.posts.map((e) => e.toJson()).toList(),
       'next_page': instance.nextPage,

--- a/lib/src/v3/models/post/get_site_metadata_response.freezed.dart
+++ b/lib/src/v3/models/post/get_site_metadata_response.freezed.dart
@@ -74,11 +74,12 @@ class _$GetSiteMetadataResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_GetSiteMetadataResponseCopyWith<$Res>
+abstract class _$$GetSiteMetadataResponseImplCopyWith<$Res>
     implements $GetSiteMetadataResponseCopyWith<$Res> {
-  factory _$$_GetSiteMetadataResponseCopyWith(_$_GetSiteMetadataResponse value,
-          $Res Function(_$_GetSiteMetadataResponse) then) =
-      __$$_GetSiteMetadataResponseCopyWithImpl<$Res>;
+  factory _$$GetSiteMetadataResponseImplCopyWith(
+          _$GetSiteMetadataResponseImpl value,
+          $Res Function(_$GetSiteMetadataResponseImpl) then) =
+      __$$GetSiteMetadataResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({SiteMetadata metadata});
@@ -88,12 +89,13 @@ abstract class _$$_GetSiteMetadataResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetSiteMetadataResponseCopyWithImpl<$Res>
+class __$$GetSiteMetadataResponseImplCopyWithImpl<$Res>
     extends _$GetSiteMetadataResponseCopyWithImpl<$Res,
-        _$_GetSiteMetadataResponse>
-    implements _$$_GetSiteMetadataResponseCopyWith<$Res> {
-  __$$_GetSiteMetadataResponseCopyWithImpl(_$_GetSiteMetadataResponse _value,
-      $Res Function(_$_GetSiteMetadataResponse) _then)
+        _$GetSiteMetadataResponseImpl>
+    implements _$$GetSiteMetadataResponseImplCopyWith<$Res> {
+  __$$GetSiteMetadataResponseImplCopyWithImpl(
+      _$GetSiteMetadataResponseImpl _value,
+      $Res Function(_$GetSiteMetadataResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -101,7 +103,7 @@ class __$$_GetSiteMetadataResponseCopyWithImpl<$Res>
   $Res call({
     Object? metadata = null,
   }) {
-    return _then(_$_GetSiteMetadataResponse(
+    return _then(_$GetSiteMetadataResponseImpl(
       metadata: null == metadata
           ? _value.metadata
           : metadata // ignore: cast_nullable_to_non_nullable
@@ -113,11 +115,11 @@ class __$$_GetSiteMetadataResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetSiteMetadataResponse extends _GetSiteMetadataResponse {
-  const _$_GetSiteMetadataResponse({required this.metadata}) : super._();
+class _$GetSiteMetadataResponseImpl extends _GetSiteMetadataResponse {
+  const _$GetSiteMetadataResponseImpl({required this.metadata}) : super._();
 
-  factory _$_GetSiteMetadataResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetSiteMetadataResponseFromJson(json);
+  factory _$GetSiteMetadataResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetSiteMetadataResponseImplFromJson(json);
 
   @override
   final SiteMetadata metadata;
@@ -131,7 +133,7 @@ class _$_GetSiteMetadataResponse extends _GetSiteMetadataResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetSiteMetadataResponse &&
+            other is _$GetSiteMetadataResponseImpl &&
             (identical(other.metadata, metadata) ||
                 other.metadata == metadata));
   }
@@ -143,14 +145,13 @@ class _$_GetSiteMetadataResponse extends _GetSiteMetadataResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetSiteMetadataResponseCopyWith<_$_GetSiteMetadataResponse>
-      get copyWith =>
-          __$$_GetSiteMetadataResponseCopyWithImpl<_$_GetSiteMetadataResponse>(
-              this, _$identity);
+  _$$GetSiteMetadataResponseImplCopyWith<_$GetSiteMetadataResponseImpl>
+      get copyWith => __$$GetSiteMetadataResponseImplCopyWithImpl<
+          _$GetSiteMetadataResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetSiteMetadataResponseToJson(
+    return _$$GetSiteMetadataResponseImplToJson(
       this,
     );
   }
@@ -158,16 +159,16 @@ class _$_GetSiteMetadataResponse extends _GetSiteMetadataResponse {
 
 abstract class _GetSiteMetadataResponse extends GetSiteMetadataResponse {
   const factory _GetSiteMetadataResponse(
-      {required final SiteMetadata metadata}) = _$_GetSiteMetadataResponse;
+      {required final SiteMetadata metadata}) = _$GetSiteMetadataResponseImpl;
   const _GetSiteMetadataResponse._() : super._();
 
   factory _GetSiteMetadataResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetSiteMetadataResponse.fromJson;
+      _$GetSiteMetadataResponseImpl.fromJson;
 
   @override
   SiteMetadata get metadata;
   @override
   @JsonKey(ignore: true)
-  _$$_GetSiteMetadataResponseCopyWith<_$_GetSiteMetadataResponse>
+  _$$GetSiteMetadataResponseImplCopyWith<_$GetSiteMetadataResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/post/get_site_metadata_response.g.dart
+++ b/lib/src/v3/models/post/get_site_metadata_response.g.dart
@@ -6,14 +6,14 @@ part of 'get_site_metadata_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetSiteMetadataResponse _$$_GetSiteMetadataResponseFromJson(
+_$GetSiteMetadataResponseImpl _$$GetSiteMetadataResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GetSiteMetadataResponse(
+    _$GetSiteMetadataResponseImpl(
       metadata: SiteMetadata.fromJson(json['metadata'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_GetSiteMetadataResponseToJson(
-        _$_GetSiteMetadataResponse instance) =>
+Map<String, dynamic> _$$GetSiteMetadataResponseImplToJson(
+        _$GetSiteMetadataResponseImpl instance) =>
     <String, dynamic>{
       'metadata': instance.metadata.toJson(),
     };

--- a/lib/src/v3/models/post/list_post_reports_response.freezed.dart
+++ b/lib/src/v3/models/post/list_post_reports_response.freezed.dart
@@ -64,23 +64,25 @@ class _$ListPostReportsResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ListPostReportsResponseCopyWith<$Res>
+abstract class _$$ListPostReportsResponseImplCopyWith<$Res>
     implements $ListPostReportsResponseCopyWith<$Res> {
-  factory _$$_ListPostReportsResponseCopyWith(_$_ListPostReportsResponse value,
-          $Res Function(_$_ListPostReportsResponse) then) =
-      __$$_ListPostReportsResponseCopyWithImpl<$Res>;
+  factory _$$ListPostReportsResponseImplCopyWith(
+          _$ListPostReportsResponseImpl value,
+          $Res Function(_$ListPostReportsResponseImpl) then) =
+      __$$ListPostReportsResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<PostReportView> postReports});
 }
 
 /// @nodoc
-class __$$_ListPostReportsResponseCopyWithImpl<$Res>
+class __$$ListPostReportsResponseImplCopyWithImpl<$Res>
     extends _$ListPostReportsResponseCopyWithImpl<$Res,
-        _$_ListPostReportsResponse>
-    implements _$$_ListPostReportsResponseCopyWith<$Res> {
-  __$$_ListPostReportsResponseCopyWithImpl(_$_ListPostReportsResponse _value,
-      $Res Function(_$_ListPostReportsResponse) _then)
+        _$ListPostReportsResponseImpl>
+    implements _$$ListPostReportsResponseImplCopyWith<$Res> {
+  __$$ListPostReportsResponseImplCopyWithImpl(
+      _$ListPostReportsResponseImpl _value,
+      $Res Function(_$ListPostReportsResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -88,7 +90,7 @@ class __$$_ListPostReportsResponseCopyWithImpl<$Res>
   $Res call({
     Object? postReports = null,
   }) {
-    return _then(_$_ListPostReportsResponse(
+    return _then(_$ListPostReportsResponseImpl(
       postReports: null == postReports
           ? _value._postReports
           : postReports // ignore: cast_nullable_to_non_nullable
@@ -100,14 +102,14 @@ class __$$_ListPostReportsResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ListPostReportsResponse extends _ListPostReportsResponse {
-  const _$_ListPostReportsResponse(
+class _$ListPostReportsResponseImpl extends _ListPostReportsResponse {
+  const _$ListPostReportsResponseImpl(
       {required final List<PostReportView> postReports})
       : _postReports = postReports,
         super._();
 
-  factory _$_ListPostReportsResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_ListPostReportsResponseFromJson(json);
+  factory _$ListPostReportsResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ListPostReportsResponseImplFromJson(json);
 
   final List<PostReportView> _postReports;
   @override
@@ -126,7 +128,7 @@ class _$_ListPostReportsResponse extends _ListPostReportsResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListPostReportsResponse &&
+            other is _$ListPostReportsResponseImpl &&
             const DeepCollectionEquality()
                 .equals(other._postReports, _postReports));
   }
@@ -139,14 +141,13 @@ class _$_ListPostReportsResponse extends _ListPostReportsResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListPostReportsResponseCopyWith<_$_ListPostReportsResponse>
-      get copyWith =>
-          __$$_ListPostReportsResponseCopyWithImpl<_$_ListPostReportsResponse>(
-              this, _$identity);
+  _$$ListPostReportsResponseImplCopyWith<_$ListPostReportsResponseImpl>
+      get copyWith => __$$ListPostReportsResponseImplCopyWithImpl<
+          _$ListPostReportsResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListPostReportsResponseToJson(
+    return _$$ListPostReportsResponseImplToJson(
       this,
     );
   }
@@ -155,16 +156,16 @@ class _$_ListPostReportsResponse extends _ListPostReportsResponse {
 abstract class _ListPostReportsResponse extends ListPostReportsResponse {
   const factory _ListPostReportsResponse(
           {required final List<PostReportView> postReports}) =
-      _$_ListPostReportsResponse;
+      _$ListPostReportsResponseImpl;
   const _ListPostReportsResponse._() : super._();
 
   factory _ListPostReportsResponse.fromJson(Map<String, dynamic> json) =
-      _$_ListPostReportsResponse.fromJson;
+      _$ListPostReportsResponseImpl.fromJson;
 
   @override
   List<PostReportView> get postReports;
   @override
   @JsonKey(ignore: true)
-  _$$_ListPostReportsResponseCopyWith<_$_ListPostReportsResponse>
+  _$$ListPostReportsResponseImplCopyWith<_$ListPostReportsResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/post/list_post_reports_response.g.dart
+++ b/lib/src/v3/models/post/list_post_reports_response.g.dart
@@ -6,16 +6,16 @@ part of 'list_post_reports_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ListPostReportsResponse _$$_ListPostReportsResponseFromJson(
+_$ListPostReportsResponseImpl _$$ListPostReportsResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ListPostReportsResponse(
+    _$ListPostReportsResponseImpl(
       postReports: (json['post_reports'] as List<dynamic>)
           .map((e) => PostReportView.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$_ListPostReportsResponseToJson(
-        _$_ListPostReportsResponse instance) =>
+Map<String, dynamic> _$$ListPostReportsResponseImplToJson(
+        _$ListPostReportsResponseImpl instance) =>
     <String, dynamic>{
       'post_reports': instance.postReports.map((e) => e.toJson()).toList(),
     };

--- a/lib/src/v3/models/post/mark_post_as_read_response.freezed.dart
+++ b/lib/src/v3/models/post/mark_post_as_read_response.freezed.dart
@@ -85,11 +85,12 @@ class _$MarkPostAsReadResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_MarkPostAsReadResponseCopyWith<$Res>
+abstract class _$$MarkPostAsReadResponseImplCopyWith<$Res>
     implements $MarkPostAsReadResponseCopyWith<$Res> {
-  factory _$$_MarkPostAsReadResponseCopyWith(_$_MarkPostAsReadResponse value,
-          $Res Function(_$_MarkPostAsReadResponse) then) =
-      __$$_MarkPostAsReadResponseCopyWithImpl<$Res>;
+  factory _$$MarkPostAsReadResponseImplCopyWith(
+          _$MarkPostAsReadResponseImpl value,
+          $Res Function(_$MarkPostAsReadResponseImpl) then) =
+      __$$MarkPostAsReadResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({@deprecated PostView? postView, bool? success});
@@ -99,12 +100,13 @@ abstract class _$$_MarkPostAsReadResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_MarkPostAsReadResponseCopyWithImpl<$Res>
+class __$$MarkPostAsReadResponseImplCopyWithImpl<$Res>
     extends _$MarkPostAsReadResponseCopyWithImpl<$Res,
-        _$_MarkPostAsReadResponse>
-    implements _$$_MarkPostAsReadResponseCopyWith<$Res> {
-  __$$_MarkPostAsReadResponseCopyWithImpl(_$_MarkPostAsReadResponse _value,
-      $Res Function(_$_MarkPostAsReadResponse) _then)
+        _$MarkPostAsReadResponseImpl>
+    implements _$$MarkPostAsReadResponseImplCopyWith<$Res> {
+  __$$MarkPostAsReadResponseImplCopyWithImpl(
+      _$MarkPostAsReadResponseImpl _value,
+      $Res Function(_$MarkPostAsReadResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -113,7 +115,7 @@ class __$$_MarkPostAsReadResponseCopyWithImpl<$Res>
     Object? postView = freezed,
     Object? success = freezed,
   }) {
-    return _then(_$_MarkPostAsReadResponse(
+    return _then(_$MarkPostAsReadResponseImpl(
       postView: freezed == postView
           ? _value.postView
           : postView // ignore: cast_nullable_to_non_nullable
@@ -129,12 +131,12 @@ class __$$_MarkPostAsReadResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_MarkPostAsReadResponse extends _MarkPostAsReadResponse {
-  const _$_MarkPostAsReadResponse({@deprecated this.postView, this.success})
+class _$MarkPostAsReadResponseImpl extends _MarkPostAsReadResponse {
+  const _$MarkPostAsReadResponseImpl({@deprecated this.postView, this.success})
       : super._();
 
-  factory _$_MarkPostAsReadResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_MarkPostAsReadResponseFromJson(json);
+  factory _$MarkPostAsReadResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MarkPostAsReadResponseImplFromJson(json);
 
   @override
   @deprecated
@@ -151,7 +153,7 @@ class _$_MarkPostAsReadResponse extends _MarkPostAsReadResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_MarkPostAsReadResponse &&
+            other is _$MarkPostAsReadResponseImpl &&
             (identical(other.postView, postView) ||
                 other.postView == postView) &&
             (identical(other.success, success) || other.success == success));
@@ -164,13 +166,13 @@ class _$_MarkPostAsReadResponse extends _MarkPostAsReadResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_MarkPostAsReadResponseCopyWith<_$_MarkPostAsReadResponse> get copyWith =>
-      __$$_MarkPostAsReadResponseCopyWithImpl<_$_MarkPostAsReadResponse>(
-          this, _$identity);
+  _$$MarkPostAsReadResponseImplCopyWith<_$MarkPostAsReadResponseImpl>
+      get copyWith => __$$MarkPostAsReadResponseImplCopyWithImpl<
+          _$MarkPostAsReadResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_MarkPostAsReadResponseToJson(
+    return _$$MarkPostAsReadResponseImplToJson(
       this,
     );
   }
@@ -179,11 +181,11 @@ class _$_MarkPostAsReadResponse extends _MarkPostAsReadResponse {
 abstract class _MarkPostAsReadResponse extends MarkPostAsReadResponse {
   const factory _MarkPostAsReadResponse(
       {@deprecated final PostView? postView,
-      final bool? success}) = _$_MarkPostAsReadResponse;
+      final bool? success}) = _$MarkPostAsReadResponseImpl;
   const _MarkPostAsReadResponse._() : super._();
 
   factory _MarkPostAsReadResponse.fromJson(Map<String, dynamic> json) =
-      _$_MarkPostAsReadResponse.fromJson;
+      _$MarkPostAsReadResponseImpl.fromJson;
 
   @override
   @deprecated
@@ -192,6 +194,6 @@ abstract class _MarkPostAsReadResponse extends MarkPostAsReadResponse {
   bool? get success;
   @override
   @JsonKey(ignore: true)
-  _$$_MarkPostAsReadResponseCopyWith<_$_MarkPostAsReadResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$MarkPostAsReadResponseImplCopyWith<_$MarkPostAsReadResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/post/mark_post_as_read_response.g.dart
+++ b/lib/src/v3/models/post/mark_post_as_read_response.g.dart
@@ -6,17 +6,17 @@ part of 'mark_post_as_read_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_MarkPostAsReadResponse _$$_MarkPostAsReadResponseFromJson(
+_$MarkPostAsReadResponseImpl _$$MarkPostAsReadResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_MarkPostAsReadResponse(
+    _$MarkPostAsReadResponseImpl(
       postView: json['post_view'] == null
           ? null
           : PostView.fromJson(json['post_view'] as Map<String, dynamic>),
       success: json['success'] as bool?,
     );
 
-Map<String, dynamic> _$$_MarkPostAsReadResponseToJson(
-        _$_MarkPostAsReadResponse instance) =>
+Map<String, dynamic> _$$MarkPostAsReadResponseImplToJson(
+        _$MarkPostAsReadResponseImpl instance) =>
     <String, dynamic>{
       'post_view': instance.postView?.toJson(),
       'success': instance.success,

--- a/lib/src/v3/models/post/post_aggregates.dart
+++ b/lib/src/v3/models/post/post_aggregates.dart
@@ -10,7 +10,7 @@ part 'post_aggregates.g.dart';
 class PostAggregates with _$PostAggregates {
   @modelSerde
   const factory PostAggregates({
-    required int id,
+    @deprecated int? id,
     required int postId,
     required int comments,
     required int score,

--- a/lib/src/v3/models/post/post_aggregates.freezed.dart
+++ b/lib/src/v3/models/post/post_aggregates.freezed.dart
@@ -20,7 +20,8 @@ PostAggregates _$PostAggregatesFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$PostAggregates {
-  int get id => throw _privateConstructorUsedError;
+  @deprecated
+  int? get id => throw _privateConstructorUsedError;
   int get postId => throw _privateConstructorUsedError;
   int get comments => throw _privateConstructorUsedError;
   int get score => throw _privateConstructorUsedError;
@@ -53,7 +54,7 @@ abstract class $PostAggregatesCopyWith<$Res> {
       _$PostAggregatesCopyWithImpl<$Res, PostAggregates>;
   @useResult
   $Res call(
-      {int id,
+      {@deprecated int? id,
       int postId,
       int comments,
       int score,
@@ -81,7 +82,7 @@ class _$PostAggregatesCopyWithImpl<$Res, $Val extends PostAggregates>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? postId = null,
     Object? comments = null,
     Object? score = null,
@@ -96,10 +97,10 @@ class _$PostAggregatesCopyWithImpl<$Res, $Val extends PostAggregates>
     Object? hotRankActive = freezed,
   }) {
     return _then(_value.copyWith(
-      id: null == id
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -153,15 +154,15 @@ class _$PostAggregatesCopyWithImpl<$Res, $Val extends PostAggregates>
 }
 
 /// @nodoc
-abstract class _$$_PostAggregatesCopyWith<$Res>
+abstract class _$$PostAggregatesImplCopyWith<$Res>
     implements $PostAggregatesCopyWith<$Res> {
-  factory _$$_PostAggregatesCopyWith(
-          _$_PostAggregates value, $Res Function(_$_PostAggregates) then) =
-      __$$_PostAggregatesCopyWithImpl<$Res>;
+  factory _$$PostAggregatesImplCopyWith(_$PostAggregatesImpl value,
+          $Res Function(_$PostAggregatesImpl) then) =
+      __$$PostAggregatesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
-      {int id,
+      {@deprecated int? id,
       int postId,
       int comments,
       int score,
@@ -177,17 +178,17 @@ abstract class _$$_PostAggregatesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PostAggregatesCopyWithImpl<$Res>
-    extends _$PostAggregatesCopyWithImpl<$Res, _$_PostAggregates>
-    implements _$$_PostAggregatesCopyWith<$Res> {
-  __$$_PostAggregatesCopyWithImpl(
-      _$_PostAggregates _value, $Res Function(_$_PostAggregates) _then)
+class __$$PostAggregatesImplCopyWithImpl<$Res>
+    extends _$PostAggregatesCopyWithImpl<$Res, _$PostAggregatesImpl>
+    implements _$$PostAggregatesImplCopyWith<$Res> {
+  __$$PostAggregatesImplCopyWithImpl(
+      _$PostAggregatesImpl _value, $Res Function(_$PostAggregatesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? postId = null,
     Object? comments = null,
     Object? score = null,
@@ -201,11 +202,11 @@ class __$$_PostAggregatesCopyWithImpl<$Res>
     Object? hotRank = freezed,
     Object? hotRankActive = freezed,
   }) {
-    return _then(_$_PostAggregates(
-      id: null == id
+    return _then(_$PostAggregatesImpl(
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       postId: null == postId
           ? _value.postId
           : postId // ignore: cast_nullable_to_non_nullable
@@ -261,9 +262,9 @@ class __$$_PostAggregatesCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PostAggregates extends _PostAggregates {
-  const _$_PostAggregates(
-      {required this.id,
+class _$PostAggregatesImpl extends _PostAggregates {
+  const _$PostAggregatesImpl(
+      {@deprecated this.id,
       required this.postId,
       required this.comments,
       required this.score,
@@ -278,11 +279,12 @@ class _$_PostAggregates extends _PostAggregates {
       @deprecated this.hotRankActive})
       : super._();
 
-  factory _$_PostAggregates.fromJson(Map<String, dynamic> json) =>
-      _$$_PostAggregatesFromJson(json);
+  factory _$PostAggregatesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PostAggregatesImplFromJson(json);
 
   @override
-  final int id;
+  @deprecated
+  final int? id;
   @override
   final int postId;
   @override
@@ -323,7 +325,7 @@ class _$_PostAggregates extends _PostAggregates {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PostAggregates &&
+            other is _$PostAggregatesImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.postId, postId) || other.postId == postId) &&
             (identical(other.comments, comments) ||
@@ -368,12 +370,13 @@ class _$_PostAggregates extends _PostAggregates {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PostAggregatesCopyWith<_$_PostAggregates> get copyWith =>
-      __$$_PostAggregatesCopyWithImpl<_$_PostAggregates>(this, _$identity);
+  _$$PostAggregatesImplCopyWith<_$PostAggregatesImpl> get copyWith =>
+      __$$PostAggregatesImplCopyWithImpl<_$PostAggregatesImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PostAggregatesToJson(
+    return _$$PostAggregatesImplToJson(
       this,
     );
   }
@@ -381,7 +384,7 @@ class _$_PostAggregates extends _PostAggregates {
 
 abstract class _PostAggregates extends PostAggregates {
   const factory _PostAggregates(
-      {required final int id,
+      {@deprecated final int? id,
       required final int postId,
       required final int comments,
       required final int score,
@@ -393,14 +396,15 @@ abstract class _PostAggregates extends PostAggregates {
       @deprecated final bool? featuredCommunity,
       @deprecated final bool? featuredLocal,
       @deprecated final int? hotRank,
-      @deprecated final int? hotRankActive}) = _$_PostAggregates;
+      @deprecated final int? hotRankActive}) = _$PostAggregatesImpl;
   const _PostAggregates._() : super._();
 
   factory _PostAggregates.fromJson(Map<String, dynamic> json) =
-      _$_PostAggregates.fromJson;
+      _$PostAggregatesImpl.fromJson;
 
   @override
-  int get id;
+  @deprecated
+  int? get id;
   @override
   int get postId;
   @override
@@ -433,6 +437,6 @@ abstract class _PostAggregates extends PostAggregates {
   int? get hotRankActive;
   @override
   @JsonKey(ignore: true)
-  _$$_PostAggregatesCopyWith<_$_PostAggregates> get copyWith =>
+  _$$PostAggregatesImplCopyWith<_$PostAggregatesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/post/post_aggregates.g.dart
+++ b/lib/src/v3/models/post/post_aggregates.g.dart
@@ -6,9 +6,9 @@ part of 'post_aggregates.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PostAggregates _$$_PostAggregatesFromJson(Map<String, dynamic> json) =>
-    _$_PostAggregates(
-      id: json['id'] as int,
+_$PostAggregatesImpl _$$PostAggregatesImplFromJson(Map<String, dynamic> json) =>
+    _$PostAggregatesImpl(
+      id: json['id'] as int?,
       postId: json['post_id'] as int,
       comments: json['comments'] as int,
       score: json['score'] as int,
@@ -23,7 +23,8 @@ _$_PostAggregates _$$_PostAggregatesFromJson(Map<String, dynamic> json) =>
       hotRankActive: json['hot_rank_active'] as int?,
     );
 
-Map<String, dynamic> _$$_PostAggregatesToJson(_$_PostAggregates instance) =>
+Map<String, dynamic> _$$PostAggregatesImplToJson(
+        _$PostAggregatesImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'post_id': instance.postId,

--- a/lib/src/v3/models/post/post_report.freezed.dart
+++ b/lib/src/v3/models/post/post_report.freezed.dart
@@ -133,11 +133,11 @@ class _$PostReportCopyWithImpl<$Res, $Val extends PostReport>
 }
 
 /// @nodoc
-abstract class _$$_PostReportCopyWith<$Res>
+abstract class _$$PostReportImplCopyWith<$Res>
     implements $PostReportCopyWith<$Res> {
-  factory _$$_PostReportCopyWith(
-          _$_PostReport value, $Res Function(_$_PostReport) then) =
-      __$$_PostReportCopyWithImpl<$Res>;
+  factory _$$PostReportImplCopyWith(
+          _$PostReportImpl value, $Res Function(_$PostReportImpl) then) =
+      __$$PostReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -155,11 +155,11 @@ abstract class _$$_PostReportCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PostReportCopyWithImpl<$Res>
-    extends _$PostReportCopyWithImpl<$Res, _$_PostReport>
-    implements _$$_PostReportCopyWith<$Res> {
-  __$$_PostReportCopyWithImpl(
-      _$_PostReport _value, $Res Function(_$_PostReport) _then)
+class __$$PostReportImplCopyWithImpl<$Res>
+    extends _$PostReportCopyWithImpl<$Res, _$PostReportImpl>
+    implements _$$PostReportImplCopyWith<$Res> {
+  __$$PostReportImplCopyWithImpl(
+      _$PostReportImpl _value, $Res Function(_$PostReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -177,7 +177,7 @@ class __$$_PostReportCopyWithImpl<$Res>
     Object? published = null,
     Object? updated = freezed,
   }) {
-    return _then(_$_PostReport(
+    return _then(_$PostReportImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -229,8 +229,8 @@ class __$$_PostReportCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PostReport extends _PostReport {
-  const _$_PostReport(
+class _$PostReportImpl extends _PostReport {
+  const _$PostReportImpl(
       {required this.id,
       required this.creatorId,
       required this.postId,
@@ -244,8 +244,8 @@ class _$_PostReport extends _PostReport {
       this.updated})
       : super._();
 
-  factory _$_PostReport.fromJson(Map<String, dynamic> json) =>
-      _$$_PostReportFromJson(json);
+  factory _$PostReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PostReportImplFromJson(json);
 
   @override
   final int id;
@@ -279,7 +279,7 @@ class _$_PostReport extends _PostReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PostReport &&
+            other is _$PostReportImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -319,12 +319,12 @@ class _$_PostReport extends _PostReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PostReportCopyWith<_$_PostReport> get copyWith =>
-      __$$_PostReportCopyWithImpl<_$_PostReport>(this, _$identity);
+  _$$PostReportImplCopyWith<_$PostReportImpl> get copyWith =>
+      __$$PostReportImplCopyWithImpl<_$PostReportImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PostReportToJson(
+    return _$$PostReportImplToJson(
       this,
     );
   }
@@ -342,11 +342,11 @@ abstract class _PostReport extends PostReport {
       required final bool resolved,
       final int? resolverId,
       required final DateTime published,
-      final DateTime? updated}) = _$_PostReport;
+      final DateTime? updated}) = _$PostReportImpl;
   const _PostReport._() : super._();
 
   factory _PostReport.fromJson(Map<String, dynamic> json) =
-      _$_PostReport.fromJson;
+      _$PostReportImpl.fromJson;
 
   @override
   int get id;
@@ -372,6 +372,6 @@ abstract class _PostReport extends PostReport {
   DateTime? get updated;
   @override
   @JsonKey(ignore: true)
-  _$$_PostReportCopyWith<_$_PostReport> get copyWith =>
+  _$$PostReportImplCopyWith<_$PostReportImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/post/post_report.g.dart
+++ b/lib/src/v3/models/post/post_report.g.dart
@@ -6,8 +6,8 @@ part of 'post_report.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PostReport _$$_PostReportFromJson(Map<String, dynamic> json) =>
-    _$_PostReport(
+_$PostReportImpl _$$PostReportImplFromJson(Map<String, dynamic> json) =>
+    _$PostReportImpl(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       postId: json['post_id'] as int,
@@ -22,7 +22,7 @@ _$_PostReport _$$_PostReportFromJson(Map<String, dynamic> json) =>
           json['updated'], const ForceUtcDateTime().fromJson),
     );
 
-Map<String, dynamic> _$$_PostReportToJson(_$_PostReport instance) =>
+Map<String, dynamic> _$$PostReportImplToJson(_$PostReportImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,

--- a/lib/src/v3/models/post/post_report_response.freezed.dart
+++ b/lib/src/v3/models/post/post_report_response.freezed.dart
@@ -72,11 +72,11 @@ class _$PostReportResponseCopyWithImpl<$Res, $Val extends PostReportResponse>
 }
 
 /// @nodoc
-abstract class _$$_PostReportResponseCopyWith<$Res>
+abstract class _$$PostReportResponseImplCopyWith<$Res>
     implements $PostReportResponseCopyWith<$Res> {
-  factory _$$_PostReportResponseCopyWith(_$_PostReportResponse value,
-          $Res Function(_$_PostReportResponse) then) =
-      __$$_PostReportResponseCopyWithImpl<$Res>;
+  factory _$$PostReportResponseImplCopyWith(_$PostReportResponseImpl value,
+          $Res Function(_$PostReportResponseImpl) then) =
+      __$$PostReportResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PostReportView postReportView});
@@ -86,11 +86,11 @@ abstract class _$$_PostReportResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PostReportResponseCopyWithImpl<$Res>
-    extends _$PostReportResponseCopyWithImpl<$Res, _$_PostReportResponse>
-    implements _$$_PostReportResponseCopyWith<$Res> {
-  __$$_PostReportResponseCopyWithImpl(
-      _$_PostReportResponse _value, $Res Function(_$_PostReportResponse) _then)
+class __$$PostReportResponseImplCopyWithImpl<$Res>
+    extends _$PostReportResponseCopyWithImpl<$Res, _$PostReportResponseImpl>
+    implements _$$PostReportResponseImplCopyWith<$Res> {
+  __$$PostReportResponseImplCopyWithImpl(_$PostReportResponseImpl _value,
+      $Res Function(_$PostReportResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -98,7 +98,7 @@ class __$$_PostReportResponseCopyWithImpl<$Res>
   $Res call({
     Object? postReportView = null,
   }) {
-    return _then(_$_PostReportResponse(
+    return _then(_$PostReportResponseImpl(
       postReportView: null == postReportView
           ? _value.postReportView
           : postReportView // ignore: cast_nullable_to_non_nullable
@@ -110,11 +110,11 @@ class __$$_PostReportResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PostReportResponse extends _PostReportResponse {
-  const _$_PostReportResponse({required this.postReportView}) : super._();
+class _$PostReportResponseImpl extends _PostReportResponse {
+  const _$PostReportResponseImpl({required this.postReportView}) : super._();
 
-  factory _$_PostReportResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_PostReportResponseFromJson(json);
+  factory _$PostReportResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PostReportResponseImplFromJson(json);
 
   @override
   final PostReportView postReportView;
@@ -128,7 +128,7 @@ class _$_PostReportResponse extends _PostReportResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PostReportResponse &&
+            other is _$PostReportResponseImpl &&
             (identical(other.postReportView, postReportView) ||
                 other.postReportView == postReportView));
   }
@@ -140,13 +140,13 @@ class _$_PostReportResponse extends _PostReportResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PostReportResponseCopyWith<_$_PostReportResponse> get copyWith =>
-      __$$_PostReportResponseCopyWithImpl<_$_PostReportResponse>(
+  _$$PostReportResponseImplCopyWith<_$PostReportResponseImpl> get copyWith =>
+      __$$PostReportResponseImplCopyWithImpl<_$PostReportResponseImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PostReportResponseToJson(
+    return _$$PostReportResponseImplToJson(
       this,
     );
   }
@@ -154,16 +154,17 @@ class _$_PostReportResponse extends _PostReportResponse {
 
 abstract class _PostReportResponse extends PostReportResponse {
   const factory _PostReportResponse(
-      {required final PostReportView postReportView}) = _$_PostReportResponse;
+          {required final PostReportView postReportView}) =
+      _$PostReportResponseImpl;
   const _PostReportResponse._() : super._();
 
   factory _PostReportResponse.fromJson(Map<String, dynamic> json) =
-      _$_PostReportResponse.fromJson;
+      _$PostReportResponseImpl.fromJson;
 
   @override
   PostReportView get postReportView;
   @override
   @JsonKey(ignore: true)
-  _$$_PostReportResponseCopyWith<_$_PostReportResponse> get copyWith =>
+  _$$PostReportResponseImplCopyWith<_$PostReportResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/post/post_report_response.g.dart
+++ b/lib/src/v3/models/post/post_report_response.g.dart
@@ -6,15 +6,15 @@ part of 'post_report_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PostReportResponse _$$_PostReportResponseFromJson(
+_$PostReportResponseImpl _$$PostReportResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PostReportResponse(
+    _$PostReportResponseImpl(
       postReportView: PostReportView.fromJson(
           json['post_report_view'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_PostReportResponseToJson(
-        _$_PostReportResponse instance) =>
+Map<String, dynamic> _$$PostReportResponseImplToJson(
+        _$PostReportResponseImpl instance) =>
     <String, dynamic>{
       'post_report_view': instance.postReportView.toJson(),
     };

--- a/lib/src/v3/models/post/post_response.freezed.dart
+++ b/lib/src/v3/models/post/post_response.freezed.dart
@@ -72,11 +72,11 @@ class _$PostResponseCopyWithImpl<$Res, $Val extends PostResponse>
 }
 
 /// @nodoc
-abstract class _$$_PostResponseCopyWith<$Res>
+abstract class _$$PostResponseImplCopyWith<$Res>
     implements $PostResponseCopyWith<$Res> {
-  factory _$$_PostResponseCopyWith(
-          _$_PostResponse value, $Res Function(_$_PostResponse) then) =
-      __$$_PostResponseCopyWithImpl<$Res>;
+  factory _$$PostResponseImplCopyWith(
+          _$PostResponseImpl value, $Res Function(_$PostResponseImpl) then) =
+      __$$PostResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PostView postView});
@@ -86,11 +86,11 @@ abstract class _$$_PostResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PostResponseCopyWithImpl<$Res>
-    extends _$PostResponseCopyWithImpl<$Res, _$_PostResponse>
-    implements _$$_PostResponseCopyWith<$Res> {
-  __$$_PostResponseCopyWithImpl(
-      _$_PostResponse _value, $Res Function(_$_PostResponse) _then)
+class __$$PostResponseImplCopyWithImpl<$Res>
+    extends _$PostResponseCopyWithImpl<$Res, _$PostResponseImpl>
+    implements _$$PostResponseImplCopyWith<$Res> {
+  __$$PostResponseImplCopyWithImpl(
+      _$PostResponseImpl _value, $Res Function(_$PostResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -98,7 +98,7 @@ class __$$_PostResponseCopyWithImpl<$Res>
   $Res call({
     Object? postView = null,
   }) {
-    return _then(_$_PostResponse(
+    return _then(_$PostResponseImpl(
       postView: null == postView
           ? _value.postView
           : postView // ignore: cast_nullable_to_non_nullable
@@ -110,11 +110,11 @@ class __$$_PostResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PostResponse extends _PostResponse {
-  const _$_PostResponse({required this.postView}) : super._();
+class _$PostResponseImpl extends _PostResponse {
+  const _$PostResponseImpl({required this.postView}) : super._();
 
-  factory _$_PostResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_PostResponseFromJson(json);
+  factory _$PostResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PostResponseImplFromJson(json);
 
   @override
   final PostView postView;
@@ -128,7 +128,7 @@ class _$_PostResponse extends _PostResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PostResponse &&
+            other is _$PostResponseImpl &&
             (identical(other.postView, postView) ||
                 other.postView == postView));
   }
@@ -140,12 +140,12 @@ class _$_PostResponse extends _PostResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PostResponseCopyWith<_$_PostResponse> get copyWith =>
-      __$$_PostResponseCopyWithImpl<_$_PostResponse>(this, _$identity);
+  _$$PostResponseImplCopyWith<_$PostResponseImpl> get copyWith =>
+      __$$PostResponseImplCopyWithImpl<_$PostResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PostResponseToJson(
+    return _$$PostResponseImplToJson(
       this,
     );
   }
@@ -153,16 +153,16 @@ class _$_PostResponse extends _PostResponse {
 
 abstract class _PostResponse extends PostResponse {
   const factory _PostResponse({required final PostView postView}) =
-      _$_PostResponse;
+      _$PostResponseImpl;
   const _PostResponse._() : super._();
 
   factory _PostResponse.fromJson(Map<String, dynamic> json) =
-      _$_PostResponse.fromJson;
+      _$PostResponseImpl.fromJson;
 
   @override
   PostView get postView;
   @override
   @JsonKey(ignore: true)
-  _$$_PostResponseCopyWith<_$_PostResponse> get copyWith =>
+  _$$PostResponseImplCopyWith<_$PostResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/post/post_response.g.dart
+++ b/lib/src/v3/models/post/post_response.g.dart
@@ -6,12 +6,12 @@ part of 'post_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PostResponse _$$_PostResponseFromJson(Map<String, dynamic> json) =>
-    _$_PostResponse(
+_$PostResponseImpl _$$PostResponseImplFromJson(Map<String, dynamic> json) =>
+    _$PostResponseImpl(
       postView: PostView.fromJson(json['post_view'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_PostResponseToJson(_$_PostResponse instance) =>
+Map<String, dynamic> _$$PostResponseImplToJson(_$PostResponseImpl instance) =>
     <String, dynamic>{
       'post_view': instance.postView.toJson(),
     };

--- a/lib/src/v3/models/private_message/list_private_message_reports_response.freezed.dart
+++ b/lib/src/v3/models/private_message/list_private_message_reports_response.freezed.dart
@@ -67,25 +67,25 @@ class _$ListPrivateMessageReportsResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ListPrivateMessageReportsResponseCopyWith<$Res>
+abstract class _$$ListPrivateMessageReportsResponseImplCopyWith<$Res>
     implements $ListPrivateMessageReportsResponseCopyWith<$Res> {
-  factory _$$_ListPrivateMessageReportsResponseCopyWith(
-          _$_ListPrivateMessageReportsResponse value,
-          $Res Function(_$_ListPrivateMessageReportsResponse) then) =
-      __$$_ListPrivateMessageReportsResponseCopyWithImpl<$Res>;
+  factory _$$ListPrivateMessageReportsResponseImplCopyWith(
+          _$ListPrivateMessageReportsResponseImpl value,
+          $Res Function(_$ListPrivateMessageReportsResponseImpl) then) =
+      __$$ListPrivateMessageReportsResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<PrivateMessageReportView> privateMessageReports});
 }
 
 /// @nodoc
-class __$$_ListPrivateMessageReportsResponseCopyWithImpl<$Res>
+class __$$ListPrivateMessageReportsResponseImplCopyWithImpl<$Res>
     extends _$ListPrivateMessageReportsResponseCopyWithImpl<$Res,
-        _$_ListPrivateMessageReportsResponse>
-    implements _$$_ListPrivateMessageReportsResponseCopyWith<$Res> {
-  __$$_ListPrivateMessageReportsResponseCopyWithImpl(
-      _$_ListPrivateMessageReportsResponse _value,
-      $Res Function(_$_ListPrivateMessageReportsResponse) _then)
+        _$ListPrivateMessageReportsResponseImpl>
+    implements _$$ListPrivateMessageReportsResponseImplCopyWith<$Res> {
+  __$$ListPrivateMessageReportsResponseImplCopyWithImpl(
+      _$ListPrivateMessageReportsResponseImpl _value,
+      $Res Function(_$ListPrivateMessageReportsResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -93,7 +93,7 @@ class __$$_ListPrivateMessageReportsResponseCopyWithImpl<$Res>
   $Res call({
     Object? privateMessageReports = null,
   }) {
-    return _then(_$_ListPrivateMessageReportsResponse(
+    return _then(_$ListPrivateMessageReportsResponseImpl(
       privateMessageReports: null == privateMessageReports
           ? _value._privateMessageReports
           : privateMessageReports // ignore: cast_nullable_to_non_nullable
@@ -105,16 +105,16 @@ class __$$_ListPrivateMessageReportsResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ListPrivateMessageReportsResponse
+class _$ListPrivateMessageReportsResponseImpl
     extends _ListPrivateMessageReportsResponse {
-  const _$_ListPrivateMessageReportsResponse(
+  const _$ListPrivateMessageReportsResponseImpl(
       {required final List<PrivateMessageReportView> privateMessageReports})
       : _privateMessageReports = privateMessageReports,
         super._();
 
-  factory _$_ListPrivateMessageReportsResponse.fromJson(
+  factory _$ListPrivateMessageReportsResponseImpl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_ListPrivateMessageReportsResponseFromJson(json);
+      _$$ListPrivateMessageReportsResponseImplFromJson(json);
 
   final List<PrivateMessageReportView> _privateMessageReports;
   @override
@@ -134,7 +134,7 @@ class _$_ListPrivateMessageReportsResponse
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ListPrivateMessageReportsResponse &&
+            other is _$ListPrivateMessageReportsResponseImpl &&
             const DeepCollectionEquality()
                 .equals(other._privateMessageReports, _privateMessageReports));
   }
@@ -147,14 +147,14 @@ class _$_ListPrivateMessageReportsResponse
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ListPrivateMessageReportsResponseCopyWith<
-          _$_ListPrivateMessageReportsResponse>
-      get copyWith => __$$_ListPrivateMessageReportsResponseCopyWithImpl<
-          _$_ListPrivateMessageReportsResponse>(this, _$identity);
+  _$$ListPrivateMessageReportsResponseImplCopyWith<
+          _$ListPrivateMessageReportsResponseImpl>
+      get copyWith => __$$ListPrivateMessageReportsResponseImplCopyWithImpl<
+          _$ListPrivateMessageReportsResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ListPrivateMessageReportsResponseToJson(
+    return _$$ListPrivateMessageReportsResponseImplToJson(
       this,
     );
   }
@@ -164,18 +164,18 @@ abstract class _ListPrivateMessageReportsResponse
     extends ListPrivateMessageReportsResponse {
   const factory _ListPrivateMessageReportsResponse(
       {required final List<PrivateMessageReportView>
-          privateMessageReports}) = _$_ListPrivateMessageReportsResponse;
+          privateMessageReports}) = _$ListPrivateMessageReportsResponseImpl;
   const _ListPrivateMessageReportsResponse._() : super._();
 
   factory _ListPrivateMessageReportsResponse.fromJson(
           Map<String, dynamic> json) =
-      _$_ListPrivateMessageReportsResponse.fromJson;
+      _$ListPrivateMessageReportsResponseImpl.fromJson;
 
   @override
   List<PrivateMessageReportView> get privateMessageReports;
   @override
   @JsonKey(ignore: true)
-  _$$_ListPrivateMessageReportsResponseCopyWith<
-          _$_ListPrivateMessageReportsResponse>
+  _$$ListPrivateMessageReportsResponseImplCopyWith<
+          _$ListPrivateMessageReportsResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/private_message/list_private_message_reports_response.g.dart
+++ b/lib/src/v3/models/private_message/list_private_message_reports_response.g.dart
@@ -6,9 +6,10 @@ part of 'list_private_message_reports_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ListPrivateMessageReportsResponse
-    _$$_ListPrivateMessageReportsResponseFromJson(Map<String, dynamic> json) =>
-        _$_ListPrivateMessageReportsResponse(
+_$ListPrivateMessageReportsResponseImpl
+    _$$ListPrivateMessageReportsResponseImplFromJson(
+            Map<String, dynamic> json) =>
+        _$ListPrivateMessageReportsResponseImpl(
           privateMessageReports: (json['private_message_reports']
                   as List<dynamic>)
               .map((e) =>
@@ -16,8 +17,8 @@ _$_ListPrivateMessageReportsResponse
               .toList(),
         );
 
-Map<String, dynamic> _$$_ListPrivateMessageReportsResponseToJson(
-        _$_ListPrivateMessageReportsResponse instance) =>
+Map<String, dynamic> _$$ListPrivateMessageReportsResponseImplToJson(
+        _$ListPrivateMessageReportsResponseImpl instance) =>
     <String, dynamic>{
       'private_message_reports':
           instance.privateMessageReports.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/models/private_message/private_message.freezed.dart
+++ b/lib/src/v3/models/private_message/private_message.freezed.dart
@@ -126,11 +126,11 @@ class _$PrivateMessageCopyWithImpl<$Res, $Val extends PrivateMessage>
 }
 
 /// @nodoc
-abstract class _$$_PrivateMessageCopyWith<$Res>
+abstract class _$$PrivateMessageImplCopyWith<$Res>
     implements $PrivateMessageCopyWith<$Res> {
-  factory _$$_PrivateMessageCopyWith(
-          _$_PrivateMessage value, $Res Function(_$_PrivateMessage) then) =
-      __$$_PrivateMessageCopyWithImpl<$Res>;
+  factory _$$PrivateMessageImplCopyWith(_$PrivateMessageImpl value,
+          $Res Function(_$PrivateMessageImpl) then) =
+      __$$PrivateMessageImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -147,11 +147,11 @@ abstract class _$$_PrivateMessageCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PrivateMessageCopyWithImpl<$Res>
-    extends _$PrivateMessageCopyWithImpl<$Res, _$_PrivateMessage>
-    implements _$$_PrivateMessageCopyWith<$Res> {
-  __$$_PrivateMessageCopyWithImpl(
-      _$_PrivateMessage _value, $Res Function(_$_PrivateMessage) _then)
+class __$$PrivateMessageImplCopyWithImpl<$Res>
+    extends _$PrivateMessageCopyWithImpl<$Res, _$PrivateMessageImpl>
+    implements _$$PrivateMessageImplCopyWith<$Res> {
+  __$$PrivateMessageImplCopyWithImpl(
+      _$PrivateMessageImpl _value, $Res Function(_$PrivateMessageImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -168,7 +168,7 @@ class __$$_PrivateMessageCopyWithImpl<$Res>
     Object? apId = null,
     Object? local = null,
   }) {
-    return _then(_$_PrivateMessage(
+    return _then(_$PrivateMessageImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -216,8 +216,8 @@ class __$$_PrivateMessageCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PrivateMessage extends _PrivateMessage {
-  const _$_PrivateMessage(
+class _$PrivateMessageImpl extends _PrivateMessage {
+  const _$PrivateMessageImpl(
       {required this.id,
       required this.creatorId,
       required this.recipientId,
@@ -230,8 +230,8 @@ class _$_PrivateMessage extends _PrivateMessage {
       required this.local})
       : super._();
 
-  factory _$_PrivateMessage.fromJson(Map<String, dynamic> json) =>
-      _$$_PrivateMessageFromJson(json);
+  factory _$PrivateMessageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PrivateMessageImplFromJson(json);
 
   @override
   final int id;
@@ -263,7 +263,7 @@ class _$_PrivateMessage extends _PrivateMessage {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PrivateMessage &&
+            other is _$PrivateMessageImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -287,12 +287,13 @@ class _$_PrivateMessage extends _PrivateMessage {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PrivateMessageCopyWith<_$_PrivateMessage> get copyWith =>
-      __$$_PrivateMessageCopyWithImpl<_$_PrivateMessage>(this, _$identity);
+  _$$PrivateMessageImplCopyWith<_$PrivateMessageImpl> get copyWith =>
+      __$$PrivateMessageImplCopyWithImpl<_$PrivateMessageImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PrivateMessageToJson(
+    return _$$PrivateMessageImplToJson(
       this,
     );
   }
@@ -309,11 +310,11 @@ abstract class _PrivateMessage extends PrivateMessage {
       required final DateTime published,
       final DateTime? updated,
       required final String apId,
-      required final bool local}) = _$_PrivateMessage;
+      required final bool local}) = _$PrivateMessageImpl;
   const _PrivateMessage._() : super._();
 
   factory _PrivateMessage.fromJson(Map<String, dynamic> json) =
-      _$_PrivateMessage.fromJson;
+      _$PrivateMessageImpl.fromJson;
 
   @override
   int get id;
@@ -337,6 +338,6 @@ abstract class _PrivateMessage extends PrivateMessage {
   bool get local;
   @override
   @JsonKey(ignore: true)
-  _$$_PrivateMessageCopyWith<_$_PrivateMessage> get copyWith =>
+  _$$PrivateMessageImplCopyWith<_$PrivateMessageImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/private_message/private_message.g.dart
+++ b/lib/src/v3/models/private_message/private_message.g.dart
@@ -6,8 +6,8 @@ part of 'private_message.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PrivateMessage _$$_PrivateMessageFromJson(Map<String, dynamic> json) =>
-    _$_PrivateMessage(
+_$PrivateMessageImpl _$$PrivateMessageImplFromJson(Map<String, dynamic> json) =>
+    _$PrivateMessageImpl(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       recipientId: json['recipient_id'] as int,
@@ -21,7 +21,8 @@ _$_PrivateMessage _$$_PrivateMessageFromJson(Map<String, dynamic> json) =>
       local: json['local'] as bool,
     );
 
-Map<String, dynamic> _$$_PrivateMessageToJson(_$_PrivateMessage instance) =>
+Map<String, dynamic> _$$PrivateMessageImplToJson(
+        _$PrivateMessageImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,

--- a/lib/src/v3/models/private_message/private_message_report.freezed.dart
+++ b/lib/src/v3/models/private_message/private_message_report.freezed.dart
@@ -120,11 +120,11 @@ class _$PrivateMessageReportCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_PrivateMessageReportCopyWith<$Res>
+abstract class _$$PrivateMessageReportImplCopyWith<$Res>
     implements $PrivateMessageReportCopyWith<$Res> {
-  factory _$$_PrivateMessageReportCopyWith(_$_PrivateMessageReport value,
-          $Res Function(_$_PrivateMessageReport) then) =
-      __$$_PrivateMessageReportCopyWithImpl<$Res>;
+  factory _$$PrivateMessageReportImplCopyWith(_$PrivateMessageReportImpl value,
+          $Res Function(_$PrivateMessageReportImpl) then) =
+      __$$PrivateMessageReportImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -140,11 +140,11 @@ abstract class _$$_PrivateMessageReportCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PrivateMessageReportCopyWithImpl<$Res>
-    extends _$PrivateMessageReportCopyWithImpl<$Res, _$_PrivateMessageReport>
-    implements _$$_PrivateMessageReportCopyWith<$Res> {
-  __$$_PrivateMessageReportCopyWithImpl(_$_PrivateMessageReport _value,
-      $Res Function(_$_PrivateMessageReport) _then)
+class __$$PrivateMessageReportImplCopyWithImpl<$Res>
+    extends _$PrivateMessageReportCopyWithImpl<$Res, _$PrivateMessageReportImpl>
+    implements _$$PrivateMessageReportImplCopyWith<$Res> {
+  __$$PrivateMessageReportImplCopyWithImpl(_$PrivateMessageReportImpl _value,
+      $Res Function(_$PrivateMessageReportImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -160,7 +160,7 @@ class __$$_PrivateMessageReportCopyWithImpl<$Res>
     Object? published = null,
     Object? updated = freezed,
   }) {
-    return _then(_$_PrivateMessageReport(
+    return _then(_$PrivateMessageReportImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -204,8 +204,8 @@ class __$$_PrivateMessageReportCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PrivateMessageReport extends _PrivateMessageReport {
-  const _$_PrivateMessageReport(
+class _$PrivateMessageReportImpl extends _PrivateMessageReport {
+  const _$PrivateMessageReportImpl(
       {required this.id,
       required this.creatorId,
       required this.privateMessageId,
@@ -217,8 +217,8 @@ class _$_PrivateMessageReport extends _PrivateMessageReport {
       this.updated})
       : super._();
 
-  factory _$_PrivateMessageReport.fromJson(Map<String, dynamic> json) =>
-      _$$_PrivateMessageReportFromJson(json);
+  factory _$PrivateMessageReportImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PrivateMessageReportImplFromJson(json);
 
   @override
   final int id;
@@ -248,7 +248,7 @@ class _$_PrivateMessageReport extends _PrivateMessageReport {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PrivateMessageReport &&
+            other is _$PrivateMessageReportImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.creatorId, creatorId) ||
                 other.creatorId == creatorId) &&
@@ -274,13 +274,14 @@ class _$_PrivateMessageReport extends _PrivateMessageReport {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PrivateMessageReportCopyWith<_$_PrivateMessageReport> get copyWith =>
-      __$$_PrivateMessageReportCopyWithImpl<_$_PrivateMessageReport>(
-          this, _$identity);
+  _$$PrivateMessageReportImplCopyWith<_$PrivateMessageReportImpl>
+      get copyWith =>
+          __$$PrivateMessageReportImplCopyWithImpl<_$PrivateMessageReportImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PrivateMessageReportToJson(
+    return _$$PrivateMessageReportImplToJson(
       this,
     );
   }
@@ -296,11 +297,11 @@ abstract class _PrivateMessageReport extends PrivateMessageReport {
       required final bool resolved,
       final int? resolverId,
       required final DateTime published,
-      final DateTime? updated}) = _$_PrivateMessageReport;
+      final DateTime? updated}) = _$PrivateMessageReportImpl;
   const _PrivateMessageReport._() : super._();
 
   factory _PrivateMessageReport.fromJson(Map<String, dynamic> json) =
-      _$_PrivateMessageReport.fromJson;
+      _$PrivateMessageReportImpl.fromJson;
 
   @override
   int get id;
@@ -322,6 +323,6 @@ abstract class _PrivateMessageReport extends PrivateMessageReport {
   DateTime? get updated;
   @override
   @JsonKey(ignore: true)
-  _$$_PrivateMessageReportCopyWith<_$_PrivateMessageReport> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$PrivateMessageReportImplCopyWith<_$PrivateMessageReportImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/private_message/private_message_report.g.dart
+++ b/lib/src/v3/models/private_message/private_message_report.g.dart
@@ -6,9 +6,9 @@ part of 'private_message_report.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PrivateMessageReport _$$_PrivateMessageReportFromJson(
+_$PrivateMessageReportImpl _$$PrivateMessageReportImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PrivateMessageReport(
+    _$PrivateMessageReportImpl(
       id: json['id'] as int,
       creatorId: json['creator_id'] as int,
       privateMessageId: json['private_message_id'] as int,
@@ -21,8 +21,8 @@ _$_PrivateMessageReport _$$_PrivateMessageReportFromJson(
           json['updated'], const ForceUtcDateTime().fromJson),
     );
 
-Map<String, dynamic> _$$_PrivateMessageReportToJson(
-        _$_PrivateMessageReport instance) =>
+Map<String, dynamic> _$$PrivateMessageReportImplToJson(
+        _$PrivateMessageReportImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'creator_id': instance.creatorId,

--- a/lib/src/v3/models/private_message/private_message_report_response.freezed.dart
+++ b/lib/src/v3/models/private_message/private_message_report_response.freezed.dart
@@ -78,12 +78,12 @@ class _$PrivateMessageReportResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_PrivateMessageReportResponseCopyWith<$Res>
+abstract class _$$PrivateMessageReportResponseImplCopyWith<$Res>
     implements $PrivateMessageReportResponseCopyWith<$Res> {
-  factory _$$_PrivateMessageReportResponseCopyWith(
-          _$_PrivateMessageReportResponse value,
-          $Res Function(_$_PrivateMessageReportResponse) then) =
-      __$$_PrivateMessageReportResponseCopyWithImpl<$Res>;
+  factory _$$PrivateMessageReportResponseImplCopyWith(
+          _$PrivateMessageReportResponseImpl value,
+          $Res Function(_$PrivateMessageReportResponseImpl) then) =
+      __$$PrivateMessageReportResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PrivateMessageReportView privateMessageReportView});
@@ -93,13 +93,13 @@ abstract class _$$_PrivateMessageReportResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PrivateMessageReportResponseCopyWithImpl<$Res>
+class __$$PrivateMessageReportResponseImplCopyWithImpl<$Res>
     extends _$PrivateMessageReportResponseCopyWithImpl<$Res,
-        _$_PrivateMessageReportResponse>
-    implements _$$_PrivateMessageReportResponseCopyWith<$Res> {
-  __$$_PrivateMessageReportResponseCopyWithImpl(
-      _$_PrivateMessageReportResponse _value,
-      $Res Function(_$_PrivateMessageReportResponse) _then)
+        _$PrivateMessageReportResponseImpl>
+    implements _$$PrivateMessageReportResponseImplCopyWith<$Res> {
+  __$$PrivateMessageReportResponseImplCopyWithImpl(
+      _$PrivateMessageReportResponseImpl _value,
+      $Res Function(_$PrivateMessageReportResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -107,7 +107,7 @@ class __$$_PrivateMessageReportResponseCopyWithImpl<$Res>
   $Res call({
     Object? privateMessageReportView = null,
   }) {
-    return _then(_$_PrivateMessageReportResponse(
+    return _then(_$PrivateMessageReportResponseImpl(
       privateMessageReportView: null == privateMessageReportView
           ? _value.privateMessageReportView
           : privateMessageReportView // ignore: cast_nullable_to_non_nullable
@@ -119,13 +119,14 @@ class __$$_PrivateMessageReportResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PrivateMessageReportResponse extends _PrivateMessageReportResponse {
-  const _$_PrivateMessageReportResponse(
+class _$PrivateMessageReportResponseImpl extends _PrivateMessageReportResponse {
+  const _$PrivateMessageReportResponseImpl(
       {required this.privateMessageReportView})
       : super._();
 
-  factory _$_PrivateMessageReportResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_PrivateMessageReportResponseFromJson(json);
+  factory _$PrivateMessageReportResponseImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$PrivateMessageReportResponseImplFromJson(json);
 
   @override
   final PrivateMessageReportView privateMessageReportView;
@@ -139,7 +140,7 @@ class _$_PrivateMessageReportResponse extends _PrivateMessageReportResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PrivateMessageReportResponse &&
+            other is _$PrivateMessageReportResponseImpl &&
             (identical(
                     other.privateMessageReportView, privateMessageReportView) ||
                 other.privateMessageReportView == privateMessageReportView));
@@ -152,13 +153,14 @@ class _$_PrivateMessageReportResponse extends _PrivateMessageReportResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PrivateMessageReportResponseCopyWith<_$_PrivateMessageReportResponse>
-      get copyWith => __$$_PrivateMessageReportResponseCopyWithImpl<
-          _$_PrivateMessageReportResponse>(this, _$identity);
+  _$$PrivateMessageReportResponseImplCopyWith<
+          _$PrivateMessageReportResponseImpl>
+      get copyWith => __$$PrivateMessageReportResponseImplCopyWithImpl<
+          _$PrivateMessageReportResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PrivateMessageReportResponseToJson(
+    return _$$PrivateMessageReportResponseImplToJson(
       this,
     );
   }
@@ -168,16 +170,17 @@ abstract class _PrivateMessageReportResponse
     extends PrivateMessageReportResponse {
   const factory _PrivateMessageReportResponse(
           {required final PrivateMessageReportView privateMessageReportView}) =
-      _$_PrivateMessageReportResponse;
+      _$PrivateMessageReportResponseImpl;
   const _PrivateMessageReportResponse._() : super._();
 
   factory _PrivateMessageReportResponse.fromJson(Map<String, dynamic> json) =
-      _$_PrivateMessageReportResponse.fromJson;
+      _$PrivateMessageReportResponseImpl.fromJson;
 
   @override
   PrivateMessageReportView get privateMessageReportView;
   @override
   @JsonKey(ignore: true)
-  _$$_PrivateMessageReportResponseCopyWith<_$_PrivateMessageReportResponse>
+  _$$PrivateMessageReportResponseImplCopyWith<
+          _$PrivateMessageReportResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/private_message/private_message_report_response.g.dart
+++ b/lib/src/v3/models/private_message/private_message_report_response.g.dart
@@ -6,15 +6,15 @@ part of 'private_message_report_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PrivateMessageReportResponse _$$_PrivateMessageReportResponseFromJson(
+_$PrivateMessageReportResponseImpl _$$PrivateMessageReportResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PrivateMessageReportResponse(
+    _$PrivateMessageReportResponseImpl(
       privateMessageReportView: PrivateMessageReportView.fromJson(
           json['private_message_report_view'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_PrivateMessageReportResponseToJson(
-        _$_PrivateMessageReportResponse instance) =>
+Map<String, dynamic> _$$PrivateMessageReportResponseImplToJson(
+        _$PrivateMessageReportResponseImpl instance) =>
     <String, dynamic>{
       'private_message_report_view': instance.privateMessageReportView.toJson(),
     };

--- a/lib/src/v3/models/private_message/private_message_response.freezed.dart
+++ b/lib/src/v3/models/private_message/private_message_response.freezed.dart
@@ -76,11 +76,12 @@ class _$PrivateMessageResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_PrivateMessageResponseCopyWith<$Res>
+abstract class _$$PrivateMessageResponseImplCopyWith<$Res>
     implements $PrivateMessageResponseCopyWith<$Res> {
-  factory _$$_PrivateMessageResponseCopyWith(_$_PrivateMessageResponse value,
-          $Res Function(_$_PrivateMessageResponse) then) =
-      __$$_PrivateMessageResponseCopyWithImpl<$Res>;
+  factory _$$PrivateMessageResponseImplCopyWith(
+          _$PrivateMessageResponseImpl value,
+          $Res Function(_$PrivateMessageResponseImpl) then) =
+      __$$PrivateMessageResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PrivateMessageView privateMessageView});
@@ -90,12 +91,13 @@ abstract class _$$_PrivateMessageResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PrivateMessageResponseCopyWithImpl<$Res>
+class __$$PrivateMessageResponseImplCopyWithImpl<$Res>
     extends _$PrivateMessageResponseCopyWithImpl<$Res,
-        _$_PrivateMessageResponse>
-    implements _$$_PrivateMessageResponseCopyWith<$Res> {
-  __$$_PrivateMessageResponseCopyWithImpl(_$_PrivateMessageResponse _value,
-      $Res Function(_$_PrivateMessageResponse) _then)
+        _$PrivateMessageResponseImpl>
+    implements _$$PrivateMessageResponseImplCopyWith<$Res> {
+  __$$PrivateMessageResponseImplCopyWithImpl(
+      _$PrivateMessageResponseImpl _value,
+      $Res Function(_$PrivateMessageResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -103,7 +105,7 @@ class __$$_PrivateMessageResponseCopyWithImpl<$Res>
   $Res call({
     Object? privateMessageView = null,
   }) {
-    return _then(_$_PrivateMessageResponse(
+    return _then(_$PrivateMessageResponseImpl(
       privateMessageView: null == privateMessageView
           ? _value.privateMessageView
           : privateMessageView // ignore: cast_nullable_to_non_nullable
@@ -115,12 +117,12 @@ class __$$_PrivateMessageResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PrivateMessageResponse extends _PrivateMessageResponse {
-  const _$_PrivateMessageResponse({required this.privateMessageView})
+class _$PrivateMessageResponseImpl extends _PrivateMessageResponse {
+  const _$PrivateMessageResponseImpl({required this.privateMessageView})
       : super._();
 
-  factory _$_PrivateMessageResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_PrivateMessageResponseFromJson(json);
+  factory _$PrivateMessageResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PrivateMessageResponseImplFromJson(json);
 
   @override
   final PrivateMessageView privateMessageView;
@@ -134,7 +136,7 @@ class _$_PrivateMessageResponse extends _PrivateMessageResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PrivateMessageResponse &&
+            other is _$PrivateMessageResponseImpl &&
             (identical(other.privateMessageView, privateMessageView) ||
                 other.privateMessageView == privateMessageView));
   }
@@ -146,13 +148,13 @@ class _$_PrivateMessageResponse extends _PrivateMessageResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PrivateMessageResponseCopyWith<_$_PrivateMessageResponse> get copyWith =>
-      __$$_PrivateMessageResponseCopyWithImpl<_$_PrivateMessageResponse>(
-          this, _$identity);
+  _$$PrivateMessageResponseImplCopyWith<_$PrivateMessageResponseImpl>
+      get copyWith => __$$PrivateMessageResponseImplCopyWithImpl<
+          _$PrivateMessageResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PrivateMessageResponseToJson(
+    return _$$PrivateMessageResponseImplToJson(
       this,
     );
   }
@@ -161,16 +163,16 @@ class _$_PrivateMessageResponse extends _PrivateMessageResponse {
 abstract class _PrivateMessageResponse extends PrivateMessageResponse {
   const factory _PrivateMessageResponse(
           {required final PrivateMessageView privateMessageView}) =
-      _$_PrivateMessageResponse;
+      _$PrivateMessageResponseImpl;
   const _PrivateMessageResponse._() : super._();
 
   factory _PrivateMessageResponse.fromJson(Map<String, dynamic> json) =
-      _$_PrivateMessageResponse.fromJson;
+      _$PrivateMessageResponseImpl.fromJson;
 
   @override
   PrivateMessageView get privateMessageView;
   @override
   @JsonKey(ignore: true)
-  _$$_PrivateMessageResponseCopyWith<_$_PrivateMessageResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$PrivateMessageResponseImplCopyWith<_$PrivateMessageResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/private_message/private_message_response.g.dart
+++ b/lib/src/v3/models/private_message/private_message_response.g.dart
@@ -6,15 +6,15 @@ part of 'private_message_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PrivateMessageResponse _$$_PrivateMessageResponseFromJson(
+_$PrivateMessageResponseImpl _$$PrivateMessageResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PrivateMessageResponse(
+    _$PrivateMessageResponseImpl(
       privateMessageView: PrivateMessageView.fromJson(
           json['private_message_view'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_PrivateMessageResponseToJson(
-        _$_PrivateMessageResponse instance) =>
+Map<String, dynamic> _$$PrivateMessageResponseImplToJson(
+        _$PrivateMessageResponseImpl instance) =>
     <String, dynamic>{
       'private_message_view': instance.privateMessageView.toJson(),
     };

--- a/lib/src/v3/models/private_message/private_messages_response.freezed.dart
+++ b/lib/src/v3/models/private_message/private_messages_response.freezed.dart
@@ -65,23 +65,25 @@ class _$PrivateMessagesResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_PrivateMessagesResponseCopyWith<$Res>
+abstract class _$$PrivateMessagesResponseImplCopyWith<$Res>
     implements $PrivateMessagesResponseCopyWith<$Res> {
-  factory _$$_PrivateMessagesResponseCopyWith(_$_PrivateMessagesResponse value,
-          $Res Function(_$_PrivateMessagesResponse) then) =
-      __$$_PrivateMessagesResponseCopyWithImpl<$Res>;
+  factory _$$PrivateMessagesResponseImplCopyWith(
+          _$PrivateMessagesResponseImpl value,
+          $Res Function(_$PrivateMessagesResponseImpl) then) =
+      __$$PrivateMessagesResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<PrivateMessageView> privateMessages});
 }
 
 /// @nodoc
-class __$$_PrivateMessagesResponseCopyWithImpl<$Res>
+class __$$PrivateMessagesResponseImplCopyWithImpl<$Res>
     extends _$PrivateMessagesResponseCopyWithImpl<$Res,
-        _$_PrivateMessagesResponse>
-    implements _$$_PrivateMessagesResponseCopyWith<$Res> {
-  __$$_PrivateMessagesResponseCopyWithImpl(_$_PrivateMessagesResponse _value,
-      $Res Function(_$_PrivateMessagesResponse) _then)
+        _$PrivateMessagesResponseImpl>
+    implements _$$PrivateMessagesResponseImplCopyWith<$Res> {
+  __$$PrivateMessagesResponseImplCopyWithImpl(
+      _$PrivateMessagesResponseImpl _value,
+      $Res Function(_$PrivateMessagesResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -89,7 +91,7 @@ class __$$_PrivateMessagesResponseCopyWithImpl<$Res>
   $Res call({
     Object? privateMessages = null,
   }) {
-    return _then(_$_PrivateMessagesResponse(
+    return _then(_$PrivateMessagesResponseImpl(
       privateMessages: null == privateMessages
           ? _value._privateMessages
           : privateMessages // ignore: cast_nullable_to_non_nullable
@@ -101,14 +103,14 @@ class __$$_PrivateMessagesResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PrivateMessagesResponse extends _PrivateMessagesResponse {
-  const _$_PrivateMessagesResponse(
+class _$PrivateMessagesResponseImpl extends _PrivateMessagesResponse {
+  const _$PrivateMessagesResponseImpl(
       {required final List<PrivateMessageView> privateMessages})
       : _privateMessages = privateMessages,
         super._();
 
-  factory _$_PrivateMessagesResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_PrivateMessagesResponseFromJson(json);
+  factory _$PrivateMessagesResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PrivateMessagesResponseImplFromJson(json);
 
   final List<PrivateMessageView> _privateMessages;
   @override
@@ -127,7 +129,7 @@ class _$_PrivateMessagesResponse extends _PrivateMessagesResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PrivateMessagesResponse &&
+            other is _$PrivateMessagesResponseImpl &&
             const DeepCollectionEquality()
                 .equals(other._privateMessages, _privateMessages));
   }
@@ -140,14 +142,13 @@ class _$_PrivateMessagesResponse extends _PrivateMessagesResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PrivateMessagesResponseCopyWith<_$_PrivateMessagesResponse>
-      get copyWith =>
-          __$$_PrivateMessagesResponseCopyWithImpl<_$_PrivateMessagesResponse>(
-              this, _$identity);
+  _$$PrivateMessagesResponseImplCopyWith<_$PrivateMessagesResponseImpl>
+      get copyWith => __$$PrivateMessagesResponseImplCopyWithImpl<
+          _$PrivateMessagesResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PrivateMessagesResponseToJson(
+    return _$$PrivateMessagesResponseImplToJson(
       this,
     );
   }
@@ -156,16 +157,16 @@ class _$_PrivateMessagesResponse extends _PrivateMessagesResponse {
 abstract class _PrivateMessagesResponse extends PrivateMessagesResponse {
   const factory _PrivateMessagesResponse(
           {required final List<PrivateMessageView> privateMessages}) =
-      _$_PrivateMessagesResponse;
+      _$PrivateMessagesResponseImpl;
   const _PrivateMessagesResponse._() : super._();
 
   factory _PrivateMessagesResponse.fromJson(Map<String, dynamic> json) =
-      _$_PrivateMessagesResponse.fromJson;
+      _$PrivateMessagesResponseImpl.fromJson;
 
   @override
   List<PrivateMessageView> get privateMessages;
   @override
   @JsonKey(ignore: true)
-  _$$_PrivateMessagesResponseCopyWith<_$_PrivateMessagesResponse>
+  _$$PrivateMessagesResponseImplCopyWith<_$PrivateMessagesResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/private_message/private_messages_response.g.dart
+++ b/lib/src/v3/models/private_message/private_messages_response.g.dart
@@ -6,16 +6,16 @@ part of 'private_messages_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PrivateMessagesResponse _$$_PrivateMessagesResponseFromJson(
+_$PrivateMessagesResponseImpl _$$PrivateMessagesResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PrivateMessagesResponse(
+    _$PrivateMessagesResponseImpl(
       privateMessages: (json['private_messages'] as List<dynamic>)
           .map((e) => PrivateMessageView.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$_PrivateMessagesResponseToJson(
-        _$_PrivateMessagesResponse instance) =>
+Map<String, dynamic> _$$PrivateMessagesResponseImplToJson(
+        _$PrivateMessagesResponseImpl instance) =>
     <String, dynamic>{
       'private_messages':
           instance.privateMessages.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/models/resolve_object/resolve_object_response.freezed.dart
+++ b/lib/src/v3/models/resolve_object/resolve_object_response.freezed.dart
@@ -139,11 +139,12 @@ class _$ResolveObjectResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ResolveObjectResponseCopyWith<$Res>
+abstract class _$$ResolveObjectResponseImplCopyWith<$Res>
     implements $ResolveObjectResponseCopyWith<$Res> {
-  factory _$$_ResolveObjectResponseCopyWith(_$_ResolveObjectResponse value,
-          $Res Function(_$_ResolveObjectResponse) then) =
-      __$$_ResolveObjectResponseCopyWithImpl<$Res>;
+  factory _$$ResolveObjectResponseImplCopyWith(
+          _$ResolveObjectResponseImpl value,
+          $Res Function(_$ResolveObjectResponseImpl) then) =
+      __$$ResolveObjectResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -163,11 +164,12 @@ abstract class _$$_ResolveObjectResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ResolveObjectResponseCopyWithImpl<$Res>
-    extends _$ResolveObjectResponseCopyWithImpl<$Res, _$_ResolveObjectResponse>
-    implements _$$_ResolveObjectResponseCopyWith<$Res> {
-  __$$_ResolveObjectResponseCopyWithImpl(_$_ResolveObjectResponse _value,
-      $Res Function(_$_ResolveObjectResponse) _then)
+class __$$ResolveObjectResponseImplCopyWithImpl<$Res>
+    extends _$ResolveObjectResponseCopyWithImpl<$Res,
+        _$ResolveObjectResponseImpl>
+    implements _$$ResolveObjectResponseImplCopyWith<$Res> {
+  __$$ResolveObjectResponseImplCopyWithImpl(_$ResolveObjectResponseImpl _value,
+      $Res Function(_$ResolveObjectResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -178,7 +180,7 @@ class __$$_ResolveObjectResponseCopyWithImpl<$Res>
     Object? community = freezed,
     Object? person = freezed,
   }) {
-    return _then(_$_ResolveObjectResponse(
+    return _then(_$ResolveObjectResponseImpl(
       comment: freezed == comment
           ? _value.comment
           : comment // ignore: cast_nullable_to_non_nullable
@@ -202,13 +204,13 @@ class __$$_ResolveObjectResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ResolveObjectResponse extends _ResolveObjectResponse {
-  const _$_ResolveObjectResponse(
+class _$ResolveObjectResponseImpl extends _ResolveObjectResponse {
+  const _$ResolveObjectResponseImpl(
       {this.comment, this.post, this.community, this.person})
       : super._();
 
-  factory _$_ResolveObjectResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_ResolveObjectResponseFromJson(json);
+  factory _$ResolveObjectResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ResolveObjectResponseImplFromJson(json);
 
   @override
   final CommentView? comment;
@@ -228,7 +230,7 @@ class _$_ResolveObjectResponse extends _ResolveObjectResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ResolveObjectResponse &&
+            other is _$ResolveObjectResponseImpl &&
             (identical(other.comment, comment) || other.comment == comment) &&
             (identical(other.post, post) || other.post == post) &&
             (identical(other.community, community) ||
@@ -244,13 +246,13 @@ class _$_ResolveObjectResponse extends _ResolveObjectResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ResolveObjectResponseCopyWith<_$_ResolveObjectResponse> get copyWith =>
-      __$$_ResolveObjectResponseCopyWithImpl<_$_ResolveObjectResponse>(
-          this, _$identity);
+  _$$ResolveObjectResponseImplCopyWith<_$ResolveObjectResponseImpl>
+      get copyWith => __$$ResolveObjectResponseImplCopyWithImpl<
+          _$ResolveObjectResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ResolveObjectResponseToJson(
+    return _$$ResolveObjectResponseImplToJson(
       this,
     );
   }
@@ -261,11 +263,11 @@ abstract class _ResolveObjectResponse extends ResolveObjectResponse {
       {final CommentView? comment,
       final PostView? post,
       final CommunityView? community,
-      final PersonView? person}) = _$_ResolveObjectResponse;
+      final PersonView? person}) = _$ResolveObjectResponseImpl;
   const _ResolveObjectResponse._() : super._();
 
   factory _ResolveObjectResponse.fromJson(Map<String, dynamic> json) =
-      _$_ResolveObjectResponse.fromJson;
+      _$ResolveObjectResponseImpl.fromJson;
 
   @override
   CommentView? get comment;
@@ -277,6 +279,6 @@ abstract class _ResolveObjectResponse extends ResolveObjectResponse {
   PersonView? get person;
   @override
   @JsonKey(ignore: true)
-  _$$_ResolveObjectResponseCopyWith<_$_ResolveObjectResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ResolveObjectResponseImplCopyWith<_$ResolveObjectResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/resolve_object/resolve_object_response.g.dart
+++ b/lib/src/v3/models/resolve_object/resolve_object_response.g.dart
@@ -6,9 +6,9 @@ part of 'resolve_object_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ResolveObjectResponse _$$_ResolveObjectResponseFromJson(
+_$ResolveObjectResponseImpl _$$ResolveObjectResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ResolveObjectResponse(
+    _$ResolveObjectResponseImpl(
       comment: json['comment'] == null
           ? null
           : CommentView.fromJson(json['comment'] as Map<String, dynamic>),
@@ -23,8 +23,8 @@ _$_ResolveObjectResponse _$$_ResolveObjectResponseFromJson(
           : PersonView.fromJson(json['person'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_ResolveObjectResponseToJson(
-        _$_ResolveObjectResponse instance) =>
+Map<String, dynamic> _$$ResolveObjectResponseImplToJson(
+        _$ResolveObjectResponseImpl instance) =>
     <String, dynamic>{
       'comment': instance.comment?.toJson(),
       'post': instance.post?.toJson(),

--- a/lib/src/v3/models/search/search_response.freezed.dart
+++ b/lib/src/v3/models/search/search_response.freezed.dart
@@ -92,11 +92,11 @@ class _$SearchResponseCopyWithImpl<$Res, $Val extends SearchResponse>
 }
 
 /// @nodoc
-abstract class _$$_SearchResponseCopyWith<$Res>
+abstract class _$$SearchResponseImplCopyWith<$Res>
     implements $SearchResponseCopyWith<$Res> {
-  factory _$$_SearchResponseCopyWith(
-          _$_SearchResponse value, $Res Function(_$_SearchResponse) then) =
-      __$$_SearchResponseCopyWithImpl<$Res>;
+  factory _$$SearchResponseImplCopyWith(_$SearchResponseImpl value,
+          $Res Function(_$SearchResponseImpl) then) =
+      __$$SearchResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -108,11 +108,11 @@ abstract class _$$_SearchResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_SearchResponseCopyWithImpl<$Res>
-    extends _$SearchResponseCopyWithImpl<$Res, _$_SearchResponse>
-    implements _$$_SearchResponseCopyWith<$Res> {
-  __$$_SearchResponseCopyWithImpl(
-      _$_SearchResponse _value, $Res Function(_$_SearchResponse) _then)
+class __$$SearchResponseImplCopyWithImpl<$Res>
+    extends _$SearchResponseCopyWithImpl<$Res, _$SearchResponseImpl>
+    implements _$$SearchResponseImplCopyWith<$Res> {
+  __$$SearchResponseImplCopyWithImpl(
+      _$SearchResponseImpl _value, $Res Function(_$SearchResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -124,7 +124,7 @@ class __$$_SearchResponseCopyWithImpl<$Res>
     Object? communities = null,
     Object? users = null,
   }) {
-    return _then(_$_SearchResponse(
+    return _then(_$SearchResponseImpl(
       type: null == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
@@ -152,8 +152,8 @@ class __$$_SearchResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_SearchResponse extends _SearchResponse {
-  const _$_SearchResponse(
+class _$SearchResponseImpl extends _SearchResponse {
+  const _$SearchResponseImpl(
       {@JsonKey(name: 'type_') required this.type,
       required final List<CommentView> comments,
       required final List<PostView> posts,
@@ -165,8 +165,8 @@ class _$_SearchResponse extends _SearchResponse {
         _users = users,
         super._();
 
-  factory _$_SearchResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_SearchResponseFromJson(json);
+  factory _$SearchResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SearchResponseImplFromJson(json);
 
   @override
   @JsonKey(name: 'type_')
@@ -212,7 +212,7 @@ class _$_SearchResponse extends _SearchResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SearchResponse &&
+            other is _$SearchResponseImpl &&
             (identical(other.type, type) || other.type == type) &&
             const DeepCollectionEquality().equals(other._comments, _comments) &&
             const DeepCollectionEquality().equals(other._posts, _posts) &&
@@ -234,12 +234,13 @@ class _$_SearchResponse extends _SearchResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SearchResponseCopyWith<_$_SearchResponse> get copyWith =>
-      __$$_SearchResponseCopyWithImpl<_$_SearchResponse>(this, _$identity);
+  _$$SearchResponseImplCopyWith<_$SearchResponseImpl> get copyWith =>
+      __$$SearchResponseImplCopyWithImpl<_$SearchResponseImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SearchResponseToJson(
+    return _$$SearchResponseImplToJson(
       this,
     );
   }
@@ -251,11 +252,11 @@ abstract class _SearchResponse extends SearchResponse {
       required final List<CommentView> comments,
       required final List<PostView> posts,
       required final List<CommunityView> communities,
-      required final List<PersonView> users}) = _$_SearchResponse;
+      required final List<PersonView> users}) = _$SearchResponseImpl;
   const _SearchResponse._() : super._();
 
   factory _SearchResponse.fromJson(Map<String, dynamic> json) =
-      _$_SearchResponse.fromJson;
+      _$SearchResponseImpl.fromJson;
 
   @override
   @JsonKey(name: 'type_')
@@ -270,6 +271,6 @@ abstract class _SearchResponse extends SearchResponse {
   List<PersonView> get users;
   @override
   @JsonKey(ignore: true)
-  _$$_SearchResponseCopyWith<_$_SearchResponse> get copyWith =>
+  _$$SearchResponseImplCopyWith<_$SearchResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/search/search_response.g.dart
+++ b/lib/src/v3/models/search/search_response.g.dart
@@ -6,8 +6,8 @@ part of 'search_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_SearchResponse _$$_SearchResponseFromJson(Map<String, dynamic> json) =>
-    _$_SearchResponse(
+_$SearchResponseImpl _$$SearchResponseImplFromJson(Map<String, dynamic> json) =>
+    _$SearchResponseImpl(
       type: SearchType.fromJson(json['type_'] as String),
       comments: (json['comments'] as List<dynamic>)
           .map((e) => CommentView.fromJson(e as Map<String, dynamic>))
@@ -23,7 +23,8 @@ _$_SearchResponse _$$_SearchResponseFromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
-Map<String, dynamic> _$$_SearchResponseToJson(_$_SearchResponse instance) =>
+Map<String, dynamic> _$$SearchResponseImplToJson(
+        _$SearchResponseImpl instance) =>
     <String, dynamic>{
       'type_': instance.type.toJson(),
       'comments': instance.comments.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/models/site/block_instance_response.freezed.dart
+++ b/lib/src/v3/models/site/block_instance_response.freezed.dart
@@ -64,22 +64,24 @@ class _$BlockInstanceResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_BlockInstanceResponseCopyWith<$Res>
+abstract class _$$BlockInstanceResponseImplCopyWith<$Res>
     implements $BlockInstanceResponseCopyWith<$Res> {
-  factory _$$_BlockInstanceResponseCopyWith(_$_BlockInstanceResponse value,
-          $Res Function(_$_BlockInstanceResponse) then) =
-      __$$_BlockInstanceResponseCopyWithImpl<$Res>;
+  factory _$$BlockInstanceResponseImplCopyWith(
+          _$BlockInstanceResponseImpl value,
+          $Res Function(_$BlockInstanceResponseImpl) then) =
+      __$$BlockInstanceResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool blocked});
 }
 
 /// @nodoc
-class __$$_BlockInstanceResponseCopyWithImpl<$Res>
-    extends _$BlockInstanceResponseCopyWithImpl<$Res, _$_BlockInstanceResponse>
-    implements _$$_BlockInstanceResponseCopyWith<$Res> {
-  __$$_BlockInstanceResponseCopyWithImpl(_$_BlockInstanceResponse _value,
-      $Res Function(_$_BlockInstanceResponse) _then)
+class __$$BlockInstanceResponseImplCopyWithImpl<$Res>
+    extends _$BlockInstanceResponseCopyWithImpl<$Res,
+        _$BlockInstanceResponseImpl>
+    implements _$$BlockInstanceResponseImplCopyWith<$Res> {
+  __$$BlockInstanceResponseImplCopyWithImpl(_$BlockInstanceResponseImpl _value,
+      $Res Function(_$BlockInstanceResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -87,7 +89,7 @@ class __$$_BlockInstanceResponseCopyWithImpl<$Res>
   $Res call({
     Object? blocked = null,
   }) {
-    return _then(_$_BlockInstanceResponse(
+    return _then(_$BlockInstanceResponseImpl(
       blocked: null == blocked
           ? _value.blocked
           : blocked // ignore: cast_nullable_to_non_nullable
@@ -99,11 +101,11 @@ class __$$_BlockInstanceResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_BlockInstanceResponse extends _BlockInstanceResponse {
-  const _$_BlockInstanceResponse({required this.blocked}) : super._();
+class _$BlockInstanceResponseImpl extends _BlockInstanceResponse {
+  const _$BlockInstanceResponseImpl({required this.blocked}) : super._();
 
-  factory _$_BlockInstanceResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_BlockInstanceResponseFromJson(json);
+  factory _$BlockInstanceResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BlockInstanceResponseImplFromJson(json);
 
   @override
   final bool blocked;
@@ -117,7 +119,7 @@ class _$_BlockInstanceResponse extends _BlockInstanceResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BlockInstanceResponse &&
+            other is _$BlockInstanceResponseImpl &&
             (identical(other.blocked, blocked) || other.blocked == blocked));
   }
 
@@ -128,13 +130,13 @@ class _$_BlockInstanceResponse extends _BlockInstanceResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BlockInstanceResponseCopyWith<_$_BlockInstanceResponse> get copyWith =>
-      __$$_BlockInstanceResponseCopyWithImpl<_$_BlockInstanceResponse>(
-          this, _$identity);
+  _$$BlockInstanceResponseImplCopyWith<_$BlockInstanceResponseImpl>
+      get copyWith => __$$BlockInstanceResponseImplCopyWithImpl<
+          _$BlockInstanceResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BlockInstanceResponseToJson(
+    return _$$BlockInstanceResponseImplToJson(
       this,
     );
   }
@@ -142,16 +144,16 @@ class _$_BlockInstanceResponse extends _BlockInstanceResponse {
 
 abstract class _BlockInstanceResponse extends BlockInstanceResponse {
   const factory _BlockInstanceResponse({required final bool blocked}) =
-      _$_BlockInstanceResponse;
+      _$BlockInstanceResponseImpl;
   const _BlockInstanceResponse._() : super._();
 
   factory _BlockInstanceResponse.fromJson(Map<String, dynamic> json) =
-      _$_BlockInstanceResponse.fromJson;
+      _$BlockInstanceResponseImpl.fromJson;
 
   @override
   bool get blocked;
   @override
   @JsonKey(ignore: true)
-  _$$_BlockInstanceResponseCopyWith<_$_BlockInstanceResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$BlockInstanceResponseImplCopyWith<_$BlockInstanceResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/site/block_instance_response.g.dart
+++ b/lib/src/v3/models/site/block_instance_response.g.dart
@@ -6,14 +6,14 @@ part of 'block_instance_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_BlockInstanceResponse _$$_BlockInstanceResponseFromJson(
+_$BlockInstanceResponseImpl _$$BlockInstanceResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_BlockInstanceResponse(
+    _$BlockInstanceResponseImpl(
       blocked: json['blocked'] as bool,
     );
 
-Map<String, dynamic> _$$_BlockInstanceResponseToJson(
-        _$_BlockInstanceResponse instance) =>
+Map<String, dynamic> _$$BlockInstanceResponseImplToJson(
+        _$BlockInstanceResponseImpl instance) =>
     <String, dynamic>{
       'blocked': instance.blocked,
     };

--- a/lib/src/v3/models/site/get_site_response.freezed.dart
+++ b/lib/src/v3/models/site/get_site_response.freezed.dart
@@ -135,11 +135,11 @@ class _$GetSiteResponseCopyWithImpl<$Res, $Val extends GetSiteResponse>
 }
 
 /// @nodoc
-abstract class _$$_GetSiteResponseCopyWith<$Res>
+abstract class _$$GetSiteResponseImplCopyWith<$Res>
     implements $GetSiteResponseCopyWith<$Res> {
-  factory _$$_GetSiteResponseCopyWith(
-          _$_GetSiteResponse value, $Res Function(_$_GetSiteResponse) then) =
-      __$$_GetSiteResponseCopyWithImpl<$Res>;
+  factory _$$GetSiteResponseImplCopyWith(_$GetSiteResponseImpl value,
+          $Res Function(_$GetSiteResponseImpl) then) =
+      __$$GetSiteResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -159,11 +159,11 @@ abstract class _$$_GetSiteResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetSiteResponseCopyWithImpl<$Res>
-    extends _$GetSiteResponseCopyWithImpl<$Res, _$_GetSiteResponse>
-    implements _$$_GetSiteResponseCopyWith<$Res> {
-  __$$_GetSiteResponseCopyWithImpl(
-      _$_GetSiteResponse _value, $Res Function(_$_GetSiteResponse) _then)
+class __$$GetSiteResponseImplCopyWithImpl<$Res>
+    extends _$GetSiteResponseCopyWithImpl<$Res, _$GetSiteResponseImpl>
+    implements _$$GetSiteResponseImplCopyWith<$Res> {
+  __$$GetSiteResponseImplCopyWithImpl(
+      _$GetSiteResponseImpl _value, $Res Function(_$GetSiteResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -178,7 +178,7 @@ class __$$_GetSiteResponseCopyWithImpl<$Res>
     Object? taglines = null,
     Object? customEmojis = null,
   }) {
-    return _then(_$_GetSiteResponse(
+    return _then(_$GetSiteResponseImpl(
       siteView: null == siteView
           ? _value.siteView
           : siteView // ignore: cast_nullable_to_non_nullable
@@ -218,8 +218,8 @@ class __$$_GetSiteResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetSiteResponse extends _GetSiteResponse {
-  const _$_GetSiteResponse(
+class _$GetSiteResponseImpl extends _GetSiteResponse {
+  const _$GetSiteResponseImpl(
       {required this.siteView,
       required final List<PersonView> admins,
       required this.version,
@@ -235,8 +235,8 @@ class _$_GetSiteResponse extends _GetSiteResponse {
         _customEmojis = customEmojis,
         super._();
 
-  factory _$_GetSiteResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetSiteResponseFromJson(json);
+  factory _$GetSiteResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetSiteResponseImplFromJson(json);
 
   @override
   final SiteView siteView;
@@ -294,7 +294,7 @@ class _$_GetSiteResponse extends _GetSiteResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetSiteResponse &&
+            other is _$GetSiteResponseImpl &&
             (identical(other.siteView, siteView) ||
                 other.siteView == siteView) &&
             const DeepCollectionEquality().equals(other._admins, _admins) &&
@@ -325,12 +325,13 @@ class _$_GetSiteResponse extends _GetSiteResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetSiteResponseCopyWith<_$_GetSiteResponse> get copyWith =>
-      __$$_GetSiteResponseCopyWithImpl<_$_GetSiteResponse>(this, _$identity);
+  _$$GetSiteResponseImplCopyWith<_$GetSiteResponseImpl> get copyWith =>
+      __$$GetSiteResponseImplCopyWithImpl<_$GetSiteResponseImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetSiteResponseToJson(
+    return _$$GetSiteResponseImplToJson(
       this,
     );
   }
@@ -338,18 +339,19 @@ class _$_GetSiteResponse extends _GetSiteResponse {
 
 abstract class _GetSiteResponse extends GetSiteResponse {
   const factory _GetSiteResponse(
-      {required final SiteView siteView,
-      required final List<PersonView> admins,
-      required final String version,
-      final MyUserInfo? myUser,
-      required final List<Language> allLanguages,
-      required final List<int> discussionLanguages,
-      required final List<Tagline> taglines,
-      required final List<CustomEmojiView> customEmojis}) = _$_GetSiteResponse;
+          {required final SiteView siteView,
+          required final List<PersonView> admins,
+          required final String version,
+          final MyUserInfo? myUser,
+          required final List<Language> allLanguages,
+          required final List<int> discussionLanguages,
+          required final List<Tagline> taglines,
+          required final List<CustomEmojiView> customEmojis}) =
+      _$GetSiteResponseImpl;
   const _GetSiteResponse._() : super._();
 
   factory _GetSiteResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetSiteResponse.fromJson;
+      _$GetSiteResponseImpl.fromJson;
 
   @override
   SiteView get siteView;
@@ -369,6 +371,6 @@ abstract class _GetSiteResponse extends GetSiteResponse {
   List<CustomEmojiView> get customEmojis;
   @override
   @JsonKey(ignore: true)
-  _$$_GetSiteResponseCopyWith<_$_GetSiteResponse> get copyWith =>
+  _$$GetSiteResponseImplCopyWith<_$GetSiteResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/site/get_site_response.g.dart
+++ b/lib/src/v3/models/site/get_site_response.g.dart
@@ -6,8 +6,9 @@ part of 'get_site_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetSiteResponse _$$_GetSiteResponseFromJson(Map<String, dynamic> json) =>
-    _$_GetSiteResponse(
+_$GetSiteResponseImpl _$$GetSiteResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$GetSiteResponseImpl(
       siteView: SiteView.fromJson(json['site_view'] as Map<String, dynamic>),
       admins: (json['admins'] as List<dynamic>)
           .map((e) => PersonView.fromJson(e as Map<String, dynamic>))
@@ -30,7 +31,8 @@ _$_GetSiteResponse _$$_GetSiteResponseFromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
-Map<String, dynamic> _$$_GetSiteResponseToJson(_$_GetSiteResponse instance) =>
+Map<String, dynamic> _$$GetSiteResponseImplToJson(
+        _$GetSiteResponseImpl instance) =>
     <String, dynamic>{
       'site_view': instance.siteView.toJson(),
       'admins': instance.admins.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/models/site/local_site.dart
+++ b/lib/src/v3/models/site/local_site.dart
@@ -34,6 +34,7 @@ class LocalSite with _$LocalSite {
     DateTime? updated,
     required RegistrationMode registrationMode,
     required bool reportsEmailAdmins,
+    bool? federationSignedFetch, // Only available in lemmy v0.19.0 and above
   }) = _LocalSite;
 
   const LocalSite._();

--- a/lib/src/v3/models/site/local_site.freezed.dart
+++ b/lib/src/v3/models/site/local_site.freezed.dart
@@ -43,6 +43,7 @@ mixin _$LocalSite {
   DateTime? get updated => throw _privateConstructorUsedError;
   RegistrationMode get registrationMode => throw _privateConstructorUsedError;
   bool get reportsEmailAdmins => throw _privateConstructorUsedError;
+  bool? get federationSignedFetch => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -78,7 +79,8 @@ abstract class $LocalSiteCopyWith<$Res> {
       DateTime published,
       DateTime? updated,
       RegistrationMode registrationMode,
-      bool reportsEmailAdmins});
+      bool reportsEmailAdmins,
+      bool? federationSignedFetch});
 }
 
 /// @nodoc
@@ -117,6 +119,7 @@ class _$LocalSiteCopyWithImpl<$Res, $Val extends LocalSite>
     Object? updated = freezed,
     Object? registrationMode = null,
     Object? reportsEmailAdmins = null,
+    Object? federationSignedFetch = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -211,15 +214,20 @@ class _$LocalSiteCopyWithImpl<$Res, $Val extends LocalSite>
           ? _value.reportsEmailAdmins
           : reportsEmailAdmins // ignore: cast_nullable_to_non_nullable
               as bool,
+      federationSignedFetch: freezed == federationSignedFetch
+          ? _value.federationSignedFetch
+          : federationSignedFetch // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ) as $Val);
   }
 }
 
 /// @nodoc
-abstract class _$$_LocalSiteCopyWith<$Res> implements $LocalSiteCopyWith<$Res> {
-  factory _$$_LocalSiteCopyWith(
-          _$_LocalSite value, $Res Function(_$_LocalSite) then) =
-      __$$_LocalSiteCopyWithImpl<$Res>;
+abstract class _$$LocalSiteImplCopyWith<$Res>
+    implements $LocalSiteCopyWith<$Res> {
+  factory _$$LocalSiteImplCopyWith(
+          _$LocalSiteImpl value, $Res Function(_$LocalSiteImpl) then) =
+      __$$LocalSiteImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -245,15 +253,16 @@ abstract class _$$_LocalSiteCopyWith<$Res> implements $LocalSiteCopyWith<$Res> {
       DateTime published,
       DateTime? updated,
       RegistrationMode registrationMode,
-      bool reportsEmailAdmins});
+      bool reportsEmailAdmins,
+      bool? federationSignedFetch});
 }
 
 /// @nodoc
-class __$$_LocalSiteCopyWithImpl<$Res>
-    extends _$LocalSiteCopyWithImpl<$Res, _$_LocalSite>
-    implements _$$_LocalSiteCopyWith<$Res> {
-  __$$_LocalSiteCopyWithImpl(
-      _$_LocalSite _value, $Res Function(_$_LocalSite) _then)
+class __$$LocalSiteImplCopyWithImpl<$Res>
+    extends _$LocalSiteCopyWithImpl<$Res, _$LocalSiteImpl>
+    implements _$$LocalSiteImplCopyWith<$Res> {
+  __$$LocalSiteImplCopyWithImpl(
+      _$LocalSiteImpl _value, $Res Function(_$LocalSiteImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -282,8 +291,9 @@ class __$$_LocalSiteCopyWithImpl<$Res>
     Object? updated = freezed,
     Object? registrationMode = null,
     Object? reportsEmailAdmins = null,
+    Object? federationSignedFetch = freezed,
   }) {
-    return _then(_$_LocalSite(
+    return _then(_$LocalSiteImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -376,6 +386,10 @@ class __$$_LocalSiteCopyWithImpl<$Res>
           ? _value.reportsEmailAdmins
           : reportsEmailAdmins // ignore: cast_nullable_to_non_nullable
               as bool,
+      federationSignedFetch: freezed == federationSignedFetch
+          ? _value.federationSignedFetch
+          : federationSignedFetch // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ));
   }
 }
@@ -383,8 +397,8 @@ class __$$_LocalSiteCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_LocalSite extends _LocalSite {
-  const _$_LocalSite(
+class _$LocalSiteImpl extends _LocalSite {
+  const _$LocalSiteImpl(
       {required this.id,
       required this.siteId,
       required this.siteSetup,
@@ -407,11 +421,12 @@ class _$_LocalSite extends _LocalSite {
       required this.published,
       this.updated,
       required this.registrationMode,
-      required this.reportsEmailAdmins})
+      required this.reportsEmailAdmins,
+      this.federationSignedFetch})
       : super._();
 
-  factory _$_LocalSite.fromJson(Map<String, dynamic> json) =>
-      _$$_LocalSiteFromJson(json);
+  factory _$LocalSiteImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LocalSiteImplFromJson(json);
 
   @override
   final int id;
@@ -459,17 +474,19 @@ class _$_LocalSite extends _LocalSite {
   final RegistrationMode registrationMode;
   @override
   final bool reportsEmailAdmins;
+  @override
+  final bool? federationSignedFetch;
 
   @override
   String toString() {
-    return 'LocalSite(id: $id, siteId: $siteId, siteSetup: $siteSetup, enableDownvotes: $enableDownvotes, enableNsfw: $enableNsfw, communityCreationAdminOnly: $communityCreationAdminOnly, requireEmailVerification: $requireEmailVerification, applicationQuestion: $applicationQuestion, privateInstance: $privateInstance, defaultTheme: $defaultTheme, defaultPostListingType: $defaultPostListingType, legalInformation: $legalInformation, hideModlogModNames: $hideModlogModNames, applicationEmailAdmins: $applicationEmailAdmins, slurFilterRegex: $slurFilterRegex, actorNameMaxLength: $actorNameMaxLength, federationEnabled: $federationEnabled, captchaEnabled: $captchaEnabled, captchaDifficulty: $captchaDifficulty, published: $published, updated: $updated, registrationMode: $registrationMode, reportsEmailAdmins: $reportsEmailAdmins)';
+    return 'LocalSite(id: $id, siteId: $siteId, siteSetup: $siteSetup, enableDownvotes: $enableDownvotes, enableNsfw: $enableNsfw, communityCreationAdminOnly: $communityCreationAdminOnly, requireEmailVerification: $requireEmailVerification, applicationQuestion: $applicationQuestion, privateInstance: $privateInstance, defaultTheme: $defaultTheme, defaultPostListingType: $defaultPostListingType, legalInformation: $legalInformation, hideModlogModNames: $hideModlogModNames, applicationEmailAdmins: $applicationEmailAdmins, slurFilterRegex: $slurFilterRegex, actorNameMaxLength: $actorNameMaxLength, federationEnabled: $federationEnabled, captchaEnabled: $captchaEnabled, captchaDifficulty: $captchaDifficulty, published: $published, updated: $updated, registrationMode: $registrationMode, reportsEmailAdmins: $reportsEmailAdmins, federationSignedFetch: $federationSignedFetch)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LocalSite &&
+            other is _$LocalSiteImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.siteId, siteId) || other.siteId == siteId) &&
             (identical(other.siteSetup, siteSetup) ||
@@ -515,7 +532,9 @@ class _$_LocalSite extends _LocalSite {
             (identical(other.registrationMode, registrationMode) ||
                 other.registrationMode == registrationMode) &&
             (identical(other.reportsEmailAdmins, reportsEmailAdmins) ||
-                other.reportsEmailAdmins == reportsEmailAdmins));
+                other.reportsEmailAdmins == reportsEmailAdmins) &&
+            (identical(other.federationSignedFetch, federationSignedFetch) ||
+                other.federationSignedFetch == federationSignedFetch));
   }
 
   @JsonKey(ignore: true)
@@ -544,18 +563,19 @@ class _$_LocalSite extends _LocalSite {
         published,
         updated,
         registrationMode,
-        reportsEmailAdmins
+        reportsEmailAdmins,
+        federationSignedFetch
       ]);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LocalSiteCopyWith<_$_LocalSite> get copyWith =>
-      __$$_LocalSiteCopyWithImpl<_$_LocalSite>(this, _$identity);
+  _$$LocalSiteImplCopyWith<_$LocalSiteImpl> get copyWith =>
+      __$$LocalSiteImplCopyWithImpl<_$LocalSiteImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LocalSiteToJson(
+    return _$$LocalSiteImplToJson(
       this,
     );
   }
@@ -585,11 +605,12 @@ abstract class _LocalSite extends LocalSite {
       required final DateTime published,
       final DateTime? updated,
       required final RegistrationMode registrationMode,
-      required final bool reportsEmailAdmins}) = _$_LocalSite;
+      required final bool reportsEmailAdmins,
+      final bool? federationSignedFetch}) = _$LocalSiteImpl;
   const _LocalSite._() : super._();
 
   factory _LocalSite.fromJson(Map<String, dynamic> json) =
-      _$_LocalSite.fromJson;
+      _$LocalSiteImpl.fromJson;
 
   @override
   int get id;
@@ -638,7 +659,9 @@ abstract class _LocalSite extends LocalSite {
   @override
   bool get reportsEmailAdmins;
   @override
+  bool? get federationSignedFetch;
+  @override
   @JsonKey(ignore: true)
-  _$$_LocalSiteCopyWith<_$_LocalSite> get copyWith =>
+  _$$LocalSiteImplCopyWith<_$LocalSiteImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/site/local_site.g.dart
+++ b/lib/src/v3/models/site/local_site.g.dart
@@ -6,7 +6,8 @@ part of 'local_site.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LocalSite _$$_LocalSiteFromJson(Map<String, dynamic> json) => _$_LocalSite(
+_$LocalSiteImpl _$$LocalSiteImplFromJson(Map<String, dynamic> json) =>
+    _$LocalSiteImpl(
       id: json['id'] as int,
       siteId: json['site_id'] as int,
       siteSetup: json['site_setup'] as bool,
@@ -33,9 +34,10 @@ _$_LocalSite _$$_LocalSiteFromJson(Map<String, dynamic> json) => _$_LocalSite(
       registrationMode:
           RegistrationMode.fromJson(json['registration_mode'] as String),
       reportsEmailAdmins: json['reports_email_admins'] as bool,
+      federationSignedFetch: json['federation_signed_fetch'] as bool?,
     );
 
-Map<String, dynamic> _$$_LocalSiteToJson(_$_LocalSite instance) =>
+Map<String, dynamic> _$$LocalSiteImplToJson(_$LocalSiteImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'site_id': instance.siteId,
@@ -61,6 +63,7 @@ Map<String, dynamic> _$$_LocalSiteToJson(_$_LocalSite instance) =>
           instance.updated, const ForceUtcDateTime().toJson),
       'registration_mode': instance.registrationMode.toJson(),
       'reports_email_admins': instance.reportsEmailAdmins,
+      'federation_signed_fetch': instance.federationSignedFetch,
     };
 
 Value? _$JsonConverterFromJson<Json, Value>(

--- a/lib/src/v3/models/site/local_site_rate_limit.dart
+++ b/lib/src/v3/models/site/local_site_rate_limit.dart
@@ -10,7 +10,7 @@ part 'local_site_rate_limit.g.dart';
 class LocalSiteRateLimit with _$LocalSiteRateLimit {
   @modelSerde
   const factory LocalSiteRateLimit({
-    required int id,
+    @deprecated int? id,
     required int localSiteId,
     required int message,
     required int messagePerSecond,

--- a/lib/src/v3/models/site/local_site_rate_limit.freezed.dart
+++ b/lib/src/v3/models/site/local_site_rate_limit.freezed.dart
@@ -20,7 +20,8 @@ LocalSiteRateLimit _$LocalSiteRateLimitFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$LocalSiteRateLimit {
-  int get id => throw _privateConstructorUsedError;
+  @deprecated
+  int? get id => throw _privateConstructorUsedError;
   int get localSiteId => throw _privateConstructorUsedError;
   int get message => throw _privateConstructorUsedError;
   int get messagePerSecond => throw _privateConstructorUsedError;
@@ -53,7 +54,7 @@ abstract class $LocalSiteRateLimitCopyWith<$Res> {
       _$LocalSiteRateLimitCopyWithImpl<$Res, LocalSiteRateLimit>;
   @useResult
   $Res call(
-      {int id,
+      {@deprecated int? id,
       int localSiteId,
       int message,
       int messagePerSecond,
@@ -86,7 +87,7 @@ class _$LocalSiteRateLimitCopyWithImpl<$Res, $Val extends LocalSiteRateLimit>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? localSiteId = null,
     Object? message = null,
     Object? messagePerSecond = null,
@@ -106,10 +107,10 @@ class _$LocalSiteRateLimitCopyWithImpl<$Res, $Val extends LocalSiteRateLimit>
     Object? importUserSettingsPerSecond = freezed,
   }) {
     return _then(_value.copyWith(
-      id: null == id
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       localSiteId: null == localSiteId
           ? _value.localSiteId
           : localSiteId // ignore: cast_nullable_to_non_nullable
@@ -183,15 +184,15 @@ class _$LocalSiteRateLimitCopyWithImpl<$Res, $Val extends LocalSiteRateLimit>
 }
 
 /// @nodoc
-abstract class _$$_LocalSiteRateLimitCopyWith<$Res>
+abstract class _$$LocalSiteRateLimitImplCopyWith<$Res>
     implements $LocalSiteRateLimitCopyWith<$Res> {
-  factory _$$_LocalSiteRateLimitCopyWith(_$_LocalSiteRateLimit value,
-          $Res Function(_$_LocalSiteRateLimit) then) =
-      __$$_LocalSiteRateLimitCopyWithImpl<$Res>;
+  factory _$$LocalSiteRateLimitImplCopyWith(_$LocalSiteRateLimitImpl value,
+          $Res Function(_$LocalSiteRateLimitImpl) then) =
+      __$$LocalSiteRateLimitImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
-      {int id,
+      {@deprecated int? id,
       int localSiteId,
       int message,
       int messagePerSecond,
@@ -212,17 +213,17 @@ abstract class _$$_LocalSiteRateLimitCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_LocalSiteRateLimitCopyWithImpl<$Res>
-    extends _$LocalSiteRateLimitCopyWithImpl<$Res, _$_LocalSiteRateLimit>
-    implements _$$_LocalSiteRateLimitCopyWith<$Res> {
-  __$$_LocalSiteRateLimitCopyWithImpl(
-      _$_LocalSiteRateLimit _value, $Res Function(_$_LocalSiteRateLimit) _then)
+class __$$LocalSiteRateLimitImplCopyWithImpl<$Res>
+    extends _$LocalSiteRateLimitCopyWithImpl<$Res, _$LocalSiteRateLimitImpl>
+    implements _$$LocalSiteRateLimitImplCopyWith<$Res> {
+  __$$LocalSiteRateLimitImplCopyWithImpl(_$LocalSiteRateLimitImpl _value,
+      $Res Function(_$LocalSiteRateLimitImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? localSiteId = null,
     Object? message = null,
     Object? messagePerSecond = null,
@@ -241,11 +242,11 @@ class __$$_LocalSiteRateLimitCopyWithImpl<$Res>
     Object? importUserSettings = freezed,
     Object? importUserSettingsPerSecond = freezed,
   }) {
-    return _then(_$_LocalSiteRateLimit(
-      id: null == id
+    return _then(_$LocalSiteRateLimitImpl(
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       localSiteId: null == localSiteId
           ? _value.localSiteId
           : localSiteId // ignore: cast_nullable_to_non_nullable
@@ -321,9 +322,9 @@ class __$$_LocalSiteRateLimitCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_LocalSiteRateLimit extends _LocalSiteRateLimit {
-  const _$_LocalSiteRateLimit(
-      {required this.id,
+class _$LocalSiteRateLimitImpl extends _LocalSiteRateLimit {
+  const _$LocalSiteRateLimitImpl(
+      {@deprecated this.id,
       required this.localSiteId,
       required this.message,
       required this.messagePerSecond,
@@ -343,11 +344,12 @@ class _$_LocalSiteRateLimit extends _LocalSiteRateLimit {
       this.importUserSettingsPerSecond})
       : super._();
 
-  factory _$_LocalSiteRateLimit.fromJson(Map<String, dynamic> json) =>
-      _$$_LocalSiteRateLimitFromJson(json);
+  factory _$LocalSiteRateLimitImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LocalSiteRateLimitImplFromJson(json);
 
   @override
-  final int id;
+  @deprecated
+  final int? id;
   @override
   final int localSiteId;
   @override
@@ -393,7 +395,7 @@ class _$_LocalSiteRateLimit extends _LocalSiteRateLimit {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LocalSiteRateLimit &&
+            other is _$LocalSiteRateLimitImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.localSiteId, localSiteId) ||
                 other.localSiteId == localSiteId) &&
@@ -453,13 +455,13 @@ class _$_LocalSiteRateLimit extends _LocalSiteRateLimit {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LocalSiteRateLimitCopyWith<_$_LocalSiteRateLimit> get copyWith =>
-      __$$_LocalSiteRateLimitCopyWithImpl<_$_LocalSiteRateLimit>(
+  _$$LocalSiteRateLimitImplCopyWith<_$LocalSiteRateLimitImpl> get copyWith =>
+      __$$LocalSiteRateLimitImplCopyWithImpl<_$LocalSiteRateLimitImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LocalSiteRateLimitToJson(
+    return _$$LocalSiteRateLimitImplToJson(
       this,
     );
   }
@@ -467,7 +469,7 @@ class _$_LocalSiteRateLimit extends _LocalSiteRateLimit {
 
 abstract class _LocalSiteRateLimit extends LocalSiteRateLimit {
   const factory _LocalSiteRateLimit(
-      {required final int id,
+      {@deprecated final int? id,
       required final int localSiteId,
       required final int message,
       required final int messagePerSecond,
@@ -484,14 +486,15 @@ abstract class _LocalSiteRateLimit extends LocalSiteRateLimit {
       required final DateTime published,
       final DateTime? updated,
       final int? importUserSettings,
-      final int? importUserSettingsPerSecond}) = _$_LocalSiteRateLimit;
+      final int? importUserSettingsPerSecond}) = _$LocalSiteRateLimitImpl;
   const _LocalSiteRateLimit._() : super._();
 
   factory _LocalSiteRateLimit.fromJson(Map<String, dynamic> json) =
-      _$_LocalSiteRateLimit.fromJson;
+      _$LocalSiteRateLimitImpl.fromJson;
 
   @override
-  int get id;
+  @deprecated
+  int? get id;
   @override
   int get localSiteId;
   @override
@@ -528,6 +531,6 @@ abstract class _LocalSiteRateLimit extends LocalSiteRateLimit {
   int? get importUserSettingsPerSecond;
   @override
   @JsonKey(ignore: true)
-  _$$_LocalSiteRateLimitCopyWith<_$_LocalSiteRateLimit> get copyWith =>
+  _$$LocalSiteRateLimitImplCopyWith<_$LocalSiteRateLimitImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/site/local_site_rate_limit.g.dart
+++ b/lib/src/v3/models/site/local_site_rate_limit.g.dart
@@ -6,10 +6,10 @@ part of 'local_site_rate_limit.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LocalSiteRateLimit _$$_LocalSiteRateLimitFromJson(
+_$LocalSiteRateLimitImpl _$$LocalSiteRateLimitImplFromJson(
         Map<String, dynamic> json) =>
-    _$_LocalSiteRateLimit(
-      id: json['id'] as int,
+    _$LocalSiteRateLimitImpl(
+      id: json['id'] as int?,
       localSiteId: json['local_site_id'] as int,
       message: json['message'] as int,
       messagePerSecond: json['message_per_second'] as int,
@@ -31,8 +31,8 @@ _$_LocalSiteRateLimit _$$_LocalSiteRateLimitFromJson(
           json['import_user_settings_per_second'] as int?,
     );
 
-Map<String, dynamic> _$$_LocalSiteRateLimitToJson(
-        _$_LocalSiteRateLimit instance) =>
+Map<String, dynamic> _$$LocalSiteRateLimitImplToJson(
+        _$LocalSiteRateLimitImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'local_site_id': instance.localSiteId,

--- a/lib/src/v3/models/site/site_aggregates.dart
+++ b/lib/src/v3/models/site/site_aggregates.dart
@@ -9,7 +9,7 @@ part 'site_aggregates.g.dart';
 class SiteAggregates with _$SiteAggregates {
   @modelSerde
   const factory SiteAggregates({
-    required int id,
+    @deprecated int? id,
     required int siteId,
     required int users,
     required int posts,

--- a/lib/src/v3/models/site/site_aggregates.freezed.dart
+++ b/lib/src/v3/models/site/site_aggregates.freezed.dart
@@ -20,7 +20,8 @@ SiteAggregates _$SiteAggregatesFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$SiteAggregates {
-  int get id => throw _privateConstructorUsedError;
+  @deprecated
+  int? get id => throw _privateConstructorUsedError;
   int get siteId => throw _privateConstructorUsedError;
   int get users => throw _privateConstructorUsedError;
   int get posts => throw _privateConstructorUsedError;
@@ -44,7 +45,7 @@ abstract class $SiteAggregatesCopyWith<$Res> {
       _$SiteAggregatesCopyWithImpl<$Res, SiteAggregates>;
   @useResult
   $Res call(
-      {int id,
+      {@deprecated int? id,
       int siteId,
       int users,
       int posts,
@@ -69,7 +70,7 @@ class _$SiteAggregatesCopyWithImpl<$Res, $Val extends SiteAggregates>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? siteId = null,
     Object? users = null,
     Object? posts = null,
@@ -81,10 +82,10 @@ class _$SiteAggregatesCopyWithImpl<$Res, $Val extends SiteAggregates>
     Object? usersActiveHalfYear = null,
   }) {
     return _then(_value.copyWith(
-      id: null == id
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       siteId: null == siteId
           ? _value.siteId
           : siteId // ignore: cast_nullable_to_non_nullable
@@ -126,15 +127,15 @@ class _$SiteAggregatesCopyWithImpl<$Res, $Val extends SiteAggregates>
 }
 
 /// @nodoc
-abstract class _$$_SiteAggregatesCopyWith<$Res>
+abstract class _$$SiteAggregatesImplCopyWith<$Res>
     implements $SiteAggregatesCopyWith<$Res> {
-  factory _$$_SiteAggregatesCopyWith(
-          _$_SiteAggregates value, $Res Function(_$_SiteAggregates) then) =
-      __$$_SiteAggregatesCopyWithImpl<$Res>;
+  factory _$$SiteAggregatesImplCopyWith(_$SiteAggregatesImpl value,
+          $Res Function(_$SiteAggregatesImpl) then) =
+      __$$SiteAggregatesImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
-      {int id,
+      {@deprecated int? id,
       int siteId,
       int users,
       int posts,
@@ -147,17 +148,17 @@ abstract class _$$_SiteAggregatesCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_SiteAggregatesCopyWithImpl<$Res>
-    extends _$SiteAggregatesCopyWithImpl<$Res, _$_SiteAggregates>
-    implements _$$_SiteAggregatesCopyWith<$Res> {
-  __$$_SiteAggregatesCopyWithImpl(
-      _$_SiteAggregates _value, $Res Function(_$_SiteAggregates) _then)
+class __$$SiteAggregatesImplCopyWithImpl<$Res>
+    extends _$SiteAggregatesCopyWithImpl<$Res, _$SiteAggregatesImpl>
+    implements _$$SiteAggregatesImplCopyWith<$Res> {
+  __$$SiteAggregatesImplCopyWithImpl(
+      _$SiteAggregatesImpl _value, $Res Function(_$SiteAggregatesImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = null,
+    Object? id = freezed,
     Object? siteId = null,
     Object? users = null,
     Object? posts = null,
@@ -168,11 +169,11 @@ class __$$_SiteAggregatesCopyWithImpl<$Res>
     Object? usersActiveMonth = null,
     Object? usersActiveHalfYear = null,
   }) {
-    return _then(_$_SiteAggregates(
-      id: null == id
+    return _then(_$SiteAggregatesImpl(
+      id: freezed == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       siteId: null == siteId
           ? _value.siteId
           : siteId // ignore: cast_nullable_to_non_nullable
@@ -216,9 +217,9 @@ class __$$_SiteAggregatesCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_SiteAggregates extends _SiteAggregates {
-  const _$_SiteAggregates(
-      {required this.id,
+class _$SiteAggregatesImpl extends _SiteAggregates {
+  const _$SiteAggregatesImpl(
+      {@deprecated this.id,
       required this.siteId,
       required this.users,
       required this.posts,
@@ -230,11 +231,12 @@ class _$_SiteAggregates extends _SiteAggregates {
       required this.usersActiveHalfYear})
       : super._();
 
-  factory _$_SiteAggregates.fromJson(Map<String, dynamic> json) =>
-      _$$_SiteAggregatesFromJson(json);
+  factory _$SiteAggregatesImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SiteAggregatesImplFromJson(json);
 
   @override
-  final int id;
+  @deprecated
+  final int? id;
   @override
   final int siteId;
   @override
@@ -263,7 +265,7 @@ class _$_SiteAggregates extends _SiteAggregates {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SiteAggregates &&
+            other is _$SiteAggregatesImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.siteId, siteId) || other.siteId == siteId) &&
             (identical(other.users, users) || other.users == users) &&
@@ -300,12 +302,13 @@ class _$_SiteAggregates extends _SiteAggregates {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SiteAggregatesCopyWith<_$_SiteAggregates> get copyWith =>
-      __$$_SiteAggregatesCopyWithImpl<_$_SiteAggregates>(this, _$identity);
+  _$$SiteAggregatesImplCopyWith<_$SiteAggregatesImpl> get copyWith =>
+      __$$SiteAggregatesImplCopyWithImpl<_$SiteAggregatesImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SiteAggregatesToJson(
+    return _$$SiteAggregatesImplToJson(
       this,
     );
   }
@@ -313,7 +316,7 @@ class _$_SiteAggregates extends _SiteAggregates {
 
 abstract class _SiteAggregates extends SiteAggregates {
   const factory _SiteAggregates(
-      {required final int id,
+      {@deprecated final int? id,
       required final int siteId,
       required final int users,
       required final int posts,
@@ -322,14 +325,15 @@ abstract class _SiteAggregates extends SiteAggregates {
       required final int usersActiveDay,
       required final int usersActiveWeek,
       required final int usersActiveMonth,
-      required final int usersActiveHalfYear}) = _$_SiteAggregates;
+      required final int usersActiveHalfYear}) = _$SiteAggregatesImpl;
   const _SiteAggregates._() : super._();
 
   factory _SiteAggregates.fromJson(Map<String, dynamic> json) =
-      _$_SiteAggregates.fromJson;
+      _$SiteAggregatesImpl.fromJson;
 
   @override
-  int get id;
+  @deprecated
+  int? get id;
   @override
   int get siteId;
   @override
@@ -350,6 +354,6 @@ abstract class _SiteAggregates extends SiteAggregates {
   int get usersActiveHalfYear;
   @override
   @JsonKey(ignore: true)
-  _$$_SiteAggregatesCopyWith<_$_SiteAggregates> get copyWith =>
+  _$$SiteAggregatesImplCopyWith<_$SiteAggregatesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/site/site_aggregates.g.dart
+++ b/lib/src/v3/models/site/site_aggregates.g.dart
@@ -6,9 +6,9 @@ part of 'site_aggregates.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_SiteAggregates _$$_SiteAggregatesFromJson(Map<String, dynamic> json) =>
-    _$_SiteAggregates(
-      id: json['id'] as int,
+_$SiteAggregatesImpl _$$SiteAggregatesImplFromJson(Map<String, dynamic> json) =>
+    _$SiteAggregatesImpl(
+      id: json['id'] as int?,
       siteId: json['site_id'] as int,
       users: json['users'] as int,
       posts: json['posts'] as int,
@@ -20,7 +20,8 @@ _$_SiteAggregates _$$_SiteAggregatesFromJson(Map<String, dynamic> json) =>
       usersActiveHalfYear: json['users_active_half_year'] as int,
     );
 
-Map<String, dynamic> _$$_SiteAggregatesToJson(_$_SiteAggregates instance) =>
+Map<String, dynamic> _$$SiteAggregatesImplToJson(
+        _$SiteAggregatesImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'site_id': instance.siteId,

--- a/lib/src/v3/models/site/site_metadata.freezed.dart
+++ b/lib/src/v3/models/site/site_metadata.freezed.dart
@@ -84,11 +84,11 @@ class _$SiteMetadataCopyWithImpl<$Res, $Val extends SiteMetadata>
 }
 
 /// @nodoc
-abstract class _$$_SiteMetadataCopyWith<$Res>
+abstract class _$$SiteMetadataImplCopyWith<$Res>
     implements $SiteMetadataCopyWith<$Res> {
-  factory _$$_SiteMetadataCopyWith(
-          _$_SiteMetadata value, $Res Function(_$_SiteMetadata) then) =
-      __$$_SiteMetadataCopyWithImpl<$Res>;
+  factory _$$SiteMetadataImplCopyWith(
+          _$SiteMetadataImpl value, $Res Function(_$SiteMetadataImpl) then) =
+      __$$SiteMetadataImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -99,11 +99,11 @@ abstract class _$$_SiteMetadataCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_SiteMetadataCopyWithImpl<$Res>
-    extends _$SiteMetadataCopyWithImpl<$Res, _$_SiteMetadata>
-    implements _$$_SiteMetadataCopyWith<$Res> {
-  __$$_SiteMetadataCopyWithImpl(
-      _$_SiteMetadata _value, $Res Function(_$_SiteMetadata) _then)
+class __$$SiteMetadataImplCopyWithImpl<$Res>
+    extends _$SiteMetadataCopyWithImpl<$Res, _$SiteMetadataImpl>
+    implements _$$SiteMetadataImplCopyWith<$Res> {
+  __$$SiteMetadataImplCopyWithImpl(
+      _$SiteMetadataImpl _value, $Res Function(_$SiteMetadataImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -114,7 +114,7 @@ class __$$_SiteMetadataCopyWithImpl<$Res>
     Object? image = freezed,
     Object? embedVideoUrl = freezed,
   }) {
-    return _then(_$_SiteMetadata(
+    return _then(_$SiteMetadataImpl(
       title: freezed == title
           ? _value.title
           : title // ignore: cast_nullable_to_non_nullable
@@ -138,13 +138,13 @@ class __$$_SiteMetadataCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_SiteMetadata extends _SiteMetadata {
-  const _$_SiteMetadata(
+class _$SiteMetadataImpl extends _SiteMetadata {
+  const _$SiteMetadataImpl(
       {this.title, this.description, this.image, this.embedVideoUrl})
       : super._();
 
-  factory _$_SiteMetadata.fromJson(Map<String, dynamic> json) =>
-      _$$_SiteMetadataFromJson(json);
+  factory _$SiteMetadataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SiteMetadataImplFromJson(json);
 
   @override
   final String? title;
@@ -164,7 +164,7 @@ class _$_SiteMetadata extends _SiteMetadata {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SiteMetadata &&
+            other is _$SiteMetadataImpl &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.description, description) ||
                 other.description == description) &&
@@ -181,12 +181,12 @@ class _$_SiteMetadata extends _SiteMetadata {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SiteMetadataCopyWith<_$_SiteMetadata> get copyWith =>
-      __$$_SiteMetadataCopyWithImpl<_$_SiteMetadata>(this, _$identity);
+  _$$SiteMetadataImplCopyWith<_$SiteMetadataImpl> get copyWith =>
+      __$$SiteMetadataImplCopyWithImpl<_$SiteMetadataImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SiteMetadataToJson(
+    return _$$SiteMetadataImplToJson(
       this,
     );
   }
@@ -197,11 +197,11 @@ abstract class _SiteMetadata extends SiteMetadata {
       {final String? title,
       final String? description,
       final String? image,
-      final String? embedVideoUrl}) = _$_SiteMetadata;
+      final String? embedVideoUrl}) = _$SiteMetadataImpl;
   const _SiteMetadata._() : super._();
 
   factory _SiteMetadata.fromJson(Map<String, dynamic> json) =
-      _$_SiteMetadata.fromJson;
+      _$SiteMetadataImpl.fromJson;
 
   @override
   String? get title;
@@ -213,6 +213,6 @@ abstract class _SiteMetadata extends SiteMetadata {
   String? get embedVideoUrl;
   @override
   @JsonKey(ignore: true)
-  _$$_SiteMetadataCopyWith<_$_SiteMetadata> get copyWith =>
+  _$$SiteMetadataImplCopyWith<_$SiteMetadataImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/site/site_metadata.g.dart
+++ b/lib/src/v3/models/site/site_metadata.g.dart
@@ -6,15 +6,15 @@ part of 'site_metadata.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_SiteMetadata _$$_SiteMetadataFromJson(Map<String, dynamic> json) =>
-    _$_SiteMetadata(
+_$SiteMetadataImpl _$$SiteMetadataImplFromJson(Map<String, dynamic> json) =>
+    _$SiteMetadataImpl(
       title: json['title'] as String?,
       description: json['description'] as String?,
       image: json['image'] as String?,
       embedVideoUrl: json['embed_video_url'] as String?,
     );
 
-Map<String, dynamic> _$$_SiteMetadataToJson(_$_SiteMetadata instance) =>
+Map<String, dynamic> _$$SiteMetadataImplToJson(_$SiteMetadataImpl instance) =>
     <String, dynamic>{
       'title': instance.title,
       'description': instance.description,

--- a/lib/src/v3/models/site/site_response.freezed.dart
+++ b/lib/src/v3/models/site/site_response.freezed.dart
@@ -78,11 +78,11 @@ class _$SiteResponseCopyWithImpl<$Res, $Val extends SiteResponse>
 }
 
 /// @nodoc
-abstract class _$$_SiteResponseCopyWith<$Res>
+abstract class _$$SiteResponseImplCopyWith<$Res>
     implements $SiteResponseCopyWith<$Res> {
-  factory _$$_SiteResponseCopyWith(
-          _$_SiteResponse value, $Res Function(_$_SiteResponse) then) =
-      __$$_SiteResponseCopyWithImpl<$Res>;
+  factory _$$SiteResponseImplCopyWith(
+          _$SiteResponseImpl value, $Res Function(_$SiteResponseImpl) then) =
+      __$$SiteResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({SiteView siteView, List<Tagline> taglines});
@@ -92,11 +92,11 @@ abstract class _$$_SiteResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_SiteResponseCopyWithImpl<$Res>
-    extends _$SiteResponseCopyWithImpl<$Res, _$_SiteResponse>
-    implements _$$_SiteResponseCopyWith<$Res> {
-  __$$_SiteResponseCopyWithImpl(
-      _$_SiteResponse _value, $Res Function(_$_SiteResponse) _then)
+class __$$SiteResponseImplCopyWithImpl<$Res>
+    extends _$SiteResponseCopyWithImpl<$Res, _$SiteResponseImpl>
+    implements _$$SiteResponseImplCopyWith<$Res> {
+  __$$SiteResponseImplCopyWithImpl(
+      _$SiteResponseImpl _value, $Res Function(_$SiteResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -105,7 +105,7 @@ class __$$_SiteResponseCopyWithImpl<$Res>
     Object? siteView = null,
     Object? taglines = null,
   }) {
-    return _then(_$_SiteResponse(
+    return _then(_$SiteResponseImpl(
       siteView: null == siteView
           ? _value.siteView
           : siteView // ignore: cast_nullable_to_non_nullable
@@ -121,14 +121,14 @@ class __$$_SiteResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_SiteResponse extends _SiteResponse {
-  const _$_SiteResponse(
+class _$SiteResponseImpl extends _SiteResponse {
+  const _$SiteResponseImpl(
       {required this.siteView, required final List<Tagline> taglines})
       : _taglines = taglines,
         super._();
 
-  factory _$_SiteResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_SiteResponseFromJson(json);
+  factory _$SiteResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SiteResponseImplFromJson(json);
 
   @override
   final SiteView siteView;
@@ -149,7 +149,7 @@ class _$_SiteResponse extends _SiteResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SiteResponse &&
+            other is _$SiteResponseImpl &&
             (identical(other.siteView, siteView) ||
                 other.siteView == siteView) &&
             const DeepCollectionEquality().equals(other._taglines, _taglines));
@@ -163,12 +163,12 @@ class _$_SiteResponse extends _SiteResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SiteResponseCopyWith<_$_SiteResponse> get copyWith =>
-      __$$_SiteResponseCopyWithImpl<_$_SiteResponse>(this, _$identity);
+  _$$SiteResponseImplCopyWith<_$SiteResponseImpl> get copyWith =>
+      __$$SiteResponseImplCopyWithImpl<_$SiteResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SiteResponseToJson(
+    return _$$SiteResponseImplToJson(
       this,
     );
   }
@@ -177,11 +177,11 @@ class _$_SiteResponse extends _SiteResponse {
 abstract class _SiteResponse extends SiteResponse {
   const factory _SiteResponse(
       {required final SiteView siteView,
-      required final List<Tagline> taglines}) = _$_SiteResponse;
+      required final List<Tagline> taglines}) = _$SiteResponseImpl;
   const _SiteResponse._() : super._();
 
   factory _SiteResponse.fromJson(Map<String, dynamic> json) =
-      _$_SiteResponse.fromJson;
+      _$SiteResponseImpl.fromJson;
 
   @override
   SiteView get siteView;
@@ -189,6 +189,6 @@ abstract class _SiteResponse extends SiteResponse {
   List<Tagline> get taglines;
   @override
   @JsonKey(ignore: true)
-  _$$_SiteResponseCopyWith<_$_SiteResponse> get copyWith =>
+  _$$SiteResponseImplCopyWith<_$SiteResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/site/site_response.g.dart
+++ b/lib/src/v3/models/site/site_response.g.dart
@@ -6,15 +6,15 @@ part of 'site_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_SiteResponse _$$_SiteResponseFromJson(Map<String, dynamic> json) =>
-    _$_SiteResponse(
+_$SiteResponseImpl _$$SiteResponseImplFromJson(Map<String, dynamic> json) =>
+    _$SiteResponseImpl(
       siteView: SiteView.fromJson(json['site_view'] as Map<String, dynamic>),
       taglines: (json['taglines'] as List<dynamic>)
           .map((e) => Tagline.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$_SiteResponseToJson(_$_SiteResponse instance) =>
+Map<String, dynamic> _$$SiteResponseImplToJson(_$SiteResponseImpl instance) =>
     <String, dynamic>{
       'site_view': instance.siteView.toJson(),
       'taglines': instance.taglines.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/models/site/site_view.freezed.dart
+++ b/lib/src/v3/models/site/site_view.freezed.dart
@@ -122,10 +122,11 @@ class _$SiteViewCopyWithImpl<$Res, $Val extends SiteView>
 }
 
 /// @nodoc
-abstract class _$$_SiteViewCopyWith<$Res> implements $SiteViewCopyWith<$Res> {
-  factory _$$_SiteViewCopyWith(
-          _$_SiteView value, $Res Function(_$_SiteView) then) =
-      __$$_SiteViewCopyWithImpl<$Res>;
+abstract class _$$SiteViewImplCopyWith<$Res>
+    implements $SiteViewCopyWith<$Res> {
+  factory _$$SiteViewImplCopyWith(
+          _$SiteViewImpl value, $Res Function(_$SiteViewImpl) then) =
+      __$$SiteViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -145,11 +146,11 @@ abstract class _$$_SiteViewCopyWith<$Res> implements $SiteViewCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_SiteViewCopyWithImpl<$Res>
-    extends _$SiteViewCopyWithImpl<$Res, _$_SiteView>
-    implements _$$_SiteViewCopyWith<$Res> {
-  __$$_SiteViewCopyWithImpl(
-      _$_SiteView _value, $Res Function(_$_SiteView) _then)
+class __$$SiteViewImplCopyWithImpl<$Res>
+    extends _$SiteViewCopyWithImpl<$Res, _$SiteViewImpl>
+    implements _$$SiteViewImplCopyWith<$Res> {
+  __$$SiteViewImplCopyWithImpl(
+      _$SiteViewImpl _value, $Res Function(_$SiteViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -160,7 +161,7 @@ class __$$_SiteViewCopyWithImpl<$Res>
     Object? localSiteRateLimit = null,
     Object? counts = null,
   }) {
-    return _then(_$_SiteView(
+    return _then(_$SiteViewImpl(
       site: null == site
           ? _value.site
           : site // ignore: cast_nullable_to_non_nullable
@@ -184,16 +185,16 @@ class __$$_SiteViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_SiteView extends _SiteView {
-  const _$_SiteView(
+class _$SiteViewImpl extends _SiteView {
+  const _$SiteViewImpl(
       {required this.site,
       required this.localSite,
       required this.localSiteRateLimit,
       required this.counts})
       : super._();
 
-  factory _$_SiteView.fromJson(Map<String, dynamic> json) =>
-      _$$_SiteViewFromJson(json);
+  factory _$SiteViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SiteViewImplFromJson(json);
 
   @override
   final Site site;
@@ -213,7 +214,7 @@ class _$_SiteView extends _SiteView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SiteView &&
+            other is _$SiteViewImpl &&
             (identical(other.site, site) || other.site == site) &&
             (identical(other.localSite, localSite) ||
                 other.localSite == localSite) &&
@@ -230,12 +231,12 @@ class _$_SiteView extends _SiteView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SiteViewCopyWith<_$_SiteView> get copyWith =>
-      __$$_SiteViewCopyWithImpl<_$_SiteView>(this, _$identity);
+  _$$SiteViewImplCopyWith<_$SiteViewImpl> get copyWith =>
+      __$$SiteViewImplCopyWithImpl<_$SiteViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SiteViewToJson(
+    return _$$SiteViewImplToJson(
       this,
     );
   }
@@ -246,10 +247,11 @@ abstract class _SiteView extends SiteView {
       {required final Site site,
       required final LocalSite localSite,
       required final LocalSiteRateLimit localSiteRateLimit,
-      required final SiteAggregates counts}) = _$_SiteView;
+      required final SiteAggregates counts}) = _$SiteViewImpl;
   const _SiteView._() : super._();
 
-  factory _SiteView.fromJson(Map<String, dynamic> json) = _$_SiteView.fromJson;
+  factory _SiteView.fromJson(Map<String, dynamic> json) =
+      _$SiteViewImpl.fromJson;
 
   @override
   Site get site;
@@ -261,6 +263,6 @@ abstract class _SiteView extends SiteView {
   SiteAggregates get counts;
   @override
   @JsonKey(ignore: true)
-  _$$_SiteViewCopyWith<_$_SiteView> get copyWith =>
+  _$$SiteViewImplCopyWith<_$SiteViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/site/site_view.g.dart
+++ b/lib/src/v3/models/site/site_view.g.dart
@@ -6,7 +6,8 @@ part of 'site_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_SiteView _$$_SiteViewFromJson(Map<String, dynamic> json) => _$_SiteView(
+_$SiteViewImpl _$$SiteViewImplFromJson(Map<String, dynamic> json) =>
+    _$SiteViewImpl(
       site: Site.fromJson(json['site'] as Map<String, dynamic>),
       localSite: LocalSite.fromJson(json['local_site'] as Map<String, dynamic>),
       localSiteRateLimit: LocalSiteRateLimit.fromJson(
@@ -14,7 +15,7 @@ _$_SiteView _$$_SiteViewFromJson(Map<String, dynamic> json) => _$_SiteView(
       counts: SiteAggregates.fromJson(json['counts'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_SiteViewToJson(_$_SiteView instance) =>
+Map<String, dynamic> _$$SiteViewImplToJson(_$SiteViewImpl instance) =>
     <String, dynamic>{
       'site': instance.site.toJson(),
       'local_site': instance.localSite.toJson(),

--- a/lib/src/v3/models/tagline/tagline.freezed.dart
+++ b/lib/src/v3/models/tagline/tagline.freezed.dart
@@ -89,10 +89,10 @@ class _$TaglineCopyWithImpl<$Res, $Val extends Tagline>
 }
 
 /// @nodoc
-abstract class _$$_TaglineCopyWith<$Res> implements $TaglineCopyWith<$Res> {
-  factory _$$_TaglineCopyWith(
-          _$_Tagline value, $Res Function(_$_Tagline) then) =
-      __$$_TaglineCopyWithImpl<$Res>;
+abstract class _$$TaglineImplCopyWith<$Res> implements $TaglineCopyWith<$Res> {
+  factory _$$TaglineImplCopyWith(
+          _$TaglineImpl value, $Res Function(_$TaglineImpl) then) =
+      __$$TaglineImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -104,10 +104,11 @@ abstract class _$$_TaglineCopyWith<$Res> implements $TaglineCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_TaglineCopyWithImpl<$Res>
-    extends _$TaglineCopyWithImpl<$Res, _$_Tagline>
-    implements _$$_TaglineCopyWith<$Res> {
-  __$$_TaglineCopyWithImpl(_$_Tagline _value, $Res Function(_$_Tagline) _then)
+class __$$TaglineImplCopyWithImpl<$Res>
+    extends _$TaglineCopyWithImpl<$Res, _$TaglineImpl>
+    implements _$$TaglineImplCopyWith<$Res> {
+  __$$TaglineImplCopyWithImpl(
+      _$TaglineImpl _value, $Res Function(_$TaglineImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -119,7 +120,7 @@ class __$$_TaglineCopyWithImpl<$Res>
     Object? published = null,
     Object? updated = freezed,
   }) {
-    return _then(_$_Tagline(
+    return _then(_$TaglineImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -147,8 +148,8 @@ class __$$_TaglineCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_Tagline extends _Tagline {
-  const _$_Tagline(
+class _$TaglineImpl extends _Tagline {
+  const _$TaglineImpl(
       {required this.id,
       required this.localSiteId,
       required this.content,
@@ -156,8 +157,8 @@ class _$_Tagline extends _Tagline {
       this.updated})
       : super._();
 
-  factory _$_Tagline.fromJson(Map<String, dynamic> json) =>
-      _$$_TaglineFromJson(json);
+  factory _$TaglineImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TaglineImplFromJson(json);
 
   @override
   final int id;
@@ -179,7 +180,7 @@ class _$_Tagline extends _Tagline {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Tagline &&
+            other is _$TaglineImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.localSiteId, localSiteId) ||
                 other.localSiteId == localSiteId) &&
@@ -197,12 +198,12 @@ class _$_Tagline extends _Tagline {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_TaglineCopyWith<_$_Tagline> get copyWith =>
-      __$$_TaglineCopyWithImpl<_$_Tagline>(this, _$identity);
+  _$$TaglineImplCopyWith<_$TaglineImpl> get copyWith =>
+      __$$TaglineImplCopyWithImpl<_$TaglineImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_TaglineToJson(
+    return _$$TaglineImplToJson(
       this,
     );
   }
@@ -214,10 +215,10 @@ abstract class _Tagline extends Tagline {
       required final int localSiteId,
       required final String content,
       required final DateTime published,
-      final DateTime? updated}) = _$_Tagline;
+      final DateTime? updated}) = _$TaglineImpl;
   const _Tagline._() : super._();
 
-  factory _Tagline.fromJson(Map<String, dynamic> json) = _$_Tagline.fromJson;
+  factory _Tagline.fromJson(Map<String, dynamic> json) = _$TaglineImpl.fromJson;
 
   @override
   int get id;
@@ -231,6 +232,6 @@ abstract class _Tagline extends Tagline {
   DateTime? get updated;
   @override
   @JsonKey(ignore: true)
-  _$$_TaglineCopyWith<_$_Tagline> get copyWith =>
+  _$$TaglineImplCopyWith<_$TaglineImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/tagline/tagline.g.dart
+++ b/lib/src/v3/models/tagline/tagline.g.dart
@@ -6,7 +6,8 @@ part of 'tagline.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Tagline _$$_TaglineFromJson(Map<String, dynamic> json) => _$_Tagline(
+_$TaglineImpl _$$TaglineImplFromJson(Map<String, dynamic> json) =>
+    _$TaglineImpl(
       id: json['id'] as int,
       localSiteId: json['local_site_id'] as int,
       content: json['content'] as String,
@@ -15,7 +16,7 @@ _$_Tagline _$$_TaglineFromJson(Map<String, dynamic> json) => _$_Tagline(
           json['updated'], const ForceUtcDateTime().fromJson),
     );
 
-Map<String, dynamic> _$$_TaglineToJson(_$_Tagline instance) =>
+Map<String, dynamic> _$$TaglineImplToJson(_$TaglineImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'local_site_id': instance.localSiteId,

--- a/lib/src/v3/models/user/ban_person_response.freezed.dart
+++ b/lib/src/v3/models/user/ban_person_response.freezed.dart
@@ -78,11 +78,11 @@ class _$BanPersonResponseCopyWithImpl<$Res, $Val extends BanPersonResponse>
 }
 
 /// @nodoc
-abstract class _$$_BanPersonResponseCopyWith<$Res>
+abstract class _$$BanPersonResponseImplCopyWith<$Res>
     implements $BanPersonResponseCopyWith<$Res> {
-  factory _$$_BanPersonResponseCopyWith(_$_BanPersonResponse value,
-          $Res Function(_$_BanPersonResponse) then) =
-      __$$_BanPersonResponseCopyWithImpl<$Res>;
+  factory _$$BanPersonResponseImplCopyWith(_$BanPersonResponseImpl value,
+          $Res Function(_$BanPersonResponseImpl) then) =
+      __$$BanPersonResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonView personView, bool banned});
@@ -92,11 +92,11 @@ abstract class _$$_BanPersonResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_BanPersonResponseCopyWithImpl<$Res>
-    extends _$BanPersonResponseCopyWithImpl<$Res, _$_BanPersonResponse>
-    implements _$$_BanPersonResponseCopyWith<$Res> {
-  __$$_BanPersonResponseCopyWithImpl(
-      _$_BanPersonResponse _value, $Res Function(_$_BanPersonResponse) _then)
+class __$$BanPersonResponseImplCopyWithImpl<$Res>
+    extends _$BanPersonResponseCopyWithImpl<$Res, _$BanPersonResponseImpl>
+    implements _$$BanPersonResponseImplCopyWith<$Res> {
+  __$$BanPersonResponseImplCopyWithImpl(_$BanPersonResponseImpl _value,
+      $Res Function(_$BanPersonResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -105,7 +105,7 @@ class __$$_BanPersonResponseCopyWithImpl<$Res>
     Object? personView = null,
     Object? banned = null,
   }) {
-    return _then(_$_BanPersonResponse(
+    return _then(_$BanPersonResponseImpl(
       personView: null == personView
           ? _value.personView
           : personView // ignore: cast_nullable_to_non_nullable
@@ -121,12 +121,13 @@ class __$$_BanPersonResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_BanPersonResponse extends _BanPersonResponse {
-  const _$_BanPersonResponse({required this.personView, required this.banned})
+class _$BanPersonResponseImpl extends _BanPersonResponse {
+  const _$BanPersonResponseImpl(
+      {required this.personView, required this.banned})
       : super._();
 
-  factory _$_BanPersonResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_BanPersonResponseFromJson(json);
+  factory _$BanPersonResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BanPersonResponseImplFromJson(json);
 
   @override
   final PersonView personView;
@@ -142,7 +143,7 @@ class _$_BanPersonResponse extends _BanPersonResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BanPersonResponse &&
+            other is _$BanPersonResponseImpl &&
             (identical(other.personView, personView) ||
                 other.personView == personView) &&
             (identical(other.banned, banned) || other.banned == banned));
@@ -155,13 +156,13 @@ class _$_BanPersonResponse extends _BanPersonResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BanPersonResponseCopyWith<_$_BanPersonResponse> get copyWith =>
-      __$$_BanPersonResponseCopyWithImpl<_$_BanPersonResponse>(
+  _$$BanPersonResponseImplCopyWith<_$BanPersonResponseImpl> get copyWith =>
+      __$$BanPersonResponseImplCopyWithImpl<_$BanPersonResponseImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BanPersonResponseToJson(
+    return _$$BanPersonResponseImplToJson(
       this,
     );
   }
@@ -170,11 +171,11 @@ class _$_BanPersonResponse extends _BanPersonResponse {
 abstract class _BanPersonResponse extends BanPersonResponse {
   const factory _BanPersonResponse(
       {required final PersonView personView,
-      required final bool banned}) = _$_BanPersonResponse;
+      required final bool banned}) = _$BanPersonResponseImpl;
   const _BanPersonResponse._() : super._();
 
   factory _BanPersonResponse.fromJson(Map<String, dynamic> json) =
-      _$_BanPersonResponse.fromJson;
+      _$BanPersonResponseImpl.fromJson;
 
   @override
   PersonView get personView;
@@ -182,6 +183,6 @@ abstract class _BanPersonResponse extends BanPersonResponse {
   bool get banned;
   @override
   @JsonKey(ignore: true)
-  _$$_BanPersonResponseCopyWith<_$_BanPersonResponse> get copyWith =>
+  _$$BanPersonResponseImplCopyWith<_$BanPersonResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/ban_person_response.g.dart
+++ b/lib/src/v3/models/user/ban_person_response.g.dart
@@ -6,15 +6,16 @@ part of 'ban_person_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_BanPersonResponse _$$_BanPersonResponseFromJson(Map<String, dynamic> json) =>
-    _$_BanPersonResponse(
+_$BanPersonResponseImpl _$$BanPersonResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$BanPersonResponseImpl(
       personView:
           PersonView.fromJson(json['person_view'] as Map<String, dynamic>),
       banned: json['banned'] as bool,
     );
 
-Map<String, dynamic> _$$_BanPersonResponseToJson(
-        _$_BanPersonResponse instance) =>
+Map<String, dynamic> _$$BanPersonResponseImplToJson(
+        _$BanPersonResponseImpl instance) =>
     <String, dynamic>{
       'person_view': instance.personView.toJson(),
       'banned': instance.banned,

--- a/lib/src/v3/models/user/banned_persons_response.freezed.dart
+++ b/lib/src/v3/models/user/banned_persons_response.freezed.dart
@@ -64,22 +64,24 @@ class _$BannedPersonsResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_BannedPersonsResponseCopyWith<$Res>
+abstract class _$$BannedPersonsResponseImplCopyWith<$Res>
     implements $BannedPersonsResponseCopyWith<$Res> {
-  factory _$$_BannedPersonsResponseCopyWith(_$_BannedPersonsResponse value,
-          $Res Function(_$_BannedPersonsResponse) then) =
-      __$$_BannedPersonsResponseCopyWithImpl<$Res>;
+  factory _$$BannedPersonsResponseImplCopyWith(
+          _$BannedPersonsResponseImpl value,
+          $Res Function(_$BannedPersonsResponseImpl) then) =
+      __$$BannedPersonsResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<PersonView> banned});
 }
 
 /// @nodoc
-class __$$_BannedPersonsResponseCopyWithImpl<$Res>
-    extends _$BannedPersonsResponseCopyWithImpl<$Res, _$_BannedPersonsResponse>
-    implements _$$_BannedPersonsResponseCopyWith<$Res> {
-  __$$_BannedPersonsResponseCopyWithImpl(_$_BannedPersonsResponse _value,
-      $Res Function(_$_BannedPersonsResponse) _then)
+class __$$BannedPersonsResponseImplCopyWithImpl<$Res>
+    extends _$BannedPersonsResponseCopyWithImpl<$Res,
+        _$BannedPersonsResponseImpl>
+    implements _$$BannedPersonsResponseImplCopyWith<$Res> {
+  __$$BannedPersonsResponseImplCopyWithImpl(_$BannedPersonsResponseImpl _value,
+      $Res Function(_$BannedPersonsResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -87,7 +89,7 @@ class __$$_BannedPersonsResponseCopyWithImpl<$Res>
   $Res call({
     Object? banned = null,
   }) {
-    return _then(_$_BannedPersonsResponse(
+    return _then(_$BannedPersonsResponseImpl(
       banned: null == banned
           ? _value._banned
           : banned // ignore: cast_nullable_to_non_nullable
@@ -99,13 +101,13 @@ class __$$_BannedPersonsResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_BannedPersonsResponse extends _BannedPersonsResponse {
-  const _$_BannedPersonsResponse({required final List<PersonView> banned})
+class _$BannedPersonsResponseImpl extends _BannedPersonsResponse {
+  const _$BannedPersonsResponseImpl({required final List<PersonView> banned})
       : _banned = banned,
         super._();
 
-  factory _$_BannedPersonsResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_BannedPersonsResponseFromJson(json);
+  factory _$BannedPersonsResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BannedPersonsResponseImplFromJson(json);
 
   final List<PersonView> _banned;
   @override
@@ -124,7 +126,7 @@ class _$_BannedPersonsResponse extends _BannedPersonsResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BannedPersonsResponse &&
+            other is _$BannedPersonsResponseImpl &&
             const DeepCollectionEquality().equals(other._banned, _banned));
   }
 
@@ -136,13 +138,13 @@ class _$_BannedPersonsResponse extends _BannedPersonsResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BannedPersonsResponseCopyWith<_$_BannedPersonsResponse> get copyWith =>
-      __$$_BannedPersonsResponseCopyWithImpl<_$_BannedPersonsResponse>(
-          this, _$identity);
+  _$$BannedPersonsResponseImplCopyWith<_$BannedPersonsResponseImpl>
+      get copyWith => __$$BannedPersonsResponseImplCopyWithImpl<
+          _$BannedPersonsResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BannedPersonsResponseToJson(
+    return _$$BannedPersonsResponseImplToJson(
       this,
     );
   }
@@ -150,16 +152,16 @@ class _$_BannedPersonsResponse extends _BannedPersonsResponse {
 
 abstract class _BannedPersonsResponse extends BannedPersonsResponse {
   const factory _BannedPersonsResponse(
-      {required final List<PersonView> banned}) = _$_BannedPersonsResponse;
+      {required final List<PersonView> banned}) = _$BannedPersonsResponseImpl;
   const _BannedPersonsResponse._() : super._();
 
   factory _BannedPersonsResponse.fromJson(Map<String, dynamic> json) =
-      _$_BannedPersonsResponse.fromJson;
+      _$BannedPersonsResponseImpl.fromJson;
 
   @override
   List<PersonView> get banned;
   @override
   @JsonKey(ignore: true)
-  _$$_BannedPersonsResponseCopyWith<_$_BannedPersonsResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$BannedPersonsResponseImplCopyWith<_$BannedPersonsResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/banned_persons_response.g.dart
+++ b/lib/src/v3/models/user/banned_persons_response.g.dart
@@ -6,16 +6,16 @@ part of 'banned_persons_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_BannedPersonsResponse _$$_BannedPersonsResponseFromJson(
+_$BannedPersonsResponseImpl _$$BannedPersonsResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_BannedPersonsResponse(
+    _$BannedPersonsResponseImpl(
       banned: (json['banned'] as List<dynamic>)
           .map((e) => PersonView.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$_BannedPersonsResponseToJson(
-        _$_BannedPersonsResponse instance) =>
+Map<String, dynamic> _$$BannedPersonsResponseImplToJson(
+        _$BannedPersonsResponseImpl instance) =>
     <String, dynamic>{
       'banned': instance.banned.map((e) => e.toJson()).toList(),
     };

--- a/lib/src/v3/models/user/block_person_response.freezed.dart
+++ b/lib/src/v3/models/user/block_person_response.freezed.dart
@@ -78,11 +78,11 @@ class _$BlockPersonResponseCopyWithImpl<$Res, $Val extends BlockPersonResponse>
 }
 
 /// @nodoc
-abstract class _$$_BlockPersonResponseCopyWith<$Res>
+abstract class _$$BlockPersonResponseImplCopyWith<$Res>
     implements $BlockPersonResponseCopyWith<$Res> {
-  factory _$$_BlockPersonResponseCopyWith(_$_BlockPersonResponse value,
-          $Res Function(_$_BlockPersonResponse) then) =
-      __$$_BlockPersonResponseCopyWithImpl<$Res>;
+  factory _$$BlockPersonResponseImplCopyWith(_$BlockPersonResponseImpl value,
+          $Res Function(_$BlockPersonResponseImpl) then) =
+      __$$BlockPersonResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonView personView, bool blocked});
@@ -92,11 +92,11 @@ abstract class _$$_BlockPersonResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_BlockPersonResponseCopyWithImpl<$Res>
-    extends _$BlockPersonResponseCopyWithImpl<$Res, _$_BlockPersonResponse>
-    implements _$$_BlockPersonResponseCopyWith<$Res> {
-  __$$_BlockPersonResponseCopyWithImpl(_$_BlockPersonResponse _value,
-      $Res Function(_$_BlockPersonResponse) _then)
+class __$$BlockPersonResponseImplCopyWithImpl<$Res>
+    extends _$BlockPersonResponseCopyWithImpl<$Res, _$BlockPersonResponseImpl>
+    implements _$$BlockPersonResponseImplCopyWith<$Res> {
+  __$$BlockPersonResponseImplCopyWithImpl(_$BlockPersonResponseImpl _value,
+      $Res Function(_$BlockPersonResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -105,7 +105,7 @@ class __$$_BlockPersonResponseCopyWithImpl<$Res>
     Object? personView = null,
     Object? blocked = null,
   }) {
-    return _then(_$_BlockPersonResponse(
+    return _then(_$BlockPersonResponseImpl(
       personView: null == personView
           ? _value.personView
           : personView // ignore: cast_nullable_to_non_nullable
@@ -121,13 +121,13 @@ class __$$_BlockPersonResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_BlockPersonResponse extends _BlockPersonResponse {
-  const _$_BlockPersonResponse(
+class _$BlockPersonResponseImpl extends _BlockPersonResponse {
+  const _$BlockPersonResponseImpl(
       {required this.personView, required this.blocked})
       : super._();
 
-  factory _$_BlockPersonResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_BlockPersonResponseFromJson(json);
+  factory _$BlockPersonResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$BlockPersonResponseImplFromJson(json);
 
   @override
   final PersonView personView;
@@ -143,7 +143,7 @@ class _$_BlockPersonResponse extends _BlockPersonResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_BlockPersonResponse &&
+            other is _$BlockPersonResponseImpl &&
             (identical(other.personView, personView) ||
                 other.personView == personView) &&
             (identical(other.blocked, blocked) || other.blocked == blocked));
@@ -156,13 +156,13 @@ class _$_BlockPersonResponse extends _BlockPersonResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_BlockPersonResponseCopyWith<_$_BlockPersonResponse> get copyWith =>
-      __$$_BlockPersonResponseCopyWithImpl<_$_BlockPersonResponse>(
+  _$$BlockPersonResponseImplCopyWith<_$BlockPersonResponseImpl> get copyWith =>
+      __$$BlockPersonResponseImplCopyWithImpl<_$BlockPersonResponseImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_BlockPersonResponseToJson(
+    return _$$BlockPersonResponseImplToJson(
       this,
     );
   }
@@ -171,11 +171,11 @@ class _$_BlockPersonResponse extends _BlockPersonResponse {
 abstract class _BlockPersonResponse extends BlockPersonResponse {
   const factory _BlockPersonResponse(
       {required final PersonView personView,
-      required final bool blocked}) = _$_BlockPersonResponse;
+      required final bool blocked}) = _$BlockPersonResponseImpl;
   const _BlockPersonResponse._() : super._();
 
   factory _BlockPersonResponse.fromJson(Map<String, dynamic> json) =
-      _$_BlockPersonResponse.fromJson;
+      _$BlockPersonResponseImpl.fromJson;
 
   @override
   PersonView get personView;
@@ -183,6 +183,6 @@ abstract class _BlockPersonResponse extends BlockPersonResponse {
   bool get blocked;
   @override
   @JsonKey(ignore: true)
-  _$$_BlockPersonResponseCopyWith<_$_BlockPersonResponse> get copyWith =>
+  _$$BlockPersonResponseImplCopyWith<_$BlockPersonResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/block_person_response.g.dart
+++ b/lib/src/v3/models/user/block_person_response.g.dart
@@ -6,16 +6,16 @@ part of 'block_person_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_BlockPersonResponse _$$_BlockPersonResponseFromJson(
+_$BlockPersonResponseImpl _$$BlockPersonResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_BlockPersonResponse(
+    _$BlockPersonResponseImpl(
       personView:
           PersonView.fromJson(json['person_view'] as Map<String, dynamic>),
       blocked: json['blocked'] as bool,
     );
 
-Map<String, dynamic> _$$_BlockPersonResponseToJson(
-        _$_BlockPersonResponse instance) =>
+Map<String, dynamic> _$$BlockPersonResponseImplToJson(
+        _$BlockPersonResponseImpl instance) =>
     <String, dynamic>{
       'person_view': instance.personView.toJson(),
       'blocked': instance.blocked,

--- a/lib/src/v3/models/user/captcha_response.freezed.dart
+++ b/lib/src/v3/models/user/captcha_response.freezed.dart
@@ -74,22 +74,22 @@ class _$CaptchaResponseCopyWithImpl<$Res, $Val extends CaptchaResponse>
 }
 
 /// @nodoc
-abstract class _$$_CaptchaResponseCopyWith<$Res>
+abstract class _$$CaptchaResponseImplCopyWith<$Res>
     implements $CaptchaResponseCopyWith<$Res> {
-  factory _$$_CaptchaResponseCopyWith(
-          _$_CaptchaResponse value, $Res Function(_$_CaptchaResponse) then) =
-      __$$_CaptchaResponseCopyWithImpl<$Res>;
+  factory _$$CaptchaResponseImplCopyWith(_$CaptchaResponseImpl value,
+          $Res Function(_$CaptchaResponseImpl) then) =
+      __$$CaptchaResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String png, String wav, String uuid});
 }
 
 /// @nodoc
-class __$$_CaptchaResponseCopyWithImpl<$Res>
-    extends _$CaptchaResponseCopyWithImpl<$Res, _$_CaptchaResponse>
-    implements _$$_CaptchaResponseCopyWith<$Res> {
-  __$$_CaptchaResponseCopyWithImpl(
-      _$_CaptchaResponse _value, $Res Function(_$_CaptchaResponse) _then)
+class __$$CaptchaResponseImplCopyWithImpl<$Res>
+    extends _$CaptchaResponseCopyWithImpl<$Res, _$CaptchaResponseImpl>
+    implements _$$CaptchaResponseImplCopyWith<$Res> {
+  __$$CaptchaResponseImplCopyWithImpl(
+      _$CaptchaResponseImpl _value, $Res Function(_$CaptchaResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -99,7 +99,7 @@ class __$$_CaptchaResponseCopyWithImpl<$Res>
     Object? wav = null,
     Object? uuid = null,
   }) {
-    return _then(_$_CaptchaResponse(
+    return _then(_$CaptchaResponseImpl(
       png: null == png
           ? _value.png
           : png // ignore: cast_nullable_to_non_nullable
@@ -119,13 +119,13 @@ class __$$_CaptchaResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CaptchaResponse extends _CaptchaResponse {
-  const _$_CaptchaResponse(
+class _$CaptchaResponseImpl extends _CaptchaResponse {
+  const _$CaptchaResponseImpl(
       {required this.png, required this.wav, required this.uuid})
       : super._();
 
-  factory _$_CaptchaResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_CaptchaResponseFromJson(json);
+  factory _$CaptchaResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CaptchaResponseImplFromJson(json);
 
   @override
   final String png;
@@ -143,7 +143,7 @@ class _$_CaptchaResponse extends _CaptchaResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CaptchaResponse &&
+            other is _$CaptchaResponseImpl &&
             (identical(other.png, png) || other.png == png) &&
             (identical(other.wav, wav) || other.wav == wav) &&
             (identical(other.uuid, uuid) || other.uuid == uuid));
@@ -156,12 +156,13 @@ class _$_CaptchaResponse extends _CaptchaResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CaptchaResponseCopyWith<_$_CaptchaResponse> get copyWith =>
-      __$$_CaptchaResponseCopyWithImpl<_$_CaptchaResponse>(this, _$identity);
+  _$$CaptchaResponseImplCopyWith<_$CaptchaResponseImpl> get copyWith =>
+      __$$CaptchaResponseImplCopyWithImpl<_$CaptchaResponseImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CaptchaResponseToJson(
+    return _$$CaptchaResponseImplToJson(
       this,
     );
   }
@@ -171,11 +172,11 @@ abstract class _CaptchaResponse extends CaptchaResponse {
   const factory _CaptchaResponse(
       {required final String png,
       required final String wav,
-      required final String uuid}) = _$_CaptchaResponse;
+      required final String uuid}) = _$CaptchaResponseImpl;
   const _CaptchaResponse._() : super._();
 
   factory _CaptchaResponse.fromJson(Map<String, dynamic> json) =
-      _$_CaptchaResponse.fromJson;
+      _$CaptchaResponseImpl.fromJson;
 
   @override
   String get png;
@@ -185,6 +186,6 @@ abstract class _CaptchaResponse extends CaptchaResponse {
   String get uuid;
   @override
   @JsonKey(ignore: true)
-  _$$_CaptchaResponseCopyWith<_$_CaptchaResponse> get copyWith =>
+  _$$CaptchaResponseImplCopyWith<_$CaptchaResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/captcha_response.g.dart
+++ b/lib/src/v3/models/user/captcha_response.g.dart
@@ -6,14 +6,16 @@ part of 'captcha_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CaptchaResponse _$$_CaptchaResponseFromJson(Map<String, dynamic> json) =>
-    _$_CaptchaResponse(
+_$CaptchaResponseImpl _$$CaptchaResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CaptchaResponseImpl(
       png: json['png'] as String,
       wav: json['wav'] as String,
       uuid: json['uuid'] as String,
     );
 
-Map<String, dynamic> _$$_CaptchaResponseToJson(_$_CaptchaResponse instance) =>
+Map<String, dynamic> _$$CaptchaResponseImplToJson(
+        _$CaptchaResponseImpl instance) =>
     <String, dynamic>{
       'png': instance.png,
       'wav': instance.wav,

--- a/lib/src/v3/models/user/delete_account_response.freezed.dart
+++ b/lib/src/v3/models/user/delete_account_response.freezed.dart
@@ -64,22 +64,24 @@ class _$DeleteAccountResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_DeleteAccountResponseCopyWith<$Res>
+abstract class _$$DeleteAccountResponseImplCopyWith<$Res>
     implements $DeleteAccountResponseCopyWith<$Res> {
-  factory _$$_DeleteAccountResponseCopyWith(_$_DeleteAccountResponse value,
-          $Res Function(_$_DeleteAccountResponse) then) =
-      __$$_DeleteAccountResponseCopyWithImpl<$Res>;
+  factory _$$DeleteAccountResponseImplCopyWith(
+          _$DeleteAccountResponseImpl value,
+          $Res Function(_$DeleteAccountResponseImpl) then) =
+      __$$DeleteAccountResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool? success});
 }
 
 /// @nodoc
-class __$$_DeleteAccountResponseCopyWithImpl<$Res>
-    extends _$DeleteAccountResponseCopyWithImpl<$Res, _$_DeleteAccountResponse>
-    implements _$$_DeleteAccountResponseCopyWith<$Res> {
-  __$$_DeleteAccountResponseCopyWithImpl(_$_DeleteAccountResponse _value,
-      $Res Function(_$_DeleteAccountResponse) _then)
+class __$$DeleteAccountResponseImplCopyWithImpl<$Res>
+    extends _$DeleteAccountResponseCopyWithImpl<$Res,
+        _$DeleteAccountResponseImpl>
+    implements _$$DeleteAccountResponseImplCopyWith<$Res> {
+  __$$DeleteAccountResponseImplCopyWithImpl(_$DeleteAccountResponseImpl _value,
+      $Res Function(_$DeleteAccountResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -87,7 +89,7 @@ class __$$_DeleteAccountResponseCopyWithImpl<$Res>
   $Res call({
     Object? success = freezed,
   }) {
-    return _then(_$_DeleteAccountResponse(
+    return _then(_$DeleteAccountResponseImpl(
       success: freezed == success
           ? _value.success
           : success // ignore: cast_nullable_to_non_nullable
@@ -99,11 +101,11 @@ class __$$_DeleteAccountResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_DeleteAccountResponse extends _DeleteAccountResponse {
-  const _$_DeleteAccountResponse({this.success}) : super._();
+class _$DeleteAccountResponseImpl extends _DeleteAccountResponse {
+  const _$DeleteAccountResponseImpl({this.success}) : super._();
 
-  factory _$_DeleteAccountResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_DeleteAccountResponseFromJson(json);
+  factory _$DeleteAccountResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeleteAccountResponseImplFromJson(json);
 
   @override
   final bool? success;
@@ -117,7 +119,7 @@ class _$_DeleteAccountResponse extends _DeleteAccountResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_DeleteAccountResponse &&
+            other is _$DeleteAccountResponseImpl &&
             (identical(other.success, success) || other.success == success));
   }
 
@@ -128,13 +130,13 @@ class _$_DeleteAccountResponse extends _DeleteAccountResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_DeleteAccountResponseCopyWith<_$_DeleteAccountResponse> get copyWith =>
-      __$$_DeleteAccountResponseCopyWithImpl<_$_DeleteAccountResponse>(
-          this, _$identity);
+  _$$DeleteAccountResponseImplCopyWith<_$DeleteAccountResponseImpl>
+      get copyWith => __$$DeleteAccountResponseImplCopyWithImpl<
+          _$DeleteAccountResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DeleteAccountResponseToJson(
+    return _$$DeleteAccountResponseImplToJson(
       this,
     );
   }
@@ -142,16 +144,16 @@ class _$_DeleteAccountResponse extends _DeleteAccountResponse {
 
 abstract class _DeleteAccountResponse extends DeleteAccountResponse {
   const factory _DeleteAccountResponse({final bool? success}) =
-      _$_DeleteAccountResponse;
+      _$DeleteAccountResponseImpl;
   const _DeleteAccountResponse._() : super._();
 
   factory _DeleteAccountResponse.fromJson(Map<String, dynamic> json) =
-      _$_DeleteAccountResponse.fromJson;
+      _$DeleteAccountResponseImpl.fromJson;
 
   @override
   bool? get success;
   @override
   @JsonKey(ignore: true)
-  _$$_DeleteAccountResponseCopyWith<_$_DeleteAccountResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$DeleteAccountResponseImplCopyWith<_$DeleteAccountResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/delete_account_response.g.dart
+++ b/lib/src/v3/models/user/delete_account_response.g.dart
@@ -6,14 +6,14 @@ part of 'delete_account_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_DeleteAccountResponse _$$_DeleteAccountResponseFromJson(
+_$DeleteAccountResponseImpl _$$DeleteAccountResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_DeleteAccountResponse(
+    _$DeleteAccountResponseImpl(
       success: json['success'] as bool?,
     );
 
-Map<String, dynamic> _$$_DeleteAccountResponseToJson(
-        _$_DeleteAccountResponse instance) =>
+Map<String, dynamic> _$$DeleteAccountResponseImplToJson(
+        _$DeleteAccountResponseImpl instance) =>
     <String, dynamic>{
       'success': instance.success,
     };

--- a/lib/src/v3/models/user/generate_totp_secret_response.freezed.dart
+++ b/lib/src/v3/models/user/generate_totp_secret_response.freezed.dart
@@ -65,25 +65,25 @@ class _$GenerateTotpSecretResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_GenerateTotpSecretResponseCopyWith<$Res>
+abstract class _$$GenerateTotpSecretResponseImplCopyWith<$Res>
     implements $GenerateTotpSecretResponseCopyWith<$Res> {
-  factory _$$_GenerateTotpSecretResponseCopyWith(
-          _$_GenerateTotpSecretResponse value,
-          $Res Function(_$_GenerateTotpSecretResponse) then) =
-      __$$_GenerateTotpSecretResponseCopyWithImpl<$Res>;
+  factory _$$GenerateTotpSecretResponseImplCopyWith(
+          _$GenerateTotpSecretResponseImpl value,
+          $Res Function(_$GenerateTotpSecretResponseImpl) then) =
+      __$$GenerateTotpSecretResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String totpSecretUrl});
 }
 
 /// @nodoc
-class __$$_GenerateTotpSecretResponseCopyWithImpl<$Res>
+class __$$GenerateTotpSecretResponseImplCopyWithImpl<$Res>
     extends _$GenerateTotpSecretResponseCopyWithImpl<$Res,
-        _$_GenerateTotpSecretResponse>
-    implements _$$_GenerateTotpSecretResponseCopyWith<$Res> {
-  __$$_GenerateTotpSecretResponseCopyWithImpl(
-      _$_GenerateTotpSecretResponse _value,
-      $Res Function(_$_GenerateTotpSecretResponse) _then)
+        _$GenerateTotpSecretResponseImpl>
+    implements _$$GenerateTotpSecretResponseImplCopyWith<$Res> {
+  __$$GenerateTotpSecretResponseImplCopyWithImpl(
+      _$GenerateTotpSecretResponseImpl _value,
+      $Res Function(_$GenerateTotpSecretResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -91,7 +91,7 @@ class __$$_GenerateTotpSecretResponseCopyWithImpl<$Res>
   $Res call({
     Object? totpSecretUrl = null,
   }) {
-    return _then(_$_GenerateTotpSecretResponse(
+    return _then(_$GenerateTotpSecretResponseImpl(
       totpSecretUrl: null == totpSecretUrl
           ? _value.totpSecretUrl
           : totpSecretUrl // ignore: cast_nullable_to_non_nullable
@@ -103,12 +103,13 @@ class __$$_GenerateTotpSecretResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GenerateTotpSecretResponse extends _GenerateTotpSecretResponse {
-  const _$_GenerateTotpSecretResponse({required this.totpSecretUrl})
+class _$GenerateTotpSecretResponseImpl extends _GenerateTotpSecretResponse {
+  const _$GenerateTotpSecretResponseImpl({required this.totpSecretUrl})
       : super._();
 
-  factory _$_GenerateTotpSecretResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GenerateTotpSecretResponseFromJson(json);
+  factory _$GenerateTotpSecretResponseImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$GenerateTotpSecretResponseImplFromJson(json);
 
   @override
   final String totpSecretUrl;
@@ -122,7 +123,7 @@ class _$_GenerateTotpSecretResponse extends _GenerateTotpSecretResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GenerateTotpSecretResponse &&
+            other is _$GenerateTotpSecretResponseImpl &&
             (identical(other.totpSecretUrl, totpSecretUrl) ||
                 other.totpSecretUrl == totpSecretUrl));
   }
@@ -134,13 +135,13 @@ class _$_GenerateTotpSecretResponse extends _GenerateTotpSecretResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GenerateTotpSecretResponseCopyWith<_$_GenerateTotpSecretResponse>
-      get copyWith => __$$_GenerateTotpSecretResponseCopyWithImpl<
-          _$_GenerateTotpSecretResponse>(this, _$identity);
+  _$$GenerateTotpSecretResponseImplCopyWith<_$GenerateTotpSecretResponseImpl>
+      get copyWith => __$$GenerateTotpSecretResponseImplCopyWithImpl<
+          _$GenerateTotpSecretResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GenerateTotpSecretResponseToJson(
+    return _$$GenerateTotpSecretResponseImplToJson(
       this,
     );
   }
@@ -148,16 +149,16 @@ class _$_GenerateTotpSecretResponse extends _GenerateTotpSecretResponse {
 
 abstract class _GenerateTotpSecretResponse extends GenerateTotpSecretResponse {
   const factory _GenerateTotpSecretResponse(
-      {required final String totpSecretUrl}) = _$_GenerateTotpSecretResponse;
+      {required final String totpSecretUrl}) = _$GenerateTotpSecretResponseImpl;
   const _GenerateTotpSecretResponse._() : super._();
 
   factory _GenerateTotpSecretResponse.fromJson(Map<String, dynamic> json) =
-      _$_GenerateTotpSecretResponse.fromJson;
+      _$GenerateTotpSecretResponseImpl.fromJson;
 
   @override
   String get totpSecretUrl;
   @override
   @JsonKey(ignore: true)
-  _$$_GenerateTotpSecretResponseCopyWith<_$_GenerateTotpSecretResponse>
+  _$$GenerateTotpSecretResponseImplCopyWith<_$GenerateTotpSecretResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/generate_totp_secret_response.g.dart
+++ b/lib/src/v3/models/user/generate_totp_secret_response.g.dart
@@ -6,14 +6,14 @@ part of 'generate_totp_secret_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GenerateTotpSecretResponse _$$_GenerateTotpSecretResponseFromJson(
+_$GenerateTotpSecretResponseImpl _$$GenerateTotpSecretResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GenerateTotpSecretResponse(
+    _$GenerateTotpSecretResponseImpl(
       totpSecretUrl: json['totp_secret_url'] as String,
     );
 
-Map<String, dynamic> _$$_GenerateTotpSecretResponseToJson(
-        _$_GenerateTotpSecretResponse instance) =>
+Map<String, dynamic> _$$GenerateTotpSecretResponseImplToJson(
+        _$GenerateTotpSecretResponseImpl instance) =>
     <String, dynamic>{
       'totp_secret_url': instance.totpSecretUrl,
     };

--- a/lib/src/v3/models/user/get_captcha_response.freezed.dart
+++ b/lib/src/v3/models/user/get_captcha_response.freezed.dart
@@ -76,11 +76,11 @@ class _$GetCaptchaResponseCopyWithImpl<$Res, $Val extends GetCaptchaResponse>
 }
 
 /// @nodoc
-abstract class _$$_GetCaptchaResponseCopyWith<$Res>
+abstract class _$$GetCaptchaResponseImplCopyWith<$Res>
     implements $GetCaptchaResponseCopyWith<$Res> {
-  factory _$$_GetCaptchaResponseCopyWith(_$_GetCaptchaResponse value,
-          $Res Function(_$_GetCaptchaResponse) then) =
-      __$$_GetCaptchaResponseCopyWithImpl<$Res>;
+  factory _$$GetCaptchaResponseImplCopyWith(_$GetCaptchaResponseImpl value,
+          $Res Function(_$GetCaptchaResponseImpl) then) =
+      __$$GetCaptchaResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CaptchaResponse? ok});
@@ -90,11 +90,11 @@ abstract class _$$_GetCaptchaResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetCaptchaResponseCopyWithImpl<$Res>
-    extends _$GetCaptchaResponseCopyWithImpl<$Res, _$_GetCaptchaResponse>
-    implements _$$_GetCaptchaResponseCopyWith<$Res> {
-  __$$_GetCaptchaResponseCopyWithImpl(
-      _$_GetCaptchaResponse _value, $Res Function(_$_GetCaptchaResponse) _then)
+class __$$GetCaptchaResponseImplCopyWithImpl<$Res>
+    extends _$GetCaptchaResponseCopyWithImpl<$Res, _$GetCaptchaResponseImpl>
+    implements _$$GetCaptchaResponseImplCopyWith<$Res> {
+  __$$GetCaptchaResponseImplCopyWithImpl(_$GetCaptchaResponseImpl _value,
+      $Res Function(_$GetCaptchaResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -102,7 +102,7 @@ class __$$_GetCaptchaResponseCopyWithImpl<$Res>
   $Res call({
     Object? ok = freezed,
   }) {
-    return _then(_$_GetCaptchaResponse(
+    return _then(_$GetCaptchaResponseImpl(
       ok: freezed == ok
           ? _value.ok
           : ok // ignore: cast_nullable_to_non_nullable
@@ -114,11 +114,11 @@ class __$$_GetCaptchaResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetCaptchaResponse extends _GetCaptchaResponse {
-  const _$_GetCaptchaResponse({this.ok}) : super._();
+class _$GetCaptchaResponseImpl extends _GetCaptchaResponse {
+  const _$GetCaptchaResponseImpl({this.ok}) : super._();
 
-  factory _$_GetCaptchaResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetCaptchaResponseFromJson(json);
+  factory _$GetCaptchaResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetCaptchaResponseImplFromJson(json);
 
   @override
   final CaptchaResponse? ok;
@@ -132,7 +132,7 @@ class _$_GetCaptchaResponse extends _GetCaptchaResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetCaptchaResponse &&
+            other is _$GetCaptchaResponseImpl &&
             (identical(other.ok, ok) || other.ok == ok));
   }
 
@@ -143,13 +143,13 @@ class _$_GetCaptchaResponse extends _GetCaptchaResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetCaptchaResponseCopyWith<_$_GetCaptchaResponse> get copyWith =>
-      __$$_GetCaptchaResponseCopyWithImpl<_$_GetCaptchaResponse>(
+  _$$GetCaptchaResponseImplCopyWith<_$GetCaptchaResponseImpl> get copyWith =>
+      __$$GetCaptchaResponseImplCopyWithImpl<_$GetCaptchaResponseImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetCaptchaResponseToJson(
+    return _$$GetCaptchaResponseImplToJson(
       this,
     );
   }
@@ -157,16 +157,16 @@ class _$_GetCaptchaResponse extends _GetCaptchaResponse {
 
 abstract class _GetCaptchaResponse extends GetCaptchaResponse {
   const factory _GetCaptchaResponse({final CaptchaResponse? ok}) =
-      _$_GetCaptchaResponse;
+      _$GetCaptchaResponseImpl;
   const _GetCaptchaResponse._() : super._();
 
   factory _GetCaptchaResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetCaptchaResponse.fromJson;
+      _$GetCaptchaResponseImpl.fromJson;
 
   @override
   CaptchaResponse? get ok;
   @override
   @JsonKey(ignore: true)
-  _$$_GetCaptchaResponseCopyWith<_$_GetCaptchaResponse> get copyWith =>
+  _$$GetCaptchaResponseImplCopyWith<_$GetCaptchaResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/get_captcha_response.g.dart
+++ b/lib/src/v3/models/user/get_captcha_response.g.dart
@@ -6,16 +6,16 @@ part of 'get_captcha_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetCaptchaResponse _$$_GetCaptchaResponseFromJson(
+_$GetCaptchaResponseImpl _$$GetCaptchaResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GetCaptchaResponse(
+    _$GetCaptchaResponseImpl(
       ok: json['ok'] == null
           ? null
           : CaptchaResponse.fromJson(json['ok'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_GetCaptchaResponseToJson(
-        _$_GetCaptchaResponse instance) =>
+Map<String, dynamic> _$$GetCaptchaResponseImplToJson(
+        _$GetCaptchaResponseImpl instance) =>
     <String, dynamic>{
       'ok': instance.ok?.toJson(),
     };

--- a/lib/src/v3/models/user/get_person_details_response.freezed.dart
+++ b/lib/src/v3/models/user/get_person_details_response.freezed.dart
@@ -97,12 +97,12 @@ class _$GetPersonDetailsResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_GetPersonDetailsResponseCopyWith<$Res>
+abstract class _$$GetPersonDetailsResponseImplCopyWith<$Res>
     implements $GetPersonDetailsResponseCopyWith<$Res> {
-  factory _$$_GetPersonDetailsResponseCopyWith(
-          _$_GetPersonDetailsResponse value,
-          $Res Function(_$_GetPersonDetailsResponse) then) =
-      __$$_GetPersonDetailsResponseCopyWithImpl<$Res>;
+  factory _$$GetPersonDetailsResponseImplCopyWith(
+          _$GetPersonDetailsResponseImpl value,
+          $Res Function(_$GetPersonDetailsResponseImpl) then) =
+      __$$GetPersonDetailsResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -116,12 +116,13 @@ abstract class _$$_GetPersonDetailsResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetPersonDetailsResponseCopyWithImpl<$Res>
+class __$$GetPersonDetailsResponseImplCopyWithImpl<$Res>
     extends _$GetPersonDetailsResponseCopyWithImpl<$Res,
-        _$_GetPersonDetailsResponse>
-    implements _$$_GetPersonDetailsResponseCopyWith<$Res> {
-  __$$_GetPersonDetailsResponseCopyWithImpl(_$_GetPersonDetailsResponse _value,
-      $Res Function(_$_GetPersonDetailsResponse) _then)
+        _$GetPersonDetailsResponseImpl>
+    implements _$$GetPersonDetailsResponseImplCopyWith<$Res> {
+  __$$GetPersonDetailsResponseImplCopyWithImpl(
+      _$GetPersonDetailsResponseImpl _value,
+      $Res Function(_$GetPersonDetailsResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -132,7 +133,7 @@ class __$$_GetPersonDetailsResponseCopyWithImpl<$Res>
     Object? posts = null,
     Object? moderates = null,
   }) {
-    return _then(_$_GetPersonDetailsResponse(
+    return _then(_$GetPersonDetailsResponseImpl(
       personView: null == personView
           ? _value.personView
           : personView // ignore: cast_nullable_to_non_nullable
@@ -156,8 +157,8 @@ class __$$_GetPersonDetailsResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetPersonDetailsResponse extends _GetPersonDetailsResponse {
-  const _$_GetPersonDetailsResponse(
+class _$GetPersonDetailsResponseImpl extends _GetPersonDetailsResponse {
+  const _$GetPersonDetailsResponseImpl(
       {required this.personView,
       required final List<CommentView> comments,
       required final List<PostView> posts,
@@ -167,8 +168,8 @@ class _$_GetPersonDetailsResponse extends _GetPersonDetailsResponse {
         _moderates = moderates,
         super._();
 
-  factory _$_GetPersonDetailsResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPersonDetailsResponseFromJson(json);
+  factory _$GetPersonDetailsResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPersonDetailsResponseImplFromJson(json);
 
   @override
   final PersonView personView;
@@ -205,7 +206,7 @@ class _$_GetPersonDetailsResponse extends _GetPersonDetailsResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPersonDetailsResponse &&
+            other is _$GetPersonDetailsResponseImpl &&
             (identical(other.personView, personView) ||
                 other.personView == personView) &&
             const DeepCollectionEquality().equals(other._comments, _comments) &&
@@ -226,13 +227,13 @@ class _$_GetPersonDetailsResponse extends _GetPersonDetailsResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPersonDetailsResponseCopyWith<_$_GetPersonDetailsResponse>
-      get copyWith => __$$_GetPersonDetailsResponseCopyWithImpl<
-          _$_GetPersonDetailsResponse>(this, _$identity);
+  _$$GetPersonDetailsResponseImplCopyWith<_$GetPersonDetailsResponseImpl>
+      get copyWith => __$$GetPersonDetailsResponseImplCopyWithImpl<
+          _$GetPersonDetailsResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPersonDetailsResponseToJson(
+    return _$$GetPersonDetailsResponseImplToJson(
       this,
     );
   }
@@ -244,11 +245,11 @@ abstract class _GetPersonDetailsResponse extends GetPersonDetailsResponse {
           required final List<CommentView> comments,
           required final List<PostView> posts,
           required final List<CommunityModeratorView> moderates}) =
-      _$_GetPersonDetailsResponse;
+      _$GetPersonDetailsResponseImpl;
   const _GetPersonDetailsResponse._() : super._();
 
   factory _GetPersonDetailsResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetPersonDetailsResponse.fromJson;
+      _$GetPersonDetailsResponseImpl.fromJson;
 
   @override
   PersonView get personView;
@@ -260,6 +261,6 @@ abstract class _GetPersonDetailsResponse extends GetPersonDetailsResponse {
   List<CommunityModeratorView> get moderates;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPersonDetailsResponseCopyWith<_$_GetPersonDetailsResponse>
+  _$$GetPersonDetailsResponseImplCopyWith<_$GetPersonDetailsResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/get_person_details_response.g.dart
+++ b/lib/src/v3/models/user/get_person_details_response.g.dart
@@ -6,9 +6,9 @@ part of 'get_person_details_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetPersonDetailsResponse _$$_GetPersonDetailsResponseFromJson(
+_$GetPersonDetailsResponseImpl _$$GetPersonDetailsResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GetPersonDetailsResponse(
+    _$GetPersonDetailsResponseImpl(
       personView:
           PersonView.fromJson(json['person_view'] as Map<String, dynamic>),
       comments: (json['comments'] as List<dynamic>)
@@ -23,8 +23,8 @@ _$_GetPersonDetailsResponse _$$_GetPersonDetailsResponseFromJson(
           .toList(),
     );
 
-Map<String, dynamic> _$$_GetPersonDetailsResponseToJson(
-        _$_GetPersonDetailsResponse instance) =>
+Map<String, dynamic> _$$GetPersonDetailsResponseImplToJson(
+        _$GetPersonDetailsResponseImpl instance) =>
     <String, dynamic>{
       'person_view': instance.personView.toJson(),
       'comments': instance.comments.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/models/user/get_person_mentions_response.freezed.dart
+++ b/lib/src/v3/models/user/get_person_mentions_response.freezed.dart
@@ -64,25 +64,25 @@ class _$GetPersonMentionsResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_GetPersonMentionsResponseCopyWith<$Res>
+abstract class _$$GetPersonMentionsResponseImplCopyWith<$Res>
     implements $GetPersonMentionsResponseCopyWith<$Res> {
-  factory _$$_GetPersonMentionsResponseCopyWith(
-          _$_GetPersonMentionsResponse value,
-          $Res Function(_$_GetPersonMentionsResponse) then) =
-      __$$_GetPersonMentionsResponseCopyWithImpl<$Res>;
+  factory _$$GetPersonMentionsResponseImplCopyWith(
+          _$GetPersonMentionsResponseImpl value,
+          $Res Function(_$GetPersonMentionsResponseImpl) then) =
+      __$$GetPersonMentionsResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<PersonMentionView> mentions});
 }
 
 /// @nodoc
-class __$$_GetPersonMentionsResponseCopyWithImpl<$Res>
+class __$$GetPersonMentionsResponseImplCopyWithImpl<$Res>
     extends _$GetPersonMentionsResponseCopyWithImpl<$Res,
-        _$_GetPersonMentionsResponse>
-    implements _$$_GetPersonMentionsResponseCopyWith<$Res> {
-  __$$_GetPersonMentionsResponseCopyWithImpl(
-      _$_GetPersonMentionsResponse _value,
-      $Res Function(_$_GetPersonMentionsResponse) _then)
+        _$GetPersonMentionsResponseImpl>
+    implements _$$GetPersonMentionsResponseImplCopyWith<$Res> {
+  __$$GetPersonMentionsResponseImplCopyWithImpl(
+      _$GetPersonMentionsResponseImpl _value,
+      $Res Function(_$GetPersonMentionsResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -90,7 +90,7 @@ class __$$_GetPersonMentionsResponseCopyWithImpl<$Res>
   $Res call({
     Object? mentions = null,
   }) {
-    return _then(_$_GetPersonMentionsResponse(
+    return _then(_$GetPersonMentionsResponseImpl(
       mentions: null == mentions
           ? _value._mentions
           : mentions // ignore: cast_nullable_to_non_nullable
@@ -102,14 +102,14 @@ class __$$_GetPersonMentionsResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetPersonMentionsResponse extends _GetPersonMentionsResponse {
-  const _$_GetPersonMentionsResponse(
+class _$GetPersonMentionsResponseImpl extends _GetPersonMentionsResponse {
+  const _$GetPersonMentionsResponseImpl(
       {required final List<PersonMentionView> mentions})
       : _mentions = mentions,
         super._();
 
-  factory _$_GetPersonMentionsResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetPersonMentionsResponseFromJson(json);
+  factory _$GetPersonMentionsResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetPersonMentionsResponseImplFromJson(json);
 
   final List<PersonMentionView> _mentions;
   @override
@@ -128,7 +128,7 @@ class _$_GetPersonMentionsResponse extends _GetPersonMentionsResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetPersonMentionsResponse &&
+            other is _$GetPersonMentionsResponseImpl &&
             const DeepCollectionEquality().equals(other._mentions, _mentions));
   }
 
@@ -140,13 +140,13 @@ class _$_GetPersonMentionsResponse extends _GetPersonMentionsResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetPersonMentionsResponseCopyWith<_$_GetPersonMentionsResponse>
-      get copyWith => __$$_GetPersonMentionsResponseCopyWithImpl<
-          _$_GetPersonMentionsResponse>(this, _$identity);
+  _$$GetPersonMentionsResponseImplCopyWith<_$GetPersonMentionsResponseImpl>
+      get copyWith => __$$GetPersonMentionsResponseImplCopyWithImpl<
+          _$GetPersonMentionsResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetPersonMentionsResponseToJson(
+    return _$$GetPersonMentionsResponseImplToJson(
       this,
     );
   }
@@ -155,16 +155,16 @@ class _$_GetPersonMentionsResponse extends _GetPersonMentionsResponse {
 abstract class _GetPersonMentionsResponse extends GetPersonMentionsResponse {
   const factory _GetPersonMentionsResponse(
           {required final List<PersonMentionView> mentions}) =
-      _$_GetPersonMentionsResponse;
+      _$GetPersonMentionsResponseImpl;
   const _GetPersonMentionsResponse._() : super._();
 
   factory _GetPersonMentionsResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetPersonMentionsResponse.fromJson;
+      _$GetPersonMentionsResponseImpl.fromJson;
 
   @override
   List<PersonMentionView> get mentions;
   @override
   @JsonKey(ignore: true)
-  _$$_GetPersonMentionsResponseCopyWith<_$_GetPersonMentionsResponse>
+  _$$GetPersonMentionsResponseImplCopyWith<_$GetPersonMentionsResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/get_person_mentions_response.g.dart
+++ b/lib/src/v3/models/user/get_person_mentions_response.g.dart
@@ -6,16 +6,16 @@ part of 'get_person_mentions_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetPersonMentionsResponse _$$_GetPersonMentionsResponseFromJson(
+_$GetPersonMentionsResponseImpl _$$GetPersonMentionsResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GetPersonMentionsResponse(
+    _$GetPersonMentionsResponseImpl(
       mentions: (json['mentions'] as List<dynamic>)
           .map((e) => PersonMentionView.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$_GetPersonMentionsResponseToJson(
-        _$_GetPersonMentionsResponse instance) =>
+Map<String, dynamic> _$$GetPersonMentionsResponseImplToJson(
+        _$GetPersonMentionsResponseImpl instance) =>
     <String, dynamic>{
       'mentions': instance.mentions.map((e) => e.toJson()).toList(),
     };

--- a/lib/src/v3/models/user/get_replies_response.freezed.dart
+++ b/lib/src/v3/models/user/get_replies_response.freezed.dart
@@ -62,22 +62,22 @@ class _$GetRepliesResponseCopyWithImpl<$Res, $Val extends GetRepliesResponse>
 }
 
 /// @nodoc
-abstract class _$$_GetRepliesResponseCopyWith<$Res>
+abstract class _$$GetRepliesResponseImplCopyWith<$Res>
     implements $GetRepliesResponseCopyWith<$Res> {
-  factory _$$_GetRepliesResponseCopyWith(_$_GetRepliesResponse value,
-          $Res Function(_$_GetRepliesResponse) then) =
-      __$$_GetRepliesResponseCopyWithImpl<$Res>;
+  factory _$$GetRepliesResponseImplCopyWith(_$GetRepliesResponseImpl value,
+          $Res Function(_$GetRepliesResponseImpl) then) =
+      __$$GetRepliesResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({List<CommentReplyView> replies});
 }
 
 /// @nodoc
-class __$$_GetRepliesResponseCopyWithImpl<$Res>
-    extends _$GetRepliesResponseCopyWithImpl<$Res, _$_GetRepliesResponse>
-    implements _$$_GetRepliesResponseCopyWith<$Res> {
-  __$$_GetRepliesResponseCopyWithImpl(
-      _$_GetRepliesResponse _value, $Res Function(_$_GetRepliesResponse) _then)
+class __$$GetRepliesResponseImplCopyWithImpl<$Res>
+    extends _$GetRepliesResponseCopyWithImpl<$Res, _$GetRepliesResponseImpl>
+    implements _$$GetRepliesResponseImplCopyWith<$Res> {
+  __$$GetRepliesResponseImplCopyWithImpl(_$GetRepliesResponseImpl _value,
+      $Res Function(_$GetRepliesResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -85,7 +85,7 @@ class __$$_GetRepliesResponseCopyWithImpl<$Res>
   $Res call({
     Object? replies = null,
   }) {
-    return _then(_$_GetRepliesResponse(
+    return _then(_$GetRepliesResponseImpl(
       replies: null == replies
           ? _value._replies
           : replies // ignore: cast_nullable_to_non_nullable
@@ -97,13 +97,14 @@ class __$$_GetRepliesResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetRepliesResponse extends _GetRepliesResponse {
-  const _$_GetRepliesResponse({required final List<CommentReplyView> replies})
+class _$GetRepliesResponseImpl extends _GetRepliesResponse {
+  const _$GetRepliesResponseImpl(
+      {required final List<CommentReplyView> replies})
       : _replies = replies,
         super._();
 
-  factory _$_GetRepliesResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetRepliesResponseFromJson(json);
+  factory _$GetRepliesResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetRepliesResponseImplFromJson(json);
 
   final List<CommentReplyView> _replies;
   @override
@@ -122,7 +123,7 @@ class _$_GetRepliesResponse extends _GetRepliesResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetRepliesResponse &&
+            other is _$GetRepliesResponseImpl &&
             const DeepCollectionEquality().equals(other._replies, _replies));
   }
 
@@ -134,13 +135,13 @@ class _$_GetRepliesResponse extends _GetRepliesResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetRepliesResponseCopyWith<_$_GetRepliesResponse> get copyWith =>
-      __$$_GetRepliesResponseCopyWithImpl<_$_GetRepliesResponse>(
+  _$$GetRepliesResponseImplCopyWith<_$GetRepliesResponseImpl> get copyWith =>
+      __$$GetRepliesResponseImplCopyWithImpl<_$GetRepliesResponseImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetRepliesResponseToJson(
+    return _$$GetRepliesResponseImplToJson(
       this,
     );
   }
@@ -148,16 +149,17 @@ class _$_GetRepliesResponse extends _GetRepliesResponse {
 
 abstract class _GetRepliesResponse extends GetRepliesResponse {
   const factory _GetRepliesResponse(
-      {required final List<CommentReplyView> replies}) = _$_GetRepliesResponse;
+          {required final List<CommentReplyView> replies}) =
+      _$GetRepliesResponseImpl;
   const _GetRepliesResponse._() : super._();
 
   factory _GetRepliesResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetRepliesResponse.fromJson;
+      _$GetRepliesResponseImpl.fromJson;
 
   @override
   List<CommentReplyView> get replies;
   @override
   @JsonKey(ignore: true)
-  _$$_GetRepliesResponseCopyWith<_$_GetRepliesResponse> get copyWith =>
+  _$$GetRepliesResponseImplCopyWith<_$GetRepliesResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/get_replies_response.g.dart
+++ b/lib/src/v3/models/user/get_replies_response.g.dart
@@ -6,16 +6,16 @@ part of 'get_replies_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetRepliesResponse _$$_GetRepliesResponseFromJson(
+_$GetRepliesResponseImpl _$$GetRepliesResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GetRepliesResponse(
+    _$GetRepliesResponseImpl(
       replies: (json['replies'] as List<dynamic>)
           .map((e) => CommentReplyView.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$$_GetRepliesResponseToJson(
-        _$_GetRepliesResponse instance) =>
+Map<String, dynamic> _$$GetRepliesResponseImplToJson(
+        _$GetRepliesResponseImpl instance) =>
     <String, dynamic>{
       'replies': instance.replies.map((e) => e.toJson()).toList(),
     };

--- a/lib/src/v3/models/user/get_report_count_response.freezed.dart
+++ b/lib/src/v3/models/user/get_report_count_response.freezed.dart
@@ -86,11 +86,12 @@ class _$GetReportCountResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_GetReportCountResponseCopyWith<$Res>
+abstract class _$$GetReportCountResponseImplCopyWith<$Res>
     implements $GetReportCountResponseCopyWith<$Res> {
-  factory _$$_GetReportCountResponseCopyWith(_$_GetReportCountResponse value,
-          $Res Function(_$_GetReportCountResponse) then) =
-      __$$_GetReportCountResponseCopyWithImpl<$Res>;
+  factory _$$GetReportCountResponseImplCopyWith(
+          _$GetReportCountResponseImpl value,
+          $Res Function(_$GetReportCountResponseImpl) then) =
+      __$$GetReportCountResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -101,12 +102,13 @@ abstract class _$$_GetReportCountResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_GetReportCountResponseCopyWithImpl<$Res>
+class __$$GetReportCountResponseImplCopyWithImpl<$Res>
     extends _$GetReportCountResponseCopyWithImpl<$Res,
-        _$_GetReportCountResponse>
-    implements _$$_GetReportCountResponseCopyWith<$Res> {
-  __$$_GetReportCountResponseCopyWithImpl(_$_GetReportCountResponse _value,
-      $Res Function(_$_GetReportCountResponse) _then)
+        _$GetReportCountResponseImpl>
+    implements _$$GetReportCountResponseImplCopyWith<$Res> {
+  __$$GetReportCountResponseImplCopyWithImpl(
+      _$GetReportCountResponseImpl _value,
+      $Res Function(_$GetReportCountResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -117,7 +119,7 @@ class __$$_GetReportCountResponseCopyWithImpl<$Res>
     Object? postReports = null,
     Object? privateMessageReports = freezed,
   }) {
-    return _then(_$_GetReportCountResponse(
+    return _then(_$GetReportCountResponseImpl(
       communityId: freezed == communityId
           ? _value.communityId
           : communityId // ignore: cast_nullable_to_non_nullable
@@ -141,16 +143,16 @@ class __$$_GetReportCountResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetReportCountResponse extends _GetReportCountResponse {
-  const _$_GetReportCountResponse(
+class _$GetReportCountResponseImpl extends _GetReportCountResponse {
+  const _$GetReportCountResponseImpl(
       {this.communityId,
       required this.commentReports,
       required this.postReports,
       this.privateMessageReports})
       : super._();
 
-  factory _$_GetReportCountResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetReportCountResponseFromJson(json);
+  factory _$GetReportCountResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetReportCountResponseImplFromJson(json);
 
   @override
   final int? communityId;
@@ -170,7 +172,7 @@ class _$_GetReportCountResponse extends _GetReportCountResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetReportCountResponse &&
+            other is _$GetReportCountResponseImpl &&
             (identical(other.communityId, communityId) ||
                 other.communityId == communityId) &&
             (identical(other.commentReports, commentReports) ||
@@ -189,13 +191,13 @@ class _$_GetReportCountResponse extends _GetReportCountResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetReportCountResponseCopyWith<_$_GetReportCountResponse> get copyWith =>
-      __$$_GetReportCountResponseCopyWithImpl<_$_GetReportCountResponse>(
-          this, _$identity);
+  _$$GetReportCountResponseImplCopyWith<_$GetReportCountResponseImpl>
+      get copyWith => __$$GetReportCountResponseImplCopyWithImpl<
+          _$GetReportCountResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetReportCountResponseToJson(
+    return _$$GetReportCountResponseImplToJson(
       this,
     );
   }
@@ -206,11 +208,11 @@ abstract class _GetReportCountResponse extends GetReportCountResponse {
       {final int? communityId,
       required final int commentReports,
       required final int postReports,
-      final int? privateMessageReports}) = _$_GetReportCountResponse;
+      final int? privateMessageReports}) = _$GetReportCountResponseImpl;
   const _GetReportCountResponse._() : super._();
 
   factory _GetReportCountResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetReportCountResponse.fromJson;
+      _$GetReportCountResponseImpl.fromJson;
 
   @override
   int? get communityId;
@@ -222,6 +224,6 @@ abstract class _GetReportCountResponse extends GetReportCountResponse {
   int? get privateMessageReports;
   @override
   @JsonKey(ignore: true)
-  _$$_GetReportCountResponseCopyWith<_$_GetReportCountResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$GetReportCountResponseImplCopyWith<_$GetReportCountResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/get_report_count_response.g.dart
+++ b/lib/src/v3/models/user/get_report_count_response.g.dart
@@ -6,17 +6,17 @@ part of 'get_report_count_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetReportCountResponse _$$_GetReportCountResponseFromJson(
+_$GetReportCountResponseImpl _$$GetReportCountResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GetReportCountResponse(
+    _$GetReportCountResponseImpl(
       communityId: json['community_id'] as int?,
       commentReports: json['comment_reports'] as int,
       postReports: json['post_reports'] as int,
       privateMessageReports: json['private_message_reports'] as int?,
     );
 
-Map<String, dynamic> _$$_GetReportCountResponseToJson(
-        _$_GetReportCountResponse instance) =>
+Map<String, dynamic> _$$GetReportCountResponseImplToJson(
+        _$GetReportCountResponseImpl instance) =>
     <String, dynamic>{
       'community_id': instance.communityId,
       'comment_reports': instance.commentReports,

--- a/lib/src/v3/models/user/get_unread_count_response.freezed.dart
+++ b/lib/src/v3/models/user/get_unread_count_response.freezed.dart
@@ -76,23 +76,25 @@ class _$GetUnreadCountResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_GetUnreadCountResponseCopyWith<$Res>
+abstract class _$$GetUnreadCountResponseImplCopyWith<$Res>
     implements $GetUnreadCountResponseCopyWith<$Res> {
-  factory _$$_GetUnreadCountResponseCopyWith(_$_GetUnreadCountResponse value,
-          $Res Function(_$_GetUnreadCountResponse) then) =
-      __$$_GetUnreadCountResponseCopyWithImpl<$Res>;
+  factory _$$GetUnreadCountResponseImplCopyWith(
+          _$GetUnreadCountResponseImpl value,
+          $Res Function(_$GetUnreadCountResponseImpl) then) =
+      __$$GetUnreadCountResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({int replies, int mentions, int privateMessages});
 }
 
 /// @nodoc
-class __$$_GetUnreadCountResponseCopyWithImpl<$Res>
+class __$$GetUnreadCountResponseImplCopyWithImpl<$Res>
     extends _$GetUnreadCountResponseCopyWithImpl<$Res,
-        _$_GetUnreadCountResponse>
-    implements _$$_GetUnreadCountResponseCopyWith<$Res> {
-  __$$_GetUnreadCountResponseCopyWithImpl(_$_GetUnreadCountResponse _value,
-      $Res Function(_$_GetUnreadCountResponse) _then)
+        _$GetUnreadCountResponseImpl>
+    implements _$$GetUnreadCountResponseImplCopyWith<$Res> {
+  __$$GetUnreadCountResponseImplCopyWithImpl(
+      _$GetUnreadCountResponseImpl _value,
+      $Res Function(_$GetUnreadCountResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -102,7 +104,7 @@ class __$$_GetUnreadCountResponseCopyWithImpl<$Res>
     Object? mentions = null,
     Object? privateMessages = null,
   }) {
-    return _then(_$_GetUnreadCountResponse(
+    return _then(_$GetUnreadCountResponseImpl(
       replies: null == replies
           ? _value.replies
           : replies // ignore: cast_nullable_to_non_nullable
@@ -122,15 +124,15 @@ class __$$_GetUnreadCountResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_GetUnreadCountResponse extends _GetUnreadCountResponse {
-  const _$_GetUnreadCountResponse(
+class _$GetUnreadCountResponseImpl extends _GetUnreadCountResponse {
+  const _$GetUnreadCountResponseImpl(
       {required this.replies,
       required this.mentions,
       required this.privateMessages})
       : super._();
 
-  factory _$_GetUnreadCountResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_GetUnreadCountResponseFromJson(json);
+  factory _$GetUnreadCountResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$GetUnreadCountResponseImplFromJson(json);
 
   @override
   final int replies;
@@ -148,7 +150,7 @@ class _$_GetUnreadCountResponse extends _GetUnreadCountResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GetUnreadCountResponse &&
+            other is _$GetUnreadCountResponseImpl &&
             (identical(other.replies, replies) || other.replies == replies) &&
             (identical(other.mentions, mentions) ||
                 other.mentions == mentions) &&
@@ -164,13 +166,13 @@ class _$_GetUnreadCountResponse extends _GetUnreadCountResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GetUnreadCountResponseCopyWith<_$_GetUnreadCountResponse> get copyWith =>
-      __$$_GetUnreadCountResponseCopyWithImpl<_$_GetUnreadCountResponse>(
-          this, _$identity);
+  _$$GetUnreadCountResponseImplCopyWith<_$GetUnreadCountResponseImpl>
+      get copyWith => __$$GetUnreadCountResponseImplCopyWithImpl<
+          _$GetUnreadCountResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_GetUnreadCountResponseToJson(
+    return _$$GetUnreadCountResponseImplToJson(
       this,
     );
   }
@@ -180,11 +182,11 @@ abstract class _GetUnreadCountResponse extends GetUnreadCountResponse {
   const factory _GetUnreadCountResponse(
       {required final int replies,
       required final int mentions,
-      required final int privateMessages}) = _$_GetUnreadCountResponse;
+      required final int privateMessages}) = _$GetUnreadCountResponseImpl;
   const _GetUnreadCountResponse._() : super._();
 
   factory _GetUnreadCountResponse.fromJson(Map<String, dynamic> json) =
-      _$_GetUnreadCountResponse.fromJson;
+      _$GetUnreadCountResponseImpl.fromJson;
 
   @override
   int get replies;
@@ -194,6 +196,6 @@ abstract class _GetUnreadCountResponse extends GetUnreadCountResponse {
   int get privateMessages;
   @override
   @JsonKey(ignore: true)
-  _$$_GetUnreadCountResponseCopyWith<_$_GetUnreadCountResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$GetUnreadCountResponseImplCopyWith<_$GetUnreadCountResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/get_unread_count_response.g.dart
+++ b/lib/src/v3/models/user/get_unread_count_response.g.dart
@@ -6,16 +6,16 @@ part of 'get_unread_count_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_GetUnreadCountResponse _$$_GetUnreadCountResponseFromJson(
+_$GetUnreadCountResponseImpl _$$GetUnreadCountResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_GetUnreadCountResponse(
+    _$GetUnreadCountResponseImpl(
       replies: json['replies'] as int,
       mentions: json['mentions'] as int,
       privateMessages: json['private_messages'] as int,
     );
 
-Map<String, dynamic> _$$_GetUnreadCountResponseToJson(
-        _$_GetUnreadCountResponse instance) =>
+Map<String, dynamic> _$$GetUnreadCountResponseImplToJson(
+        _$GetUnreadCountResponseImpl instance) =>
     <String, dynamic>{
       'replies': instance.replies,
       'mentions': instance.mentions,

--- a/lib/src/v3/models/user/login_response.freezed.dart
+++ b/lib/src/v3/models/user/login_response.freezed.dart
@@ -74,22 +74,22 @@ class _$LoginResponseCopyWithImpl<$Res, $Val extends LoginResponse>
 }
 
 /// @nodoc
-abstract class _$$_LoginResponseCopyWith<$Res>
+abstract class _$$LoginResponseImplCopyWith<$Res>
     implements $LoginResponseCopyWith<$Res> {
-  factory _$$_LoginResponseCopyWith(
-          _$_LoginResponse value, $Res Function(_$_LoginResponse) then) =
-      __$$_LoginResponseCopyWithImpl<$Res>;
+  factory _$$LoginResponseImplCopyWith(
+          _$LoginResponseImpl value, $Res Function(_$LoginResponseImpl) then) =
+      __$$LoginResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String? jwt, bool registrationCreated, bool verifyEmailSent});
 }
 
 /// @nodoc
-class __$$_LoginResponseCopyWithImpl<$Res>
-    extends _$LoginResponseCopyWithImpl<$Res, _$_LoginResponse>
-    implements _$$_LoginResponseCopyWith<$Res> {
-  __$$_LoginResponseCopyWithImpl(
-      _$_LoginResponse _value, $Res Function(_$_LoginResponse) _then)
+class __$$LoginResponseImplCopyWithImpl<$Res>
+    extends _$LoginResponseCopyWithImpl<$Res, _$LoginResponseImpl>
+    implements _$$LoginResponseImplCopyWith<$Res> {
+  __$$LoginResponseImplCopyWithImpl(
+      _$LoginResponseImpl _value, $Res Function(_$LoginResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -99,7 +99,7 @@ class __$$_LoginResponseCopyWithImpl<$Res>
     Object? registrationCreated = null,
     Object? verifyEmailSent = null,
   }) {
-    return _then(_$_LoginResponse(
+    return _then(_$LoginResponseImpl(
       jwt: freezed == jwt
           ? _value.jwt
           : jwt // ignore: cast_nullable_to_non_nullable
@@ -119,15 +119,15 @@ class __$$_LoginResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_LoginResponse extends _LoginResponse {
-  const _$_LoginResponse(
+class _$LoginResponseImpl extends _LoginResponse {
+  const _$LoginResponseImpl(
       {this.jwt,
       required this.registrationCreated,
       required this.verifyEmailSent})
       : super._();
 
-  factory _$_LoginResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_LoginResponseFromJson(json);
+  factory _$LoginResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LoginResponseImplFromJson(json);
 
   @override
   final String? jwt;
@@ -145,7 +145,7 @@ class _$_LoginResponse extends _LoginResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LoginResponse &&
+            other is _$LoginResponseImpl &&
             (identical(other.jwt, jwt) || other.jwt == jwt) &&
             (identical(other.registrationCreated, registrationCreated) ||
                 other.registrationCreated == registrationCreated) &&
@@ -161,12 +161,12 @@ class _$_LoginResponse extends _LoginResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LoginResponseCopyWith<_$_LoginResponse> get copyWith =>
-      __$$_LoginResponseCopyWithImpl<_$_LoginResponse>(this, _$identity);
+  _$$LoginResponseImplCopyWith<_$LoginResponseImpl> get copyWith =>
+      __$$LoginResponseImplCopyWithImpl<_$LoginResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LoginResponseToJson(
+    return _$$LoginResponseImplToJson(
       this,
     );
   }
@@ -176,11 +176,11 @@ abstract class _LoginResponse extends LoginResponse {
   const factory _LoginResponse(
       {final String? jwt,
       required final bool registrationCreated,
-      required final bool verifyEmailSent}) = _$_LoginResponse;
+      required final bool verifyEmailSent}) = _$LoginResponseImpl;
   const _LoginResponse._() : super._();
 
   factory _LoginResponse.fromJson(Map<String, dynamic> json) =
-      _$_LoginResponse.fromJson;
+      _$LoginResponseImpl.fromJson;
 
   @override
   String? get jwt;
@@ -190,6 +190,6 @@ abstract class _LoginResponse extends LoginResponse {
   bool get verifyEmailSent;
   @override
   @JsonKey(ignore: true)
-  _$$_LoginResponseCopyWith<_$_LoginResponse> get copyWith =>
+  _$$LoginResponseImplCopyWith<_$LoginResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/login_response.g.dart
+++ b/lib/src/v3/models/user/login_response.g.dart
@@ -6,14 +6,14 @@ part of 'login_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LoginResponse _$$_LoginResponseFromJson(Map<String, dynamic> json) =>
-    _$_LoginResponse(
+_$LoginResponseImpl _$$LoginResponseImplFromJson(Map<String, dynamic> json) =>
+    _$LoginResponseImpl(
       jwt: json['jwt'] as String?,
       registrationCreated: json['registration_created'] as bool,
       verifyEmailSent: json['verify_email_sent'] as bool,
     );
 
-Map<String, dynamic> _$$_LoginResponseToJson(_$_LoginResponse instance) =>
+Map<String, dynamic> _$$LoginResponseImplToJson(_$LoginResponseImpl instance) =>
     <String, dynamic>{
       'jwt': instance.jwt,
       'registration_created': instance.registrationCreated,

--- a/lib/src/v3/models/user/password_change_after_reset_response.freezed.dart
+++ b/lib/src/v3/models/user/password_change_after_reset_response.freezed.dart
@@ -91,12 +91,12 @@ class _$PasswordChangeAfterResetResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_PasswordChangeAfterResetResponseCopyWith<$Res>
+abstract class _$$PasswordChangeAfterResetResponseImplCopyWith<$Res>
     implements $PasswordChangeAfterResetResponseCopyWith<$Res> {
-  factory _$$_PasswordChangeAfterResetResponseCopyWith(
-          _$_PasswordChangeAfterResetResponse value,
-          $Res Function(_$_PasswordChangeAfterResetResponse) then) =
-      __$$_PasswordChangeAfterResetResponseCopyWithImpl<$Res>;
+  factory _$$PasswordChangeAfterResetResponseImplCopyWith(
+          _$PasswordChangeAfterResetResponseImpl value,
+          $Res Function(_$PasswordChangeAfterResetResponseImpl) then) =
+      __$$PasswordChangeAfterResetResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -107,13 +107,13 @@ abstract class _$$_PasswordChangeAfterResetResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PasswordChangeAfterResetResponseCopyWithImpl<$Res>
+class __$$PasswordChangeAfterResetResponseImplCopyWithImpl<$Res>
     extends _$PasswordChangeAfterResetResponseCopyWithImpl<$Res,
-        _$_PasswordChangeAfterResetResponse>
-    implements _$$_PasswordChangeAfterResetResponseCopyWith<$Res> {
-  __$$_PasswordChangeAfterResetResponseCopyWithImpl(
-      _$_PasswordChangeAfterResetResponse _value,
-      $Res Function(_$_PasswordChangeAfterResetResponse) _then)
+        _$PasswordChangeAfterResetResponseImpl>
+    implements _$$PasswordChangeAfterResetResponseImplCopyWith<$Res> {
+  __$$PasswordChangeAfterResetResponseImplCopyWithImpl(
+      _$PasswordChangeAfterResetResponseImpl _value,
+      $Res Function(_$PasswordChangeAfterResetResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -124,7 +124,7 @@ class __$$_PasswordChangeAfterResetResponseCopyWithImpl<$Res>
     Object? verifyEmailSent = freezed,
     Object? success = freezed,
   }) {
-    return _then(_$_PasswordChangeAfterResetResponse(
+    return _then(_$PasswordChangeAfterResetResponseImpl(
       jwt: freezed == jwt
           ? _value.jwt
           : jwt // ignore: cast_nullable_to_non_nullable
@@ -148,18 +148,18 @@ class __$$_PasswordChangeAfterResetResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PasswordChangeAfterResetResponse
+class _$PasswordChangeAfterResetResponseImpl
     extends _PasswordChangeAfterResetResponse {
-  const _$_PasswordChangeAfterResetResponse(
+  const _$PasswordChangeAfterResetResponseImpl(
       {@deprecated this.jwt,
       @deprecated this.registrationCreated,
       @deprecated this.verifyEmailSent,
       this.success})
       : super._();
 
-  factory _$_PasswordChangeAfterResetResponse.fromJson(
+  factory _$PasswordChangeAfterResetResponseImpl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_PasswordChangeAfterResetResponseFromJson(json);
+      _$$PasswordChangeAfterResetResponseImplFromJson(json);
 
   @override
   @deprecated
@@ -182,7 +182,7 @@ class _$_PasswordChangeAfterResetResponse
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PasswordChangeAfterResetResponse &&
+            other is _$PasswordChangeAfterResetResponseImpl &&
             (identical(other.jwt, jwt) || other.jwt == jwt) &&
             (identical(other.registrationCreated, registrationCreated) ||
                 other.registrationCreated == registrationCreated) &&
@@ -199,14 +199,14 @@ class _$_PasswordChangeAfterResetResponse
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PasswordChangeAfterResetResponseCopyWith<
-          _$_PasswordChangeAfterResetResponse>
-      get copyWith => __$$_PasswordChangeAfterResetResponseCopyWithImpl<
-          _$_PasswordChangeAfterResetResponse>(this, _$identity);
+  _$$PasswordChangeAfterResetResponseImplCopyWith<
+          _$PasswordChangeAfterResetResponseImpl>
+      get copyWith => __$$PasswordChangeAfterResetResponseImplCopyWithImpl<
+          _$PasswordChangeAfterResetResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PasswordChangeAfterResetResponseToJson(
+    return _$$PasswordChangeAfterResetResponseImplToJson(
       this,
     );
   }
@@ -218,11 +218,12 @@ abstract class _PasswordChangeAfterResetResponse
       {@deprecated final String? jwt,
       @deprecated final bool? registrationCreated,
       @deprecated final bool? verifyEmailSent,
-      final bool? success}) = _$_PasswordChangeAfterResetResponse;
+      final bool? success}) = _$PasswordChangeAfterResetResponseImpl;
   const _PasswordChangeAfterResetResponse._() : super._();
 
   factory _PasswordChangeAfterResetResponse.fromJson(
-      Map<String, dynamic> json) = _$_PasswordChangeAfterResetResponse.fromJson;
+          Map<String, dynamic> json) =
+      _$PasswordChangeAfterResetResponseImpl.fromJson;
 
   @override
   @deprecated
@@ -237,7 +238,7 @@ abstract class _PasswordChangeAfterResetResponse
   bool? get success;
   @override
   @JsonKey(ignore: true)
-  _$$_PasswordChangeAfterResetResponseCopyWith<
-          _$_PasswordChangeAfterResetResponse>
+  _$$PasswordChangeAfterResetResponseImplCopyWith<
+          _$PasswordChangeAfterResetResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/password_change_after_reset_response.g.dart
+++ b/lib/src/v3/models/user/password_change_after_reset_response.g.dart
@@ -6,17 +6,18 @@ part of 'password_change_after_reset_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PasswordChangeAfterResetResponse
-    _$$_PasswordChangeAfterResetResponseFromJson(Map<String, dynamic> json) =>
-        _$_PasswordChangeAfterResetResponse(
+_$PasswordChangeAfterResetResponseImpl
+    _$$PasswordChangeAfterResetResponseImplFromJson(
+            Map<String, dynamic> json) =>
+        _$PasswordChangeAfterResetResponseImpl(
           jwt: json['jwt'] as String?,
           registrationCreated: json['registration_created'] as bool?,
           verifyEmailSent: json['verify_email_sent'] as bool?,
           success: json['success'] as bool?,
         );
 
-Map<String, dynamic> _$$_PasswordChangeAfterResetResponseToJson(
-        _$_PasswordChangeAfterResetResponse instance) =>
+Map<String, dynamic> _$$PasswordChangeAfterResetResponseImplToJson(
+        _$PasswordChangeAfterResetResponseImpl instance) =>
     <String, dynamic>{
       'jwt': instance.jwt,
       'registration_created': instance.registrationCreated,

--- a/lib/src/v3/models/user/password_reset_response.freezed.dart
+++ b/lib/src/v3/models/user/password_reset_response.freezed.dart
@@ -64,22 +64,24 @@ class _$PasswordResetResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_PasswordResetResponseCopyWith<$Res>
+abstract class _$$PasswordResetResponseImplCopyWith<$Res>
     implements $PasswordResetResponseCopyWith<$Res> {
-  factory _$$_PasswordResetResponseCopyWith(_$_PasswordResetResponse value,
-          $Res Function(_$_PasswordResetResponse) then) =
-      __$$_PasswordResetResponseCopyWithImpl<$Res>;
+  factory _$$PasswordResetResponseImplCopyWith(
+          _$PasswordResetResponseImpl value,
+          $Res Function(_$PasswordResetResponseImpl) then) =
+      __$$PasswordResetResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool? success});
 }
 
 /// @nodoc
-class __$$_PasswordResetResponseCopyWithImpl<$Res>
-    extends _$PasswordResetResponseCopyWithImpl<$Res, _$_PasswordResetResponse>
-    implements _$$_PasswordResetResponseCopyWith<$Res> {
-  __$$_PasswordResetResponseCopyWithImpl(_$_PasswordResetResponse _value,
-      $Res Function(_$_PasswordResetResponse) _then)
+class __$$PasswordResetResponseImplCopyWithImpl<$Res>
+    extends _$PasswordResetResponseCopyWithImpl<$Res,
+        _$PasswordResetResponseImpl>
+    implements _$$PasswordResetResponseImplCopyWith<$Res> {
+  __$$PasswordResetResponseImplCopyWithImpl(_$PasswordResetResponseImpl _value,
+      $Res Function(_$PasswordResetResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -87,7 +89,7 @@ class __$$_PasswordResetResponseCopyWithImpl<$Res>
   $Res call({
     Object? success = freezed,
   }) {
-    return _then(_$_PasswordResetResponse(
+    return _then(_$PasswordResetResponseImpl(
       success: freezed == success
           ? _value.success
           : success // ignore: cast_nullable_to_non_nullable
@@ -99,11 +101,11 @@ class __$$_PasswordResetResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PasswordResetResponse extends _PasswordResetResponse {
-  const _$_PasswordResetResponse({this.success}) : super._();
+class _$PasswordResetResponseImpl extends _PasswordResetResponse {
+  const _$PasswordResetResponseImpl({this.success}) : super._();
 
-  factory _$_PasswordResetResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_PasswordResetResponseFromJson(json);
+  factory _$PasswordResetResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PasswordResetResponseImplFromJson(json);
 
   @override
   final bool? success;
@@ -117,7 +119,7 @@ class _$_PasswordResetResponse extends _PasswordResetResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PasswordResetResponse &&
+            other is _$PasswordResetResponseImpl &&
             (identical(other.success, success) || other.success == success));
   }
 
@@ -128,13 +130,13 @@ class _$_PasswordResetResponse extends _PasswordResetResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PasswordResetResponseCopyWith<_$_PasswordResetResponse> get copyWith =>
-      __$$_PasswordResetResponseCopyWithImpl<_$_PasswordResetResponse>(
-          this, _$identity);
+  _$$PasswordResetResponseImplCopyWith<_$PasswordResetResponseImpl>
+      get copyWith => __$$PasswordResetResponseImplCopyWithImpl<
+          _$PasswordResetResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PasswordResetResponseToJson(
+    return _$$PasswordResetResponseImplToJson(
       this,
     );
   }
@@ -142,16 +144,16 @@ class _$_PasswordResetResponse extends _PasswordResetResponse {
 
 abstract class _PasswordResetResponse extends PasswordResetResponse {
   const factory _PasswordResetResponse({final bool? success}) =
-      _$_PasswordResetResponse;
+      _$PasswordResetResponseImpl;
   const _PasswordResetResponse._() : super._();
 
   factory _PasswordResetResponse.fromJson(Map<String, dynamic> json) =
-      _$_PasswordResetResponse.fromJson;
+      _$PasswordResetResponseImpl.fromJson;
 
   @override
   bool? get success;
   @override
   @JsonKey(ignore: true)
-  _$$_PasswordResetResponseCopyWith<_$_PasswordResetResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$PasswordResetResponseImplCopyWith<_$PasswordResetResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/password_reset_response.g.dart
+++ b/lib/src/v3/models/user/password_reset_response.g.dart
@@ -6,14 +6,14 @@ part of 'password_reset_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PasswordResetResponse _$$_PasswordResetResponseFromJson(
+_$PasswordResetResponseImpl _$$PasswordResetResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PasswordResetResponse(
+    _$PasswordResetResponseImpl(
       success: json['success'] as bool?,
     );
 
-Map<String, dynamic> _$$_PasswordResetResponseToJson(
-        _$_PasswordResetResponse instance) =>
+Map<String, dynamic> _$$PasswordResetResponseImplToJson(
+        _$PasswordResetResponseImpl instance) =>
     <String, dynamic>{
       'success': instance.success,
     };

--- a/lib/src/v3/models/user/person_mention_response.freezed.dart
+++ b/lib/src/v3/models/user/person_mention_response.freezed.dart
@@ -74,11 +74,12 @@ class _$PersonMentionResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_PersonMentionResponseCopyWith<$Res>
+abstract class _$$PersonMentionResponseImplCopyWith<$Res>
     implements $PersonMentionResponseCopyWith<$Res> {
-  factory _$$_PersonMentionResponseCopyWith(_$_PersonMentionResponse value,
-          $Res Function(_$_PersonMentionResponse) then) =
-      __$$_PersonMentionResponseCopyWithImpl<$Res>;
+  factory _$$PersonMentionResponseImplCopyWith(
+          _$PersonMentionResponseImpl value,
+          $Res Function(_$PersonMentionResponseImpl) then) =
+      __$$PersonMentionResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PersonMentionView personMentionView});
@@ -88,11 +89,12 @@ abstract class _$$_PersonMentionResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PersonMentionResponseCopyWithImpl<$Res>
-    extends _$PersonMentionResponseCopyWithImpl<$Res, _$_PersonMentionResponse>
-    implements _$$_PersonMentionResponseCopyWith<$Res> {
-  __$$_PersonMentionResponseCopyWithImpl(_$_PersonMentionResponse _value,
-      $Res Function(_$_PersonMentionResponse) _then)
+class __$$PersonMentionResponseImplCopyWithImpl<$Res>
+    extends _$PersonMentionResponseCopyWithImpl<$Res,
+        _$PersonMentionResponseImpl>
+    implements _$$PersonMentionResponseImplCopyWith<$Res> {
+  __$$PersonMentionResponseImplCopyWithImpl(_$PersonMentionResponseImpl _value,
+      $Res Function(_$PersonMentionResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -100,7 +102,7 @@ class __$$_PersonMentionResponseCopyWithImpl<$Res>
   $Res call({
     Object? personMentionView = null,
   }) {
-    return _then(_$_PersonMentionResponse(
+    return _then(_$PersonMentionResponseImpl(
       personMentionView: null == personMentionView
           ? _value.personMentionView
           : personMentionView // ignore: cast_nullable_to_non_nullable
@@ -112,11 +114,12 @@ class __$$_PersonMentionResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PersonMentionResponse extends _PersonMentionResponse {
-  const _$_PersonMentionResponse({required this.personMentionView}) : super._();
+class _$PersonMentionResponseImpl extends _PersonMentionResponse {
+  const _$PersonMentionResponseImpl({required this.personMentionView})
+      : super._();
 
-  factory _$_PersonMentionResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_PersonMentionResponseFromJson(json);
+  factory _$PersonMentionResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonMentionResponseImplFromJson(json);
 
   @override
   final PersonMentionView personMentionView;
@@ -130,7 +133,7 @@ class _$_PersonMentionResponse extends _PersonMentionResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PersonMentionResponse &&
+            other is _$PersonMentionResponseImpl &&
             (identical(other.personMentionView, personMentionView) ||
                 other.personMentionView == personMentionView));
   }
@@ -142,13 +145,13 @@ class _$_PersonMentionResponse extends _PersonMentionResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PersonMentionResponseCopyWith<_$_PersonMentionResponse> get copyWith =>
-      __$$_PersonMentionResponseCopyWithImpl<_$_PersonMentionResponse>(
-          this, _$identity);
+  _$$PersonMentionResponseImplCopyWith<_$PersonMentionResponseImpl>
+      get copyWith => __$$PersonMentionResponseImplCopyWithImpl<
+          _$PersonMentionResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PersonMentionResponseToJson(
+    return _$$PersonMentionResponseImplToJson(
       this,
     );
   }
@@ -157,16 +160,16 @@ class _$_PersonMentionResponse extends _PersonMentionResponse {
 abstract class _PersonMentionResponse extends PersonMentionResponse {
   const factory _PersonMentionResponse(
           {required final PersonMentionView personMentionView}) =
-      _$_PersonMentionResponse;
+      _$PersonMentionResponseImpl;
   const _PersonMentionResponse._() : super._();
 
   factory _PersonMentionResponse.fromJson(Map<String, dynamic> json) =
-      _$_PersonMentionResponse.fromJson;
+      _$PersonMentionResponseImpl.fromJson;
 
   @override
   PersonMentionView get personMentionView;
   @override
   @JsonKey(ignore: true)
-  _$$_PersonMentionResponseCopyWith<_$_PersonMentionResponse> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$PersonMentionResponseImplCopyWith<_$PersonMentionResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/person_mention_response.g.dart
+++ b/lib/src/v3/models/user/person_mention_response.g.dart
@@ -6,15 +6,15 @@ part of 'person_mention_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PersonMentionResponse _$$_PersonMentionResponseFromJson(
+_$PersonMentionResponseImpl _$$PersonMentionResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PersonMentionResponse(
+    _$PersonMentionResponseImpl(
       personMentionView: PersonMentionView.fromJson(
           json['person_mention_view'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_PersonMentionResponseToJson(
-        _$_PersonMentionResponse instance) =>
+Map<String, dynamic> _$$PersonMentionResponseImplToJson(
+        _$PersonMentionResponseImpl instance) =>
     <String, dynamic>{
       'person_mention_view': instance.personMentionView.toJson(),
     };

--- a/lib/src/v3/models/user/save_user_settings_response.freezed.dart
+++ b/lib/src/v3/models/user/save_user_settings_response.freezed.dart
@@ -89,12 +89,12 @@ class _$SaveUserSettingsResponseCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_SaveUserSettingsResponseCopyWith<$Res>
+abstract class _$$SaveUserSettingsResponseImplCopyWith<$Res>
     implements $SaveUserSettingsResponseCopyWith<$Res> {
-  factory _$$_SaveUserSettingsResponseCopyWith(
-          _$_SaveUserSettingsResponse value,
-          $Res Function(_$_SaveUserSettingsResponse) then) =
-      __$$_SaveUserSettingsResponseCopyWithImpl<$Res>;
+  factory _$$SaveUserSettingsResponseImplCopyWith(
+          _$SaveUserSettingsResponseImpl value,
+          $Res Function(_$SaveUserSettingsResponseImpl) then) =
+      __$$SaveUserSettingsResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -105,12 +105,13 @@ abstract class _$$_SaveUserSettingsResponseCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_SaveUserSettingsResponseCopyWithImpl<$Res>
+class __$$SaveUserSettingsResponseImplCopyWithImpl<$Res>
     extends _$SaveUserSettingsResponseCopyWithImpl<$Res,
-        _$_SaveUserSettingsResponse>
-    implements _$$_SaveUserSettingsResponseCopyWith<$Res> {
-  __$$_SaveUserSettingsResponseCopyWithImpl(_$_SaveUserSettingsResponse _value,
-      $Res Function(_$_SaveUserSettingsResponse) _then)
+        _$SaveUserSettingsResponseImpl>
+    implements _$$SaveUserSettingsResponseImplCopyWith<$Res> {
+  __$$SaveUserSettingsResponseImplCopyWithImpl(
+      _$SaveUserSettingsResponseImpl _value,
+      $Res Function(_$SaveUserSettingsResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -121,7 +122,7 @@ class __$$_SaveUserSettingsResponseCopyWithImpl<$Res>
     Object? verifyEmailSent = freezed,
     Object? success = freezed,
   }) {
-    return _then(_$_SaveUserSettingsResponse(
+    return _then(_$SaveUserSettingsResponseImpl(
       jwt: freezed == jwt
           ? _value.jwt
           : jwt // ignore: cast_nullable_to_non_nullable
@@ -145,16 +146,16 @@ class __$$_SaveUserSettingsResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_SaveUserSettingsResponse extends _SaveUserSettingsResponse {
-  const _$_SaveUserSettingsResponse(
+class _$SaveUserSettingsResponseImpl extends _SaveUserSettingsResponse {
+  const _$SaveUserSettingsResponseImpl(
       {@deprecated this.jwt,
       @deprecated this.registrationCreated,
       @deprecated this.verifyEmailSent,
       this.success})
       : super._();
 
-  factory _$_SaveUserSettingsResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_SaveUserSettingsResponseFromJson(json);
+  factory _$SaveUserSettingsResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SaveUserSettingsResponseImplFromJson(json);
 
   @override
   @deprecated
@@ -177,7 +178,7 @@ class _$_SaveUserSettingsResponse extends _SaveUserSettingsResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SaveUserSettingsResponse &&
+            other is _$SaveUserSettingsResponseImpl &&
             (identical(other.jwt, jwt) || other.jwt == jwt) &&
             (identical(other.registrationCreated, registrationCreated) ||
                 other.registrationCreated == registrationCreated) &&
@@ -194,13 +195,13 @@ class _$_SaveUserSettingsResponse extends _SaveUserSettingsResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SaveUserSettingsResponseCopyWith<_$_SaveUserSettingsResponse>
-      get copyWith => __$$_SaveUserSettingsResponseCopyWithImpl<
-          _$_SaveUserSettingsResponse>(this, _$identity);
+  _$$SaveUserSettingsResponseImplCopyWith<_$SaveUserSettingsResponseImpl>
+      get copyWith => __$$SaveUserSettingsResponseImplCopyWithImpl<
+          _$SaveUserSettingsResponseImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SaveUserSettingsResponseToJson(
+    return _$$SaveUserSettingsResponseImplToJson(
       this,
     );
   }
@@ -211,11 +212,11 @@ abstract class _SaveUserSettingsResponse extends SaveUserSettingsResponse {
       {@deprecated final String? jwt,
       @deprecated final bool? registrationCreated,
       @deprecated final bool? verifyEmailSent,
-      final bool? success}) = _$_SaveUserSettingsResponse;
+      final bool? success}) = _$SaveUserSettingsResponseImpl;
   const _SaveUserSettingsResponse._() : super._();
 
   factory _SaveUserSettingsResponse.fromJson(Map<String, dynamic> json) =
-      _$_SaveUserSettingsResponse.fromJson;
+      _$SaveUserSettingsResponseImpl.fromJson;
 
   @override
   @deprecated
@@ -230,6 +231,6 @@ abstract class _SaveUserSettingsResponse extends SaveUserSettingsResponse {
   bool? get success;
   @override
   @JsonKey(ignore: true)
-  _$$_SaveUserSettingsResponseCopyWith<_$_SaveUserSettingsResponse>
+  _$$SaveUserSettingsResponseImplCopyWith<_$SaveUserSettingsResponseImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/save_user_settings_response.g.dart
+++ b/lib/src/v3/models/user/save_user_settings_response.g.dart
@@ -6,17 +6,17 @@ part of 'save_user_settings_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_SaveUserSettingsResponse _$$_SaveUserSettingsResponseFromJson(
+_$SaveUserSettingsResponseImpl _$$SaveUserSettingsResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_SaveUserSettingsResponse(
+    _$SaveUserSettingsResponseImpl(
       jwt: json['jwt'] as String?,
       registrationCreated: json['registration_created'] as bool?,
       verifyEmailSent: json['verify_email_sent'] as bool?,
       success: json['success'] as bool?,
     );
 
-Map<String, dynamic> _$$_SaveUserSettingsResponseToJson(
-        _$_SaveUserSettingsResponse instance) =>
+Map<String, dynamic> _$$SaveUserSettingsResponseImplToJson(
+        _$SaveUserSettingsResponseImpl instance) =>
     <String, dynamic>{
       'jwt': instance.jwt,
       'registration_created': instance.registrationCreated,

--- a/lib/src/v3/models/user/success_response.freezed.dart
+++ b/lib/src/v3/models/user/success_response.freezed.dart
@@ -62,22 +62,22 @@ class _$SuccessResponseCopyWithImpl<$Res, $Val extends SuccessResponse>
 }
 
 /// @nodoc
-abstract class _$$_SuccessResponseCopyWith<$Res>
+abstract class _$$SuccessResponseImplCopyWith<$Res>
     implements $SuccessResponseCopyWith<$Res> {
-  factory _$$_SuccessResponseCopyWith(
-          _$_SuccessResponse value, $Res Function(_$_SuccessResponse) then) =
-      __$$_SuccessResponseCopyWithImpl<$Res>;
+  factory _$$SuccessResponseImplCopyWith(_$SuccessResponseImpl value,
+          $Res Function(_$SuccessResponseImpl) then) =
+      __$$SuccessResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool success});
 }
 
 /// @nodoc
-class __$$_SuccessResponseCopyWithImpl<$Res>
-    extends _$SuccessResponseCopyWithImpl<$Res, _$_SuccessResponse>
-    implements _$$_SuccessResponseCopyWith<$Res> {
-  __$$_SuccessResponseCopyWithImpl(
-      _$_SuccessResponse _value, $Res Function(_$_SuccessResponse) _then)
+class __$$SuccessResponseImplCopyWithImpl<$Res>
+    extends _$SuccessResponseCopyWithImpl<$Res, _$SuccessResponseImpl>
+    implements _$$SuccessResponseImplCopyWith<$Res> {
+  __$$SuccessResponseImplCopyWithImpl(
+      _$SuccessResponseImpl _value, $Res Function(_$SuccessResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -85,7 +85,7 @@ class __$$_SuccessResponseCopyWithImpl<$Res>
   $Res call({
     Object? success = null,
   }) {
-    return _then(_$_SuccessResponse(
+    return _then(_$SuccessResponseImpl(
       success: null == success
           ? _value.success
           : success // ignore: cast_nullable_to_non_nullable
@@ -97,11 +97,11 @@ class __$$_SuccessResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_SuccessResponse extends _SuccessResponse {
-  const _$_SuccessResponse({required this.success}) : super._();
+class _$SuccessResponseImpl extends _SuccessResponse {
+  const _$SuccessResponseImpl({required this.success}) : super._();
 
-  factory _$_SuccessResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_SuccessResponseFromJson(json);
+  factory _$SuccessResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SuccessResponseImplFromJson(json);
 
   @override
   final bool success;
@@ -115,7 +115,7 @@ class _$_SuccessResponse extends _SuccessResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_SuccessResponse &&
+            other is _$SuccessResponseImpl &&
             (identical(other.success, success) || other.success == success));
   }
 
@@ -126,12 +126,13 @@ class _$_SuccessResponse extends _SuccessResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SuccessResponseCopyWith<_$_SuccessResponse> get copyWith =>
-      __$$_SuccessResponseCopyWithImpl<_$_SuccessResponse>(this, _$identity);
+  _$$SuccessResponseImplCopyWith<_$SuccessResponseImpl> get copyWith =>
+      __$$SuccessResponseImplCopyWithImpl<_$SuccessResponseImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_SuccessResponseToJson(
+    return _$$SuccessResponseImplToJson(
       this,
     );
   }
@@ -139,16 +140,16 @@ class _$_SuccessResponse extends _SuccessResponse {
 
 abstract class _SuccessResponse extends SuccessResponse {
   const factory _SuccessResponse({required final bool success}) =
-      _$_SuccessResponse;
+      _$SuccessResponseImpl;
   const _SuccessResponse._() : super._();
 
   factory _SuccessResponse.fromJson(Map<String, dynamic> json) =
-      _$_SuccessResponse.fromJson;
+      _$SuccessResponseImpl.fromJson;
 
   @override
   bool get success;
   @override
   @JsonKey(ignore: true)
-  _$$_SuccessResponseCopyWith<_$_SuccessResponse> get copyWith =>
+  _$$SuccessResponseImplCopyWith<_$SuccessResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/success_response.g.dart
+++ b/lib/src/v3/models/user/success_response.g.dart
@@ -6,12 +6,14 @@ part of 'success_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_SuccessResponse _$$_SuccessResponseFromJson(Map<String, dynamic> json) =>
-    _$_SuccessResponse(
+_$SuccessResponseImpl _$$SuccessResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$SuccessResponseImpl(
       success: json['success'] as bool,
     );
 
-Map<String, dynamic> _$$_SuccessResponseToJson(_$_SuccessResponse instance) =>
+Map<String, dynamic> _$$SuccessResponseImplToJson(
+        _$SuccessResponseImpl instance) =>
     <String, dynamic>{
       'success': instance.success,
     };

--- a/lib/src/v3/models/user/update_totp_response.freezed.dart
+++ b/lib/src/v3/models/user/update_totp_response.freezed.dart
@@ -62,22 +62,22 @@ class _$UpdateTotpResponseCopyWithImpl<$Res, $Val extends UpdateTotpResponse>
 }
 
 /// @nodoc
-abstract class _$$_UpdateTotpResponseCopyWith<$Res>
+abstract class _$$UpdateTotpResponseImplCopyWith<$Res>
     implements $UpdateTotpResponseCopyWith<$Res> {
-  factory _$$_UpdateTotpResponseCopyWith(_$_UpdateTotpResponse value,
-          $Res Function(_$_UpdateTotpResponse) then) =
-      __$$_UpdateTotpResponseCopyWithImpl<$Res>;
+  factory _$$UpdateTotpResponseImplCopyWith(_$UpdateTotpResponseImpl value,
+          $Res Function(_$UpdateTotpResponseImpl) then) =
+      __$$UpdateTotpResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool enabled});
 }
 
 /// @nodoc
-class __$$_UpdateTotpResponseCopyWithImpl<$Res>
-    extends _$UpdateTotpResponseCopyWithImpl<$Res, _$_UpdateTotpResponse>
-    implements _$$_UpdateTotpResponseCopyWith<$Res> {
-  __$$_UpdateTotpResponseCopyWithImpl(
-      _$_UpdateTotpResponse _value, $Res Function(_$_UpdateTotpResponse) _then)
+class __$$UpdateTotpResponseImplCopyWithImpl<$Res>
+    extends _$UpdateTotpResponseCopyWithImpl<$Res, _$UpdateTotpResponseImpl>
+    implements _$$UpdateTotpResponseImplCopyWith<$Res> {
+  __$$UpdateTotpResponseImplCopyWithImpl(_$UpdateTotpResponseImpl _value,
+      $Res Function(_$UpdateTotpResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -85,7 +85,7 @@ class __$$_UpdateTotpResponseCopyWithImpl<$Res>
   $Res call({
     Object? enabled = null,
   }) {
-    return _then(_$_UpdateTotpResponse(
+    return _then(_$UpdateTotpResponseImpl(
       enabled: null == enabled
           ? _value.enabled
           : enabled // ignore: cast_nullable_to_non_nullable
@@ -97,11 +97,11 @@ class __$$_UpdateTotpResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_UpdateTotpResponse extends _UpdateTotpResponse {
-  const _$_UpdateTotpResponse({required this.enabled}) : super._();
+class _$UpdateTotpResponseImpl extends _UpdateTotpResponse {
+  const _$UpdateTotpResponseImpl({required this.enabled}) : super._();
 
-  factory _$_UpdateTotpResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_UpdateTotpResponseFromJson(json);
+  factory _$UpdateTotpResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UpdateTotpResponseImplFromJson(json);
 
   @override
   final bool enabled;
@@ -115,7 +115,7 @@ class _$_UpdateTotpResponse extends _UpdateTotpResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_UpdateTotpResponse &&
+            other is _$UpdateTotpResponseImpl &&
             (identical(other.enabled, enabled) || other.enabled == enabled));
   }
 
@@ -126,13 +126,13 @@ class _$_UpdateTotpResponse extends _UpdateTotpResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_UpdateTotpResponseCopyWith<_$_UpdateTotpResponse> get copyWith =>
-      __$$_UpdateTotpResponseCopyWithImpl<_$_UpdateTotpResponse>(
+  _$$UpdateTotpResponseImplCopyWith<_$UpdateTotpResponseImpl> get copyWith =>
+      __$$UpdateTotpResponseImplCopyWithImpl<_$UpdateTotpResponseImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_UpdateTotpResponseToJson(
+    return _$$UpdateTotpResponseImplToJson(
       this,
     );
   }
@@ -140,16 +140,16 @@ class _$_UpdateTotpResponse extends _UpdateTotpResponse {
 
 abstract class _UpdateTotpResponse extends UpdateTotpResponse {
   const factory _UpdateTotpResponse({required final bool enabled}) =
-      _$_UpdateTotpResponse;
+      _$UpdateTotpResponseImpl;
   const _UpdateTotpResponse._() : super._();
 
   factory _UpdateTotpResponse.fromJson(Map<String, dynamic> json) =
-      _$_UpdateTotpResponse.fromJson;
+      _$UpdateTotpResponseImpl.fromJson;
 
   @override
   bool get enabled;
   @override
   @JsonKey(ignore: true)
-  _$$_UpdateTotpResponseCopyWith<_$_UpdateTotpResponse> get copyWith =>
+  _$$UpdateTotpResponseImplCopyWith<_$UpdateTotpResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/update_totp_response.g.dart
+++ b/lib/src/v3/models/user/update_totp_response.g.dart
@@ -6,14 +6,14 @@ part of 'update_totp_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_UpdateTotpResponse _$$_UpdateTotpResponseFromJson(
+_$UpdateTotpResponseImpl _$$UpdateTotpResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_UpdateTotpResponse(
+    _$UpdateTotpResponseImpl(
       enabled: json['enabled'] as bool,
     );
 
-Map<String, dynamic> _$$_UpdateTotpResponseToJson(
-        _$_UpdateTotpResponse instance) =>
+Map<String, dynamic> _$$UpdateTotpResponseImplToJson(
+        _$UpdateTotpResponseImpl instance) =>
     <String, dynamic>{
       'enabled': instance.enabled,
     };

--- a/lib/src/v3/models/user/verify_email_response.freezed.dart
+++ b/lib/src/v3/models/user/verify_email_response.freezed.dart
@@ -62,22 +62,22 @@ class _$VerifyEmailResponseCopyWithImpl<$Res, $Val extends VerifyEmailResponse>
 }
 
 /// @nodoc
-abstract class _$$_VerifyEmailResponseCopyWith<$Res>
+abstract class _$$VerifyEmailResponseImplCopyWith<$Res>
     implements $VerifyEmailResponseCopyWith<$Res> {
-  factory _$$_VerifyEmailResponseCopyWith(_$_VerifyEmailResponse value,
-          $Res Function(_$_VerifyEmailResponse) then) =
-      __$$_VerifyEmailResponseCopyWithImpl<$Res>;
+  factory _$$VerifyEmailResponseImplCopyWith(_$VerifyEmailResponseImpl value,
+          $Res Function(_$VerifyEmailResponseImpl) then) =
+      __$$VerifyEmailResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool? success});
 }
 
 /// @nodoc
-class __$$_VerifyEmailResponseCopyWithImpl<$Res>
-    extends _$VerifyEmailResponseCopyWithImpl<$Res, _$_VerifyEmailResponse>
-    implements _$$_VerifyEmailResponseCopyWith<$Res> {
-  __$$_VerifyEmailResponseCopyWithImpl(_$_VerifyEmailResponse _value,
-      $Res Function(_$_VerifyEmailResponse) _then)
+class __$$VerifyEmailResponseImplCopyWithImpl<$Res>
+    extends _$VerifyEmailResponseCopyWithImpl<$Res, _$VerifyEmailResponseImpl>
+    implements _$$VerifyEmailResponseImplCopyWith<$Res> {
+  __$$VerifyEmailResponseImplCopyWithImpl(_$VerifyEmailResponseImpl _value,
+      $Res Function(_$VerifyEmailResponseImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -85,7 +85,7 @@ class __$$_VerifyEmailResponseCopyWithImpl<$Res>
   $Res call({
     Object? success = freezed,
   }) {
-    return _then(_$_VerifyEmailResponse(
+    return _then(_$VerifyEmailResponseImpl(
       success: freezed == success
           ? _value.success
           : success // ignore: cast_nullable_to_non_nullable
@@ -97,11 +97,11 @@ class __$$_VerifyEmailResponseCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_VerifyEmailResponse extends _VerifyEmailResponse {
-  const _$_VerifyEmailResponse({this.success}) : super._();
+class _$VerifyEmailResponseImpl extends _VerifyEmailResponse {
+  const _$VerifyEmailResponseImpl({this.success}) : super._();
 
-  factory _$_VerifyEmailResponse.fromJson(Map<String, dynamic> json) =>
-      _$$_VerifyEmailResponseFromJson(json);
+  factory _$VerifyEmailResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$VerifyEmailResponseImplFromJson(json);
 
   @override
   final bool? success;
@@ -115,7 +115,7 @@ class _$_VerifyEmailResponse extends _VerifyEmailResponse {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_VerifyEmailResponse &&
+            other is _$VerifyEmailResponseImpl &&
             (identical(other.success, success) || other.success == success));
   }
 
@@ -126,13 +126,13 @@ class _$_VerifyEmailResponse extends _VerifyEmailResponse {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_VerifyEmailResponseCopyWith<_$_VerifyEmailResponse> get copyWith =>
-      __$$_VerifyEmailResponseCopyWithImpl<_$_VerifyEmailResponse>(
+  _$$VerifyEmailResponseImplCopyWith<_$VerifyEmailResponseImpl> get copyWith =>
+      __$$VerifyEmailResponseImplCopyWithImpl<_$VerifyEmailResponseImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_VerifyEmailResponseToJson(
+    return _$$VerifyEmailResponseImplToJson(
       this,
     );
   }
@@ -140,16 +140,16 @@ class _$_VerifyEmailResponse extends _VerifyEmailResponse {
 
 abstract class _VerifyEmailResponse extends VerifyEmailResponse {
   const factory _VerifyEmailResponse({final bool? success}) =
-      _$_VerifyEmailResponse;
+      _$VerifyEmailResponseImpl;
   const _VerifyEmailResponse._() : super._();
 
   factory _VerifyEmailResponse.fromJson(Map<String, dynamic> json) =
-      _$_VerifyEmailResponse.fromJson;
+      _$VerifyEmailResponseImpl.fromJson;
 
   @override
   bool? get success;
   @override
   @JsonKey(ignore: true)
-  _$$_VerifyEmailResponseCopyWith<_$_VerifyEmailResponse> get copyWith =>
+  _$$VerifyEmailResponseImplCopyWith<_$VerifyEmailResponseImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/models/user/verify_email_response.g.dart
+++ b/lib/src/v3/models/user/verify_email_response.g.dart
@@ -6,14 +6,14 @@ part of 'verify_email_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_VerifyEmailResponse _$$_VerifyEmailResponseFromJson(
+_$VerifyEmailResponseImpl _$$VerifyEmailResponseImplFromJson(
         Map<String, dynamic> json) =>
-    _$_VerifyEmailResponse(
+    _$VerifyEmailResponseImpl(
       success: json['success'] as bool?,
     );
 
-Map<String, dynamic> _$$_VerifyEmailResponseToJson(
-        _$_VerifyEmailResponse instance) =>
+Map<String, dynamic> _$$VerifyEmailResponseImplToJson(
+        _$VerifyEmailResponseImpl instance) =>
     <String, dynamic>{
       'success': instance.success,
     };

--- a/lib/src/v3/views/admin_purge_comment_view.freezed.dart
+++ b/lib/src/v3/views/admin_purge_comment_view.freezed.dart
@@ -108,11 +108,12 @@ class _$AdminPurgeCommentViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgeCommentViewCopyWith<$Res>
+abstract class _$$AdminPurgeCommentViewImplCopyWith<$Res>
     implements $AdminPurgeCommentViewCopyWith<$Res> {
-  factory _$$_AdminPurgeCommentViewCopyWith(_$_AdminPurgeCommentView value,
-          $Res Function(_$_AdminPurgeCommentView) then) =
-      __$$_AdminPurgeCommentViewCopyWithImpl<$Res>;
+  factory _$$AdminPurgeCommentViewImplCopyWith(
+          _$AdminPurgeCommentViewImpl value,
+          $Res Function(_$AdminPurgeCommentViewImpl) then) =
+      __$$AdminPurgeCommentViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({AdminPurgeComment adminPurgeComment, Person? admin, Post post});
@@ -126,11 +127,12 @@ abstract class _$$_AdminPurgeCommentViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgeCommentViewCopyWithImpl<$Res>
-    extends _$AdminPurgeCommentViewCopyWithImpl<$Res, _$_AdminPurgeCommentView>
-    implements _$$_AdminPurgeCommentViewCopyWith<$Res> {
-  __$$_AdminPurgeCommentViewCopyWithImpl(_$_AdminPurgeCommentView _value,
-      $Res Function(_$_AdminPurgeCommentView) _then)
+class __$$AdminPurgeCommentViewImplCopyWithImpl<$Res>
+    extends _$AdminPurgeCommentViewCopyWithImpl<$Res,
+        _$AdminPurgeCommentViewImpl>
+    implements _$$AdminPurgeCommentViewImplCopyWith<$Res> {
+  __$$AdminPurgeCommentViewImplCopyWithImpl(_$AdminPurgeCommentViewImpl _value,
+      $Res Function(_$AdminPurgeCommentViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -140,7 +142,7 @@ class __$$_AdminPurgeCommentViewCopyWithImpl<$Res>
     Object? admin = freezed,
     Object? post = null,
   }) {
-    return _then(_$_AdminPurgeCommentView(
+    return _then(_$AdminPurgeCommentViewImpl(
       adminPurgeComment: null == adminPurgeComment
           ? _value.adminPurgeComment
           : adminPurgeComment // ignore: cast_nullable_to_non_nullable
@@ -160,13 +162,13 @@ class __$$_AdminPurgeCommentViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgeCommentView extends _AdminPurgeCommentView {
-  const _$_AdminPurgeCommentView(
+class _$AdminPurgeCommentViewImpl extends _AdminPurgeCommentView {
+  const _$AdminPurgeCommentViewImpl(
       {required this.adminPurgeComment, this.admin, required this.post})
       : super._();
 
-  factory _$_AdminPurgeCommentView.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgeCommentViewFromJson(json);
+  factory _$AdminPurgeCommentViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgeCommentViewImplFromJson(json);
 
   @override
   final AdminPurgeComment adminPurgeComment;
@@ -184,7 +186,7 @@ class _$_AdminPurgeCommentView extends _AdminPurgeCommentView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgeCommentView &&
+            other is _$AdminPurgeCommentViewImpl &&
             (identical(other.adminPurgeComment, adminPurgeComment) ||
                 other.adminPurgeComment == adminPurgeComment) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -198,13 +200,13 @@ class _$_AdminPurgeCommentView extends _AdminPurgeCommentView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgeCommentViewCopyWith<_$_AdminPurgeCommentView> get copyWith =>
-      __$$_AdminPurgeCommentViewCopyWithImpl<_$_AdminPurgeCommentView>(
-          this, _$identity);
+  _$$AdminPurgeCommentViewImplCopyWith<_$AdminPurgeCommentViewImpl>
+      get copyWith => __$$AdminPurgeCommentViewImplCopyWithImpl<
+          _$AdminPurgeCommentViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgeCommentViewToJson(
+    return _$$AdminPurgeCommentViewImplToJson(
       this,
     );
   }
@@ -214,11 +216,11 @@ abstract class _AdminPurgeCommentView extends AdminPurgeCommentView {
   const factory _AdminPurgeCommentView(
       {required final AdminPurgeComment adminPurgeComment,
       final Person? admin,
-      required final Post post}) = _$_AdminPurgeCommentView;
+      required final Post post}) = _$AdminPurgeCommentViewImpl;
   const _AdminPurgeCommentView._() : super._();
 
   factory _AdminPurgeCommentView.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgeCommentView.fromJson;
+      _$AdminPurgeCommentViewImpl.fromJson;
 
   @override
   AdminPurgeComment get adminPurgeComment;
@@ -228,6 +230,6 @@ abstract class _AdminPurgeCommentView extends AdminPurgeCommentView {
   Post get post;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgeCommentViewCopyWith<_$_AdminPurgeCommentView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$AdminPurgeCommentViewImplCopyWith<_$AdminPurgeCommentViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/admin_purge_comment_view.g.dart
+++ b/lib/src/v3/views/admin_purge_comment_view.g.dart
@@ -6,9 +6,9 @@ part of 'admin_purge_comment_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_AdminPurgeCommentView _$$_AdminPurgeCommentViewFromJson(
+_$AdminPurgeCommentViewImpl _$$AdminPurgeCommentViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_AdminPurgeCommentView(
+    _$AdminPurgeCommentViewImpl(
       adminPurgeComment: AdminPurgeComment.fromJson(
           json['admin_purge_comment'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -17,8 +17,8 @@ _$_AdminPurgeCommentView _$$_AdminPurgeCommentViewFromJson(
       post: Post.fromJson(json['post'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_AdminPurgeCommentViewToJson(
-        _$_AdminPurgeCommentView instance) =>
+Map<String, dynamic> _$$AdminPurgeCommentViewImplToJson(
+        _$AdminPurgeCommentViewImpl instance) =>
     <String, dynamic>{
       'admin_purge_comment': instance.adminPurgeComment.toJson(),
       'admin': instance.admin?.toJson(),

--- a/lib/src/v3/views/admin_purge_community_view.freezed.dart
+++ b/lib/src/v3/views/admin_purge_community_view.freezed.dart
@@ -95,11 +95,12 @@ class _$AdminPurgeCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgeCommunityViewCopyWith<$Res>
+abstract class _$$AdminPurgeCommunityViewImplCopyWith<$Res>
     implements $AdminPurgeCommunityViewCopyWith<$Res> {
-  factory _$$_AdminPurgeCommunityViewCopyWith(_$_AdminPurgeCommunityView value,
-          $Res Function(_$_AdminPurgeCommunityView) then) =
-      __$$_AdminPurgeCommunityViewCopyWithImpl<$Res>;
+  factory _$$AdminPurgeCommunityViewImplCopyWith(
+          _$AdminPurgeCommunityViewImpl value,
+          $Res Function(_$AdminPurgeCommunityViewImpl) then) =
+      __$$AdminPurgeCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({AdminPurgeCommunity adminPurgeCommunity, Person? admin});
@@ -111,12 +112,13 @@ abstract class _$$_AdminPurgeCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgeCommunityViewCopyWithImpl<$Res>
+class __$$AdminPurgeCommunityViewImplCopyWithImpl<$Res>
     extends _$AdminPurgeCommunityViewCopyWithImpl<$Res,
-        _$_AdminPurgeCommunityView>
-    implements _$$_AdminPurgeCommunityViewCopyWith<$Res> {
-  __$$_AdminPurgeCommunityViewCopyWithImpl(_$_AdminPurgeCommunityView _value,
-      $Res Function(_$_AdminPurgeCommunityView) _then)
+        _$AdminPurgeCommunityViewImpl>
+    implements _$$AdminPurgeCommunityViewImplCopyWith<$Res> {
+  __$$AdminPurgeCommunityViewImplCopyWithImpl(
+      _$AdminPurgeCommunityViewImpl _value,
+      $Res Function(_$AdminPurgeCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -125,7 +127,7 @@ class __$$_AdminPurgeCommunityViewCopyWithImpl<$Res>
     Object? adminPurgeCommunity = null,
     Object? admin = freezed,
   }) {
-    return _then(_$_AdminPurgeCommunityView(
+    return _then(_$AdminPurgeCommunityViewImpl(
       adminPurgeCommunity: null == adminPurgeCommunity
           ? _value.adminPurgeCommunity
           : adminPurgeCommunity // ignore: cast_nullable_to_non_nullable
@@ -141,13 +143,13 @@ class __$$_AdminPurgeCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgeCommunityView extends _AdminPurgeCommunityView {
-  const _$_AdminPurgeCommunityView(
+class _$AdminPurgeCommunityViewImpl extends _AdminPurgeCommunityView {
+  const _$AdminPurgeCommunityViewImpl(
       {required this.adminPurgeCommunity, this.admin})
       : super._();
 
-  factory _$_AdminPurgeCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgeCommunityViewFromJson(json);
+  factory _$AdminPurgeCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgeCommunityViewImplFromJson(json);
 
   @override
   final AdminPurgeCommunity adminPurgeCommunity;
@@ -163,7 +165,7 @@ class _$_AdminPurgeCommunityView extends _AdminPurgeCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgeCommunityView &&
+            other is _$AdminPurgeCommunityViewImpl &&
             (identical(other.adminPurgeCommunity, adminPurgeCommunity) ||
                 other.adminPurgeCommunity == adminPurgeCommunity) &&
             (identical(other.admin, admin) || other.admin == admin));
@@ -176,14 +178,13 @@ class _$_AdminPurgeCommunityView extends _AdminPurgeCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgeCommunityViewCopyWith<_$_AdminPurgeCommunityView>
-      get copyWith =>
-          __$$_AdminPurgeCommunityViewCopyWithImpl<_$_AdminPurgeCommunityView>(
-              this, _$identity);
+  _$$AdminPurgeCommunityViewImplCopyWith<_$AdminPurgeCommunityViewImpl>
+      get copyWith => __$$AdminPurgeCommunityViewImplCopyWithImpl<
+          _$AdminPurgeCommunityViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgeCommunityViewToJson(
+    return _$$AdminPurgeCommunityViewImplToJson(
       this,
     );
   }
@@ -192,11 +193,11 @@ class _$_AdminPurgeCommunityView extends _AdminPurgeCommunityView {
 abstract class _AdminPurgeCommunityView extends AdminPurgeCommunityView {
   const factory _AdminPurgeCommunityView(
       {required final AdminPurgeCommunity adminPurgeCommunity,
-      final Person? admin}) = _$_AdminPurgeCommunityView;
+      final Person? admin}) = _$AdminPurgeCommunityViewImpl;
   const _AdminPurgeCommunityView._() : super._();
 
   factory _AdminPurgeCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgeCommunityView.fromJson;
+      _$AdminPurgeCommunityViewImpl.fromJson;
 
   @override
   AdminPurgeCommunity get adminPurgeCommunity;
@@ -204,6 +205,6 @@ abstract class _AdminPurgeCommunityView extends AdminPurgeCommunityView {
   Person? get admin;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgeCommunityViewCopyWith<_$_AdminPurgeCommunityView>
+  _$$AdminPurgeCommunityViewImplCopyWith<_$AdminPurgeCommunityViewImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/admin_purge_community_view.g.dart
+++ b/lib/src/v3/views/admin_purge_community_view.g.dart
@@ -6,9 +6,9 @@ part of 'admin_purge_community_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_AdminPurgeCommunityView _$$_AdminPurgeCommunityViewFromJson(
+_$AdminPurgeCommunityViewImpl _$$AdminPurgeCommunityViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_AdminPurgeCommunityView(
+    _$AdminPurgeCommunityViewImpl(
       adminPurgeCommunity: AdminPurgeCommunity.fromJson(
           json['admin_purge_community'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -16,8 +16,8 @@ _$_AdminPurgeCommunityView _$$_AdminPurgeCommunityViewFromJson(
           : Person.fromJson(json['admin'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_AdminPurgeCommunityViewToJson(
-        _$_AdminPurgeCommunityView instance) =>
+Map<String, dynamic> _$$AdminPurgeCommunityViewImplToJson(
+        _$AdminPurgeCommunityViewImpl instance) =>
     <String, dynamic>{
       'admin_purge_community': instance.adminPurgeCommunity.toJson(),
       'admin': instance.admin?.toJson(),

--- a/lib/src/v3/views/admin_purge_person_view.freezed.dart
+++ b/lib/src/v3/views/admin_purge_person_view.freezed.dart
@@ -92,11 +92,11 @@ class _$AdminPurgePersonViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgePersonViewCopyWith<$Res>
+abstract class _$$AdminPurgePersonViewImplCopyWith<$Res>
     implements $AdminPurgePersonViewCopyWith<$Res> {
-  factory _$$_AdminPurgePersonViewCopyWith(_$_AdminPurgePersonView value,
-          $Res Function(_$_AdminPurgePersonView) then) =
-      __$$_AdminPurgePersonViewCopyWithImpl<$Res>;
+  factory _$$AdminPurgePersonViewImplCopyWith(_$AdminPurgePersonViewImpl value,
+          $Res Function(_$AdminPurgePersonViewImpl) then) =
+      __$$AdminPurgePersonViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({AdminPurgePerson adminPurgePerson, Person? admin});
@@ -108,11 +108,11 @@ abstract class _$$_AdminPurgePersonViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgePersonViewCopyWithImpl<$Res>
-    extends _$AdminPurgePersonViewCopyWithImpl<$Res, _$_AdminPurgePersonView>
-    implements _$$_AdminPurgePersonViewCopyWith<$Res> {
-  __$$_AdminPurgePersonViewCopyWithImpl(_$_AdminPurgePersonView _value,
-      $Res Function(_$_AdminPurgePersonView) _then)
+class __$$AdminPurgePersonViewImplCopyWithImpl<$Res>
+    extends _$AdminPurgePersonViewCopyWithImpl<$Res, _$AdminPurgePersonViewImpl>
+    implements _$$AdminPurgePersonViewImplCopyWith<$Res> {
+  __$$AdminPurgePersonViewImplCopyWithImpl(_$AdminPurgePersonViewImpl _value,
+      $Res Function(_$AdminPurgePersonViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -121,7 +121,7 @@ class __$$_AdminPurgePersonViewCopyWithImpl<$Res>
     Object? adminPurgePerson = null,
     Object? admin = freezed,
   }) {
-    return _then(_$_AdminPurgePersonView(
+    return _then(_$AdminPurgePersonViewImpl(
       adminPurgePerson: null == adminPurgePerson
           ? _value.adminPurgePerson
           : adminPurgePerson // ignore: cast_nullable_to_non_nullable
@@ -137,13 +137,13 @@ class __$$_AdminPurgePersonViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgePersonView extends _AdminPurgePersonView {
-  const _$_AdminPurgePersonView(
+class _$AdminPurgePersonViewImpl extends _AdminPurgePersonView {
+  const _$AdminPurgePersonViewImpl(
       {required this.adminPurgePerson, required this.admin})
       : super._();
 
-  factory _$_AdminPurgePersonView.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgePersonViewFromJson(json);
+  factory _$AdminPurgePersonViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgePersonViewImplFromJson(json);
 
   @override
   final AdminPurgePerson adminPurgePerson;
@@ -159,7 +159,7 @@ class _$_AdminPurgePersonView extends _AdminPurgePersonView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgePersonView &&
+            other is _$AdminPurgePersonViewImpl &&
             (identical(other.adminPurgePerson, adminPurgePerson) ||
                 other.adminPurgePerson == adminPurgePerson) &&
             (identical(other.admin, admin) || other.admin == admin));
@@ -172,13 +172,14 @@ class _$_AdminPurgePersonView extends _AdminPurgePersonView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgePersonViewCopyWith<_$_AdminPurgePersonView> get copyWith =>
-      __$$_AdminPurgePersonViewCopyWithImpl<_$_AdminPurgePersonView>(
-          this, _$identity);
+  _$$AdminPurgePersonViewImplCopyWith<_$AdminPurgePersonViewImpl>
+      get copyWith =>
+          __$$AdminPurgePersonViewImplCopyWithImpl<_$AdminPurgePersonViewImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgePersonViewToJson(
+    return _$$AdminPurgePersonViewImplToJson(
       this,
     );
   }
@@ -187,11 +188,11 @@ class _$_AdminPurgePersonView extends _AdminPurgePersonView {
 abstract class _AdminPurgePersonView extends AdminPurgePersonView {
   const factory _AdminPurgePersonView(
       {required final AdminPurgePerson adminPurgePerson,
-      required final Person? admin}) = _$_AdminPurgePersonView;
+      required final Person? admin}) = _$AdminPurgePersonViewImpl;
   const _AdminPurgePersonView._() : super._();
 
   factory _AdminPurgePersonView.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgePersonView.fromJson;
+      _$AdminPurgePersonViewImpl.fromJson;
 
   @override
   AdminPurgePerson get adminPurgePerson;
@@ -199,6 +200,6 @@ abstract class _AdminPurgePersonView extends AdminPurgePersonView {
   Person? get admin;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgePersonViewCopyWith<_$_AdminPurgePersonView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$AdminPurgePersonViewImplCopyWith<_$AdminPurgePersonViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/admin_purge_person_view.g.dart
+++ b/lib/src/v3/views/admin_purge_person_view.g.dart
@@ -6,9 +6,9 @@ part of 'admin_purge_person_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_AdminPurgePersonView _$$_AdminPurgePersonViewFromJson(
+_$AdminPurgePersonViewImpl _$$AdminPurgePersonViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_AdminPurgePersonView(
+    _$AdminPurgePersonViewImpl(
       adminPurgePerson: AdminPurgePerson.fromJson(
           json['admin_purge_person'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -16,8 +16,8 @@ _$_AdminPurgePersonView _$$_AdminPurgePersonViewFromJson(
           : Person.fromJson(json['admin'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_AdminPurgePersonViewToJson(
-        _$_AdminPurgePersonView instance) =>
+Map<String, dynamic> _$$AdminPurgePersonViewImplToJson(
+        _$AdminPurgePersonViewImpl instance) =>
     <String, dynamic>{
       'admin_purge_person': instance.adminPurgePerson.toJson(),
       'admin': instance.admin?.toJson(),

--- a/lib/src/v3/views/admin_purge_post_view.freezed.dart
+++ b/lib/src/v3/views/admin_purge_post_view.freezed.dart
@@ -107,11 +107,11 @@ class _$AdminPurgePostViewCopyWithImpl<$Res, $Val extends AdminPurgePostView>
 }
 
 /// @nodoc
-abstract class _$$_AdminPurgePostViewCopyWith<$Res>
+abstract class _$$AdminPurgePostViewImplCopyWith<$Res>
     implements $AdminPurgePostViewCopyWith<$Res> {
-  factory _$$_AdminPurgePostViewCopyWith(_$_AdminPurgePostView value,
-          $Res Function(_$_AdminPurgePostView) then) =
-      __$$_AdminPurgePostViewCopyWithImpl<$Res>;
+  factory _$$AdminPurgePostViewImplCopyWith(_$AdminPurgePostViewImpl value,
+          $Res Function(_$AdminPurgePostViewImpl) then) =
+      __$$AdminPurgePostViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -126,11 +126,11 @@ abstract class _$$_AdminPurgePostViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AdminPurgePostViewCopyWithImpl<$Res>
-    extends _$AdminPurgePostViewCopyWithImpl<$Res, _$_AdminPurgePostView>
-    implements _$$_AdminPurgePostViewCopyWith<$Res> {
-  __$$_AdminPurgePostViewCopyWithImpl(
-      _$_AdminPurgePostView _value, $Res Function(_$_AdminPurgePostView) _then)
+class __$$AdminPurgePostViewImplCopyWithImpl<$Res>
+    extends _$AdminPurgePostViewCopyWithImpl<$Res, _$AdminPurgePostViewImpl>
+    implements _$$AdminPurgePostViewImplCopyWith<$Res> {
+  __$$AdminPurgePostViewImplCopyWithImpl(_$AdminPurgePostViewImpl _value,
+      $Res Function(_$AdminPurgePostViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -140,7 +140,7 @@ class __$$_AdminPurgePostViewCopyWithImpl<$Res>
     Object? admin = freezed,
     Object? community = null,
   }) {
-    return _then(_$_AdminPurgePostView(
+    return _then(_$AdminPurgePostViewImpl(
       adminPurgePost: null == adminPurgePost
           ? _value.adminPurgePost
           : adminPurgePost // ignore: cast_nullable_to_non_nullable
@@ -160,13 +160,13 @@ class __$$_AdminPurgePostViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_AdminPurgePostView extends _AdminPurgePostView {
-  const _$_AdminPurgePostView(
+class _$AdminPurgePostViewImpl extends _AdminPurgePostView {
+  const _$AdminPurgePostViewImpl(
       {required this.adminPurgePost, this.admin, required this.community})
       : super._();
 
-  factory _$_AdminPurgePostView.fromJson(Map<String, dynamic> json) =>
-      _$$_AdminPurgePostViewFromJson(json);
+  factory _$AdminPurgePostViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminPurgePostViewImplFromJson(json);
 
   @override
   final AdminPurgePost adminPurgePost;
@@ -184,7 +184,7 @@ class _$_AdminPurgePostView extends _AdminPurgePostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AdminPurgePostView &&
+            other is _$AdminPurgePostViewImpl &&
             (identical(other.adminPurgePost, adminPurgePost) ||
                 other.adminPurgePost == adminPurgePost) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -200,13 +200,13 @@ class _$_AdminPurgePostView extends _AdminPurgePostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AdminPurgePostViewCopyWith<_$_AdminPurgePostView> get copyWith =>
-      __$$_AdminPurgePostViewCopyWithImpl<_$_AdminPurgePostView>(
+  _$$AdminPurgePostViewImplCopyWith<_$AdminPurgePostViewImpl> get copyWith =>
+      __$$AdminPurgePostViewImplCopyWithImpl<_$AdminPurgePostViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AdminPurgePostViewToJson(
+    return _$$AdminPurgePostViewImplToJson(
       this,
     );
   }
@@ -216,11 +216,11 @@ abstract class _AdminPurgePostView extends AdminPurgePostView {
   const factory _AdminPurgePostView(
       {required final AdminPurgePost adminPurgePost,
       final Person? admin,
-      required final Community community}) = _$_AdminPurgePostView;
+      required final Community community}) = _$AdminPurgePostViewImpl;
   const _AdminPurgePostView._() : super._();
 
   factory _AdminPurgePostView.fromJson(Map<String, dynamic> json) =
-      _$_AdminPurgePostView.fromJson;
+      _$AdminPurgePostViewImpl.fromJson;
 
   @override
   AdminPurgePost get adminPurgePost;
@@ -230,6 +230,6 @@ abstract class _AdminPurgePostView extends AdminPurgePostView {
   Community get community;
   @override
   @JsonKey(ignore: true)
-  _$$_AdminPurgePostViewCopyWith<_$_AdminPurgePostView> get copyWith =>
+  _$$AdminPurgePostViewImplCopyWith<_$AdminPurgePostViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/admin_purge_post_view.g.dart
+++ b/lib/src/v3/views/admin_purge_post_view.g.dart
@@ -6,9 +6,9 @@ part of 'admin_purge_post_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_AdminPurgePostView _$$_AdminPurgePostViewFromJson(
+_$AdminPurgePostViewImpl _$$AdminPurgePostViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_AdminPurgePostView(
+    _$AdminPurgePostViewImpl(
       adminPurgePost: AdminPurgePost.fromJson(
           json['admin_purge_post'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -17,8 +17,8 @@ _$_AdminPurgePostView _$$_AdminPurgePostViewFromJson(
       community: Community.fromJson(json['community'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_AdminPurgePostViewToJson(
-        _$_AdminPurgePostView instance) =>
+Map<String, dynamic> _$$AdminPurgePostViewImplToJson(
+        _$AdminPurgePostViewImpl instance) =>
     <String, dynamic>{
       'admin_purge_post': instance.adminPurgePost.toJson(),
       'admin': instance.admin?.toJson(),

--- a/lib/src/v3/views/comment_reply_view.freezed.dart
+++ b/lib/src/v3/views/comment_reply_view.freezed.dart
@@ -212,11 +212,11 @@ class _$CommentReplyViewCopyWithImpl<$Res, $Val extends CommentReplyView>
 }
 
 /// @nodoc
-abstract class _$$_CommentReplyViewCopyWith<$Res>
+abstract class _$$CommentReplyViewImplCopyWith<$Res>
     implements $CommentReplyViewCopyWith<$Res> {
-  factory _$$_CommentReplyViewCopyWith(
-          _$_CommentReplyView value, $Res Function(_$_CommentReplyView) then) =
-      __$$_CommentReplyViewCopyWithImpl<$Res>;
+  factory _$$CommentReplyViewImplCopyWith(_$CommentReplyViewImpl value,
+          $Res Function(_$CommentReplyViewImpl) then) =
+      __$$CommentReplyViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -251,11 +251,11 @@ abstract class _$$_CommentReplyViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentReplyViewCopyWithImpl<$Res>
-    extends _$CommentReplyViewCopyWithImpl<$Res, _$_CommentReplyView>
-    implements _$$_CommentReplyViewCopyWith<$Res> {
-  __$$_CommentReplyViewCopyWithImpl(
-      _$_CommentReplyView _value, $Res Function(_$_CommentReplyView) _then)
+class __$$CommentReplyViewImplCopyWithImpl<$Res>
+    extends _$CommentReplyViewCopyWithImpl<$Res, _$CommentReplyViewImpl>
+    implements _$$CommentReplyViewImplCopyWith<$Res> {
+  __$$CommentReplyViewImplCopyWithImpl(_$CommentReplyViewImpl _value,
+      $Res Function(_$CommentReplyViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -275,7 +275,7 @@ class __$$_CommentReplyViewCopyWithImpl<$Res>
     Object? creatorBlocked = null,
     Object? myVote = freezed,
   }) {
-    return _then(_$_CommentReplyView(
+    return _then(_$CommentReplyViewImpl(
       commentReply: null == commentReply
           ? _value.commentReply
           : commentReply // ignore: cast_nullable_to_non_nullable
@@ -335,8 +335,8 @@ class __$$_CommentReplyViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentReplyView extends _CommentReplyView {
-  const _$_CommentReplyView(
+class _$CommentReplyViewImpl extends _CommentReplyView {
+  const _$CommentReplyViewImpl(
       {required this.commentReply,
       required this.comment,
       required this.creator,
@@ -352,8 +352,8 @@ class _$_CommentReplyView extends _CommentReplyView {
       this.myVote})
       : super._();
 
-  factory _$_CommentReplyView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentReplyViewFromJson(json);
+  factory _$CommentReplyViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentReplyViewImplFromJson(json);
 
   @override
   final CommentReply commentReply;
@@ -392,7 +392,7 @@ class _$_CommentReplyView extends _CommentReplyView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentReplyView &&
+            other is _$CommentReplyViewImpl &&
             (identical(other.commentReply, commentReply) ||
                 other.commentReply == commentReply) &&
             (identical(other.comment, comment) || other.comment == comment) &&
@@ -438,12 +438,13 @@ class _$_CommentReplyView extends _CommentReplyView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentReplyViewCopyWith<_$_CommentReplyView> get copyWith =>
-      __$$_CommentReplyViewCopyWithImpl<_$_CommentReplyView>(this, _$identity);
+  _$$CommentReplyViewImplCopyWith<_$CommentReplyViewImpl> get copyWith =>
+      __$$CommentReplyViewImplCopyWithImpl<_$CommentReplyViewImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentReplyViewToJson(
+    return _$$CommentReplyViewImplToJson(
       this,
     );
   }
@@ -463,11 +464,11 @@ abstract class _CommentReplyView extends CommentReplyView {
       required final SubscribedType subscribed,
       required final bool saved,
       required final bool creatorBlocked,
-      final num? myVote}) = _$_CommentReplyView;
+      final num? myVote}) = _$CommentReplyViewImpl;
   const _CommentReplyView._() : super._();
 
   factory _CommentReplyView.fromJson(Map<String, dynamic> json) =
-      _$_CommentReplyView.fromJson;
+      _$CommentReplyViewImpl.fromJson;
 
   @override
   CommentReply get commentReply;
@@ -497,6 +498,6 @@ abstract class _CommentReplyView extends CommentReplyView {
   num? get myVote;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentReplyViewCopyWith<_$_CommentReplyView> get copyWith =>
+  _$$CommentReplyViewImplCopyWith<_$CommentReplyViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/comment_reply_view.g.dart
+++ b/lib/src/v3/views/comment_reply_view.g.dart
@@ -6,8 +6,9 @@ part of 'comment_reply_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommentReplyView _$$_CommentReplyViewFromJson(Map<String, dynamic> json) =>
-    _$_CommentReplyView(
+_$CommentReplyViewImpl _$$CommentReplyViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CommentReplyViewImpl(
       commentReply:
           CommentReply.fromJson(json['comment_reply'] as Map<String, dynamic>),
       comment: Comment.fromJson(json['comment'] as Map<String, dynamic>),
@@ -25,7 +26,8 @@ _$_CommentReplyView _$$_CommentReplyViewFromJson(Map<String, dynamic> json) =>
       myVote: json['my_vote'] as num?,
     );
 
-Map<String, dynamic> _$$_CommentReplyViewToJson(_$_CommentReplyView instance) =>
+Map<String, dynamic> _$$CommentReplyViewImplToJson(
+        _$CommentReplyViewImpl instance) =>
     <String, dynamic>{
       'comment_reply': instance.commentReply.toJson(),
       'comment': instance.comment.toJson(),

--- a/lib/src/v3/views/comment_report_view.freezed.dart
+++ b/lib/src/v3/views/comment_report_view.freezed.dart
@@ -203,11 +203,11 @@ class _$CommentReportViewCopyWithImpl<$Res, $Val extends CommentReportView>
 }
 
 /// @nodoc
-abstract class _$$_CommentReportViewCopyWith<$Res>
+abstract class _$$CommentReportViewImplCopyWith<$Res>
     implements $CommentReportViewCopyWith<$Res> {
-  factory _$$_CommentReportViewCopyWith(_$_CommentReportView value,
-          $Res Function(_$_CommentReportView) then) =
-      __$$_CommentReportViewCopyWithImpl<$Res>;
+  factory _$$CommentReportViewImplCopyWith(_$CommentReportViewImpl value,
+          $Res Function(_$CommentReportViewImpl) then) =
+      __$$CommentReportViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -241,11 +241,11 @@ abstract class _$$_CommentReportViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentReportViewCopyWithImpl<$Res>
-    extends _$CommentReportViewCopyWithImpl<$Res, _$_CommentReportView>
-    implements _$$_CommentReportViewCopyWith<$Res> {
-  __$$_CommentReportViewCopyWithImpl(
-      _$_CommentReportView _value, $Res Function(_$_CommentReportView) _then)
+class __$$CommentReportViewImplCopyWithImpl<$Res>
+    extends _$CommentReportViewCopyWithImpl<$Res, _$CommentReportViewImpl>
+    implements _$$CommentReportViewImplCopyWith<$Res> {
+  __$$CommentReportViewImplCopyWithImpl(_$CommentReportViewImpl _value,
+      $Res Function(_$CommentReportViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -262,7 +262,7 @@ class __$$_CommentReportViewCopyWithImpl<$Res>
     Object? myVote = freezed,
     Object? resolver = freezed,
   }) {
-    return _then(_$_CommentReportView(
+    return _then(_$CommentReportViewImpl(
       commentReport: null == commentReport
           ? _value.commentReport
           : commentReport // ignore: cast_nullable_to_non_nullable
@@ -310,8 +310,8 @@ class __$$_CommentReportViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentReportView extends _CommentReportView {
-  const _$_CommentReportView(
+class _$CommentReportViewImpl extends _CommentReportView {
+  const _$CommentReportViewImpl(
       {required this.commentReport,
       required this.comment,
       required this.post,
@@ -324,8 +324,8 @@ class _$_CommentReportView extends _CommentReportView {
       this.resolver})
       : super._();
 
-  factory _$_CommentReportView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentReportViewFromJson(json);
+  factory _$CommentReportViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentReportViewImplFromJson(json);
 
   @override
   final CommentReport commentReport;
@@ -357,7 +357,7 @@ class _$_CommentReportView extends _CommentReportView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentReportView &&
+            other is _$CommentReportViewImpl &&
             (identical(other.commentReport, commentReport) ||
                 other.commentReport == commentReport) &&
             (identical(other.comment, comment) || other.comment == comment) &&
@@ -395,13 +395,13 @@ class _$_CommentReportView extends _CommentReportView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentReportViewCopyWith<_$_CommentReportView> get copyWith =>
-      __$$_CommentReportViewCopyWithImpl<_$_CommentReportView>(
+  _$$CommentReportViewImplCopyWith<_$CommentReportViewImpl> get copyWith =>
+      __$$CommentReportViewImplCopyWithImpl<_$CommentReportViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentReportViewToJson(
+    return _$$CommentReportViewImplToJson(
       this,
     );
   }
@@ -418,11 +418,11 @@ abstract class _CommentReportView extends CommentReportView {
       required final CommentAggregates counts,
       required final bool creatorBannedFromCommunity,
       final num? myVote,
-      final Person? resolver}) = _$_CommentReportView;
+      final Person? resolver}) = _$CommentReportViewImpl;
   const _CommentReportView._() : super._();
 
   factory _CommentReportView.fromJson(Map<String, dynamic> json) =
-      _$_CommentReportView.fromJson;
+      _$CommentReportViewImpl.fromJson;
 
   @override
   CommentReport get commentReport;
@@ -446,6 +446,6 @@ abstract class _CommentReportView extends CommentReportView {
   Person? get resolver;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentReportViewCopyWith<_$_CommentReportView> get copyWith =>
+  _$$CommentReportViewImplCopyWith<_$CommentReportViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/comment_report_view.g.dart
+++ b/lib/src/v3/views/comment_report_view.g.dart
@@ -6,8 +6,9 @@ part of 'comment_report_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommentReportView _$$_CommentReportViewFromJson(Map<String, dynamic> json) =>
-    _$_CommentReportView(
+_$CommentReportViewImpl _$$CommentReportViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CommentReportViewImpl(
       commentReport: CommentReport.fromJson(
           json['comment_report'] as Map<String, dynamic>),
       comment: Comment.fromJson(json['comment'] as Map<String, dynamic>),
@@ -25,8 +26,8 @@ _$_CommentReportView _$$_CommentReportViewFromJson(Map<String, dynamic> json) =>
           : Person.fromJson(json['resolver'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_CommentReportViewToJson(
-        _$_CommentReportView instance) =>
+Map<String, dynamic> _$$CommentReportViewImplToJson(
+        _$CommentReportViewImpl instance) =>
     <String, dynamic>{
       'comment_report': instance.commentReport.toJson(),
       'comment': instance.comment.toJson(),

--- a/lib/src/v3/views/comment_view.freezed.dart
+++ b/lib/src/v3/views/comment_view.freezed.dart
@@ -180,11 +180,11 @@ class _$CommentViewCopyWithImpl<$Res, $Val extends CommentView>
 }
 
 /// @nodoc
-abstract class _$$_CommentViewCopyWith<$Res>
+abstract class _$$CommentViewImplCopyWith<$Res>
     implements $CommentViewCopyWith<$Res> {
-  factory _$$_CommentViewCopyWith(
-          _$_CommentView value, $Res Function(_$_CommentView) then) =
-      __$$_CommentViewCopyWithImpl<$Res>;
+  factory _$$CommentViewImplCopyWith(
+          _$CommentViewImpl value, $Res Function(_$CommentViewImpl) then) =
+      __$$CommentViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -213,11 +213,11 @@ abstract class _$$_CommentViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommentViewCopyWithImpl<$Res>
-    extends _$CommentViewCopyWithImpl<$Res, _$_CommentView>
-    implements _$$_CommentViewCopyWith<$Res> {
-  __$$_CommentViewCopyWithImpl(
-      _$_CommentView _value, $Res Function(_$_CommentView) _then)
+class __$$CommentViewImplCopyWithImpl<$Res>
+    extends _$CommentViewCopyWithImpl<$Res, _$CommentViewImpl>
+    implements _$$CommentViewImplCopyWith<$Res> {
+  __$$CommentViewImplCopyWithImpl(
+      _$CommentViewImpl _value, $Res Function(_$CommentViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -235,7 +235,7 @@ class __$$_CommentViewCopyWithImpl<$Res>
     Object? creatorBlocked = null,
     Object? myVote = freezed,
   }) {
-    return _then(_$_CommentView(
+    return _then(_$CommentViewImpl(
       comment: null == comment
           ? _value.comment
           : comment // ignore: cast_nullable_to_non_nullable
@@ -287,8 +287,8 @@ class __$$_CommentViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommentView extends _CommentView {
-  const _$_CommentView(
+class _$CommentViewImpl extends _CommentView {
+  const _$CommentViewImpl(
       {required this.comment,
       required this.creator,
       required this.post,
@@ -302,8 +302,8 @@ class _$_CommentView extends _CommentView {
       this.myVote})
       : super._();
 
-  factory _$_CommentView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommentViewFromJson(json);
+  factory _$CommentViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommentViewImplFromJson(json);
 
   @override
   final Comment comment;
@@ -338,7 +338,7 @@ class _$_CommentView extends _CommentView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommentView &&
+            other is _$CommentViewImpl &&
             (identical(other.comment, comment) || other.comment == comment) &&
             (identical(other.creator, creator) || other.creator == creator) &&
             (identical(other.post, post) || other.post == post) &&
@@ -378,12 +378,12 @@ class _$_CommentView extends _CommentView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommentViewCopyWith<_$_CommentView> get copyWith =>
-      __$$_CommentViewCopyWithImpl<_$_CommentView>(this, _$identity);
+  _$$CommentViewImplCopyWith<_$CommentViewImpl> get copyWith =>
+      __$$CommentViewImplCopyWithImpl<_$CommentViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommentViewToJson(
+    return _$$CommentViewImplToJson(
       this,
     );
   }
@@ -401,11 +401,11 @@ abstract class _CommentView extends CommentView {
       required final SubscribedType subscribed,
       required final bool saved,
       required final bool creatorBlocked,
-      final int? myVote}) = _$_CommentView;
+      final int? myVote}) = _$CommentViewImpl;
   const _CommentView._() : super._();
 
   factory _CommentView.fromJson(Map<String, dynamic> json) =
-      _$_CommentView.fromJson;
+      _$CommentViewImpl.fromJson;
 
   @override
   Comment get comment;
@@ -431,6 +431,6 @@ abstract class _CommentView extends CommentView {
   int? get myVote;
   @override
   @JsonKey(ignore: true)
-  _$$_CommentViewCopyWith<_$_CommentView> get copyWith =>
+  _$$CommentViewImplCopyWith<_$CommentViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/comment_view.g.dart
+++ b/lib/src/v3/views/comment_view.g.dart
@@ -6,8 +6,8 @@ part of 'comment_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommentView _$$_CommentViewFromJson(Map<String, dynamic> json) =>
-    _$_CommentView(
+_$CommentViewImpl _$$CommentViewImplFromJson(Map<String, dynamic> json) =>
+    _$CommentViewImpl(
       comment: Comment.fromJson(json['comment'] as Map<String, dynamic>),
       creator: Person.fromJson(json['creator'] as Map<String, dynamic>),
       post: Post.fromJson(json['post'] as Map<String, dynamic>),
@@ -22,7 +22,7 @@ _$_CommentView _$$_CommentViewFromJson(Map<String, dynamic> json) =>
       myVote: json['my_vote'] as int?,
     );
 
-Map<String, dynamic> _$$_CommentViewToJson(_$_CommentView instance) =>
+Map<String, dynamic> _$$CommentViewImplToJson(_$CommentViewImpl instance) =>
     <String, dynamic>{
       'comment': instance.comment.toJson(),
       'creator': instance.creator.toJson(),

--- a/lib/src/v3/views/community_block_view.freezed.dart
+++ b/lib/src/v3/views/community_block_view.freezed.dart
@@ -87,11 +87,11 @@ class _$CommunityBlockViewCopyWithImpl<$Res, $Val extends CommunityBlockView>
 }
 
 /// @nodoc
-abstract class _$$_CommunityBlockViewCopyWith<$Res>
+abstract class _$$CommunityBlockViewImplCopyWith<$Res>
     implements $CommunityBlockViewCopyWith<$Res> {
-  factory _$$_CommunityBlockViewCopyWith(_$_CommunityBlockView value,
-          $Res Function(_$_CommunityBlockView) then) =
-      __$$_CommunityBlockViewCopyWithImpl<$Res>;
+  factory _$$CommunityBlockViewImplCopyWith(_$CommunityBlockViewImpl value,
+          $Res Function(_$CommunityBlockViewImpl) then) =
+      __$$CommunityBlockViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({Person person, Community community});
@@ -103,11 +103,11 @@ abstract class _$$_CommunityBlockViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunityBlockViewCopyWithImpl<$Res>
-    extends _$CommunityBlockViewCopyWithImpl<$Res, _$_CommunityBlockView>
-    implements _$$_CommunityBlockViewCopyWith<$Res> {
-  __$$_CommunityBlockViewCopyWithImpl(
-      _$_CommunityBlockView _value, $Res Function(_$_CommunityBlockView) _then)
+class __$$CommunityBlockViewImplCopyWithImpl<$Res>
+    extends _$CommunityBlockViewCopyWithImpl<$Res, _$CommunityBlockViewImpl>
+    implements _$$CommunityBlockViewImplCopyWith<$Res> {
+  __$$CommunityBlockViewImplCopyWithImpl(_$CommunityBlockViewImpl _value,
+      $Res Function(_$CommunityBlockViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -116,7 +116,7 @@ class __$$_CommunityBlockViewCopyWithImpl<$Res>
     Object? person = null,
     Object? community = null,
   }) {
-    return _then(_$_CommunityBlockView(
+    return _then(_$CommunityBlockViewImpl(
       person: null == person
           ? _value.person
           : person // ignore: cast_nullable_to_non_nullable
@@ -132,12 +132,13 @@ class __$$_CommunityBlockViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunityBlockView extends _CommunityBlockView {
-  const _$_CommunityBlockView({required this.person, required this.community})
+class _$CommunityBlockViewImpl extends _CommunityBlockView {
+  const _$CommunityBlockViewImpl(
+      {required this.person, required this.community})
       : super._();
 
-  factory _$_CommunityBlockView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityBlockViewFromJson(json);
+  factory _$CommunityBlockViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityBlockViewImplFromJson(json);
 
   @override
   final Person person;
@@ -153,7 +154,7 @@ class _$_CommunityBlockView extends _CommunityBlockView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunityBlockView &&
+            other is _$CommunityBlockViewImpl &&
             (identical(other.person, person) || other.person == person) &&
             (identical(other.community, community) ||
                 other.community == community));
@@ -166,13 +167,13 @@ class _$_CommunityBlockView extends _CommunityBlockView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityBlockViewCopyWith<_$_CommunityBlockView> get copyWith =>
-      __$$_CommunityBlockViewCopyWithImpl<_$_CommunityBlockView>(
+  _$$CommunityBlockViewImplCopyWith<_$CommunityBlockViewImpl> get copyWith =>
+      __$$CommunityBlockViewImplCopyWithImpl<_$CommunityBlockViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityBlockViewToJson(
+    return _$$CommunityBlockViewImplToJson(
       this,
     );
   }
@@ -181,11 +182,11 @@ class _$_CommunityBlockView extends _CommunityBlockView {
 abstract class _CommunityBlockView extends CommunityBlockView {
   const factory _CommunityBlockView(
       {required final Person person,
-      required final Community community}) = _$_CommunityBlockView;
+      required final Community community}) = _$CommunityBlockViewImpl;
   const _CommunityBlockView._() : super._();
 
   factory _CommunityBlockView.fromJson(Map<String, dynamic> json) =
-      _$_CommunityBlockView.fromJson;
+      _$CommunityBlockViewImpl.fromJson;
 
   @override
   Person get person;
@@ -193,6 +194,6 @@ abstract class _CommunityBlockView extends CommunityBlockView {
   Community get community;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityBlockViewCopyWith<_$_CommunityBlockView> get copyWith =>
+  _$$CommunityBlockViewImplCopyWith<_$CommunityBlockViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/community_block_view.g.dart
+++ b/lib/src/v3/views/community_block_view.g.dart
@@ -6,15 +6,15 @@ part of 'community_block_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommunityBlockView _$$_CommunityBlockViewFromJson(
+_$CommunityBlockViewImpl _$$CommunityBlockViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CommunityBlockView(
+    _$CommunityBlockViewImpl(
       person: Person.fromJson(json['person'] as Map<String, dynamic>),
       community: Community.fromJson(json['community'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_CommunityBlockViewToJson(
-        _$_CommunityBlockView instance) =>
+Map<String, dynamic> _$$CommunityBlockViewImplToJson(
+        _$CommunityBlockViewImpl instance) =>
     <String, dynamic>{
       'person': instance.person.toJson(),
       'community': instance.community.toJson(),

--- a/lib/src/v3/views/community_follower_view.freezed.dart
+++ b/lib/src/v3/views/community_follower_view.freezed.dart
@@ -89,11 +89,12 @@ class _$CommunityFollowerViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_CommunityFollowerViewCopyWith<$Res>
+abstract class _$$CommunityFollowerViewImplCopyWith<$Res>
     implements $CommunityFollowerViewCopyWith<$Res> {
-  factory _$$_CommunityFollowerViewCopyWith(_$_CommunityFollowerView value,
-          $Res Function(_$_CommunityFollowerView) then) =
-      __$$_CommunityFollowerViewCopyWithImpl<$Res>;
+  factory _$$CommunityFollowerViewImplCopyWith(
+          _$CommunityFollowerViewImpl value,
+          $Res Function(_$CommunityFollowerViewImpl) then) =
+      __$$CommunityFollowerViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({Community community, Person follower});
@@ -105,11 +106,12 @@ abstract class _$$_CommunityFollowerViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunityFollowerViewCopyWithImpl<$Res>
-    extends _$CommunityFollowerViewCopyWithImpl<$Res, _$_CommunityFollowerView>
-    implements _$$_CommunityFollowerViewCopyWith<$Res> {
-  __$$_CommunityFollowerViewCopyWithImpl(_$_CommunityFollowerView _value,
-      $Res Function(_$_CommunityFollowerView) _then)
+class __$$CommunityFollowerViewImplCopyWithImpl<$Res>
+    extends _$CommunityFollowerViewCopyWithImpl<$Res,
+        _$CommunityFollowerViewImpl>
+    implements _$$CommunityFollowerViewImplCopyWith<$Res> {
+  __$$CommunityFollowerViewImplCopyWithImpl(_$CommunityFollowerViewImpl _value,
+      $Res Function(_$CommunityFollowerViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -118,7 +120,7 @@ class __$$_CommunityFollowerViewCopyWithImpl<$Res>
     Object? community = null,
     Object? follower = null,
   }) {
-    return _then(_$_CommunityFollowerView(
+    return _then(_$CommunityFollowerViewImpl(
       community: null == community
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
@@ -134,13 +136,13 @@ class __$$_CommunityFollowerViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunityFollowerView extends _CommunityFollowerView {
-  const _$_CommunityFollowerView(
+class _$CommunityFollowerViewImpl extends _CommunityFollowerView {
+  const _$CommunityFollowerViewImpl(
       {required this.community, required this.follower})
       : super._();
 
-  factory _$_CommunityFollowerView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityFollowerViewFromJson(json);
+  factory _$CommunityFollowerViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityFollowerViewImplFromJson(json);
 
   @override
   final Community community;
@@ -156,7 +158,7 @@ class _$_CommunityFollowerView extends _CommunityFollowerView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunityFollowerView &&
+            other is _$CommunityFollowerViewImpl &&
             (identical(other.community, community) ||
                 other.community == community) &&
             (identical(other.follower, follower) ||
@@ -170,13 +172,13 @@ class _$_CommunityFollowerView extends _CommunityFollowerView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityFollowerViewCopyWith<_$_CommunityFollowerView> get copyWith =>
-      __$$_CommunityFollowerViewCopyWithImpl<_$_CommunityFollowerView>(
-          this, _$identity);
+  _$$CommunityFollowerViewImplCopyWith<_$CommunityFollowerViewImpl>
+      get copyWith => __$$CommunityFollowerViewImplCopyWithImpl<
+          _$CommunityFollowerViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityFollowerViewToJson(
+    return _$$CommunityFollowerViewImplToJson(
       this,
     );
   }
@@ -185,11 +187,11 @@ class _$_CommunityFollowerView extends _CommunityFollowerView {
 abstract class _CommunityFollowerView extends CommunityFollowerView {
   const factory _CommunityFollowerView(
       {required final Community community,
-      required final Person follower}) = _$_CommunityFollowerView;
+      required final Person follower}) = _$CommunityFollowerViewImpl;
   const _CommunityFollowerView._() : super._();
 
   factory _CommunityFollowerView.fromJson(Map<String, dynamic> json) =
-      _$_CommunityFollowerView.fromJson;
+      _$CommunityFollowerViewImpl.fromJson;
 
   @override
   Community get community;
@@ -197,6 +199,6 @@ abstract class _CommunityFollowerView extends CommunityFollowerView {
   Person get follower;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityFollowerViewCopyWith<_$_CommunityFollowerView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$CommunityFollowerViewImplCopyWith<_$CommunityFollowerViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/community_follower_view.g.dart
+++ b/lib/src/v3/views/community_follower_view.g.dart
@@ -6,15 +6,15 @@ part of 'community_follower_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommunityFollowerView _$$_CommunityFollowerViewFromJson(
+_$CommunityFollowerViewImpl _$$CommunityFollowerViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CommunityFollowerView(
+    _$CommunityFollowerViewImpl(
       community: Community.fromJson(json['community'] as Map<String, dynamic>),
       follower: Person.fromJson(json['follower'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_CommunityFollowerViewToJson(
-        _$_CommunityFollowerView instance) =>
+Map<String, dynamic> _$$CommunityFollowerViewImplToJson(
+        _$CommunityFollowerViewImpl instance) =>
     <String, dynamic>{
       'community': instance.community.toJson(),
       'follower': instance.follower.toJson(),

--- a/lib/src/v3/views/community_moderator_view.freezed.dart
+++ b/lib/src/v3/views/community_moderator_view.freezed.dart
@@ -89,11 +89,12 @@ class _$CommunityModeratorViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_CommunityModeratorViewCopyWith<$Res>
+abstract class _$$CommunityModeratorViewImplCopyWith<$Res>
     implements $CommunityModeratorViewCopyWith<$Res> {
-  factory _$$_CommunityModeratorViewCopyWith(_$_CommunityModeratorView value,
-          $Res Function(_$_CommunityModeratorView) then) =
-      __$$_CommunityModeratorViewCopyWithImpl<$Res>;
+  factory _$$CommunityModeratorViewImplCopyWith(
+          _$CommunityModeratorViewImpl value,
+          $Res Function(_$CommunityModeratorViewImpl) then) =
+      __$$CommunityModeratorViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({Community community, Person moderator});
@@ -105,12 +106,13 @@ abstract class _$$_CommunityModeratorViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunityModeratorViewCopyWithImpl<$Res>
+class __$$CommunityModeratorViewImplCopyWithImpl<$Res>
     extends _$CommunityModeratorViewCopyWithImpl<$Res,
-        _$_CommunityModeratorView>
-    implements _$$_CommunityModeratorViewCopyWith<$Res> {
-  __$$_CommunityModeratorViewCopyWithImpl(_$_CommunityModeratorView _value,
-      $Res Function(_$_CommunityModeratorView) _then)
+        _$CommunityModeratorViewImpl>
+    implements _$$CommunityModeratorViewImplCopyWith<$Res> {
+  __$$CommunityModeratorViewImplCopyWithImpl(
+      _$CommunityModeratorViewImpl _value,
+      $Res Function(_$CommunityModeratorViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -119,7 +121,7 @@ class __$$_CommunityModeratorViewCopyWithImpl<$Res>
     Object? community = null,
     Object? moderator = null,
   }) {
-    return _then(_$_CommunityModeratorView(
+    return _then(_$CommunityModeratorViewImpl(
       community: null == community
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
@@ -135,13 +137,13 @@ class __$$_CommunityModeratorViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunityModeratorView extends _CommunityModeratorView {
-  const _$_CommunityModeratorView(
+class _$CommunityModeratorViewImpl extends _CommunityModeratorView {
+  const _$CommunityModeratorViewImpl(
       {required this.community, required this.moderator})
       : super._();
 
-  factory _$_CommunityModeratorView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityModeratorViewFromJson(json);
+  factory _$CommunityModeratorViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityModeratorViewImplFromJson(json);
 
   @override
   final Community community;
@@ -157,7 +159,7 @@ class _$_CommunityModeratorView extends _CommunityModeratorView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunityModeratorView &&
+            other is _$CommunityModeratorViewImpl &&
             (identical(other.community, community) ||
                 other.community == community) &&
             (identical(other.moderator, moderator) ||
@@ -171,13 +173,13 @@ class _$_CommunityModeratorView extends _CommunityModeratorView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityModeratorViewCopyWith<_$_CommunityModeratorView> get copyWith =>
-      __$$_CommunityModeratorViewCopyWithImpl<_$_CommunityModeratorView>(
-          this, _$identity);
+  _$$CommunityModeratorViewImplCopyWith<_$CommunityModeratorViewImpl>
+      get copyWith => __$$CommunityModeratorViewImplCopyWithImpl<
+          _$CommunityModeratorViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityModeratorViewToJson(
+    return _$$CommunityModeratorViewImplToJson(
       this,
     );
   }
@@ -186,11 +188,11 @@ class _$_CommunityModeratorView extends _CommunityModeratorView {
 abstract class _CommunityModeratorView extends CommunityModeratorView {
   const factory _CommunityModeratorView(
       {required final Community community,
-      required final Person moderator}) = _$_CommunityModeratorView;
+      required final Person moderator}) = _$CommunityModeratorViewImpl;
   const _CommunityModeratorView._() : super._();
 
   factory _CommunityModeratorView.fromJson(Map<String, dynamic> json) =
-      _$_CommunityModeratorView.fromJson;
+      _$CommunityModeratorViewImpl.fromJson;
 
   @override
   Community get community;
@@ -198,6 +200,6 @@ abstract class _CommunityModeratorView extends CommunityModeratorView {
   Person get moderator;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityModeratorViewCopyWith<_$_CommunityModeratorView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$CommunityModeratorViewImplCopyWith<_$CommunityModeratorViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/community_moderator_view.g.dart
+++ b/lib/src/v3/views/community_moderator_view.g.dart
@@ -6,15 +6,15 @@ part of 'community_moderator_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommunityModeratorView _$$_CommunityModeratorViewFromJson(
+_$CommunityModeratorViewImpl _$$CommunityModeratorViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_CommunityModeratorView(
+    _$CommunityModeratorViewImpl(
       community: Community.fromJson(json['community'] as Map<String, dynamic>),
       moderator: Person.fromJson(json['moderator'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_CommunityModeratorViewToJson(
-        _$_CommunityModeratorView instance) =>
+Map<String, dynamic> _$$CommunityModeratorViewImplToJson(
+        _$CommunityModeratorViewImpl instance) =>
     <String, dynamic>{
       'community': instance.community.toJson(),
       'moderator': instance.moderator.toJson(),

--- a/lib/src/v3/views/community_view.freezed.dart
+++ b/lib/src/v3/views/community_view.freezed.dart
@@ -103,11 +103,11 @@ class _$CommunityViewCopyWithImpl<$Res, $Val extends CommunityView>
 }
 
 /// @nodoc
-abstract class _$$_CommunityViewCopyWith<$Res>
+abstract class _$$CommunityViewImplCopyWith<$Res>
     implements $CommunityViewCopyWith<$Res> {
-  factory _$$_CommunityViewCopyWith(
-          _$_CommunityView value, $Res Function(_$_CommunityView) then) =
-      __$$_CommunityViewCopyWithImpl<$Res>;
+  factory _$$CommunityViewImplCopyWith(
+          _$CommunityViewImpl value, $Res Function(_$CommunityViewImpl) then) =
+      __$$CommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -123,11 +123,11 @@ abstract class _$$_CommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CommunityViewCopyWithImpl<$Res>
-    extends _$CommunityViewCopyWithImpl<$Res, _$_CommunityView>
-    implements _$$_CommunityViewCopyWith<$Res> {
-  __$$_CommunityViewCopyWithImpl(
-      _$_CommunityView _value, $Res Function(_$_CommunityView) _then)
+class __$$CommunityViewImplCopyWithImpl<$Res>
+    extends _$CommunityViewCopyWithImpl<$Res, _$CommunityViewImpl>
+    implements _$$CommunityViewImplCopyWith<$Res> {
+  __$$CommunityViewImplCopyWithImpl(
+      _$CommunityViewImpl _value, $Res Function(_$CommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -138,7 +138,7 @@ class __$$_CommunityViewCopyWithImpl<$Res>
     Object? blocked = null,
     Object? counts = null,
   }) {
-    return _then(_$_CommunityView(
+    return _then(_$CommunityViewImpl(
       community: null == community
           ? _value.community
           : community // ignore: cast_nullable_to_non_nullable
@@ -162,16 +162,16 @@ class __$$_CommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CommunityView extends _CommunityView {
-  const _$_CommunityView(
+class _$CommunityViewImpl extends _CommunityView {
+  const _$CommunityViewImpl(
       {required this.community,
       required this.subscribed,
       required this.blocked,
       required this.counts})
       : super._();
 
-  factory _$_CommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_CommunityViewFromJson(json);
+  factory _$CommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CommunityViewImplFromJson(json);
 
   @override
   final Community community;
@@ -191,7 +191,7 @@ class _$_CommunityView extends _CommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CommunityView &&
+            other is _$CommunityViewImpl &&
             (identical(other.community, community) ||
                 other.community == community) &&
             (identical(other.subscribed, subscribed) ||
@@ -208,12 +208,12 @@ class _$_CommunityView extends _CommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CommunityViewCopyWith<_$_CommunityView> get copyWith =>
-      __$$_CommunityViewCopyWithImpl<_$_CommunityView>(this, _$identity);
+  _$$CommunityViewImplCopyWith<_$CommunityViewImpl> get copyWith =>
+      __$$CommunityViewImplCopyWithImpl<_$CommunityViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CommunityViewToJson(
+    return _$$CommunityViewImplToJson(
       this,
     );
   }
@@ -224,11 +224,11 @@ abstract class _CommunityView extends CommunityView {
       {required final Community community,
       required final SubscribedType subscribed,
       required final bool blocked,
-      required final CommunityAggregates counts}) = _$_CommunityView;
+      required final CommunityAggregates counts}) = _$CommunityViewImpl;
   const _CommunityView._() : super._();
 
   factory _CommunityView.fromJson(Map<String, dynamic> json) =
-      _$_CommunityView.fromJson;
+      _$CommunityViewImpl.fromJson;
 
   @override
   Community get community;
@@ -240,6 +240,6 @@ abstract class _CommunityView extends CommunityView {
   CommunityAggregates get counts;
   @override
   @JsonKey(ignore: true)
-  _$$_CommunityViewCopyWith<_$_CommunityView> get copyWith =>
+  _$$CommunityViewImplCopyWith<_$CommunityViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/community_view.g.dart
+++ b/lib/src/v3/views/community_view.g.dart
@@ -6,8 +6,8 @@ part of 'community_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CommunityView _$$_CommunityViewFromJson(Map<String, dynamic> json) =>
-    _$_CommunityView(
+_$CommunityViewImpl _$$CommunityViewImplFromJson(Map<String, dynamic> json) =>
+    _$CommunityViewImpl(
       community: Community.fromJson(json['community'] as Map<String, dynamic>),
       subscribed: SubscribedType.fromJson(json['subscribed'] as String),
       blocked: json['blocked'] as bool,
@@ -15,7 +15,7 @@ _$_CommunityView _$$_CommunityViewFromJson(Map<String, dynamic> json) =>
           CommunityAggregates.fromJson(json['counts'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_CommunityViewToJson(_$_CommunityView instance) =>
+Map<String, dynamic> _$$CommunityViewImplToJson(_$CommunityViewImpl instance) =>
     <String, dynamic>{
       'community': instance.community.toJson(),
       'subscribed': instance.subscribed.toJson(),

--- a/lib/src/v3/views/custom_emoji_view.freezed.dart
+++ b/lib/src/v3/views/custom_emoji_view.freezed.dart
@@ -78,11 +78,11 @@ class _$CustomEmojiViewCopyWithImpl<$Res, $Val extends CustomEmojiView>
 }
 
 /// @nodoc
-abstract class _$$_CustomEmojiViewCopyWith<$Res>
+abstract class _$$CustomEmojiViewImplCopyWith<$Res>
     implements $CustomEmojiViewCopyWith<$Res> {
-  factory _$$_CustomEmojiViewCopyWith(
-          _$_CustomEmojiView value, $Res Function(_$_CustomEmojiView) then) =
-      __$$_CustomEmojiViewCopyWithImpl<$Res>;
+  factory _$$CustomEmojiViewImplCopyWith(_$CustomEmojiViewImpl value,
+          $Res Function(_$CustomEmojiViewImpl) then) =
+      __$$CustomEmojiViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({CustomEmoji customEmoji, List<CustomEmojiKeyword> keywords});
@@ -92,11 +92,11 @@ abstract class _$$_CustomEmojiViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_CustomEmojiViewCopyWithImpl<$Res>
-    extends _$CustomEmojiViewCopyWithImpl<$Res, _$_CustomEmojiView>
-    implements _$$_CustomEmojiViewCopyWith<$Res> {
-  __$$_CustomEmojiViewCopyWithImpl(
-      _$_CustomEmojiView _value, $Res Function(_$_CustomEmojiView) _then)
+class __$$CustomEmojiViewImplCopyWithImpl<$Res>
+    extends _$CustomEmojiViewCopyWithImpl<$Res, _$CustomEmojiViewImpl>
+    implements _$$CustomEmojiViewImplCopyWith<$Res> {
+  __$$CustomEmojiViewImplCopyWithImpl(
+      _$CustomEmojiViewImpl _value, $Res Function(_$CustomEmojiViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -105,7 +105,7 @@ class __$$_CustomEmojiViewCopyWithImpl<$Res>
     Object? customEmoji = null,
     Object? keywords = null,
   }) {
-    return _then(_$_CustomEmojiView(
+    return _then(_$CustomEmojiViewImpl(
       customEmoji: null == customEmoji
           ? _value.customEmoji
           : customEmoji // ignore: cast_nullable_to_non_nullable
@@ -121,15 +121,15 @@ class __$$_CustomEmojiViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_CustomEmojiView extends _CustomEmojiView {
-  const _$_CustomEmojiView(
+class _$CustomEmojiViewImpl extends _CustomEmojiView {
+  const _$CustomEmojiViewImpl(
       {required this.customEmoji,
       required final List<CustomEmojiKeyword> keywords})
       : _keywords = keywords,
         super._();
 
-  factory _$_CustomEmojiView.fromJson(Map<String, dynamic> json) =>
-      _$$_CustomEmojiViewFromJson(json);
+  factory _$CustomEmojiViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CustomEmojiViewImplFromJson(json);
 
   @override
   final CustomEmoji customEmoji;
@@ -150,7 +150,7 @@ class _$_CustomEmojiView extends _CustomEmojiView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_CustomEmojiView &&
+            other is _$CustomEmojiViewImpl &&
             (identical(other.customEmoji, customEmoji) ||
                 other.customEmoji == customEmoji) &&
             const DeepCollectionEquality().equals(other._keywords, _keywords));
@@ -164,12 +164,13 @@ class _$_CustomEmojiView extends _CustomEmojiView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_CustomEmojiViewCopyWith<_$_CustomEmojiView> get copyWith =>
-      __$$_CustomEmojiViewCopyWithImpl<_$_CustomEmojiView>(this, _$identity);
+  _$$CustomEmojiViewImplCopyWith<_$CustomEmojiViewImpl> get copyWith =>
+      __$$CustomEmojiViewImplCopyWithImpl<_$CustomEmojiViewImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CustomEmojiViewToJson(
+    return _$$CustomEmojiViewImplToJson(
       this,
     );
   }
@@ -177,12 +178,13 @@ class _$_CustomEmojiView extends _CustomEmojiView {
 
 abstract class _CustomEmojiView extends CustomEmojiView {
   const factory _CustomEmojiView(
-      {required final CustomEmoji customEmoji,
-      required final List<CustomEmojiKeyword> keywords}) = _$_CustomEmojiView;
+          {required final CustomEmoji customEmoji,
+          required final List<CustomEmojiKeyword> keywords}) =
+      _$CustomEmojiViewImpl;
   const _CustomEmojiView._() : super._();
 
   factory _CustomEmojiView.fromJson(Map<String, dynamic> json) =
-      _$_CustomEmojiView.fromJson;
+      _$CustomEmojiViewImpl.fromJson;
 
   @override
   CustomEmoji get customEmoji;
@@ -190,6 +192,6 @@ abstract class _CustomEmojiView extends CustomEmojiView {
   List<CustomEmojiKeyword> get keywords;
   @override
   @JsonKey(ignore: true)
-  _$$_CustomEmojiViewCopyWith<_$_CustomEmojiView> get copyWith =>
+  _$$CustomEmojiViewImplCopyWith<_$CustomEmojiViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/custom_emoji_view.g.dart
+++ b/lib/src/v3/views/custom_emoji_view.g.dart
@@ -6,8 +6,9 @@ part of 'custom_emoji_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_CustomEmojiView _$$_CustomEmojiViewFromJson(Map<String, dynamic> json) =>
-    _$_CustomEmojiView(
+_$CustomEmojiViewImpl _$$CustomEmojiViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$CustomEmojiViewImpl(
       customEmoji:
           CustomEmoji.fromJson(json['custom_emoji'] as Map<String, dynamic>),
       keywords: (json['keywords'] as List<dynamic>)
@@ -15,7 +16,8 @@ _$_CustomEmojiView _$$_CustomEmojiViewFromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
-Map<String, dynamic> _$$_CustomEmojiViewToJson(_$_CustomEmojiView instance) =>
+Map<String, dynamic> _$$CustomEmojiViewImplToJson(
+        _$CustomEmojiViewImpl instance) =>
     <String, dynamic>{
       'custom_emoji': instance.customEmoji.toJson(),
       'keywords': instance.keywords.map((e) => e.toJson()).toList(),

--- a/lib/src/v3/views/instance_block_view.freezed.dart
+++ b/lib/src/v3/views/instance_block_view.freezed.dart
@@ -106,11 +106,11 @@ class _$InstanceBlockViewCopyWithImpl<$Res, $Val extends InstanceBlockView>
 }
 
 /// @nodoc
-abstract class _$$_InstanceBlockViewCopyWith<$Res>
+abstract class _$$InstanceBlockViewImplCopyWith<$Res>
     implements $InstanceBlockViewCopyWith<$Res> {
-  factory _$$_InstanceBlockViewCopyWith(_$_InstanceBlockView value,
-          $Res Function(_$_InstanceBlockView) then) =
-      __$$_InstanceBlockViewCopyWithImpl<$Res>;
+  factory _$$InstanceBlockViewImplCopyWith(_$InstanceBlockViewImpl value,
+          $Res Function(_$InstanceBlockViewImpl) then) =
+      __$$InstanceBlockViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({Person person, Instance instance, Site? site});
@@ -124,11 +124,11 @@ abstract class _$$_InstanceBlockViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_InstanceBlockViewCopyWithImpl<$Res>
-    extends _$InstanceBlockViewCopyWithImpl<$Res, _$_InstanceBlockView>
-    implements _$$_InstanceBlockViewCopyWith<$Res> {
-  __$$_InstanceBlockViewCopyWithImpl(
-      _$_InstanceBlockView _value, $Res Function(_$_InstanceBlockView) _then)
+class __$$InstanceBlockViewImplCopyWithImpl<$Res>
+    extends _$InstanceBlockViewCopyWithImpl<$Res, _$InstanceBlockViewImpl>
+    implements _$$InstanceBlockViewImplCopyWith<$Res> {
+  __$$InstanceBlockViewImplCopyWithImpl(_$InstanceBlockViewImpl _value,
+      $Res Function(_$InstanceBlockViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -138,7 +138,7 @@ class __$$_InstanceBlockViewCopyWithImpl<$Res>
     Object? instance = null,
     Object? site = freezed,
   }) {
-    return _then(_$_InstanceBlockView(
+    return _then(_$InstanceBlockViewImpl(
       person: null == person
           ? _value.person
           : person // ignore: cast_nullable_to_non_nullable
@@ -158,13 +158,13 @@ class __$$_InstanceBlockViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_InstanceBlockView extends _InstanceBlockView {
-  const _$_InstanceBlockView(
+class _$InstanceBlockViewImpl extends _InstanceBlockView {
+  const _$InstanceBlockViewImpl(
       {required this.person, required this.instance, this.site})
       : super._();
 
-  factory _$_InstanceBlockView.fromJson(Map<String, dynamic> json) =>
-      _$$_InstanceBlockViewFromJson(json);
+  factory _$InstanceBlockViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InstanceBlockViewImplFromJson(json);
 
   @override
   final Person person;
@@ -182,7 +182,7 @@ class _$_InstanceBlockView extends _InstanceBlockView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_InstanceBlockView &&
+            other is _$InstanceBlockViewImpl &&
             (identical(other.person, person) || other.person == person) &&
             (identical(other.instance, instance) ||
                 other.instance == instance) &&
@@ -196,13 +196,13 @@ class _$_InstanceBlockView extends _InstanceBlockView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_InstanceBlockViewCopyWith<_$_InstanceBlockView> get copyWith =>
-      __$$_InstanceBlockViewCopyWithImpl<_$_InstanceBlockView>(
+  _$$InstanceBlockViewImplCopyWith<_$InstanceBlockViewImpl> get copyWith =>
+      __$$InstanceBlockViewImplCopyWithImpl<_$InstanceBlockViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_InstanceBlockViewToJson(
+    return _$$InstanceBlockViewImplToJson(
       this,
     );
   }
@@ -212,11 +212,11 @@ abstract class _InstanceBlockView extends InstanceBlockView {
   const factory _InstanceBlockView(
       {required final Person person,
       required final Instance instance,
-      final Site? site}) = _$_InstanceBlockView;
+      final Site? site}) = _$InstanceBlockViewImpl;
   const _InstanceBlockView._() : super._();
 
   factory _InstanceBlockView.fromJson(Map<String, dynamic> json) =
-      _$_InstanceBlockView.fromJson;
+      _$InstanceBlockViewImpl.fromJson;
 
   @override
   Person get person;
@@ -226,6 +226,6 @@ abstract class _InstanceBlockView extends InstanceBlockView {
   Site? get site;
   @override
   @JsonKey(ignore: true)
-  _$$_InstanceBlockViewCopyWith<_$_InstanceBlockView> get copyWith =>
+  _$$InstanceBlockViewImplCopyWith<_$InstanceBlockViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/instance_block_view.g.dart
+++ b/lib/src/v3/views/instance_block_view.g.dart
@@ -6,8 +6,9 @@ part of 'instance_block_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_InstanceBlockView _$$_InstanceBlockViewFromJson(Map<String, dynamic> json) =>
-    _$_InstanceBlockView(
+_$InstanceBlockViewImpl _$$InstanceBlockViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InstanceBlockViewImpl(
       person: Person.fromJson(json['person'] as Map<String, dynamic>),
       instance: Instance.fromJson(json['instance'] as Map<String, dynamic>),
       site: json['site'] == null
@@ -15,8 +16,8 @@ _$_InstanceBlockView _$$_InstanceBlockViewFromJson(Map<String, dynamic> json) =>
           : Site.fromJson(json['site'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_InstanceBlockViewToJson(
-        _$_InstanceBlockView instance) =>
+Map<String, dynamic> _$$InstanceBlockViewImplToJson(
+        _$InstanceBlockViewImpl instance) =>
     <String, dynamic>{
       'person': instance.person.toJson(),
       'instance': instance.instance.toJson(),

--- a/lib/src/v3/views/local_user_view.freezed.dart
+++ b/lib/src/v3/views/local_user_view.freezed.dart
@@ -102,11 +102,11 @@ class _$LocalUserViewCopyWithImpl<$Res, $Val extends LocalUserView>
 }
 
 /// @nodoc
-abstract class _$$_LocalUserViewCopyWith<$Res>
+abstract class _$$LocalUserViewImplCopyWith<$Res>
     implements $LocalUserViewCopyWith<$Res> {
-  factory _$$_LocalUserViewCopyWith(
-          _$_LocalUserView value, $Res Function(_$_LocalUserView) then) =
-      __$$_LocalUserViewCopyWithImpl<$Res>;
+  factory _$$LocalUserViewImplCopyWith(
+          _$LocalUserViewImpl value, $Res Function(_$LocalUserViewImpl) then) =
+      __$$LocalUserViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({LocalUser localUser, Person person, PersonAggregates counts});
@@ -120,11 +120,11 @@ abstract class _$$_LocalUserViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_LocalUserViewCopyWithImpl<$Res>
-    extends _$LocalUserViewCopyWithImpl<$Res, _$_LocalUserView>
-    implements _$$_LocalUserViewCopyWith<$Res> {
-  __$$_LocalUserViewCopyWithImpl(
-      _$_LocalUserView _value, $Res Function(_$_LocalUserView) _then)
+class __$$LocalUserViewImplCopyWithImpl<$Res>
+    extends _$LocalUserViewCopyWithImpl<$Res, _$LocalUserViewImpl>
+    implements _$$LocalUserViewImplCopyWith<$Res> {
+  __$$LocalUserViewImplCopyWithImpl(
+      _$LocalUserViewImpl _value, $Res Function(_$LocalUserViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -134,7 +134,7 @@ class __$$_LocalUserViewCopyWithImpl<$Res>
     Object? person = null,
     Object? counts = null,
   }) {
-    return _then(_$_LocalUserView(
+    return _then(_$LocalUserViewImpl(
       localUser: null == localUser
           ? _value.localUser
           : localUser // ignore: cast_nullable_to_non_nullable
@@ -154,13 +154,13 @@ class __$$_LocalUserViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_LocalUserView extends _LocalUserView {
-  const _$_LocalUserView(
+class _$LocalUserViewImpl extends _LocalUserView {
+  const _$LocalUserViewImpl(
       {required this.localUser, required this.person, required this.counts})
       : super._();
 
-  factory _$_LocalUserView.fromJson(Map<String, dynamic> json) =>
-      _$$_LocalUserViewFromJson(json);
+  factory _$LocalUserViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LocalUserViewImplFromJson(json);
 
   @override
   final LocalUser localUser;
@@ -178,7 +178,7 @@ class _$_LocalUserView extends _LocalUserView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_LocalUserView &&
+            other is _$LocalUserViewImpl &&
             (identical(other.localUser, localUser) ||
                 other.localUser == localUser) &&
             (identical(other.person, person) || other.person == person) &&
@@ -192,12 +192,12 @@ class _$_LocalUserView extends _LocalUserView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_LocalUserViewCopyWith<_$_LocalUserView> get copyWith =>
-      __$$_LocalUserViewCopyWithImpl<_$_LocalUserView>(this, _$identity);
+  _$$LocalUserViewImplCopyWith<_$LocalUserViewImpl> get copyWith =>
+      __$$LocalUserViewImplCopyWithImpl<_$LocalUserViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_LocalUserViewToJson(
+    return _$$LocalUserViewImplToJson(
       this,
     );
   }
@@ -207,11 +207,11 @@ abstract class _LocalUserView extends LocalUserView {
   const factory _LocalUserView(
       {required final LocalUser localUser,
       required final Person person,
-      required final PersonAggregates counts}) = _$_LocalUserView;
+      required final PersonAggregates counts}) = _$LocalUserViewImpl;
   const _LocalUserView._() : super._();
 
   factory _LocalUserView.fromJson(Map<String, dynamic> json) =
-      _$_LocalUserView.fromJson;
+      _$LocalUserViewImpl.fromJson;
 
   @override
   LocalUser get localUser;
@@ -221,6 +221,6 @@ abstract class _LocalUserView extends LocalUserView {
   PersonAggregates get counts;
   @override
   @JsonKey(ignore: true)
-  _$$_LocalUserViewCopyWith<_$_LocalUserView> get copyWith =>
+  _$$LocalUserViewImplCopyWith<_$LocalUserViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/local_user_view.g.dart
+++ b/lib/src/v3/views/local_user_view.g.dart
@@ -6,14 +6,14 @@ part of 'local_user_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_LocalUserView _$$_LocalUserViewFromJson(Map<String, dynamic> json) =>
-    _$_LocalUserView(
+_$LocalUserViewImpl _$$LocalUserViewImplFromJson(Map<String, dynamic> json) =>
+    _$LocalUserViewImpl(
       localUser: LocalUser.fromJson(json['local_user'] as Map<String, dynamic>),
       person: Person.fromJson(json['person'] as Map<String, dynamic>),
       counts: PersonAggregates.fromJson(json['counts'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_LocalUserViewToJson(_$_LocalUserView instance) =>
+Map<String, dynamic> _$$LocalUserViewImplToJson(_$LocalUserViewImpl instance) =>
     <String, dynamic>{
       'local_user': instance.localUser.toJson(),
       'person': instance.person.toJson(),

--- a/lib/src/v3/views/mod_add_community_view.freezed.dart
+++ b/lib/src/v3/views/mod_add_community_view.freezed.dart
@@ -125,11 +125,11 @@ class _$ModAddCommunityViewCopyWithImpl<$Res, $Val extends ModAddCommunityView>
 }
 
 /// @nodoc
-abstract class _$$_ModAddCommunityViewCopyWith<$Res>
+abstract class _$$ModAddCommunityViewImplCopyWith<$Res>
     implements $ModAddCommunityViewCopyWith<$Res> {
-  factory _$$_ModAddCommunityViewCopyWith(_$_ModAddCommunityView value,
-          $Res Function(_$_ModAddCommunityView) then) =
-      __$$_ModAddCommunityViewCopyWithImpl<$Res>;
+  factory _$$ModAddCommunityViewImplCopyWith(_$ModAddCommunityViewImpl value,
+          $Res Function(_$ModAddCommunityViewImpl) then) =
+      __$$ModAddCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -149,11 +149,11 @@ abstract class _$$_ModAddCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModAddCommunityViewCopyWithImpl<$Res>
-    extends _$ModAddCommunityViewCopyWithImpl<$Res, _$_ModAddCommunityView>
-    implements _$$_ModAddCommunityViewCopyWith<$Res> {
-  __$$_ModAddCommunityViewCopyWithImpl(_$_ModAddCommunityView _value,
-      $Res Function(_$_ModAddCommunityView) _then)
+class __$$ModAddCommunityViewImplCopyWithImpl<$Res>
+    extends _$ModAddCommunityViewCopyWithImpl<$Res, _$ModAddCommunityViewImpl>
+    implements _$$ModAddCommunityViewImplCopyWith<$Res> {
+  __$$ModAddCommunityViewImplCopyWithImpl(_$ModAddCommunityViewImpl _value,
+      $Res Function(_$ModAddCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -164,7 +164,7 @@ class __$$_ModAddCommunityViewCopyWithImpl<$Res>
     Object? community = null,
     Object? moddedPerson = null,
   }) {
-    return _then(_$_ModAddCommunityView(
+    return _then(_$ModAddCommunityViewImpl(
       modAddCommunity: null == modAddCommunity
           ? _value.modAddCommunity
           : modAddCommunity // ignore: cast_nullable_to_non_nullable
@@ -188,16 +188,16 @@ class __$$_ModAddCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModAddCommunityView extends _ModAddCommunityView {
-  const _$_ModAddCommunityView(
+class _$ModAddCommunityViewImpl extends _ModAddCommunityView {
+  const _$ModAddCommunityViewImpl(
       {required this.modAddCommunity,
       this.moderator,
       required this.community,
       required this.moddedPerson})
       : super._();
 
-  factory _$_ModAddCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModAddCommunityViewFromJson(json);
+  factory _$ModAddCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModAddCommunityViewImplFromJson(json);
 
   @override
   final ModAddCommunity modAddCommunity;
@@ -217,7 +217,7 @@ class _$_ModAddCommunityView extends _ModAddCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModAddCommunityView &&
+            other is _$ModAddCommunityViewImpl &&
             (identical(other.modAddCommunity, modAddCommunity) ||
                 other.modAddCommunity == modAddCommunity) &&
             (identical(other.moderator, moderator) ||
@@ -236,13 +236,13 @@ class _$_ModAddCommunityView extends _ModAddCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModAddCommunityViewCopyWith<_$_ModAddCommunityView> get copyWith =>
-      __$$_ModAddCommunityViewCopyWithImpl<_$_ModAddCommunityView>(
+  _$$ModAddCommunityViewImplCopyWith<_$ModAddCommunityViewImpl> get copyWith =>
+      __$$ModAddCommunityViewImplCopyWithImpl<_$ModAddCommunityViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModAddCommunityViewToJson(
+    return _$$ModAddCommunityViewImplToJson(
       this,
     );
   }
@@ -253,11 +253,11 @@ abstract class _ModAddCommunityView extends ModAddCommunityView {
       {required final ModAddCommunity modAddCommunity,
       final Person? moderator,
       required final Community community,
-      required final Person moddedPerson}) = _$_ModAddCommunityView;
+      required final Person moddedPerson}) = _$ModAddCommunityViewImpl;
   const _ModAddCommunityView._() : super._();
 
   factory _ModAddCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_ModAddCommunityView.fromJson;
+      _$ModAddCommunityViewImpl.fromJson;
 
   @override
   ModAddCommunity get modAddCommunity;
@@ -269,6 +269,6 @@ abstract class _ModAddCommunityView extends ModAddCommunityView {
   Person get moddedPerson;
   @override
   @JsonKey(ignore: true)
-  _$$_ModAddCommunityViewCopyWith<_$_ModAddCommunityView> get copyWith =>
+  _$$ModAddCommunityViewImplCopyWith<_$ModAddCommunityViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/mod_add_community_view.g.dart
+++ b/lib/src/v3/views/mod_add_community_view.g.dart
@@ -6,9 +6,9 @@ part of 'mod_add_community_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModAddCommunityView _$$_ModAddCommunityViewFromJson(
+_$ModAddCommunityViewImpl _$$ModAddCommunityViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModAddCommunityView(
+    _$ModAddCommunityViewImpl(
       modAddCommunity: ModAddCommunity.fromJson(
           json['mod_add_community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -19,8 +19,8 @@ _$_ModAddCommunityView _$$_ModAddCommunityViewFromJson(
           Person.fromJson(json['modded_person'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_ModAddCommunityViewToJson(
-        _$_ModAddCommunityView instance) =>
+Map<String, dynamic> _$$ModAddCommunityViewImplToJson(
+        _$ModAddCommunityViewImpl instance) =>
     <String, dynamic>{
       'mod_add_community': instance.modAddCommunity.toJson(),
       'moderator': instance.moderator?.toJson(),

--- a/lib/src/v3/views/mod_add_view.freezed.dart
+++ b/lib/src/v3/views/mod_add_view.freezed.dart
@@ -106,11 +106,11 @@ class _$ModAddViewCopyWithImpl<$Res, $Val extends ModAddView>
 }
 
 /// @nodoc
-abstract class _$$_ModAddViewCopyWith<$Res>
+abstract class _$$ModAddViewImplCopyWith<$Res>
     implements $ModAddViewCopyWith<$Res> {
-  factory _$$_ModAddViewCopyWith(
-          _$_ModAddView value, $Res Function(_$_ModAddView) then) =
-      __$$_ModAddViewCopyWithImpl<$Res>;
+  factory _$$ModAddViewImplCopyWith(
+          _$ModAddViewImpl value, $Res Function(_$ModAddViewImpl) then) =
+      __$$ModAddViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({ModAdd modAdd, Person? moderator, Person moddedPerson});
@@ -124,11 +124,11 @@ abstract class _$$_ModAddViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModAddViewCopyWithImpl<$Res>
-    extends _$ModAddViewCopyWithImpl<$Res, _$_ModAddView>
-    implements _$$_ModAddViewCopyWith<$Res> {
-  __$$_ModAddViewCopyWithImpl(
-      _$_ModAddView _value, $Res Function(_$_ModAddView) _then)
+class __$$ModAddViewImplCopyWithImpl<$Res>
+    extends _$ModAddViewCopyWithImpl<$Res, _$ModAddViewImpl>
+    implements _$$ModAddViewImplCopyWith<$Res> {
+  __$$ModAddViewImplCopyWithImpl(
+      _$ModAddViewImpl _value, $Res Function(_$ModAddViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -138,7 +138,7 @@ class __$$_ModAddViewCopyWithImpl<$Res>
     Object? moderator = freezed,
     Object? moddedPerson = null,
   }) {
-    return _then(_$_ModAddView(
+    return _then(_$ModAddViewImpl(
       modAdd: null == modAdd
           ? _value.modAdd
           : modAdd // ignore: cast_nullable_to_non_nullable
@@ -158,13 +158,13 @@ class __$$_ModAddViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModAddView extends _ModAddView {
-  const _$_ModAddView(
+class _$ModAddViewImpl extends _ModAddView {
+  const _$ModAddViewImpl(
       {required this.modAdd, this.moderator, required this.moddedPerson})
       : super._();
 
-  factory _$_ModAddView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModAddViewFromJson(json);
+  factory _$ModAddViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModAddViewImplFromJson(json);
 
   @override
   final ModAdd modAdd;
@@ -182,7 +182,7 @@ class _$_ModAddView extends _ModAddView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModAddView &&
+            other is _$ModAddViewImpl &&
             (identical(other.modAdd, modAdd) || other.modAdd == modAdd) &&
             (identical(other.moderator, moderator) ||
                 other.moderator == moderator) &&
@@ -197,12 +197,12 @@ class _$_ModAddView extends _ModAddView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModAddViewCopyWith<_$_ModAddView> get copyWith =>
-      __$$_ModAddViewCopyWithImpl<_$_ModAddView>(this, _$identity);
+  _$$ModAddViewImplCopyWith<_$ModAddViewImpl> get copyWith =>
+      __$$ModAddViewImplCopyWithImpl<_$ModAddViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModAddViewToJson(
+    return _$$ModAddViewImplToJson(
       this,
     );
   }
@@ -212,11 +212,11 @@ abstract class _ModAddView extends ModAddView {
   const factory _ModAddView(
       {required final ModAdd modAdd,
       final Person? moderator,
-      required final Person moddedPerson}) = _$_ModAddView;
+      required final Person moddedPerson}) = _$ModAddViewImpl;
   const _ModAddView._() : super._();
 
   factory _ModAddView.fromJson(Map<String, dynamic> json) =
-      _$_ModAddView.fromJson;
+      _$ModAddViewImpl.fromJson;
 
   @override
   ModAdd get modAdd;
@@ -226,6 +226,6 @@ abstract class _ModAddView extends ModAddView {
   Person get moddedPerson;
   @override
   @JsonKey(ignore: true)
-  _$$_ModAddViewCopyWith<_$_ModAddView> get copyWith =>
+  _$$ModAddViewImplCopyWith<_$ModAddViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/mod_add_view.g.dart
+++ b/lib/src/v3/views/mod_add_view.g.dart
@@ -6,8 +6,8 @@ part of 'mod_add_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModAddView _$$_ModAddViewFromJson(Map<String, dynamic> json) =>
-    _$_ModAddView(
+_$ModAddViewImpl _$$ModAddViewImplFromJson(Map<String, dynamic> json) =>
+    _$ModAddViewImpl(
       modAdd: ModAdd.fromJson(json['mod_add'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
           ? null
@@ -16,7 +16,7 @@ _$_ModAddView _$$_ModAddViewFromJson(Map<String, dynamic> json) =>
           Person.fromJson(json['modded_person'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_ModAddViewToJson(_$_ModAddView instance) =>
+Map<String, dynamic> _$$ModAddViewImplToJson(_$ModAddViewImpl instance) =>
     <String, dynamic>{
       'mod_add': instance.modAdd.toJson(),
       'moderator': instance.moderator?.toJson(),

--- a/lib/src/v3/views/mod_ban_from_community_view.freezed.dart
+++ b/lib/src/v3/views/mod_ban_from_community_view.freezed.dart
@@ -129,11 +129,12 @@ class _$ModBanFromCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ModBanFromCommunityViewCopyWith<$Res>
+abstract class _$$ModBanFromCommunityViewImplCopyWith<$Res>
     implements $ModBanFromCommunityViewCopyWith<$Res> {
-  factory _$$_ModBanFromCommunityViewCopyWith(_$_ModBanFromCommunityView value,
-          $Res Function(_$_ModBanFromCommunityView) then) =
-      __$$_ModBanFromCommunityViewCopyWithImpl<$Res>;
+  factory _$$ModBanFromCommunityViewImplCopyWith(
+          _$ModBanFromCommunityViewImpl value,
+          $Res Function(_$ModBanFromCommunityViewImpl) then) =
+      __$$ModBanFromCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -153,12 +154,13 @@ abstract class _$$_ModBanFromCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModBanFromCommunityViewCopyWithImpl<$Res>
+class __$$ModBanFromCommunityViewImplCopyWithImpl<$Res>
     extends _$ModBanFromCommunityViewCopyWithImpl<$Res,
-        _$_ModBanFromCommunityView>
-    implements _$$_ModBanFromCommunityViewCopyWith<$Res> {
-  __$$_ModBanFromCommunityViewCopyWithImpl(_$_ModBanFromCommunityView _value,
-      $Res Function(_$_ModBanFromCommunityView) _then)
+        _$ModBanFromCommunityViewImpl>
+    implements _$$ModBanFromCommunityViewImplCopyWith<$Res> {
+  __$$ModBanFromCommunityViewImplCopyWithImpl(
+      _$ModBanFromCommunityViewImpl _value,
+      $Res Function(_$ModBanFromCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -169,7 +171,7 @@ class __$$_ModBanFromCommunityViewCopyWithImpl<$Res>
     Object? community = null,
     Object? bannedPerson = null,
   }) {
-    return _then(_$_ModBanFromCommunityView(
+    return _then(_$ModBanFromCommunityViewImpl(
       modBanFromCommunity: null == modBanFromCommunity
           ? _value.modBanFromCommunity
           : modBanFromCommunity // ignore: cast_nullable_to_non_nullable
@@ -193,16 +195,16 @@ class __$$_ModBanFromCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModBanFromCommunityView extends _ModBanFromCommunityView {
-  const _$_ModBanFromCommunityView(
+class _$ModBanFromCommunityViewImpl extends _ModBanFromCommunityView {
+  const _$ModBanFromCommunityViewImpl(
       {required this.modBanFromCommunity,
       this.moderator,
       required this.community,
       required this.bannedPerson})
       : super._();
 
-  factory _$_ModBanFromCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModBanFromCommunityViewFromJson(json);
+  factory _$ModBanFromCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModBanFromCommunityViewImplFromJson(json);
 
   @override
   final ModBanFromCommunity modBanFromCommunity;
@@ -222,7 +224,7 @@ class _$_ModBanFromCommunityView extends _ModBanFromCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModBanFromCommunityView &&
+            other is _$ModBanFromCommunityViewImpl &&
             (identical(other.modBanFromCommunity, modBanFromCommunity) ||
                 other.modBanFromCommunity == modBanFromCommunity) &&
             (identical(other.moderator, moderator) ||
@@ -241,14 +243,13 @@ class _$_ModBanFromCommunityView extends _ModBanFromCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModBanFromCommunityViewCopyWith<_$_ModBanFromCommunityView>
-      get copyWith =>
-          __$$_ModBanFromCommunityViewCopyWithImpl<_$_ModBanFromCommunityView>(
-              this, _$identity);
+  _$$ModBanFromCommunityViewImplCopyWith<_$ModBanFromCommunityViewImpl>
+      get copyWith => __$$ModBanFromCommunityViewImplCopyWithImpl<
+          _$ModBanFromCommunityViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModBanFromCommunityViewToJson(
+    return _$$ModBanFromCommunityViewImplToJson(
       this,
     );
   }
@@ -259,11 +260,11 @@ abstract class _ModBanFromCommunityView extends ModBanFromCommunityView {
       {required final ModBanFromCommunity modBanFromCommunity,
       final Person? moderator,
       required final Community community,
-      required final Person bannedPerson}) = _$_ModBanFromCommunityView;
+      required final Person bannedPerson}) = _$ModBanFromCommunityViewImpl;
   const _ModBanFromCommunityView._() : super._();
 
   factory _ModBanFromCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_ModBanFromCommunityView.fromJson;
+      _$ModBanFromCommunityViewImpl.fromJson;
 
   @override
   ModBanFromCommunity get modBanFromCommunity;
@@ -275,6 +276,6 @@ abstract class _ModBanFromCommunityView extends ModBanFromCommunityView {
   Person get bannedPerson;
   @override
   @JsonKey(ignore: true)
-  _$$_ModBanFromCommunityViewCopyWith<_$_ModBanFromCommunityView>
+  _$$ModBanFromCommunityViewImplCopyWith<_$ModBanFromCommunityViewImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/mod_ban_from_community_view.g.dart
+++ b/lib/src/v3/views/mod_ban_from_community_view.g.dart
@@ -6,9 +6,9 @@ part of 'mod_ban_from_community_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModBanFromCommunityView _$$_ModBanFromCommunityViewFromJson(
+_$ModBanFromCommunityViewImpl _$$ModBanFromCommunityViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModBanFromCommunityView(
+    _$ModBanFromCommunityViewImpl(
       modBanFromCommunity: ModBanFromCommunity.fromJson(
           json['mod_ban_from_community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -19,8 +19,8 @@ _$_ModBanFromCommunityView _$$_ModBanFromCommunityViewFromJson(
           Person.fromJson(json['banned_person'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_ModBanFromCommunityViewToJson(
-        _$_ModBanFromCommunityView instance) =>
+Map<String, dynamic> _$$ModBanFromCommunityViewImplToJson(
+        _$ModBanFromCommunityViewImpl instance) =>
     <String, dynamic>{
       'mod_ban_from_community': instance.modBanFromCommunity.toJson(),
       'moderator': instance.moderator?.toJson(),

--- a/lib/src/v3/views/mod_ban_view.freezed.dart
+++ b/lib/src/v3/views/mod_ban_view.freezed.dart
@@ -106,11 +106,11 @@ class _$ModBanViewCopyWithImpl<$Res, $Val extends ModBanView>
 }
 
 /// @nodoc
-abstract class _$$_ModBanViewCopyWith<$Res>
+abstract class _$$ModBanViewImplCopyWith<$Res>
     implements $ModBanViewCopyWith<$Res> {
-  factory _$$_ModBanViewCopyWith(
-          _$_ModBanView value, $Res Function(_$_ModBanView) then) =
-      __$$_ModBanViewCopyWithImpl<$Res>;
+  factory _$$ModBanViewImplCopyWith(
+          _$ModBanViewImpl value, $Res Function(_$ModBanViewImpl) then) =
+      __$$ModBanViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({ModBan modBan, Person? moderator, Person bannedPerson});
@@ -124,11 +124,11 @@ abstract class _$$_ModBanViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModBanViewCopyWithImpl<$Res>
-    extends _$ModBanViewCopyWithImpl<$Res, _$_ModBanView>
-    implements _$$_ModBanViewCopyWith<$Res> {
-  __$$_ModBanViewCopyWithImpl(
-      _$_ModBanView _value, $Res Function(_$_ModBanView) _then)
+class __$$ModBanViewImplCopyWithImpl<$Res>
+    extends _$ModBanViewCopyWithImpl<$Res, _$ModBanViewImpl>
+    implements _$$ModBanViewImplCopyWith<$Res> {
+  __$$ModBanViewImplCopyWithImpl(
+      _$ModBanViewImpl _value, $Res Function(_$ModBanViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -138,7 +138,7 @@ class __$$_ModBanViewCopyWithImpl<$Res>
     Object? moderator = freezed,
     Object? bannedPerson = null,
   }) {
-    return _then(_$_ModBanView(
+    return _then(_$ModBanViewImpl(
       modBan: null == modBan
           ? _value.modBan
           : modBan // ignore: cast_nullable_to_non_nullable
@@ -158,13 +158,13 @@ class __$$_ModBanViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModBanView extends _ModBanView {
-  const _$_ModBanView(
+class _$ModBanViewImpl extends _ModBanView {
+  const _$ModBanViewImpl(
       {required this.modBan, this.moderator, required this.bannedPerson})
       : super._();
 
-  factory _$_ModBanView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModBanViewFromJson(json);
+  factory _$ModBanViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModBanViewImplFromJson(json);
 
   @override
   final ModBan modBan;
@@ -182,7 +182,7 @@ class _$_ModBanView extends _ModBanView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModBanView &&
+            other is _$ModBanViewImpl &&
             (identical(other.modBan, modBan) || other.modBan == modBan) &&
             (identical(other.moderator, moderator) ||
                 other.moderator == moderator) &&
@@ -197,12 +197,12 @@ class _$_ModBanView extends _ModBanView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModBanViewCopyWith<_$_ModBanView> get copyWith =>
-      __$$_ModBanViewCopyWithImpl<_$_ModBanView>(this, _$identity);
+  _$$ModBanViewImplCopyWith<_$ModBanViewImpl> get copyWith =>
+      __$$ModBanViewImplCopyWithImpl<_$ModBanViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModBanViewToJson(
+    return _$$ModBanViewImplToJson(
       this,
     );
   }
@@ -212,11 +212,11 @@ abstract class _ModBanView extends ModBanView {
   const factory _ModBanView(
       {required final ModBan modBan,
       final Person? moderator,
-      required final Person bannedPerson}) = _$_ModBanView;
+      required final Person bannedPerson}) = _$ModBanViewImpl;
   const _ModBanView._() : super._();
 
   factory _ModBanView.fromJson(Map<String, dynamic> json) =
-      _$_ModBanView.fromJson;
+      _$ModBanViewImpl.fromJson;
 
   @override
   ModBan get modBan;
@@ -226,6 +226,6 @@ abstract class _ModBanView extends ModBanView {
   Person get bannedPerson;
   @override
   @JsonKey(ignore: true)
-  _$$_ModBanViewCopyWith<_$_ModBanView> get copyWith =>
+  _$$ModBanViewImplCopyWith<_$ModBanViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/mod_ban_view.g.dart
+++ b/lib/src/v3/views/mod_ban_view.g.dart
@@ -6,8 +6,8 @@ part of 'mod_ban_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModBanView _$$_ModBanViewFromJson(Map<String, dynamic> json) =>
-    _$_ModBanView(
+_$ModBanViewImpl _$$ModBanViewImplFromJson(Map<String, dynamic> json) =>
+    _$ModBanViewImpl(
       modBan: ModBan.fromJson(json['mod_ban'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
           ? null
@@ -16,7 +16,7 @@ _$_ModBanView _$$_ModBanViewFromJson(Map<String, dynamic> json) =>
           Person.fromJson(json['banned_person'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_ModBanViewToJson(_$_ModBanView instance) =>
+Map<String, dynamic> _$$ModBanViewImplToJson(_$ModBanViewImpl instance) =>
     <String, dynamic>{
       'mod_ban': instance.modBan.toJson(),
       'moderator': instance.moderator?.toJson(),

--- a/lib/src/v3/views/mod_feature_post_view.freezed.dart
+++ b/lib/src/v3/views/mod_feature_post_view.freezed.dart
@@ -125,11 +125,11 @@ class _$ModFeaturePostViewCopyWithImpl<$Res, $Val extends ModFeaturePostView>
 }
 
 /// @nodoc
-abstract class _$$_ModFeaturePostViewCopyWith<$Res>
+abstract class _$$ModFeaturePostViewImplCopyWith<$Res>
     implements $ModFeaturePostViewCopyWith<$Res> {
-  factory _$$_ModFeaturePostViewCopyWith(_$_ModFeaturePostView value,
-          $Res Function(_$_ModFeaturePostView) then) =
-      __$$_ModFeaturePostViewCopyWithImpl<$Res>;
+  factory _$$ModFeaturePostViewImplCopyWith(_$ModFeaturePostViewImpl value,
+          $Res Function(_$ModFeaturePostViewImpl) then) =
+      __$$ModFeaturePostViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -149,11 +149,11 @@ abstract class _$$_ModFeaturePostViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModFeaturePostViewCopyWithImpl<$Res>
-    extends _$ModFeaturePostViewCopyWithImpl<$Res, _$_ModFeaturePostView>
-    implements _$$_ModFeaturePostViewCopyWith<$Res> {
-  __$$_ModFeaturePostViewCopyWithImpl(
-      _$_ModFeaturePostView _value, $Res Function(_$_ModFeaturePostView) _then)
+class __$$ModFeaturePostViewImplCopyWithImpl<$Res>
+    extends _$ModFeaturePostViewCopyWithImpl<$Res, _$ModFeaturePostViewImpl>
+    implements _$$ModFeaturePostViewImplCopyWith<$Res> {
+  __$$ModFeaturePostViewImplCopyWithImpl(_$ModFeaturePostViewImpl _value,
+      $Res Function(_$ModFeaturePostViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -164,7 +164,7 @@ class __$$_ModFeaturePostViewCopyWithImpl<$Res>
     Object? post = null,
     Object? community = null,
   }) {
-    return _then(_$_ModFeaturePostView(
+    return _then(_$ModFeaturePostViewImpl(
       modFeaturePost: null == modFeaturePost
           ? _value.modFeaturePost
           : modFeaturePost // ignore: cast_nullable_to_non_nullable
@@ -188,16 +188,16 @@ class __$$_ModFeaturePostViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModFeaturePostView extends _ModFeaturePostView {
-  const _$_ModFeaturePostView(
+class _$ModFeaturePostViewImpl extends _ModFeaturePostView {
+  const _$ModFeaturePostViewImpl(
       {required this.modFeaturePost,
       this.moderator,
       required this.post,
       required this.community})
       : super._();
 
-  factory _$_ModFeaturePostView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModFeaturePostViewFromJson(json);
+  factory _$ModFeaturePostViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModFeaturePostViewImplFromJson(json);
 
   @override
   final ModFeaturePost modFeaturePost;
@@ -217,7 +217,7 @@ class _$_ModFeaturePostView extends _ModFeaturePostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModFeaturePostView &&
+            other is _$ModFeaturePostViewImpl &&
             (identical(other.modFeaturePost, modFeaturePost) ||
                 other.modFeaturePost == modFeaturePost) &&
             (identical(other.moderator, moderator) ||
@@ -235,13 +235,13 @@ class _$_ModFeaturePostView extends _ModFeaturePostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModFeaturePostViewCopyWith<_$_ModFeaturePostView> get copyWith =>
-      __$$_ModFeaturePostViewCopyWithImpl<_$_ModFeaturePostView>(
+  _$$ModFeaturePostViewImplCopyWith<_$ModFeaturePostViewImpl> get copyWith =>
+      __$$ModFeaturePostViewImplCopyWithImpl<_$ModFeaturePostViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModFeaturePostViewToJson(
+    return _$$ModFeaturePostViewImplToJson(
       this,
     );
   }
@@ -252,11 +252,11 @@ abstract class _ModFeaturePostView extends ModFeaturePostView {
       {required final ModFeaturePost modFeaturePost,
       final Person? moderator,
       required final Post post,
-      required final Community community}) = _$_ModFeaturePostView;
+      required final Community community}) = _$ModFeaturePostViewImpl;
   const _ModFeaturePostView._() : super._();
 
   factory _ModFeaturePostView.fromJson(Map<String, dynamic> json) =
-      _$_ModFeaturePostView.fromJson;
+      _$ModFeaturePostViewImpl.fromJson;
 
   @override
   ModFeaturePost get modFeaturePost;
@@ -268,6 +268,6 @@ abstract class _ModFeaturePostView extends ModFeaturePostView {
   Community get community;
   @override
   @JsonKey(ignore: true)
-  _$$_ModFeaturePostViewCopyWith<_$_ModFeaturePostView> get copyWith =>
+  _$$ModFeaturePostViewImplCopyWith<_$ModFeaturePostViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/mod_feature_post_view.g.dart
+++ b/lib/src/v3/views/mod_feature_post_view.g.dart
@@ -6,9 +6,9 @@ part of 'mod_feature_post_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModFeaturePostView _$$_ModFeaturePostViewFromJson(
+_$ModFeaturePostViewImpl _$$ModFeaturePostViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModFeaturePostView(
+    _$ModFeaturePostViewImpl(
       modFeaturePost: ModFeaturePost.fromJson(
           json['mod_feature_post'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -18,8 +18,8 @@ _$_ModFeaturePostView _$$_ModFeaturePostViewFromJson(
       community: Community.fromJson(json['community'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_ModFeaturePostViewToJson(
-        _$_ModFeaturePostView instance) =>
+Map<String, dynamic> _$$ModFeaturePostViewImplToJson(
+        _$ModFeaturePostViewImpl instance) =>
     <String, dynamic>{
       'mod_feature_post': instance.modFeaturePost.toJson(),
       'moderator': instance.moderator?.toJson(),

--- a/lib/src/v3/views/mod_hide_community_view.freezed.dart
+++ b/lib/src/v3/views/mod_hide_community_view.freezed.dart
@@ -108,11 +108,11 @@ class _$ModHideCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ModHideCommunityViewCopyWith<$Res>
+abstract class _$$ModHideCommunityViewImplCopyWith<$Res>
     implements $ModHideCommunityViewCopyWith<$Res> {
-  factory _$$_ModHideCommunityViewCopyWith(_$_ModHideCommunityView value,
-          $Res Function(_$_ModHideCommunityView) then) =
-      __$$_ModHideCommunityViewCopyWithImpl<$Res>;
+  factory _$$ModHideCommunityViewImplCopyWith(_$ModHideCommunityViewImpl value,
+          $Res Function(_$ModHideCommunityViewImpl) then) =
+      __$$ModHideCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -127,11 +127,11 @@ abstract class _$$_ModHideCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModHideCommunityViewCopyWithImpl<$Res>
-    extends _$ModHideCommunityViewCopyWithImpl<$Res, _$_ModHideCommunityView>
-    implements _$$_ModHideCommunityViewCopyWith<$Res> {
-  __$$_ModHideCommunityViewCopyWithImpl(_$_ModHideCommunityView _value,
-      $Res Function(_$_ModHideCommunityView) _then)
+class __$$ModHideCommunityViewImplCopyWithImpl<$Res>
+    extends _$ModHideCommunityViewCopyWithImpl<$Res, _$ModHideCommunityViewImpl>
+    implements _$$ModHideCommunityViewImplCopyWith<$Res> {
+  __$$ModHideCommunityViewImplCopyWithImpl(_$ModHideCommunityViewImpl _value,
+      $Res Function(_$ModHideCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -141,7 +141,7 @@ class __$$_ModHideCommunityViewCopyWithImpl<$Res>
     Object? admin = freezed,
     Object? community = null,
   }) {
-    return _then(_$_ModHideCommunityView(
+    return _then(_$ModHideCommunityViewImpl(
       modHideCommunity: null == modHideCommunity
           ? _value.modHideCommunity
           : modHideCommunity // ignore: cast_nullable_to_non_nullable
@@ -161,13 +161,13 @@ class __$$_ModHideCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModHideCommunityView extends _ModHideCommunityView {
-  const _$_ModHideCommunityView(
+class _$ModHideCommunityViewImpl extends _ModHideCommunityView {
+  const _$ModHideCommunityViewImpl(
       {required this.modHideCommunity, this.admin, required this.community})
       : super._();
 
-  factory _$_ModHideCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModHideCommunityViewFromJson(json);
+  factory _$ModHideCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModHideCommunityViewImplFromJson(json);
 
   @override
   final ModHideCommunity modHideCommunity;
@@ -185,7 +185,7 @@ class _$_ModHideCommunityView extends _ModHideCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModHideCommunityView &&
+            other is _$ModHideCommunityViewImpl &&
             (identical(other.modHideCommunity, modHideCommunity) ||
                 other.modHideCommunity == modHideCommunity) &&
             (identical(other.admin, admin) || other.admin == admin) &&
@@ -201,13 +201,14 @@ class _$_ModHideCommunityView extends _ModHideCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModHideCommunityViewCopyWith<_$_ModHideCommunityView> get copyWith =>
-      __$$_ModHideCommunityViewCopyWithImpl<_$_ModHideCommunityView>(
-          this, _$identity);
+  _$$ModHideCommunityViewImplCopyWith<_$ModHideCommunityViewImpl>
+      get copyWith =>
+          __$$ModHideCommunityViewImplCopyWithImpl<_$ModHideCommunityViewImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModHideCommunityViewToJson(
+    return _$$ModHideCommunityViewImplToJson(
       this,
     );
   }
@@ -217,11 +218,11 @@ abstract class _ModHideCommunityView extends ModHideCommunityView {
   const factory _ModHideCommunityView(
       {required final ModHideCommunity modHideCommunity,
       final Person? admin,
-      required final Community community}) = _$_ModHideCommunityView;
+      required final Community community}) = _$ModHideCommunityViewImpl;
   const _ModHideCommunityView._() : super._();
 
   factory _ModHideCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_ModHideCommunityView.fromJson;
+      _$ModHideCommunityViewImpl.fromJson;
 
   @override
   ModHideCommunity get modHideCommunity;
@@ -231,6 +232,6 @@ abstract class _ModHideCommunityView extends ModHideCommunityView {
   Community get community;
   @override
   @JsonKey(ignore: true)
-  _$$_ModHideCommunityViewCopyWith<_$_ModHideCommunityView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ModHideCommunityViewImplCopyWith<_$ModHideCommunityViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/mod_hide_community_view.g.dart
+++ b/lib/src/v3/views/mod_hide_community_view.g.dart
@@ -6,9 +6,9 @@ part of 'mod_hide_community_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModHideCommunityView _$$_ModHideCommunityViewFromJson(
+_$ModHideCommunityViewImpl _$$ModHideCommunityViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModHideCommunityView(
+    _$ModHideCommunityViewImpl(
       modHideCommunity: ModHideCommunity.fromJson(
           json['mod_hide_community'] as Map<String, dynamic>),
       admin: json['admin'] == null
@@ -17,8 +17,8 @@ _$_ModHideCommunityView _$$_ModHideCommunityViewFromJson(
       community: Community.fromJson(json['community'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_ModHideCommunityViewToJson(
-        _$_ModHideCommunityView instance) =>
+Map<String, dynamic> _$$ModHideCommunityViewImplToJson(
+        _$ModHideCommunityViewImpl instance) =>
     <String, dynamic>{
       'mod_hide_community': instance.modHideCommunity.toJson(),
       'admin': instance.admin?.toJson(),

--- a/lib/src/v3/views/mod_lock_post_view.freezed.dart
+++ b/lib/src/v3/views/mod_lock_post_view.freezed.dart
@@ -125,11 +125,11 @@ class _$ModLockPostViewCopyWithImpl<$Res, $Val extends ModLockPostView>
 }
 
 /// @nodoc
-abstract class _$$_ModLockPostViewCopyWith<$Res>
+abstract class _$$ModLockPostViewImplCopyWith<$Res>
     implements $ModLockPostViewCopyWith<$Res> {
-  factory _$$_ModLockPostViewCopyWith(
-          _$_ModLockPostView value, $Res Function(_$_ModLockPostView) then) =
-      __$$_ModLockPostViewCopyWithImpl<$Res>;
+  factory _$$ModLockPostViewImplCopyWith(_$ModLockPostViewImpl value,
+          $Res Function(_$ModLockPostViewImpl) then) =
+      __$$ModLockPostViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -149,11 +149,11 @@ abstract class _$$_ModLockPostViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModLockPostViewCopyWithImpl<$Res>
-    extends _$ModLockPostViewCopyWithImpl<$Res, _$_ModLockPostView>
-    implements _$$_ModLockPostViewCopyWith<$Res> {
-  __$$_ModLockPostViewCopyWithImpl(
-      _$_ModLockPostView _value, $Res Function(_$_ModLockPostView) _then)
+class __$$ModLockPostViewImplCopyWithImpl<$Res>
+    extends _$ModLockPostViewCopyWithImpl<$Res, _$ModLockPostViewImpl>
+    implements _$$ModLockPostViewImplCopyWith<$Res> {
+  __$$ModLockPostViewImplCopyWithImpl(
+      _$ModLockPostViewImpl _value, $Res Function(_$ModLockPostViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -164,7 +164,7 @@ class __$$_ModLockPostViewCopyWithImpl<$Res>
     Object? post = null,
     Object? community = null,
   }) {
-    return _then(_$_ModLockPostView(
+    return _then(_$ModLockPostViewImpl(
       modLockPost: null == modLockPost
           ? _value.modLockPost
           : modLockPost // ignore: cast_nullable_to_non_nullable
@@ -188,16 +188,16 @@ class __$$_ModLockPostViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModLockPostView extends _ModLockPostView {
-  const _$_ModLockPostView(
+class _$ModLockPostViewImpl extends _ModLockPostView {
+  const _$ModLockPostViewImpl(
       {required this.modLockPost,
       this.moderator,
       required this.post,
       required this.community})
       : super._();
 
-  factory _$_ModLockPostView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModLockPostViewFromJson(json);
+  factory _$ModLockPostViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModLockPostViewImplFromJson(json);
 
   @override
   final ModLockPost modLockPost;
@@ -217,7 +217,7 @@ class _$_ModLockPostView extends _ModLockPostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModLockPostView &&
+            other is _$ModLockPostViewImpl &&
             (identical(other.modLockPost, modLockPost) ||
                 other.modLockPost == modLockPost) &&
             (identical(other.moderator, moderator) ||
@@ -235,12 +235,13 @@ class _$_ModLockPostView extends _ModLockPostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModLockPostViewCopyWith<_$_ModLockPostView> get copyWith =>
-      __$$_ModLockPostViewCopyWithImpl<_$_ModLockPostView>(this, _$identity);
+  _$$ModLockPostViewImplCopyWith<_$ModLockPostViewImpl> get copyWith =>
+      __$$ModLockPostViewImplCopyWithImpl<_$ModLockPostViewImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModLockPostViewToJson(
+    return _$$ModLockPostViewImplToJson(
       this,
     );
   }
@@ -251,11 +252,11 @@ abstract class _ModLockPostView extends ModLockPostView {
       {required final ModLockPost modLockPost,
       final Person? moderator,
       required final Post post,
-      required final Community community}) = _$_ModLockPostView;
+      required final Community community}) = _$ModLockPostViewImpl;
   const _ModLockPostView._() : super._();
 
   factory _ModLockPostView.fromJson(Map<String, dynamic> json) =
-      _$_ModLockPostView.fromJson;
+      _$ModLockPostViewImpl.fromJson;
 
   @override
   ModLockPost get modLockPost;
@@ -267,6 +268,6 @@ abstract class _ModLockPostView extends ModLockPostView {
   Community get community;
   @override
   @JsonKey(ignore: true)
-  _$$_ModLockPostViewCopyWith<_$_ModLockPostView> get copyWith =>
+  _$$ModLockPostViewImplCopyWith<_$ModLockPostViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/mod_lock_post_view.g.dart
+++ b/lib/src/v3/views/mod_lock_post_view.g.dart
@@ -6,8 +6,9 @@ part of 'mod_lock_post_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModLockPostView _$$_ModLockPostViewFromJson(Map<String, dynamic> json) =>
-    _$_ModLockPostView(
+_$ModLockPostViewImpl _$$ModLockPostViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ModLockPostViewImpl(
       modLockPost:
           ModLockPost.fromJson(json['mod_lock_post'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -17,7 +18,8 @@ _$_ModLockPostView _$$_ModLockPostViewFromJson(Map<String, dynamic> json) =>
       community: Community.fromJson(json['community'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_ModLockPostViewToJson(_$_ModLockPostView instance) =>
+Map<String, dynamic> _$$ModLockPostViewImplToJson(
+        _$ModLockPostViewImpl instance) =>
     <String, dynamic>{
       'mod_lock_post': instance.modLockPost.toJson(),
       'moderator': instance.moderator?.toJson(),

--- a/lib/src/v3/views/mod_remove_comment_view.freezed.dart
+++ b/lib/src/v3/views/mod_remove_comment_view.freezed.dart
@@ -158,11 +158,11 @@ class _$ModRemoveCommentViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ModRemoveCommentViewCopyWith<$Res>
+abstract class _$$ModRemoveCommentViewImplCopyWith<$Res>
     implements $ModRemoveCommentViewCopyWith<$Res> {
-  factory _$$_ModRemoveCommentViewCopyWith(_$_ModRemoveCommentView value,
-          $Res Function(_$_ModRemoveCommentView) then) =
-      __$$_ModRemoveCommentViewCopyWithImpl<$Res>;
+  factory _$$ModRemoveCommentViewImplCopyWith(_$ModRemoveCommentViewImpl value,
+          $Res Function(_$ModRemoveCommentViewImpl) then) =
+      __$$ModRemoveCommentViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -188,11 +188,11 @@ abstract class _$$_ModRemoveCommentViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModRemoveCommentViewCopyWithImpl<$Res>
-    extends _$ModRemoveCommentViewCopyWithImpl<$Res, _$_ModRemoveCommentView>
-    implements _$$_ModRemoveCommentViewCopyWith<$Res> {
-  __$$_ModRemoveCommentViewCopyWithImpl(_$_ModRemoveCommentView _value,
-      $Res Function(_$_ModRemoveCommentView) _then)
+class __$$ModRemoveCommentViewImplCopyWithImpl<$Res>
+    extends _$ModRemoveCommentViewCopyWithImpl<$Res, _$ModRemoveCommentViewImpl>
+    implements _$$ModRemoveCommentViewImplCopyWith<$Res> {
+  __$$ModRemoveCommentViewImplCopyWithImpl(_$ModRemoveCommentViewImpl _value,
+      $Res Function(_$ModRemoveCommentViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -205,7 +205,7 @@ class __$$_ModRemoveCommentViewCopyWithImpl<$Res>
     Object? post = null,
     Object? community = null,
   }) {
-    return _then(_$_ModRemoveCommentView(
+    return _then(_$ModRemoveCommentViewImpl(
       modRemoveComment: null == modRemoveComment
           ? _value.modRemoveComment
           : modRemoveComment // ignore: cast_nullable_to_non_nullable
@@ -237,8 +237,8 @@ class __$$_ModRemoveCommentViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModRemoveCommentView extends _ModRemoveCommentView {
-  const _$_ModRemoveCommentView(
+class _$ModRemoveCommentViewImpl extends _ModRemoveCommentView {
+  const _$ModRemoveCommentViewImpl(
       {required this.modRemoveComment,
       this.moderator,
       required this.comment,
@@ -247,8 +247,8 @@ class _$_ModRemoveCommentView extends _ModRemoveCommentView {
       required this.community})
       : super._();
 
-  factory _$_ModRemoveCommentView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModRemoveCommentViewFromJson(json);
+  factory _$ModRemoveCommentViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModRemoveCommentViewImplFromJson(json);
 
   @override
   final ModRemoveComment modRemoveComment;
@@ -272,7 +272,7 @@ class _$_ModRemoveCommentView extends _ModRemoveCommentView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModRemoveCommentView &&
+            other is _$ModRemoveCommentViewImpl &&
             (identical(other.modRemoveComment, modRemoveComment) ||
                 other.modRemoveComment == modRemoveComment) &&
             (identical(other.moderator, moderator) ||
@@ -293,13 +293,14 @@ class _$_ModRemoveCommentView extends _ModRemoveCommentView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModRemoveCommentViewCopyWith<_$_ModRemoveCommentView> get copyWith =>
-      __$$_ModRemoveCommentViewCopyWithImpl<_$_ModRemoveCommentView>(
-          this, _$identity);
+  _$$ModRemoveCommentViewImplCopyWith<_$ModRemoveCommentViewImpl>
+      get copyWith =>
+          __$$ModRemoveCommentViewImplCopyWithImpl<_$ModRemoveCommentViewImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModRemoveCommentViewToJson(
+    return _$$ModRemoveCommentViewImplToJson(
       this,
     );
   }
@@ -312,11 +313,11 @@ abstract class _ModRemoveCommentView extends ModRemoveCommentView {
       required final Comment comment,
       required final Person commenter,
       required final Post post,
-      required final Community community}) = _$_ModRemoveCommentView;
+      required final Community community}) = _$ModRemoveCommentViewImpl;
   const _ModRemoveCommentView._() : super._();
 
   factory _ModRemoveCommentView.fromJson(Map<String, dynamic> json) =
-      _$_ModRemoveCommentView.fromJson;
+      _$ModRemoveCommentViewImpl.fromJson;
 
   @override
   ModRemoveComment get modRemoveComment;
@@ -332,6 +333,6 @@ abstract class _ModRemoveCommentView extends ModRemoveCommentView {
   Community get community;
   @override
   @JsonKey(ignore: true)
-  _$$_ModRemoveCommentViewCopyWith<_$_ModRemoveCommentView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ModRemoveCommentViewImplCopyWith<_$ModRemoveCommentViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/mod_remove_comment_view.g.dart
+++ b/lib/src/v3/views/mod_remove_comment_view.g.dart
@@ -6,9 +6,9 @@ part of 'mod_remove_comment_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModRemoveCommentView _$$_ModRemoveCommentViewFromJson(
+_$ModRemoveCommentViewImpl _$$ModRemoveCommentViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModRemoveCommentView(
+    _$ModRemoveCommentViewImpl(
       modRemoveComment: ModRemoveComment.fromJson(
           json['mod_remove_comment'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -20,8 +20,8 @@ _$_ModRemoveCommentView _$$_ModRemoveCommentViewFromJson(
       community: Community.fromJson(json['community'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_ModRemoveCommentViewToJson(
-        _$_ModRemoveCommentView instance) =>
+Map<String, dynamic> _$$ModRemoveCommentViewImplToJson(
+        _$ModRemoveCommentViewImpl instance) =>
     <String, dynamic>{
       'mod_remove_comment': instance.modRemoveComment.toJson(),
       'moderator': instance.moderator?.toJson(),

--- a/lib/src/v3/views/mod_remove_community_view.freezed.dart
+++ b/lib/src/v3/views/mod_remove_community_view.freezed.dart
@@ -113,11 +113,12 @@ class _$ModRemoveCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ModRemoveCommunityViewCopyWith<$Res>
+abstract class _$$ModRemoveCommunityViewImplCopyWith<$Res>
     implements $ModRemoveCommunityViewCopyWith<$Res> {
-  factory _$$_ModRemoveCommunityViewCopyWith(_$_ModRemoveCommunityView value,
-          $Res Function(_$_ModRemoveCommunityView) then) =
-      __$$_ModRemoveCommunityViewCopyWithImpl<$Res>;
+  factory _$$ModRemoveCommunityViewImplCopyWith(
+          _$ModRemoveCommunityViewImpl value,
+          $Res Function(_$ModRemoveCommunityViewImpl) then) =
+      __$$ModRemoveCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -134,12 +135,13 @@ abstract class _$$_ModRemoveCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModRemoveCommunityViewCopyWithImpl<$Res>
+class __$$ModRemoveCommunityViewImplCopyWithImpl<$Res>
     extends _$ModRemoveCommunityViewCopyWithImpl<$Res,
-        _$_ModRemoveCommunityView>
-    implements _$$_ModRemoveCommunityViewCopyWith<$Res> {
-  __$$_ModRemoveCommunityViewCopyWithImpl(_$_ModRemoveCommunityView _value,
-      $Res Function(_$_ModRemoveCommunityView) _then)
+        _$ModRemoveCommunityViewImpl>
+    implements _$$ModRemoveCommunityViewImplCopyWith<$Res> {
+  __$$ModRemoveCommunityViewImplCopyWithImpl(
+      _$ModRemoveCommunityViewImpl _value,
+      $Res Function(_$ModRemoveCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -149,7 +151,7 @@ class __$$_ModRemoveCommunityViewCopyWithImpl<$Res>
     Object? moderator = freezed,
     Object? community = null,
   }) {
-    return _then(_$_ModRemoveCommunityView(
+    return _then(_$ModRemoveCommunityViewImpl(
       modRemoveCommunity: null == modRemoveCommunity
           ? _value.modRemoveCommunity
           : modRemoveCommunity // ignore: cast_nullable_to_non_nullable
@@ -169,15 +171,15 @@ class __$$_ModRemoveCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModRemoveCommunityView extends _ModRemoveCommunityView {
-  const _$_ModRemoveCommunityView(
+class _$ModRemoveCommunityViewImpl extends _ModRemoveCommunityView {
+  const _$ModRemoveCommunityViewImpl(
       {required this.modRemoveCommunity,
       this.moderator,
       required this.community})
       : super._();
 
-  factory _$_ModRemoveCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModRemoveCommunityViewFromJson(json);
+  factory _$ModRemoveCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModRemoveCommunityViewImplFromJson(json);
 
   @override
   final ModRemoveCommunity modRemoveCommunity;
@@ -195,7 +197,7 @@ class _$_ModRemoveCommunityView extends _ModRemoveCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModRemoveCommunityView &&
+            other is _$ModRemoveCommunityViewImpl &&
             (identical(other.modRemoveCommunity, modRemoveCommunity) ||
                 other.modRemoveCommunity == modRemoveCommunity) &&
             (identical(other.moderator, moderator) ||
@@ -212,13 +214,13 @@ class _$_ModRemoveCommunityView extends _ModRemoveCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModRemoveCommunityViewCopyWith<_$_ModRemoveCommunityView> get copyWith =>
-      __$$_ModRemoveCommunityViewCopyWithImpl<_$_ModRemoveCommunityView>(
-          this, _$identity);
+  _$$ModRemoveCommunityViewImplCopyWith<_$ModRemoveCommunityViewImpl>
+      get copyWith => __$$ModRemoveCommunityViewImplCopyWithImpl<
+          _$ModRemoveCommunityViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModRemoveCommunityViewToJson(
+    return _$$ModRemoveCommunityViewImplToJson(
       this,
     );
   }
@@ -228,11 +230,11 @@ abstract class _ModRemoveCommunityView extends ModRemoveCommunityView {
   const factory _ModRemoveCommunityView(
       {required final ModRemoveCommunity modRemoveCommunity,
       final Person? moderator,
-      required final Community community}) = _$_ModRemoveCommunityView;
+      required final Community community}) = _$ModRemoveCommunityViewImpl;
   const _ModRemoveCommunityView._() : super._();
 
   factory _ModRemoveCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_ModRemoveCommunityView.fromJson;
+      _$ModRemoveCommunityViewImpl.fromJson;
 
   @override
   ModRemoveCommunity get modRemoveCommunity;
@@ -242,6 +244,6 @@ abstract class _ModRemoveCommunityView extends ModRemoveCommunityView {
   Community get community;
   @override
   @JsonKey(ignore: true)
-  _$$_ModRemoveCommunityViewCopyWith<_$_ModRemoveCommunityView> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ModRemoveCommunityViewImplCopyWith<_$ModRemoveCommunityViewImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/mod_remove_community_view.g.dart
+++ b/lib/src/v3/views/mod_remove_community_view.g.dart
@@ -6,9 +6,9 @@ part of 'mod_remove_community_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModRemoveCommunityView _$$_ModRemoveCommunityViewFromJson(
+_$ModRemoveCommunityViewImpl _$$ModRemoveCommunityViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModRemoveCommunityView(
+    _$ModRemoveCommunityViewImpl(
       modRemoveCommunity: ModRemoveCommunity.fromJson(
           json['mod_remove_community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -17,8 +17,8 @@ _$_ModRemoveCommunityView _$$_ModRemoveCommunityViewFromJson(
       community: Community.fromJson(json['community'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_ModRemoveCommunityViewToJson(
-        _$_ModRemoveCommunityView instance) =>
+Map<String, dynamic> _$$ModRemoveCommunityViewImplToJson(
+        _$ModRemoveCommunityViewImpl instance) =>
     <String, dynamic>{
       'mod_remove_community': instance.modRemoveCommunity.toJson(),
       'moderator': instance.moderator?.toJson(),

--- a/lib/src/v3/views/mod_remove_post_view.freezed.dart
+++ b/lib/src/v3/views/mod_remove_post_view.freezed.dart
@@ -125,11 +125,11 @@ class _$ModRemovePostViewCopyWithImpl<$Res, $Val extends ModRemovePostView>
 }
 
 /// @nodoc
-abstract class _$$_ModRemovePostViewCopyWith<$Res>
+abstract class _$$ModRemovePostViewImplCopyWith<$Res>
     implements $ModRemovePostViewCopyWith<$Res> {
-  factory _$$_ModRemovePostViewCopyWith(_$_ModRemovePostView value,
-          $Res Function(_$_ModRemovePostView) then) =
-      __$$_ModRemovePostViewCopyWithImpl<$Res>;
+  factory _$$ModRemovePostViewImplCopyWith(_$ModRemovePostViewImpl value,
+          $Res Function(_$ModRemovePostViewImpl) then) =
+      __$$ModRemovePostViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -149,11 +149,11 @@ abstract class _$$_ModRemovePostViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModRemovePostViewCopyWithImpl<$Res>
-    extends _$ModRemovePostViewCopyWithImpl<$Res, _$_ModRemovePostView>
-    implements _$$_ModRemovePostViewCopyWith<$Res> {
-  __$$_ModRemovePostViewCopyWithImpl(
-      _$_ModRemovePostView _value, $Res Function(_$_ModRemovePostView) _then)
+class __$$ModRemovePostViewImplCopyWithImpl<$Res>
+    extends _$ModRemovePostViewCopyWithImpl<$Res, _$ModRemovePostViewImpl>
+    implements _$$ModRemovePostViewImplCopyWith<$Res> {
+  __$$ModRemovePostViewImplCopyWithImpl(_$ModRemovePostViewImpl _value,
+      $Res Function(_$ModRemovePostViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -164,7 +164,7 @@ class __$$_ModRemovePostViewCopyWithImpl<$Res>
     Object? post = null,
     Object? community = null,
   }) {
-    return _then(_$_ModRemovePostView(
+    return _then(_$ModRemovePostViewImpl(
       modRemovePost: null == modRemovePost
           ? _value.modRemovePost
           : modRemovePost // ignore: cast_nullable_to_non_nullable
@@ -188,16 +188,16 @@ class __$$_ModRemovePostViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModRemovePostView extends _ModRemovePostView {
-  const _$_ModRemovePostView(
+class _$ModRemovePostViewImpl extends _ModRemovePostView {
+  const _$ModRemovePostViewImpl(
       {required this.modRemovePost,
       this.moderator,
       required this.post,
       required this.community})
       : super._();
 
-  factory _$_ModRemovePostView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModRemovePostViewFromJson(json);
+  factory _$ModRemovePostViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModRemovePostViewImplFromJson(json);
 
   @override
   final ModRemovePost modRemovePost;
@@ -217,7 +217,7 @@ class _$_ModRemovePostView extends _ModRemovePostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModRemovePostView &&
+            other is _$ModRemovePostViewImpl &&
             (identical(other.modRemovePost, modRemovePost) ||
                 other.modRemovePost == modRemovePost) &&
             (identical(other.moderator, moderator) ||
@@ -235,13 +235,13 @@ class _$_ModRemovePostView extends _ModRemovePostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModRemovePostViewCopyWith<_$_ModRemovePostView> get copyWith =>
-      __$$_ModRemovePostViewCopyWithImpl<_$_ModRemovePostView>(
+  _$$ModRemovePostViewImplCopyWith<_$ModRemovePostViewImpl> get copyWith =>
+      __$$ModRemovePostViewImplCopyWithImpl<_$ModRemovePostViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModRemovePostViewToJson(
+    return _$$ModRemovePostViewImplToJson(
       this,
     );
   }
@@ -252,11 +252,11 @@ abstract class _ModRemovePostView extends ModRemovePostView {
       {required final ModRemovePost modRemovePost,
       final Person? moderator,
       required final Post post,
-      required final Community community}) = _$_ModRemovePostView;
+      required final Community community}) = _$ModRemovePostViewImpl;
   const _ModRemovePostView._() : super._();
 
   factory _ModRemovePostView.fromJson(Map<String, dynamic> json) =
-      _$_ModRemovePostView.fromJson;
+      _$ModRemovePostViewImpl.fromJson;
 
   @override
   ModRemovePost get modRemovePost;
@@ -268,6 +268,6 @@ abstract class _ModRemovePostView extends ModRemovePostView {
   Community get community;
   @override
   @JsonKey(ignore: true)
-  _$$_ModRemovePostViewCopyWith<_$_ModRemovePostView> get copyWith =>
+  _$$ModRemovePostViewImplCopyWith<_$ModRemovePostViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/mod_remove_post_view.g.dart
+++ b/lib/src/v3/views/mod_remove_post_view.g.dart
@@ -6,8 +6,9 @@ part of 'mod_remove_post_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModRemovePostView _$$_ModRemovePostViewFromJson(Map<String, dynamic> json) =>
-    _$_ModRemovePostView(
+_$ModRemovePostViewImpl _$$ModRemovePostViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ModRemovePostViewImpl(
       modRemovePost: ModRemovePost.fromJson(
           json['mod_remove_post'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -17,8 +18,8 @@ _$_ModRemovePostView _$$_ModRemovePostViewFromJson(Map<String, dynamic> json) =>
       community: Community.fromJson(json['community'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_ModRemovePostViewToJson(
-        _$_ModRemovePostView instance) =>
+Map<String, dynamic> _$$ModRemovePostViewImplToJson(
+        _$ModRemovePostViewImpl instance) =>
     <String, dynamic>{
       'mod_remove_post': instance.modRemovePost.toJson(),
       'moderator': instance.moderator?.toJson(),

--- a/lib/src/v3/views/mod_transfer_community_view.freezed.dart
+++ b/lib/src/v3/views/mod_transfer_community_view.freezed.dart
@@ -129,12 +129,12 @@ class _$ModTransferCommunityViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ModTransferCommunityViewCopyWith<$Res>
+abstract class _$$ModTransferCommunityViewImplCopyWith<$Res>
     implements $ModTransferCommunityViewCopyWith<$Res> {
-  factory _$$_ModTransferCommunityViewCopyWith(
-          _$_ModTransferCommunityView value,
-          $Res Function(_$_ModTransferCommunityView) then) =
-      __$$_ModTransferCommunityViewCopyWithImpl<$Res>;
+  factory _$$ModTransferCommunityViewImplCopyWith(
+          _$ModTransferCommunityViewImpl value,
+          $Res Function(_$ModTransferCommunityViewImpl) then) =
+      __$$ModTransferCommunityViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -154,12 +154,13 @@ abstract class _$$_ModTransferCommunityViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ModTransferCommunityViewCopyWithImpl<$Res>
+class __$$ModTransferCommunityViewImplCopyWithImpl<$Res>
     extends _$ModTransferCommunityViewCopyWithImpl<$Res,
-        _$_ModTransferCommunityView>
-    implements _$$_ModTransferCommunityViewCopyWith<$Res> {
-  __$$_ModTransferCommunityViewCopyWithImpl(_$_ModTransferCommunityView _value,
-      $Res Function(_$_ModTransferCommunityView) _then)
+        _$ModTransferCommunityViewImpl>
+    implements _$$ModTransferCommunityViewImplCopyWith<$Res> {
+  __$$ModTransferCommunityViewImplCopyWithImpl(
+      _$ModTransferCommunityViewImpl _value,
+      $Res Function(_$ModTransferCommunityViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -170,7 +171,7 @@ class __$$_ModTransferCommunityViewCopyWithImpl<$Res>
     Object? community = null,
     Object? moddedPerson = null,
   }) {
-    return _then(_$_ModTransferCommunityView(
+    return _then(_$ModTransferCommunityViewImpl(
       modTransferCommunity: null == modTransferCommunity
           ? _value.modTransferCommunity
           : modTransferCommunity // ignore: cast_nullable_to_non_nullable
@@ -194,16 +195,16 @@ class __$$_ModTransferCommunityViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_ModTransferCommunityView extends _ModTransferCommunityView {
-  const _$_ModTransferCommunityView(
+class _$ModTransferCommunityViewImpl extends _ModTransferCommunityView {
+  const _$ModTransferCommunityViewImpl(
       {required this.modTransferCommunity,
       this.moderator,
       required this.community,
       required this.moddedPerson})
       : super._();
 
-  factory _$_ModTransferCommunityView.fromJson(Map<String, dynamic> json) =>
-      _$$_ModTransferCommunityViewFromJson(json);
+  factory _$ModTransferCommunityViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ModTransferCommunityViewImplFromJson(json);
 
   @override
   final ModTransferCommunity modTransferCommunity;
@@ -223,7 +224,7 @@ class _$_ModTransferCommunityView extends _ModTransferCommunityView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ModTransferCommunityView &&
+            other is _$ModTransferCommunityViewImpl &&
             (identical(other.modTransferCommunity, modTransferCommunity) ||
                 other.modTransferCommunity == modTransferCommunity) &&
             (identical(other.moderator, moderator) ||
@@ -242,13 +243,13 @@ class _$_ModTransferCommunityView extends _ModTransferCommunityView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ModTransferCommunityViewCopyWith<_$_ModTransferCommunityView>
-      get copyWith => __$$_ModTransferCommunityViewCopyWithImpl<
-          _$_ModTransferCommunityView>(this, _$identity);
+  _$$ModTransferCommunityViewImplCopyWith<_$ModTransferCommunityViewImpl>
+      get copyWith => __$$ModTransferCommunityViewImplCopyWithImpl<
+          _$ModTransferCommunityViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ModTransferCommunityViewToJson(
+    return _$$ModTransferCommunityViewImplToJson(
       this,
     );
   }
@@ -259,11 +260,11 @@ abstract class _ModTransferCommunityView extends ModTransferCommunityView {
       {required final ModTransferCommunity modTransferCommunity,
       final Person? moderator,
       required final Community community,
-      required final Person moddedPerson}) = _$_ModTransferCommunityView;
+      required final Person moddedPerson}) = _$ModTransferCommunityViewImpl;
   const _ModTransferCommunityView._() : super._();
 
   factory _ModTransferCommunityView.fromJson(Map<String, dynamic> json) =
-      _$_ModTransferCommunityView.fromJson;
+      _$ModTransferCommunityViewImpl.fromJson;
 
   @override
   ModTransferCommunity get modTransferCommunity;
@@ -275,6 +276,6 @@ abstract class _ModTransferCommunityView extends ModTransferCommunityView {
   Person get moddedPerson;
   @override
   @JsonKey(ignore: true)
-  _$$_ModTransferCommunityViewCopyWith<_$_ModTransferCommunityView>
+  _$$ModTransferCommunityViewImplCopyWith<_$ModTransferCommunityViewImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/mod_transfer_community_view.g.dart
+++ b/lib/src/v3/views/mod_transfer_community_view.g.dart
@@ -6,9 +6,9 @@ part of 'mod_transfer_community_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ModTransferCommunityView _$$_ModTransferCommunityViewFromJson(
+_$ModTransferCommunityViewImpl _$$ModTransferCommunityViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_ModTransferCommunityView(
+    _$ModTransferCommunityViewImpl(
       modTransferCommunity: ModTransferCommunity.fromJson(
           json['mod_transfer_community'] as Map<String, dynamic>),
       moderator: json['moderator'] == null
@@ -19,8 +19,8 @@ _$_ModTransferCommunityView _$$_ModTransferCommunityViewFromJson(
           Person.fromJson(json['modded_person'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_ModTransferCommunityViewToJson(
-        _$_ModTransferCommunityView instance) =>
+Map<String, dynamic> _$$ModTransferCommunityViewImplToJson(
+        _$ModTransferCommunityViewImpl instance) =>
     <String, dynamic>{
       'mod_transfer_community': instance.modTransferCommunity.toJson(),
       'moderator': instance.moderator?.toJson(),

--- a/lib/src/v3/views/person_block_view.freezed.dart
+++ b/lib/src/v3/views/person_block_view.freezed.dart
@@ -87,11 +87,11 @@ class _$PersonBlockViewCopyWithImpl<$Res, $Val extends PersonBlockView>
 }
 
 /// @nodoc
-abstract class _$$_PersonBlockViewCopyWith<$Res>
+abstract class _$$PersonBlockViewImplCopyWith<$Res>
     implements $PersonBlockViewCopyWith<$Res> {
-  factory _$$_PersonBlockViewCopyWith(
-          _$_PersonBlockView value, $Res Function(_$_PersonBlockView) then) =
-      __$$_PersonBlockViewCopyWithImpl<$Res>;
+  factory _$$PersonBlockViewImplCopyWith(_$PersonBlockViewImpl value,
+          $Res Function(_$PersonBlockViewImpl) then) =
+      __$$PersonBlockViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({Person person, Person target});
@@ -103,11 +103,11 @@ abstract class _$$_PersonBlockViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PersonBlockViewCopyWithImpl<$Res>
-    extends _$PersonBlockViewCopyWithImpl<$Res, _$_PersonBlockView>
-    implements _$$_PersonBlockViewCopyWith<$Res> {
-  __$$_PersonBlockViewCopyWithImpl(
-      _$_PersonBlockView _value, $Res Function(_$_PersonBlockView) _then)
+class __$$PersonBlockViewImplCopyWithImpl<$Res>
+    extends _$PersonBlockViewCopyWithImpl<$Res, _$PersonBlockViewImpl>
+    implements _$$PersonBlockViewImplCopyWith<$Res> {
+  __$$PersonBlockViewImplCopyWithImpl(
+      _$PersonBlockViewImpl _value, $Res Function(_$PersonBlockViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -116,7 +116,7 @@ class __$$_PersonBlockViewCopyWithImpl<$Res>
     Object? person = null,
     Object? target = null,
   }) {
-    return _then(_$_PersonBlockView(
+    return _then(_$PersonBlockViewImpl(
       person: null == person
           ? _value.person
           : person // ignore: cast_nullable_to_non_nullable
@@ -132,12 +132,12 @@ class __$$_PersonBlockViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PersonBlockView extends _PersonBlockView {
-  const _$_PersonBlockView({required this.person, required this.target})
+class _$PersonBlockViewImpl extends _PersonBlockView {
+  const _$PersonBlockViewImpl({required this.person, required this.target})
       : super._();
 
-  factory _$_PersonBlockView.fromJson(Map<String, dynamic> json) =>
-      _$$_PersonBlockViewFromJson(json);
+  factory _$PersonBlockViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonBlockViewImplFromJson(json);
 
   @override
   final Person person;
@@ -153,7 +153,7 @@ class _$_PersonBlockView extends _PersonBlockView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PersonBlockView &&
+            other is _$PersonBlockViewImpl &&
             (identical(other.person, person) || other.person == person) &&
             (identical(other.target, target) || other.target == target));
   }
@@ -165,12 +165,13 @@ class _$_PersonBlockView extends _PersonBlockView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PersonBlockViewCopyWith<_$_PersonBlockView> get copyWith =>
-      __$$_PersonBlockViewCopyWithImpl<_$_PersonBlockView>(this, _$identity);
+  _$$PersonBlockViewImplCopyWith<_$PersonBlockViewImpl> get copyWith =>
+      __$$PersonBlockViewImplCopyWithImpl<_$PersonBlockViewImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PersonBlockViewToJson(
+    return _$$PersonBlockViewImplToJson(
       this,
     );
   }
@@ -179,11 +180,11 @@ class _$_PersonBlockView extends _PersonBlockView {
 abstract class _PersonBlockView extends PersonBlockView {
   const factory _PersonBlockView(
       {required final Person person,
-      required final Person target}) = _$_PersonBlockView;
+      required final Person target}) = _$PersonBlockViewImpl;
   const _PersonBlockView._() : super._();
 
   factory _PersonBlockView.fromJson(Map<String, dynamic> json) =
-      _$_PersonBlockView.fromJson;
+      _$PersonBlockViewImpl.fromJson;
 
   @override
   Person get person;
@@ -191,6 +192,6 @@ abstract class _PersonBlockView extends PersonBlockView {
   Person get target;
   @override
   @JsonKey(ignore: true)
-  _$$_PersonBlockViewCopyWith<_$_PersonBlockView> get copyWith =>
+  _$$PersonBlockViewImplCopyWith<_$PersonBlockViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/person_block_view.g.dart
+++ b/lib/src/v3/views/person_block_view.g.dart
@@ -6,13 +6,15 @@ part of 'person_block_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PersonBlockView _$$_PersonBlockViewFromJson(Map<String, dynamic> json) =>
-    _$_PersonBlockView(
+_$PersonBlockViewImpl _$$PersonBlockViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$PersonBlockViewImpl(
       person: Person.fromJson(json['person'] as Map<String, dynamic>),
       target: Person.fromJson(json['target'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_PersonBlockViewToJson(_$_PersonBlockView instance) =>
+Map<String, dynamic> _$$PersonBlockViewImplToJson(
+        _$PersonBlockViewImpl instance) =>
     <String, dynamic>{
       'person': instance.person.toJson(),
       'target': instance.target.toJson(),

--- a/lib/src/v3/views/person_mention_view.freezed.dart
+++ b/lib/src/v3/views/person_mention_view.freezed.dart
@@ -212,11 +212,11 @@ class _$PersonMentionViewCopyWithImpl<$Res, $Val extends PersonMentionView>
 }
 
 /// @nodoc
-abstract class _$$_PersonMentionViewCopyWith<$Res>
+abstract class _$$PersonMentionViewImplCopyWith<$Res>
     implements $PersonMentionViewCopyWith<$Res> {
-  factory _$$_PersonMentionViewCopyWith(_$_PersonMentionView value,
-          $Res Function(_$_PersonMentionView) then) =
-      __$$_PersonMentionViewCopyWithImpl<$Res>;
+  factory _$$PersonMentionViewImplCopyWith(_$PersonMentionViewImpl value,
+          $Res Function(_$PersonMentionViewImpl) then) =
+      __$$PersonMentionViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -251,11 +251,11 @@ abstract class _$$_PersonMentionViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PersonMentionViewCopyWithImpl<$Res>
-    extends _$PersonMentionViewCopyWithImpl<$Res, _$_PersonMentionView>
-    implements _$$_PersonMentionViewCopyWith<$Res> {
-  __$$_PersonMentionViewCopyWithImpl(
-      _$_PersonMentionView _value, $Res Function(_$_PersonMentionView) _then)
+class __$$PersonMentionViewImplCopyWithImpl<$Res>
+    extends _$PersonMentionViewCopyWithImpl<$Res, _$PersonMentionViewImpl>
+    implements _$$PersonMentionViewImplCopyWith<$Res> {
+  __$$PersonMentionViewImplCopyWithImpl(_$PersonMentionViewImpl _value,
+      $Res Function(_$PersonMentionViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -275,7 +275,7 @@ class __$$_PersonMentionViewCopyWithImpl<$Res>
     Object? creatorBlocked = null,
     Object? myVote = freezed,
   }) {
-    return _then(_$_PersonMentionView(
+    return _then(_$PersonMentionViewImpl(
       personMention: null == personMention
           ? _value.personMention
           : personMention // ignore: cast_nullable_to_non_nullable
@@ -335,8 +335,8 @@ class __$$_PersonMentionViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PersonMentionView extends _PersonMentionView {
-  const _$_PersonMentionView(
+class _$PersonMentionViewImpl extends _PersonMentionView {
+  const _$PersonMentionViewImpl(
       {required this.personMention,
       required this.comment,
       required this.creator,
@@ -352,8 +352,8 @@ class _$_PersonMentionView extends _PersonMentionView {
       required this.myVote})
       : super._();
 
-  factory _$_PersonMentionView.fromJson(Map<String, dynamic> json) =>
-      _$$_PersonMentionViewFromJson(json);
+  factory _$PersonMentionViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonMentionViewImplFromJson(json);
 
   @override
   final PersonMention personMention;
@@ -392,7 +392,7 @@ class _$_PersonMentionView extends _PersonMentionView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PersonMentionView &&
+            other is _$PersonMentionViewImpl &&
             (identical(other.personMention, personMention) ||
                 other.personMention == personMention) &&
             (identical(other.comment, comment) || other.comment == comment) &&
@@ -438,13 +438,13 @@ class _$_PersonMentionView extends _PersonMentionView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PersonMentionViewCopyWith<_$_PersonMentionView> get copyWith =>
-      __$$_PersonMentionViewCopyWithImpl<_$_PersonMentionView>(
+  _$$PersonMentionViewImplCopyWith<_$PersonMentionViewImpl> get copyWith =>
+      __$$PersonMentionViewImplCopyWithImpl<_$PersonMentionViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PersonMentionViewToJson(
+    return _$$PersonMentionViewImplToJson(
       this,
     );
   }
@@ -464,11 +464,11 @@ abstract class _PersonMentionView extends PersonMentionView {
       required final SubscribedType subscribed,
       required final bool saved,
       required final bool creatorBlocked,
-      required final int? myVote}) = _$_PersonMentionView;
+      required final int? myVote}) = _$PersonMentionViewImpl;
   const _PersonMentionView._() : super._();
 
   factory _PersonMentionView.fromJson(Map<String, dynamic> json) =
-      _$_PersonMentionView.fromJson;
+      _$PersonMentionViewImpl.fromJson;
 
   @override
   PersonMention get personMention;
@@ -498,6 +498,6 @@ abstract class _PersonMentionView extends PersonMentionView {
   int? get myVote;
   @override
   @JsonKey(ignore: true)
-  _$$_PersonMentionViewCopyWith<_$_PersonMentionView> get copyWith =>
+  _$$PersonMentionViewImplCopyWith<_$PersonMentionViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/person_mention_view.g.dart
+++ b/lib/src/v3/views/person_mention_view.g.dart
@@ -6,8 +6,9 @@ part of 'person_mention_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PersonMentionView _$$_PersonMentionViewFromJson(Map<String, dynamic> json) =>
-    _$_PersonMentionView(
+_$PersonMentionViewImpl _$$PersonMentionViewImplFromJson(
+        Map<String, dynamic> json) =>
+    _$PersonMentionViewImpl(
       personMention: PersonMention.fromJson(
           json['person_mention'] as Map<String, dynamic>),
       comment: Comment.fromJson(json['comment'] as Map<String, dynamic>),
@@ -25,8 +26,8 @@ _$_PersonMentionView _$$_PersonMentionViewFromJson(Map<String, dynamic> json) =>
       myVote: json['my_vote'] as int?,
     );
 
-Map<String, dynamic> _$$_PersonMentionViewToJson(
-        _$_PersonMentionView instance) =>
+Map<String, dynamic> _$$PersonMentionViewImplToJson(
+        _$PersonMentionViewImpl instance) =>
     <String, dynamic>{
       'person_mention': instance.personMention.toJson(),
       'comment': instance.comment.toJson(),

--- a/lib/src/v3/views/person_view.freezed.dart
+++ b/lib/src/v3/views/person_view.freezed.dart
@@ -87,11 +87,11 @@ class _$PersonViewCopyWithImpl<$Res, $Val extends PersonView>
 }
 
 /// @nodoc
-abstract class _$$_PersonViewCopyWith<$Res>
+abstract class _$$PersonViewImplCopyWith<$Res>
     implements $PersonViewCopyWith<$Res> {
-  factory _$$_PersonViewCopyWith(
-          _$_PersonView value, $Res Function(_$_PersonView) then) =
-      __$$_PersonViewCopyWithImpl<$Res>;
+  factory _$$PersonViewImplCopyWith(
+          _$PersonViewImpl value, $Res Function(_$PersonViewImpl) then) =
+      __$$PersonViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({Person person, PersonAggregates counts});
@@ -103,11 +103,11 @@ abstract class _$$_PersonViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PersonViewCopyWithImpl<$Res>
-    extends _$PersonViewCopyWithImpl<$Res, _$_PersonView>
-    implements _$$_PersonViewCopyWith<$Res> {
-  __$$_PersonViewCopyWithImpl(
-      _$_PersonView _value, $Res Function(_$_PersonView) _then)
+class __$$PersonViewImplCopyWithImpl<$Res>
+    extends _$PersonViewCopyWithImpl<$Res, _$PersonViewImpl>
+    implements _$$PersonViewImplCopyWith<$Res> {
+  __$$PersonViewImplCopyWithImpl(
+      _$PersonViewImpl _value, $Res Function(_$PersonViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -116,7 +116,7 @@ class __$$_PersonViewCopyWithImpl<$Res>
     Object? person = null,
     Object? counts = null,
   }) {
-    return _then(_$_PersonView(
+    return _then(_$PersonViewImpl(
       person: null == person
           ? _value.person
           : person // ignore: cast_nullable_to_non_nullable
@@ -132,11 +132,12 @@ class __$$_PersonViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PersonView extends _PersonView {
-  const _$_PersonView({required this.person, required this.counts}) : super._();
+class _$PersonViewImpl extends _PersonView {
+  const _$PersonViewImpl({required this.person, required this.counts})
+      : super._();
 
-  factory _$_PersonView.fromJson(Map<String, dynamic> json) =>
-      _$$_PersonViewFromJson(json);
+  factory _$PersonViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PersonViewImplFromJson(json);
 
   @override
   final Person person;
@@ -152,7 +153,7 @@ class _$_PersonView extends _PersonView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PersonView &&
+            other is _$PersonViewImpl &&
             (identical(other.person, person) || other.person == person) &&
             (identical(other.counts, counts) || other.counts == counts));
   }
@@ -164,12 +165,12 @@ class _$_PersonView extends _PersonView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PersonViewCopyWith<_$_PersonView> get copyWith =>
-      __$$_PersonViewCopyWithImpl<_$_PersonView>(this, _$identity);
+  _$$PersonViewImplCopyWith<_$PersonViewImpl> get copyWith =>
+      __$$PersonViewImplCopyWithImpl<_$PersonViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PersonViewToJson(
+    return _$$PersonViewImplToJson(
       this,
     );
   }
@@ -178,11 +179,11 @@ class _$_PersonView extends _PersonView {
 abstract class _PersonView extends PersonView {
   const factory _PersonView(
       {required final Person person,
-      required final PersonAggregates counts}) = _$_PersonView;
+      required final PersonAggregates counts}) = _$PersonViewImpl;
   const _PersonView._() : super._();
 
   factory _PersonView.fromJson(Map<String, dynamic> json) =
-      _$_PersonView.fromJson;
+      _$PersonViewImpl.fromJson;
 
   @override
   Person get person;
@@ -190,6 +191,6 @@ abstract class _PersonView extends PersonView {
   PersonAggregates get counts;
   @override
   @JsonKey(ignore: true)
-  _$$_PersonViewCopyWith<_$_PersonView> get copyWith =>
+  _$$PersonViewImplCopyWith<_$PersonViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/person_view.g.dart
+++ b/lib/src/v3/views/person_view.g.dart
@@ -6,13 +6,13 @@ part of 'person_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PersonView _$$_PersonViewFromJson(Map<String, dynamic> json) =>
-    _$_PersonView(
+_$PersonViewImpl _$$PersonViewImplFromJson(Map<String, dynamic> json) =>
+    _$PersonViewImpl(
       person: Person.fromJson(json['person'] as Map<String, dynamic>),
       counts: PersonAggregates.fromJson(json['counts'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_PersonViewToJson(_$_PersonView instance) =>
+Map<String, dynamic> _$$PersonViewImplToJson(_$PersonViewImpl instance) =>
     <String, dynamic>{
       'person': instance.person.toJson(),
       'counts': instance.counts.toJson(),

--- a/lib/src/v3/views/post_report_view.freezed.dart
+++ b/lib/src/v3/views/post_report_view.freezed.dart
@@ -187,11 +187,11 @@ class _$PostReportViewCopyWithImpl<$Res, $Val extends PostReportView>
 }
 
 /// @nodoc
-abstract class _$$_PostReportViewCopyWith<$Res>
+abstract class _$$PostReportViewImplCopyWith<$Res>
     implements $PostReportViewCopyWith<$Res> {
-  factory _$$_PostReportViewCopyWith(
-          _$_PostReportView value, $Res Function(_$_PostReportView) then) =
-      __$$_PostReportViewCopyWithImpl<$Res>;
+  factory _$$PostReportViewImplCopyWith(_$PostReportViewImpl value,
+          $Res Function(_$PostReportViewImpl) then) =
+      __$$PostReportViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -222,11 +222,11 @@ abstract class _$$_PostReportViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PostReportViewCopyWithImpl<$Res>
-    extends _$PostReportViewCopyWithImpl<$Res, _$_PostReportView>
-    implements _$$_PostReportViewCopyWith<$Res> {
-  __$$_PostReportViewCopyWithImpl(
-      _$_PostReportView _value, $Res Function(_$_PostReportView) _then)
+class __$$PostReportViewImplCopyWithImpl<$Res>
+    extends _$PostReportViewCopyWithImpl<$Res, _$PostReportViewImpl>
+    implements _$$PostReportViewImplCopyWith<$Res> {
+  __$$PostReportViewImplCopyWithImpl(
+      _$PostReportViewImpl _value, $Res Function(_$PostReportViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -242,7 +242,7 @@ class __$$_PostReportViewCopyWithImpl<$Res>
     Object? counts = null,
     Object? resolver = freezed,
   }) {
-    return _then(_$_PostReportView(
+    return _then(_$PostReportViewImpl(
       postReport: null == postReport
           ? _value.postReport
           : postReport // ignore: cast_nullable_to_non_nullable
@@ -286,8 +286,8 @@ class __$$_PostReportViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PostReportView extends _PostReportView {
-  const _$_PostReportView(
+class _$PostReportViewImpl extends _PostReportView {
+  const _$PostReportViewImpl(
       {required this.postReport,
       required this.post,
       required this.community,
@@ -299,8 +299,8 @@ class _$_PostReportView extends _PostReportView {
       this.resolver})
       : super._();
 
-  factory _$_PostReportView.fromJson(Map<String, dynamic> json) =>
-      _$$_PostReportViewFromJson(json);
+  factory _$PostReportViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PostReportViewImplFromJson(json);
 
   @override
   final PostReport postReport;
@@ -330,7 +330,7 @@ class _$_PostReportView extends _PostReportView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PostReportView &&
+            other is _$PostReportViewImpl &&
             (identical(other.postReport, postReport) ||
                 other.postReport == postReport) &&
             (identical(other.post, post) || other.post == post) &&
@@ -366,12 +366,13 @@ class _$_PostReportView extends _PostReportView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PostReportViewCopyWith<_$_PostReportView> get copyWith =>
-      __$$_PostReportViewCopyWithImpl<_$_PostReportView>(this, _$identity);
+  _$$PostReportViewImplCopyWith<_$PostReportViewImpl> get copyWith =>
+      __$$PostReportViewImplCopyWithImpl<_$PostReportViewImpl>(
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PostReportViewToJson(
+    return _$$PostReportViewImplToJson(
       this,
     );
   }
@@ -387,11 +388,11 @@ abstract class _PostReportView extends PostReportView {
       required final bool creatorBannedFromCommunity,
       final num? myVote,
       required final PostAggregates counts,
-      final Person? resolver}) = _$_PostReportView;
+      final Person? resolver}) = _$PostReportViewImpl;
   const _PostReportView._() : super._();
 
   factory _PostReportView.fromJson(Map<String, dynamic> json) =
-      _$_PostReportView.fromJson;
+      _$PostReportViewImpl.fromJson;
 
   @override
   PostReport get postReport;
@@ -413,6 +414,6 @@ abstract class _PostReportView extends PostReportView {
   Person? get resolver;
   @override
   @JsonKey(ignore: true)
-  _$$_PostReportViewCopyWith<_$_PostReportView> get copyWith =>
+  _$$PostReportViewImplCopyWith<_$PostReportViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/post_report_view.g.dart
+++ b/lib/src/v3/views/post_report_view.g.dart
@@ -6,8 +6,8 @@ part of 'post_report_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PostReportView _$$_PostReportViewFromJson(Map<String, dynamic> json) =>
-    _$_PostReportView(
+_$PostReportViewImpl _$$PostReportViewImplFromJson(Map<String, dynamic> json) =>
+    _$PostReportViewImpl(
       postReport:
           PostReport.fromJson(json['post_report'] as Map<String, dynamic>),
       post: Post.fromJson(json['post'] as Map<String, dynamic>),
@@ -23,7 +23,8 @@ _$_PostReportView _$$_PostReportViewFromJson(Map<String, dynamic> json) =>
           : Person.fromJson(json['resolver'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_PostReportViewToJson(_$_PostReportView instance) =>
+Map<String, dynamic> _$$PostReportViewImplToJson(
+        _$PostReportViewImpl instance) =>
     <String, dynamic>{
       'post_report': instance.postReport.toJson(),
       'post': instance.post.toJson(),

--- a/lib/src/v3/views/post_view.freezed.dart
+++ b/lib/src/v3/views/post_view.freezed.dart
@@ -177,10 +177,11 @@ class _$PostViewCopyWithImpl<$Res, $Val extends PostView>
 }
 
 /// @nodoc
-abstract class _$$_PostViewCopyWith<$Res> implements $PostViewCopyWith<$Res> {
-  factory _$$_PostViewCopyWith(
-          _$_PostView value, $Res Function(_$_PostView) then) =
-      __$$_PostViewCopyWithImpl<$Res>;
+abstract class _$$PostViewImplCopyWith<$Res>
+    implements $PostViewCopyWith<$Res> {
+  factory _$$PostViewImplCopyWith(
+          _$PostViewImpl value, $Res Function(_$PostViewImpl) then) =
+      __$$PostViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -208,11 +209,11 @@ abstract class _$$_PostViewCopyWith<$Res> implements $PostViewCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$$_PostViewCopyWithImpl<$Res>
-    extends _$PostViewCopyWithImpl<$Res, _$_PostView>
-    implements _$$_PostViewCopyWith<$Res> {
-  __$$_PostViewCopyWithImpl(
-      _$_PostView _value, $Res Function(_$_PostView) _then)
+class __$$PostViewImplCopyWithImpl<$Res>
+    extends _$PostViewCopyWithImpl<$Res, _$PostViewImpl>
+    implements _$$PostViewImplCopyWith<$Res> {
+  __$$PostViewImplCopyWithImpl(
+      _$PostViewImpl _value, $Res Function(_$PostViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -231,7 +232,7 @@ class __$$_PostViewCopyWithImpl<$Res>
     Object? myVote = freezed,
     Object? unreadComments = null,
   }) {
-    return _then(_$_PostView(
+    return _then(_$PostViewImpl(
       post: null == post
           ? _value.post
           : post // ignore: cast_nullable_to_non_nullable
@@ -287,8 +288,8 @@ class __$$_PostViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PostView extends _PostView {
-  const _$_PostView(
+class _$PostViewImpl extends _PostView {
+  const _$PostViewImpl(
       {required this.post,
       required this.creator,
       required this.community,
@@ -303,8 +304,8 @@ class _$_PostView extends _PostView {
       required this.unreadComments})
       : super._();
 
-  factory _$_PostView.fromJson(Map<String, dynamic> json) =>
-      _$$_PostViewFromJson(json);
+  factory _$PostViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PostViewImplFromJson(json);
 
   @override
   final Post post;
@@ -341,7 +342,7 @@ class _$_PostView extends _PostView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PostView &&
+            other is _$PostViewImpl &&
             (identical(other.post, post) || other.post == post) &&
             (identical(other.creator, creator) || other.creator == creator) &&
             (identical(other.community, community) ||
@@ -384,12 +385,12 @@ class _$_PostView extends _PostView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PostViewCopyWith<_$_PostView> get copyWith =>
-      __$$_PostViewCopyWithImpl<_$_PostView>(this, _$identity);
+  _$$PostViewImplCopyWith<_$PostViewImpl> get copyWith =>
+      __$$PostViewImplCopyWithImpl<_$PostViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PostViewToJson(
+    return _$$PostViewImplToJson(
       this,
     );
   }
@@ -408,10 +409,11 @@ abstract class _PostView extends PostView {
       required final bool read,
       required final bool creatorBlocked,
       final int? myVote,
-      required final int unreadComments}) = _$_PostView;
+      required final int unreadComments}) = _$PostViewImpl;
   const _PostView._() : super._();
 
-  factory _PostView.fromJson(Map<String, dynamic> json) = _$_PostView.fromJson;
+  factory _PostView.fromJson(Map<String, dynamic> json) =
+      _$PostViewImpl.fromJson;
 
   @override
   Post get post;
@@ -439,6 +441,6 @@ abstract class _PostView extends PostView {
   int get unreadComments;
   @override
   @JsonKey(ignore: true)
-  _$$_PostViewCopyWith<_$_PostView> get copyWith =>
+  _$$PostViewImplCopyWith<_$PostViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/post_view.g.dart
+++ b/lib/src/v3/views/post_view.g.dart
@@ -6,7 +6,8 @@ part of 'post_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PostView _$$_PostViewFromJson(Map<String, dynamic> json) => _$_PostView(
+_$PostViewImpl _$$PostViewImplFromJson(Map<String, dynamic> json) =>
+    _$PostViewImpl(
       post: Post.fromJson(json['post'] as Map<String, dynamic>),
       creator: Person.fromJson(json['creator'] as Map<String, dynamic>),
       community: Community.fromJson(json['community'] as Map<String, dynamic>),
@@ -21,7 +22,7 @@ _$_PostView _$$_PostViewFromJson(Map<String, dynamic> json) => _$_PostView(
       unreadComments: json['unread_comments'] as int,
     );
 
-Map<String, dynamic> _$$_PostViewToJson(_$_PostView instance) =>
+Map<String, dynamic> _$$PostViewImplToJson(_$PostViewImpl instance) =>
     <String, dynamic>{
       'post': instance.post.toJson(),
       'creator': instance.creator.toJson(),

--- a/lib/src/v3/views/private_message_report_view.freezed.dart
+++ b/lib/src/v3/views/private_message_report_view.freezed.dart
@@ -145,12 +145,12 @@ class _$PrivateMessageReportViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_PrivateMessageReportViewCopyWith<$Res>
+abstract class _$$PrivateMessageReportViewImplCopyWith<$Res>
     implements $PrivateMessageReportViewCopyWith<$Res> {
-  factory _$$_PrivateMessageReportViewCopyWith(
-          _$_PrivateMessageReportView value,
-          $Res Function(_$_PrivateMessageReportView) then) =
-      __$$_PrivateMessageReportViewCopyWithImpl<$Res>;
+  factory _$$PrivateMessageReportViewImplCopyWith(
+          _$PrivateMessageReportViewImpl value,
+          $Res Function(_$PrivateMessageReportViewImpl) then) =
+      __$$PrivateMessageReportViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -173,12 +173,13 @@ abstract class _$$_PrivateMessageReportViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PrivateMessageReportViewCopyWithImpl<$Res>
+class __$$PrivateMessageReportViewImplCopyWithImpl<$Res>
     extends _$PrivateMessageReportViewCopyWithImpl<$Res,
-        _$_PrivateMessageReportView>
-    implements _$$_PrivateMessageReportViewCopyWith<$Res> {
-  __$$_PrivateMessageReportViewCopyWithImpl(_$_PrivateMessageReportView _value,
-      $Res Function(_$_PrivateMessageReportView) _then)
+        _$PrivateMessageReportViewImpl>
+    implements _$$PrivateMessageReportViewImplCopyWith<$Res> {
+  __$$PrivateMessageReportViewImplCopyWithImpl(
+      _$PrivateMessageReportViewImpl _value,
+      $Res Function(_$PrivateMessageReportViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -190,7 +191,7 @@ class __$$_PrivateMessageReportViewCopyWithImpl<$Res>
     Object? creator = null,
     Object? resolver = freezed,
   }) {
-    return _then(_$_PrivateMessageReportView(
+    return _then(_$PrivateMessageReportViewImpl(
       privateMessageReport: null == privateMessageReport
           ? _value.privateMessageReport
           : privateMessageReport // ignore: cast_nullable_to_non_nullable
@@ -218,8 +219,8 @@ class __$$_PrivateMessageReportViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PrivateMessageReportView extends _PrivateMessageReportView {
-  const _$_PrivateMessageReportView(
+class _$PrivateMessageReportViewImpl extends _PrivateMessageReportView {
+  const _$PrivateMessageReportViewImpl(
       {required this.privateMessageReport,
       required this.privateMessage,
       required this.privateMessageCreator,
@@ -227,8 +228,8 @@ class _$_PrivateMessageReportView extends _PrivateMessageReportView {
       this.resolver})
       : super._();
 
-  factory _$_PrivateMessageReportView.fromJson(Map<String, dynamic> json) =>
-      _$$_PrivateMessageReportViewFromJson(json);
+  factory _$PrivateMessageReportViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PrivateMessageReportViewImplFromJson(json);
 
   @override
   final PrivateMessageReport privateMessageReport;
@@ -250,7 +251,7 @@ class _$_PrivateMessageReportView extends _PrivateMessageReportView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PrivateMessageReportView &&
+            other is _$PrivateMessageReportViewImpl &&
             (identical(other.privateMessageReport, privateMessageReport) ||
                 other.privateMessageReport == privateMessageReport) &&
             (identical(other.privateMessage, privateMessage) ||
@@ -270,13 +271,13 @@ class _$_PrivateMessageReportView extends _PrivateMessageReportView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PrivateMessageReportViewCopyWith<_$_PrivateMessageReportView>
-      get copyWith => __$$_PrivateMessageReportViewCopyWithImpl<
-          _$_PrivateMessageReportView>(this, _$identity);
+  _$$PrivateMessageReportViewImplCopyWith<_$PrivateMessageReportViewImpl>
+      get copyWith => __$$PrivateMessageReportViewImplCopyWithImpl<
+          _$PrivateMessageReportViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PrivateMessageReportViewToJson(
+    return _$$PrivateMessageReportViewImplToJson(
       this,
     );
   }
@@ -288,11 +289,11 @@ abstract class _PrivateMessageReportView extends PrivateMessageReportView {
       required final PrivateMessage privateMessage,
       required final Person privateMessageCreator,
       required final Person creator,
-      final Person? resolver}) = _$_PrivateMessageReportView;
+      final Person? resolver}) = _$PrivateMessageReportViewImpl;
   const _PrivateMessageReportView._() : super._();
 
   factory _PrivateMessageReportView.fromJson(Map<String, dynamic> json) =
-      _$_PrivateMessageReportView.fromJson;
+      _$PrivateMessageReportViewImpl.fromJson;
 
   @override
   PrivateMessageReport get privateMessageReport;
@@ -306,6 +307,6 @@ abstract class _PrivateMessageReportView extends PrivateMessageReportView {
   Person? get resolver;
   @override
   @JsonKey(ignore: true)
-  _$$_PrivateMessageReportViewCopyWith<_$_PrivateMessageReportView>
+  _$$PrivateMessageReportViewImplCopyWith<_$PrivateMessageReportViewImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/private_message_report_view.g.dart
+++ b/lib/src/v3/views/private_message_report_view.g.dart
@@ -6,9 +6,9 @@ part of 'private_message_report_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PrivateMessageReportView _$$_PrivateMessageReportViewFromJson(
+_$PrivateMessageReportViewImpl _$$PrivateMessageReportViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PrivateMessageReportView(
+    _$PrivateMessageReportViewImpl(
       privateMessageReport: PrivateMessageReport.fromJson(
           json['private_message_report'] as Map<String, dynamic>),
       privateMessage: PrivateMessage.fromJson(
@@ -21,8 +21,8 @@ _$_PrivateMessageReportView _$$_PrivateMessageReportViewFromJson(
           : Person.fromJson(json['resolver'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_PrivateMessageReportViewToJson(
-        _$_PrivateMessageReportView instance) =>
+Map<String, dynamic> _$$PrivateMessageReportViewImplToJson(
+        _$PrivateMessageReportViewImpl instance) =>
     <String, dynamic>{
       'private_message_report': instance.privateMessageReport.toJson(),
       'private_message': instance.privateMessage.toJson(),

--- a/lib/src/v3/views/private_message_view.freezed.dart
+++ b/lib/src/v3/views/private_message_view.freezed.dart
@@ -102,11 +102,11 @@ class _$PrivateMessageViewCopyWithImpl<$Res, $Val extends PrivateMessageView>
 }
 
 /// @nodoc
-abstract class _$$_PrivateMessageViewCopyWith<$Res>
+abstract class _$$PrivateMessageViewImplCopyWith<$Res>
     implements $PrivateMessageViewCopyWith<$Res> {
-  factory _$$_PrivateMessageViewCopyWith(_$_PrivateMessageView value,
-          $Res Function(_$_PrivateMessageView) then) =
-      __$$_PrivateMessageViewCopyWithImpl<$Res>;
+  factory _$$PrivateMessageViewImplCopyWith(_$PrivateMessageViewImpl value,
+          $Res Function(_$PrivateMessageViewImpl) then) =
+      __$$PrivateMessageViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({PrivateMessage privateMessage, Person creator, Person recipient});
@@ -120,11 +120,11 @@ abstract class _$$_PrivateMessageViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PrivateMessageViewCopyWithImpl<$Res>
-    extends _$PrivateMessageViewCopyWithImpl<$Res, _$_PrivateMessageView>
-    implements _$$_PrivateMessageViewCopyWith<$Res> {
-  __$$_PrivateMessageViewCopyWithImpl(
-      _$_PrivateMessageView _value, $Res Function(_$_PrivateMessageView) _then)
+class __$$PrivateMessageViewImplCopyWithImpl<$Res>
+    extends _$PrivateMessageViewCopyWithImpl<$Res, _$PrivateMessageViewImpl>
+    implements _$$PrivateMessageViewImplCopyWith<$Res> {
+  __$$PrivateMessageViewImplCopyWithImpl(_$PrivateMessageViewImpl _value,
+      $Res Function(_$PrivateMessageViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -134,7 +134,7 @@ class __$$_PrivateMessageViewCopyWithImpl<$Res>
     Object? creator = null,
     Object? recipient = null,
   }) {
-    return _then(_$_PrivateMessageView(
+    return _then(_$PrivateMessageViewImpl(
       privateMessage: null == privateMessage
           ? _value.privateMessage
           : privateMessage // ignore: cast_nullable_to_non_nullable
@@ -154,15 +154,15 @@ class __$$_PrivateMessageViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_PrivateMessageView extends _PrivateMessageView {
-  const _$_PrivateMessageView(
+class _$PrivateMessageViewImpl extends _PrivateMessageView {
+  const _$PrivateMessageViewImpl(
       {required this.privateMessage,
       required this.creator,
       required this.recipient})
       : super._();
 
-  factory _$_PrivateMessageView.fromJson(Map<String, dynamic> json) =>
-      _$$_PrivateMessageViewFromJson(json);
+  factory _$PrivateMessageViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PrivateMessageViewImplFromJson(json);
 
   @override
   final PrivateMessage privateMessage;
@@ -180,7 +180,7 @@ class _$_PrivateMessageView extends _PrivateMessageView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PrivateMessageView &&
+            other is _$PrivateMessageViewImpl &&
             (identical(other.privateMessage, privateMessage) ||
                 other.privateMessage == privateMessage) &&
             (identical(other.creator, creator) || other.creator == creator) &&
@@ -196,13 +196,13 @@ class _$_PrivateMessageView extends _PrivateMessageView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PrivateMessageViewCopyWith<_$_PrivateMessageView> get copyWith =>
-      __$$_PrivateMessageViewCopyWithImpl<_$_PrivateMessageView>(
+  _$$PrivateMessageViewImplCopyWith<_$PrivateMessageViewImpl> get copyWith =>
+      __$$PrivateMessageViewImplCopyWithImpl<_$PrivateMessageViewImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PrivateMessageViewToJson(
+    return _$$PrivateMessageViewImplToJson(
       this,
     );
   }
@@ -212,11 +212,11 @@ abstract class _PrivateMessageView extends PrivateMessageView {
   const factory _PrivateMessageView(
       {required final PrivateMessage privateMessage,
       required final Person creator,
-      required final Person recipient}) = _$_PrivateMessageView;
+      required final Person recipient}) = _$PrivateMessageViewImpl;
   const _PrivateMessageView._() : super._();
 
   factory _PrivateMessageView.fromJson(Map<String, dynamic> json) =
-      _$_PrivateMessageView.fromJson;
+      _$PrivateMessageViewImpl.fromJson;
 
   @override
   PrivateMessage get privateMessage;
@@ -226,6 +226,6 @@ abstract class _PrivateMessageView extends PrivateMessageView {
   Person get recipient;
   @override
   @JsonKey(ignore: true)
-  _$$_PrivateMessageViewCopyWith<_$_PrivateMessageView> get copyWith =>
+  _$$PrivateMessageViewImplCopyWith<_$PrivateMessageViewImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/private_message_view.g.dart
+++ b/lib/src/v3/views/private_message_view.g.dart
@@ -6,17 +6,17 @@ part of 'private_message_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PrivateMessageView _$$_PrivateMessageViewFromJson(
+_$PrivateMessageViewImpl _$$PrivateMessageViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PrivateMessageView(
+    _$PrivateMessageViewImpl(
       privateMessage: PrivateMessage.fromJson(
           json['private_message'] as Map<String, dynamic>),
       creator: Person.fromJson(json['creator'] as Map<String, dynamic>),
       recipient: Person.fromJson(json['recipient'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_PrivateMessageViewToJson(
-        _$_PrivateMessageView instance) =>
+Map<String, dynamic> _$$PrivateMessageViewImplToJson(
+        _$PrivateMessageViewImpl instance) =>
     <String, dynamic>{
       'private_message': instance.privateMessage.toJson(),
       'creator': instance.creator.toJson(),

--- a/lib/src/v3/views/registration_application_view.freezed.dart
+++ b/lib/src/v3/views/registration_application_view.freezed.dart
@@ -131,12 +131,12 @@ class _$RegistrationApplicationViewCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_RegistrationApplicationViewCopyWith<$Res>
+abstract class _$$RegistrationApplicationViewImplCopyWith<$Res>
     implements $RegistrationApplicationViewCopyWith<$Res> {
-  factory _$$_RegistrationApplicationViewCopyWith(
-          _$_RegistrationApplicationView value,
-          $Res Function(_$_RegistrationApplicationView) then) =
-      __$$_RegistrationApplicationViewCopyWithImpl<$Res>;
+  factory _$$RegistrationApplicationViewImplCopyWith(
+          _$RegistrationApplicationViewImpl value,
+          $Res Function(_$RegistrationApplicationViewImpl) then) =
+      __$$RegistrationApplicationViewImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -156,13 +156,13 @@ abstract class _$$_RegistrationApplicationViewCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_RegistrationApplicationViewCopyWithImpl<$Res>
+class __$$RegistrationApplicationViewImplCopyWithImpl<$Res>
     extends _$RegistrationApplicationViewCopyWithImpl<$Res,
-        _$_RegistrationApplicationView>
-    implements _$$_RegistrationApplicationViewCopyWith<$Res> {
-  __$$_RegistrationApplicationViewCopyWithImpl(
-      _$_RegistrationApplicationView _value,
-      $Res Function(_$_RegistrationApplicationView) _then)
+        _$RegistrationApplicationViewImpl>
+    implements _$$RegistrationApplicationViewImplCopyWith<$Res> {
+  __$$RegistrationApplicationViewImplCopyWithImpl(
+      _$RegistrationApplicationViewImpl _value,
+      $Res Function(_$RegistrationApplicationViewImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -173,7 +173,7 @@ class __$$_RegistrationApplicationViewCopyWithImpl<$Res>
     Object? creator = null,
     Object? admin = freezed,
   }) {
-    return _then(_$_RegistrationApplicationView(
+    return _then(_$RegistrationApplicationViewImpl(
       registrationApplication: null == registrationApplication
           ? _value.registrationApplication
           : registrationApplication // ignore: cast_nullable_to_non_nullable
@@ -197,16 +197,17 @@ class __$$_RegistrationApplicationViewCopyWithImpl<$Res>
 /// @nodoc
 
 @modelSerde
-class _$_RegistrationApplicationView extends _RegistrationApplicationView {
-  const _$_RegistrationApplicationView(
+class _$RegistrationApplicationViewImpl extends _RegistrationApplicationView {
+  const _$RegistrationApplicationViewImpl(
       {required this.registrationApplication,
       required this.creatorLocalUser,
       required this.creator,
       this.admin})
       : super._();
 
-  factory _$_RegistrationApplicationView.fromJson(Map<String, dynamic> json) =>
-      _$$_RegistrationApplicationViewFromJson(json);
+  factory _$RegistrationApplicationViewImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$RegistrationApplicationViewImplFromJson(json);
 
   @override
   final RegistrationApplication registrationApplication;
@@ -226,7 +227,7 @@ class _$_RegistrationApplicationView extends _RegistrationApplicationView {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_RegistrationApplicationView &&
+            other is _$RegistrationApplicationViewImpl &&
             (identical(
                     other.registrationApplication, registrationApplication) ||
                 other.registrationApplication == registrationApplication) &&
@@ -244,13 +245,13 @@ class _$_RegistrationApplicationView extends _RegistrationApplicationView {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_RegistrationApplicationViewCopyWith<_$_RegistrationApplicationView>
-      get copyWith => __$$_RegistrationApplicationViewCopyWithImpl<
-          _$_RegistrationApplicationView>(this, _$identity);
+  _$$RegistrationApplicationViewImplCopyWith<_$RegistrationApplicationViewImpl>
+      get copyWith => __$$RegistrationApplicationViewImplCopyWithImpl<
+          _$RegistrationApplicationViewImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_RegistrationApplicationViewToJson(
+    return _$$RegistrationApplicationViewImplToJson(
       this,
     );
   }
@@ -262,11 +263,11 @@ abstract class _RegistrationApplicationView
       {required final RegistrationApplication registrationApplication,
       required final LocalUser creatorLocalUser,
       required final Person creator,
-      final Person? admin}) = _$_RegistrationApplicationView;
+      final Person? admin}) = _$RegistrationApplicationViewImpl;
   const _RegistrationApplicationView._() : super._();
 
   factory _RegistrationApplicationView.fromJson(Map<String, dynamic> json) =
-      _$_RegistrationApplicationView.fromJson;
+      _$RegistrationApplicationViewImpl.fromJson;
 
   @override
   RegistrationApplication get registrationApplication;
@@ -278,6 +279,6 @@ abstract class _RegistrationApplicationView
   Person? get admin;
   @override
   @JsonKey(ignore: true)
-  _$$_RegistrationApplicationViewCopyWith<_$_RegistrationApplicationView>
+  _$$RegistrationApplicationViewImplCopyWith<_$RegistrationApplicationViewImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/v3/views/registration_application_view.g.dart
+++ b/lib/src/v3/views/registration_application_view.g.dart
@@ -6,9 +6,9 @@ part of 'registration_application_view.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_RegistrationApplicationView _$$_RegistrationApplicationViewFromJson(
+_$RegistrationApplicationViewImpl _$$RegistrationApplicationViewImplFromJson(
         Map<String, dynamic> json) =>
-    _$_RegistrationApplicationView(
+    _$RegistrationApplicationViewImpl(
       registrationApplication: RegistrationApplication.fromJson(
           json['registration_application'] as Map<String, dynamic>),
       creatorLocalUser: LocalUser.fromJson(
@@ -19,8 +19,8 @@ _$_RegistrationApplicationView _$$_RegistrationApplicationViewFromJson(
           : Person.fromJson(json['admin'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$$_RegistrationApplicationViewToJson(
-        _$_RegistrationApplicationView instance) =>
+Map<String, dynamic> _$$RegistrationApplicationViewImplToJson(
+        _$RegistrationApplicationViewImpl instance) =>
     <String, dynamic>{
       'registration_application': instance.registrationApplication.toJson(),
       'creator_local_user': instance.creatorLocalUser.toJson(),


### PR DESCRIPTION
This PR is to match parity up to 0.19.0-alpha.18:https://github.com/LemmyNet/lemmy-js-client/compare/0.19.0-alpha.16...0.19.0-alpha.18. This will remain a draft until changes are made on Thunder to allow for the changes in the responses.