### PR TITLE
Add ability to passthrough parameters to request

### DIFF
--- a/lib/src/v3/api/user/user.dart
+++ b/lib/src/v3/api/user/user.dart
@@ -128,7 +128,10 @@ class ExportSettings
 @freezed
 class ImportSettings
     with _$ImportSettings
-    implements LemmyApiQuery<SuccessResponse>, LemmyApiAuthenticatedQuery {
+    implements
+        LemmyApiQuery<SuccessResponse>,
+        LemmyApiAuthenticatedQuery,
+        PassthroughParameter {
   @apiSerde
   const factory ImportSettings({
     String? auth,
@@ -146,6 +149,9 @@ class ImportSettings
   @override
   SuccessResponse responseFactory(Map<String, dynamic> json) =>
       SuccessResponse.fromJson(json);
+
+  @override
+  String get parameter => 'data';
 }
 
 /// Only available in lemmy v0.19.0 and above

--- a/lib/src/v3/main.dart
+++ b/lib/src/v3/main.dart
@@ -22,8 +22,14 @@ class LemmyApiV3 {
     // get a future based on http method
 
     String? auth;
+    String? passthroughParameter;
+
     if (query is LemmyApiAuthenticatedQuery) {
       auth = (query as LemmyApiAuthenticatedQuery).auth;
+    }
+
+    if (query is PassthroughParameter) {
+      passthroughParameter = (query as PassthroughParameter).parameter;
     }
 
     if (debug) {
@@ -57,7 +63,7 @@ class LemmyApiV3 {
               host: host,
               path: '$extraPath${query.path}',
             ),
-            body: jsonEncode(query.toJson()),
+            body: passthroughParameter != null ? query.toJson()[passthroughParameter] as String : jsonEncode(query.toJson()),
             headers: {
               'Content-Type': 'application/json',
               if (auth != null) 'Authorization': 'Bearer $auth',

--- a/lib/src/v3/query.dart
+++ b/lib/src/v3/query.dart
@@ -12,3 +12,13 @@ abstract class LemmyApiQuery<T> {
 abstract class LemmyApiAuthenticatedQuery {
   String? get auth;
 }
+
+/// Use this class when a query requires a specific parameter to be passed directly to the body, without first encoding it as a JSON string.
+///
+/// This class allows you to specify a [parameter] that will be included in the query body as raw data.
+/// This is only used in [HttpMethod.post] requests, where the parameter is added directly to the body, rather than as a JSON-encoded string.
+///
+/// For example: the [ImportSettings] uses this class to pass the user settings as a raw string to the query.
+abstract class PassthroughParameter {
+  String get parameter;
+}


### PR DESCRIPTION
This PR adds a way to passthrough a given parameter to the resulting request using `PassthroughParameter`. This allows us to bypass some of the additional parameters that are automatically set on an given request (e.g., `auth` parameter).

In particular, this enables `ImportSettings` to work properly!