### PR TITLE
update freezed_annotation

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   json_annotation: ^4.6.0
   http: ^1.0.0
-  freezed_annotation: ^2.4.1
+  freezed_annotation: ^2.4.4
   web_socket_channel: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
It looks like this commit caused some Thunder tests to fail: https://github.com/thunder-app/lemmy_api_client/commit/8d1513a3574665b464822595ac97bb166a5ffa89

```
Error: Not found: 'package:freezed_annotation/freezed_annotation.dart'
```

Trying to update freezed_annotation package to fix it.
The tests are passing on my computer so I think we have to let the CI test it to see if this fixes it.

