### PR TITLE
build runner fails with newer versions of json_serializable

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,5 +15,5 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.6
   freezed: ^2.4.2
-  json_serializable: ^6.7.1
+  json_serializable: ">=6.7.1 <6.9.2"
   test: ^1.24.6


### PR DESCRIPTION
What about pinning all of the code generation dependencies? Like `freezed` and `json_serializable`, etc?
I don't think you have to worry about dependency conflicts by pining these versions because they are just dev dependencies. The benefit is that if someone makes a PR to add a feature and runs `run builder` all of the file will stay the same except the ones effected by their feature.  Then there could be separate PRs to bump the versions of the dev dependencies.  Because the aren't pinned, without changing the pubspec.yaml we can get two different results.  Also because there is no pubspec.lock I can't figure out which `freezed` and `json_serializable` versions are needed to recreate the generated file as they currently are.
