### PR TITLE
Option to connect to lemmy without  ssl/tls

### DIFF
--- a/lib/src/v3/main.dart
+++ b/lib/src/v3/main.dart
@@ -33,7 +33,7 @@ class LemmyApiV3 {
     }
 
     // TLS can only be disable in debug mode.
-    final bool scheme = (!tls && debug) ? 'http' : 'https';
+    final String scheme = (!tls && debug) ? 'http' : 'https';
 
     final res = await () {
       switch (query.httpMethod) {

--- a/lib/src/v3/main.dart
+++ b/lib/src/v3/main.dart
@@ -32,12 +32,15 @@ class LemmyApiV3 {
       );
     }
 
+    // TLS can only be disable in debug mode.
+    final bool scheme = (!tls && debug) ? 'http' : 'https';
+
     final res = await () {
       switch (query.httpMethod) {
         case HttpMethod.get:
           return http.get(
             Uri(
-              scheme: (!tls && debug) ? 'http' : 'https',
+              scheme: scheme,
               host: host,
               path: '$extraPath${query.path}',
               queryParameters: <String, String>{
@@ -50,7 +53,7 @@ class LemmyApiV3 {
         case HttpMethod.post:
           return http.post(
             Uri(
-              scheme: (!tls && debug) ? 'http' : 'https',
+              scheme: scheme,
               host: host,
               path: '$extraPath${query.path}',
             ),
@@ -63,7 +66,7 @@ class LemmyApiV3 {
         case HttpMethod.put:
           return http.put(
             Uri(
-              scheme: (!tls && debug) ? 'http' : 'https',
+              scheme: scheme,
               host: host,
               path: '$extraPath${query.path}',
             ),

--- a/lib/src/v3/main.dart
+++ b/lib/src/v3/main.dart
@@ -37,7 +37,7 @@ class LemmyApiV3 {
         case HttpMethod.get:
           return http.get(
             Uri(
-              scheme: tls ? 'https' : 'http',
+              scheme: (!tls && debug) ? 'http' : 'https',
               host: host,
               path: '$extraPath${query.path}',
               queryParameters: <String, String>{
@@ -50,7 +50,7 @@ class LemmyApiV3 {
         case HttpMethod.post:
           return http.post(
             Uri(
-              scheme: tls ? 'https' : 'http',
+              scheme: (!tls && debug) ? 'http' : 'https',
               host: host,
               path: '$extraPath${query.path}',
             ),
@@ -63,7 +63,7 @@ class LemmyApiV3 {
         case HttpMethod.put:
           return http.put(
             Uri(
-              scheme: tls ? 'https' : 'http',
+              scheme: (!tls && debug) ? 'http' : 'https',
               host: host,
               path: '$extraPath${query.path}',
             ),

--- a/lib/src/v3/main.dart
+++ b/lib/src/v3/main.dart
@@ -13,8 +13,9 @@ class LemmyApiV3 {
   static const extraPath = '/api/v3';
 
   final bool debug;
+  final bool tls;
 
-  const LemmyApiV3(this.host, {this.debug = false});
+  const LemmyApiV3(this.host, {this.debug = false, this.tls = true});
 
   /// Run a given query
   Future<T> run<T>(LemmyApiQuery<T> query) async {
@@ -34,35 +35,75 @@ class LemmyApiV3 {
     final res = await () {
       switch (query.httpMethod) {
         case HttpMethod.get:
-          return http.get(
-            Uri.https(
-              host,
-              '$extraPath${query.path}',
-              <String, String>{
-                for (final entry in query.toJson().entries)
-                  entry.key: entry.value.toString()
-              },
-            ),
-            headers: (auth != null) ? {'Authorization': 'Bearer $auth'} : null,
-          );
+          if (tls) {
+            return http.get(
+              Uri.https(
+                host,
+                '$extraPath${query.path}',
+                <String, String>{
+                  for (final entry in query.toJson().entries)
+                    entry.key: entry.value.toString()
+                },
+              ),
+              headers:
+                  (auth != null) ? {'Authorization': 'Bearer $auth'} : null,
+            );
+          } else {
+            return http.get(
+              Uri.http(
+                host,
+                '$extraPath${query.path}',
+                <String, String>{
+                  for (final entry in query.toJson().entries)
+                    entry.key: entry.value.toString()
+                },
+              ),
+              headers:
+                  (auth != null) ? {'Authorization': 'Bearer $auth'} : null,
+            );
+          }
+
         case HttpMethod.post:
-          return http.post(
-            Uri.https(host, '$extraPath${query.path}'),
-            body: jsonEncode(query.toJson()),
-            headers: {
-              'Content-Type': 'application/json',
-              if (auth != null) 'Authorization': 'Bearer $auth'
-            },
-          );
+          if (tls) {
+            return http.post(
+              Uri.https(host, '$extraPath${query.path}'),
+              body: jsonEncode(query.toJson()),
+              headers: {
+                'Content-Type': 'application/json',
+                if (auth != null) 'Authorization': 'Bearer $auth'
+              },
+            );
+          } else {
+            return http.post(
+              Uri.http(host, '$extraPath${query.path}'),
+              body: jsonEncode(query.toJson()),
+              headers: {
+                'Content-Type': 'application/json',
+                if (auth != null) 'Authorization': 'Bearer $auth'
+              },
+            );
+          }
+
         case HttpMethod.put:
-          return http.put(
-            Uri.https(host, '$extraPath${query.path}'),
-            body: jsonEncode(query.toJson()),
-            headers: {
-              'Content-Type': 'application/json',
-              if (auth != null) 'Authorization': 'Bearer $auth'
-            },
-          );
+          if (tls) {
+            return http.put(
+              Uri.https(host, '$extraPath${query.path}'),
+              body: jsonEncode(query.toJson()),
+              headers: {
+                'Content-Type': 'application/json',
+                if (auth != null) 'Authorization': 'Bearer $auth'
+              },
+            );
+          } else {
+            return http.put(
+              Uri.http(host, '$extraPath${query.path}'),
+              body: jsonEncode(query.toJson()),
+              headers: {
+                'Content-Type': 'application/json',
+                if (auth != null) 'Authorization': 'Bearer $auth'
+              },
+            );
+          }
       }
     }();
 

--- a/lib/src/v3/main.dart
+++ b/lib/src/v3/main.dart
@@ -35,75 +35,44 @@ class LemmyApiV3 {
     final res = await () {
       switch (query.httpMethod) {
         case HttpMethod.get:
-          if (tls) {
-            return http.get(
-              Uri.https(
-                host,
-                '$extraPath${query.path}',
-                <String, String>{
-                  for (final entry in query.toJson().entries)
-                    entry.key: entry.value.toString()
-                },
-              ),
-              headers:
-                  (auth != null) ? {'Authorization': 'Bearer $auth'} : null,
-            );
-          } else {
-            return http.get(
-              Uri.http(
-                host,
-                '$extraPath${query.path}',
-                <String, String>{
-                  for (final entry in query.toJson().entries)
-                    entry.key: entry.value.toString()
-                },
-              ),
-              headers:
-                  (auth != null) ? {'Authorization': 'Bearer $auth'} : null,
-            );
-          }
-
+          return http.get(
+            Uri(
+              scheme: tls ? 'https' : 'http',
+              host: host,
+              path: '$extraPath${query.path}',
+              queryParameters: <String, String>{
+                for (final entry in query.toJson().entries)
+                  entry.key: entry.value.toString()
+              },
+            ),
+            headers: (auth != null) ? {'Authorization': 'Bearer $auth'} : null,
+          );
         case HttpMethod.post:
-          if (tls) {
-            return http.post(
-              Uri.https(host, '$extraPath${query.path}'),
-              body: jsonEncode(query.toJson()),
-              headers: {
-                'Content-Type': 'application/json',
-                if (auth != null) 'Authorization': 'Bearer $auth'
-              },
-            );
-          } else {
-            return http.post(
-              Uri.http(host, '$extraPath${query.path}'),
-              body: jsonEncode(query.toJson()),
-              headers: {
-                'Content-Type': 'application/json',
-                if (auth != null) 'Authorization': 'Bearer $auth'
-              },
-            );
-          }
-
+          return http.post(
+            Uri(
+              scheme: tls ? 'https' : 'http',
+              host: host,
+              path: '$extraPath${query.path}',
+            ),
+            body: jsonEncode(query.toJson()),
+            headers: {
+              'Content-Type': 'application/json',
+              if (auth != null) 'Authorization': 'Bearer $auth'
+            },
+          );
         case HttpMethod.put:
-          if (tls) {
-            return http.put(
-              Uri.https(host, '$extraPath${query.path}'),
-              body: jsonEncode(query.toJson()),
-              headers: {
-                'Content-Type': 'application/json',
-                if (auth != null) 'Authorization': 'Bearer $auth'
-              },
-            );
-          } else {
-            return http.put(
-              Uri.http(host, '$extraPath${query.path}'),
-              body: jsonEncode(query.toJson()),
-              headers: {
-                'Content-Type': 'application/json',
-                if (auth != null) 'Authorization': 'Bearer $auth'
-              },
-            );
-          }
+          return http.put(
+            Uri(
+              scheme: tls ? 'https' : 'http',
+              host: host,
+              path: '$extraPath${query.path}',
+            ),
+            body: jsonEncode(query.toJson()),
+            headers: {
+              'Content-Type': 'application/json',
+              if (auth != null) 'Authorization': 'Bearer $auth'
+            },
+          );
       }
     }();
 


### PR DESCRIPTION
I am starting to work on adding SSO support for thunder. Lemmy SSO support hasn't been released yet, I so I have to develop against a local lemmy instance. I think SSL/TLS is preventing Thunder from my connecting to my local lemmy instance. The lemmy docker-compose to set up a local lemmy does not have SSL/TLS setup. I think making an option in Thunder to connect to an instance without TLS is a little bit better solution than turning on TLS on lemmy. 

Here are my notes for setting up a local dev lemmy with docker:
https://gist.github.com/gwbischof/ea41a74410b8fa890f148b5d45310513