### PR TITLE
Add debug mode to print HTTP API calls

### DIFF
--- a/lib/src/v3/main.dart
+++ b/lib/src/v3/main.dart
@@ -12,7 +12,9 @@ class LemmyApiV3 {
   final String host;
   static const extraPath = '/api/v3';
 
-  const LemmyApiV3(this.host);
+  final bool debug;
+
+  const LemmyApiV3(this.host, {this.debug = false});
 
   /// Run a given query
   Future<T> run<T>(LemmyApiQuery<T> query) async {
@@ -23,9 +25,11 @@ class LemmyApiV3 {
       auth = (query as LemmyApiAuthenticatedQuery).auth;
     }
 
-    print(
-      '${DateTime.now().toIso8601String()}: ${query.httpMethod} ${query.path}',
-    );
+    if (debug) {
+      print(
+        '${DateTime.now().toIso8601String()}: ${query.httpMethod} ${query.path}',
+      );
+    }
 
     final res = await () {
       switch (query.httpMethod) {

--- a/lib/src/v3/main.dart
+++ b/lib/src/v3/main.dart
@@ -23,6 +23,10 @@ class LemmyApiV3 {
       auth = (query as LemmyApiAuthenticatedQuery).auth;
     }
 
+    print(
+      '${DateTime.now().toIso8601String()}: ${query.httpMethod} ${query.path}',
+    );
+
     final res = await () {
       switch (query.httpMethod) {
         case HttpMethod.get:


### PR DESCRIPTION
This is a small PR which adds a `debug` mode for the API. When `debug = true` is passed into the API, it will log any HTTP requests ran by the package.

The main use for this is to be able to debug cases where unnecessary API calls are performed to optimize on data usage and rate limits applied by the instance. Here are some example debug prints:

```
2023-12-04T11:45:56.785005: HttpMethod.get /site
2023-12-04T11:45:56.785683: HttpMethod.get /community/list
2023-12-04T11:45:57.096583: HttpMethod.get /user
2023-12-04T11:45:57.101890: HttpMethod.get /community/list
2023-12-04T11:45:57.124396: HttpMethod.get /post/list
2023-12-04T11:45:57.292789: HttpMethod.get /private_message/list
```