### PR TITLE
Get connection to lemmy working in dev-container

### DIFF
--- a/test/config.example.dart
+++ b/test/config.example.dart
@@ -5,7 +5,7 @@
 String version = 'v4';
 
 /// The instance to connect to. By default, it will use the docker container port.
-String instance = 'localhost:1236';
+String instance = 'proxy:1236';
 
 /// The scheme to use. By default, it will use HTTP.
 String scheme = 'http';

--- a/test/v4_test.dart
+++ b/test/v4_test.dart
@@ -1,0 +1,33 @@
+import 'package:http/http.dart';
+import 'package:test/test.dart';
+
+import 'package:lemmy_dart_client/src/client/client.dart';
+
+// Import the auth token from the config file
+import 'config.dart';
+
+void main() {
+  late LemmyClient client;
+
+  setUpAll(() async {
+    client = await LemmyClient.initialize(
+      instance: instance,
+      version: version,
+      scheme: scheme,
+    );
+  });
+
+  group('Client', () {
+    test('should fetch the proper information when initialized', () async {
+      expect(client.site.info, isNotNull);
+      expect(client.account.info, isNull);
+    });
+
+    test('should fail when an invalid instance is given', () async {
+      expect(
+        () async => await LemmyClient.initialize(instance: 'invalid'),
+        throwsA(isA<ClientException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
I was getting this error when running the tests in the dev-container
```
ClientException with SocketException: Connection refused (OS Error: Connection refused, errno = 111), address = 127.0.0.1, port = 48874, uri=http://127.0.0.1:1236/api/v4/site
```

This change fixed the error for me.
I was planning on experimenting with generation of the api using the openapi spec from lemmy-js-client.

My intention for the file v4_test.dart was to make a test that loops through all of the endpoints defined in the openapi spec and does a basic test for each endpoint. I'm not sure how well that will work yet.  Currently v4_test is passing so someone could use it to make sure the containers are working correctly.