### PR TITLE
Add LocalImageView, return it in ListMediaResponse, update pictrs delete

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,34 +5,26 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: db4766341bd8ecb66556f31ab891a5d596ef829221993531bd64a8e6342f0cda
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
+    version: "2.11.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "6d4193120997ecfd09acf0e313f13dc122b119e5eca87ef57a7d065ec9183762"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: cf75650c66c0316274e21d7c43d3dea246273af5955bd94e8184837cd577575c
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.3"
   freezed_annotation:
     dependency: transitive
     description:
@@ -45,26 +37,26 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: e362d639ba3bc07d5a71faebb98cde68c05bfbcfbbb444b60b6f60bb67719185
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.2"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.8.1"
   lemmy_api_client:
     dependency: "direct main"
     description:
@@ -76,65 +68,73 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "5202fdd37b4da5fd14a237ed0a01cad6c1efd4c99b5b5a0d3c9237f3728c9485"
+      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.14.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "240ed0e9bd73daa2182e33c4efc68c7dd53c7c656f3da73515a2d163e151412d"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: d5f89a9e52b36240a80282b3dc0667dd36e53459717bb17b8fb102d30496606a
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: db47e4797198ee601990820437179bb90219f918962318d494ada2b4b11e6f6d
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: dd11571b8a03f7cadcf91ec26a77e02bfbd6bbba2a512924d3116646b4198fc4
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a88162591b02c1f3a3db3af8ce1ea2b374bd75a7bb8d5e353bcfbdc79d719830
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "0c2ada1b1aeb2ad031ca81872add6be049b8cb479262c6ad3c4b0f9c24eaab2f"
+      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.4.5"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"

--- a/lib/src/pictrs.dart
+++ b/lib/src/pictrs.dart
@@ -31,12 +31,16 @@ class PictrsApi {
     return PictrsUpload.fromJson(body);
   }
 
-  Future<void> delete(PictrsUploadFile pictrsFile) async {
+  Future<void> delete(
+    PictrsUploadFile pictrsFile,
+    String? auth,
+  ) async {
     final res = await http.get(
       Uri.https(
         host,
         '$extraPath/delete/${pictrsFile.deleteToken}/${pictrsFile.file}',
       ),
+      headers: {'Authorization': 'Bearer $auth'},
     );
 
     if (!res.ok) {

--- a/lib/src/v3/models/image/local_image_view.dart
+++ b/lib/src/v3/models/image/local_image_view.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../utils/serde.dart';
+import '../../models/models.dart';
+
+part 'local_image_view.freezed.dart';
+part 'local_image_view.g.dart';
+
+@freezed
+class LocalImageView with _$LocalImageView {
+  @modelSerde
+  const factory LocalImageView({
+    required Person person, // v0.19.4
+    required LocalImage localImage, // v0.19.4
+  }) = _LocalImageView;
+
+  const LocalImageView._();
+  factory LocalImageView.fromJson(Map<String, dynamic> json) =>
+      _$LocalImageViewFromJson(json);
+}

--- a/lib/src/v3/models/image/local_image_view.freezed.dart
+++ b/lib/src/v3/models/image/local_image_view.freezed.dart
@@ -1,0 +1,199 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'local_image_view.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+LocalImageView _$LocalImageViewFromJson(Map<String, dynamic> json) {
+  return _LocalImageView.fromJson(json);
+}
+
+/// @nodoc
+mixin _$LocalImageView {
+  Person get person => throw _privateConstructorUsedError; // v0.19.4
+  LocalImage get localImage => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $LocalImageViewCopyWith<LocalImageView> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LocalImageViewCopyWith<$Res> {
+  factory $LocalImageViewCopyWith(
+          LocalImageView value, $Res Function(LocalImageView) then) =
+      _$LocalImageViewCopyWithImpl<$Res, LocalImageView>;
+  @useResult
+  $Res call({Person person, LocalImage localImage});
+
+  $PersonCopyWith<$Res> get person;
+  $LocalImageCopyWith<$Res> get localImage;
+}
+
+/// @nodoc
+class _$LocalImageViewCopyWithImpl<$Res, $Val extends LocalImageView>
+    implements $LocalImageViewCopyWith<$Res> {
+  _$LocalImageViewCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? person = null,
+    Object? localImage = null,
+  }) {
+    return _then(_value.copyWith(
+      person: null == person
+          ? _value.person
+          : person // ignore: cast_nullable_to_non_nullable
+              as Person,
+      localImage: null == localImage
+          ? _value.localImage
+          : localImage // ignore: cast_nullable_to_non_nullable
+              as LocalImage,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $PersonCopyWith<$Res> get person {
+    return $PersonCopyWith<$Res>(_value.person, (value) {
+      return _then(_value.copyWith(person: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $LocalImageCopyWith<$Res> get localImage {
+    return $LocalImageCopyWith<$Res>(_value.localImage, (value) {
+      return _then(_value.copyWith(localImage: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$LocalImageViewImplCopyWith<$Res>
+    implements $LocalImageViewCopyWith<$Res> {
+  factory _$$LocalImageViewImplCopyWith(_$LocalImageViewImpl value,
+          $Res Function(_$LocalImageViewImpl) then) =
+      __$$LocalImageViewImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Person person, LocalImage localImage});
+
+  @override
+  $PersonCopyWith<$Res> get person;
+  @override
+  $LocalImageCopyWith<$Res> get localImage;
+}
+
+/// @nodoc
+class __$$LocalImageViewImplCopyWithImpl<$Res>
+    extends _$LocalImageViewCopyWithImpl<$Res, _$LocalImageViewImpl>
+    implements _$$LocalImageViewImplCopyWith<$Res> {
+  __$$LocalImageViewImplCopyWithImpl(
+      _$LocalImageViewImpl _value, $Res Function(_$LocalImageViewImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? person = null,
+    Object? localImage = null,
+  }) {
+    return _then(_$LocalImageViewImpl(
+      person: null == person
+          ? _value.person
+          : person // ignore: cast_nullable_to_non_nullable
+              as Person,
+      localImage: null == localImage
+          ? _value.localImage
+          : localImage // ignore: cast_nullable_to_non_nullable
+              as LocalImage,
+    ));
+  }
+}
+
+/// @nodoc
+
+@modelSerde
+class _$LocalImageViewImpl extends _LocalImageView {
+  const _$LocalImageViewImpl({required this.person, required this.localImage})
+      : super._();
+
+  factory _$LocalImageViewImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LocalImageViewImplFromJson(json);
+
+  @override
+  final Person person;
+// v0.19.4
+  @override
+  final LocalImage localImage;
+
+  @override
+  String toString() {
+    return 'LocalImageView(person: $person, localImage: $localImage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$LocalImageViewImpl &&
+            (identical(other.person, person) || other.person == person) &&
+            (identical(other.localImage, localImage) ||
+                other.localImage == localImage));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, person, localImage);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$LocalImageViewImplCopyWith<_$LocalImageViewImpl> get copyWith =>
+      __$$LocalImageViewImplCopyWithImpl<_$LocalImageViewImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$LocalImageViewImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _LocalImageView extends LocalImageView {
+  const factory _LocalImageView(
+      {required final Person person,
+      required final LocalImage localImage}) = _$LocalImageViewImpl;
+  const _LocalImageView._() : super._();
+
+  factory _LocalImageView.fromJson(Map<String, dynamic> json) =
+      _$LocalImageViewImpl.fromJson;
+
+  @override
+  Person get person;
+  @override // v0.19.4
+  LocalImage get localImage;
+  @override
+  @JsonKey(ignore: true)
+  _$$LocalImageViewImplCopyWith<_$LocalImageViewImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/v3/models/image/local_image_view.g.dart
+++ b/lib/src/v3/models/image/local_image_view.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'local_image_view.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$LocalImageViewImpl _$$LocalImageViewImplFromJson(Map<String, dynamic> json) =>
+    _$LocalImageViewImpl(
+      person: Person.fromJson(json['person'] as Map<String, dynamic>),
+      localImage:
+          LocalImage.fromJson(json['local_image'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$LocalImageViewImplToJson(
+        _$LocalImageViewImpl instance) =>
+    <String, dynamic>{
+      'person': instance.person.toJson(),
+      'local_image': instance.localImage.toJson(),
+    };

--- a/lib/src/v3/models/models.dart
+++ b/lib/src/v3/models/models.dart
@@ -37,6 +37,7 @@ export 'federated_instances/instance.dart';
 export 'federated_instances/instance_with_federation_state.dart';
 export 'federated_instances/readable_federation_state.dart';
 export 'image/local_image.dart';
+export 'image/local_image_view.dart';
 export 'language/language.dart';
 export 'local_user/local_user.dart';
 export 'local_user/local_user_vote_display_mode.dart';

--- a/lib/src/v3/models/user/list_media_response.dart
+++ b/lib/src/v3/models/user/list_media_response.dart
@@ -1,7 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-import '../../../../v3.dart';
 import '../../../utils/serde.dart';
+import '../image/local_image_view.dart';
 
 part 'list_media_response.freezed.dart';
 part 'list_media_response.g.dart';
@@ -10,7 +10,7 @@ part 'list_media_response.g.dart';
 class ListMediaResponse with _$ListMediaResponse {
   @modelSerde
   const factory ListMediaResponse({
-    required List<LocalImage> images,
+    required List<LocalImageView> images,
   }) = _ListMediaResponse;
 
   const ListMediaResponse._();

--- a/lib/src/v3/models/user/list_media_response.freezed.dart
+++ b/lib/src/v3/models/user/list_media_response.freezed.dart
@@ -20,7 +20,7 @@ ListMediaResponse _$ListMediaResponseFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$ListMediaResponse {
-  List<LocalImage> get images => throw _privateConstructorUsedError;
+  List<LocalImageView> get images => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -34,7 +34,7 @@ abstract class $ListMediaResponseCopyWith<$Res> {
           ListMediaResponse value, $Res Function(ListMediaResponse) then) =
       _$ListMediaResponseCopyWithImpl<$Res, ListMediaResponse>;
   @useResult
-  $Res call({List<LocalImage> images});
+  $Res call({List<LocalImageView> images});
 }
 
 /// @nodoc
@@ -56,7 +56,7 @@ class _$ListMediaResponseCopyWithImpl<$Res, $Val extends ListMediaResponse>
       images: null == images
           ? _value.images
           : images // ignore: cast_nullable_to_non_nullable
-              as List<LocalImage>,
+              as List<LocalImageView>,
     ) as $Val);
   }
 }
@@ -69,7 +69,7 @@ abstract class _$$ListMediaResponseImplCopyWith<$Res>
       __$$ListMediaResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({List<LocalImage> images});
+  $Res call({List<LocalImageView> images});
 }
 
 /// @nodoc
@@ -89,7 +89,7 @@ class __$$ListMediaResponseImplCopyWithImpl<$Res>
       images: null == images
           ? _value._images
           : images // ignore: cast_nullable_to_non_nullable
-              as List<LocalImage>,
+              as List<LocalImageView>,
     ));
   }
 }
@@ -98,16 +98,16 @@ class __$$ListMediaResponseImplCopyWithImpl<$Res>
 
 @modelSerde
 class _$ListMediaResponseImpl extends _ListMediaResponse {
-  const _$ListMediaResponseImpl({required final List<LocalImage> images})
+  const _$ListMediaResponseImpl({required final List<LocalImageView> images})
       : _images = images,
         super._();
 
   factory _$ListMediaResponseImpl.fromJson(Map<String, dynamic> json) =>
       _$$ListMediaResponseImplFromJson(json);
 
-  final List<LocalImage> _images;
+  final List<LocalImageView> _images;
   @override
-  List<LocalImage> get images {
+  List<LocalImageView> get images {
     if (_images is EqualUnmodifiableListView) return _images;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_images);
@@ -147,15 +147,15 @@ class _$ListMediaResponseImpl extends _ListMediaResponse {
 }
 
 abstract class _ListMediaResponse extends ListMediaResponse {
-  const factory _ListMediaResponse({required final List<LocalImage> images}) =
-      _$ListMediaResponseImpl;
+  const factory _ListMediaResponse(
+      {required final List<LocalImageView> images}) = _$ListMediaResponseImpl;
   const _ListMediaResponse._() : super._();
 
   factory _ListMediaResponse.fromJson(Map<String, dynamic> json) =
       _$ListMediaResponseImpl.fromJson;
 
   @override
-  List<LocalImage> get images;
+  List<LocalImageView> get images;
   @override
   @JsonKey(ignore: true)
   _$$ListMediaResponseImplCopyWith<_$ListMediaResponseImpl> get copyWith =>

--- a/lib/src/v3/models/user/list_media_response.g.dart
+++ b/lib/src/v3/models/user/list_media_response.g.dart
@@ -10,7 +10,7 @@ _$ListMediaResponseImpl _$$ListMediaResponseImplFromJson(
         Map<String, dynamic> json) =>
     _$ListMediaResponseImpl(
       images: (json['images'] as List<dynamic>)
-          .map((e) => LocalImage.fromJson(e as Map<String, dynamic>))
+          .map((e) => LocalImageView.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 


### PR DESCRIPTION
This PR updates the `ListMediaResponse` to correctly return a list of `LocalImageView`s. It also updates the Pictrs delete method to take auth. All of this is in support of allowing media deletion from Thunder.

See thunder-app/thunder#1323.